### PR TITLE
Finite-set P2: set-completion → designation + auto authorship invite

### DIFF
--- a/D-SUPPLY-FINITE-SET-01.md
+++ b/D-SUPPLY-FINITE-SET-01.md
@@ -1,0 +1,118 @@
+# D-SUPPLY-FINITE-SET-01 — Finite completable sets, cost-routed curation
+
+**Status:** ✅ **RATIFIED** 2026-07-05 (Josh, in chat). Supersedes
+`docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md` (now resolved).
+Unblocks the `D-SUPPLY-LADDER-UNIFY-01` rework and forces a revision of
+`D-AREA-EXPANSION-01` (graduation valence). Does not, by itself, un-pause the
+paid refill run — see §6.
+
+## The decision (two answers + two additions)
+
+### 1. Topics are FINITE COMPLETABLE SETS, and completion invites authorship.
+A knowledge domain is a **bounded body of ~15–30 fan-salient questions** — the
+ones a real fan of that topic would genuinely enjoy — not an infinite top-up
+pool. A player **completes** the set, earns a **designation** (a durable badge),
+and is then **invited to graduate** (a neighbor/parent topic) *and* **to author
+their own questions** for the topic they just mastered.
+
+- **Completion is a trophy, not a failure.** "Running out" — today an awkward
+  state the guard hides — becomes the intended arc: master → badge → branch out.
+  This directly answers the driving feedback ("answering ever deeper into one
+  play leads to weirdness, frustration and boredom"): we stop mining a topic past
+  its fan-salient core.
+- **Completion → contribution (Josh's addition).** At the trophy moment the
+  player is offered the authoring door: "you know this world — add the questions
+  you wish were here." Reuses the existing invited-author flow
+  (`B-CRAFTER-LIFECYCLE-01`, the `/invited` takeover + `/craft/[domain]` surface);
+  a completed player is the highest-signal candidate to author, and their
+  additions **grow the set** for the next player (finite ≠ frozen — see §4).
+- **Arcane questions are opt-in.** The fan-salient core is the default set; deep
+  cuts are generated rarely and only on a player's explicit "go deeper" — not
+  ground out automatically. (Maps onto the crafter "deep cuts" tier that exists.)
+
+### 2. Curation is COST-ROUTED hybrid (Josh's second answer).
+Not blanket-curate, not blanket-hands-off. **A human curates the domains that
+are expensive or unreliable for the machine to generate + verify; cheap,
+reliable domains fill themselves.**
+
+- **"Expensive/unreliable" is a computed per-domain signal**, from telemetry we
+  already collect (no new instrumentation):
+  - **demotion rate** — `verification_verdict='demoted'` over verified rows,
+    grouped by `canonical_subcategory`. High demotion ⇒ the machine keeps minting
+    wrong facts here ⇒ human-vetting ~50→keep ~20 beats regenerate-and-catch.
+  - **verify web-search rate** — domains where the verifier can't settle from
+    knowledge and falls to `web_search` (`web_search_requests > 0` on
+    `scope='batch-verify'` ledger rows, once attributable per domain). Niche /
+    fandom / current-events ⇒ expensive to verify.
+  - **draft/ask-to-answer kill rate** — low machine yield ⇒ expensive to fill.
+  These combine into a **curation-worthiness score** per domain.
+- **Routing:** score above a tunable threshold → the domain is flagged
+  **curate** and surfaced in the crafter "where your craft is wanted" worklist
+  (which already ranks active domains by demand × thinness — this adds a
+  cost-risk dimension). Below threshold → **auto-fill** (machine generates the
+  set, gates filter, no human in the loop).
+- **The expensive set and the authorship-invite set are the same set** — a
+  niche fandom domain is both where the machine is unreliable *and* where a
+  just-completed superfan is the ideal author. The two additions converge.
+
+## What "finite" changes (the mechanics)
+
+- **Depth threshold** stops meaning "too thin to serve" and starts meaning
+  **"set complete."** The `RETRIEVAL_POOL_DEPTH_THRESHOLD` / kb-exhaustion guard
+  is reinterpreted: reaching target depth = the set is done, trigger the trophy,
+  not "keep generating."
+- **Set size** is per-domain, seeded from the node's authored **mastery weight**
+  (`node_weight`, already seeded on 116 nodes) — a deeper topic (weight 9) gets a
+  bigger target set than a shallow one (weight 2). This reuses mastery-v2's weight
+  as the set-size signal, not just the mastery bar.
+- **Refill** flips from "drain a daily backlog forever" to **"fill each set once,
+  then stop."** A completed set is not re-refilled. This collapses the recurring
+  refill cost to a bounded, one-time-per-domain cost.
+- **Graduation** (`D-AREA-EXPANSION-01`, rung 5) flips valence: **fallback → the
+  intended arc.** That doc must be revised (do not treat graduation as "we ran
+  out" anymore).
+
+## Finite ≠ frozen (how sets grow)
+
+A set is bounded *at any moment*, not permanently sealed:
+- **Human authorship extends it** — completed players + curators add questions,
+  so a beloved topic's set organically grows past its machine-generated core.
+- **Opt-in depth extends it** — a player asking to "go deeper" mints arcane
+  questions on demand, appended to their view of the set.
+- **Re-completion** — when a set grows after a player completed it, they're
+  notified there's more (a light re-engagement hook, not a treadmill).
+
+## Build implications (phased; each independently mergeable)
+
+- **P1 — Curation-worthiness score (read-only):** per-domain demotion + verify-
+  web + kill-rate rollup; surface as a column/sort in the crafter worklist. No
+  behavior change; validates the routing signal before it gates anything.
+- **P2 — Set-completion state:** reinterpret depth-reached as "complete" for
+  auto-fill domains; wire the trophy/designation + the authorship-invite door at
+  completion (reuse the invited-author takeover). Flag-gated.
+- **P3 — Refill re-scope:** refill fills to target-set-size then stops per domain;
+  completed sets excluded. Folds into the `D-SUPPLY-LADDER-UNIFY-01` rework.
+- **P4 — Curation routing live:** the score gates which domains enter the crafter
+  worklist as "curate" vs auto-fill.
+- Revise `D-AREA-EXPANSION-01` (graduation valence) alongside P2.
+
+## Open knobs (tune later; do not block the build)
+
+- Target set size as a function of `node_weight` (linear? floor/ceiling 15/30?).
+- Curation-worthiness threshold + the weight of each signal (demotion vs web vs
+  yield) — calibrate against the crafter's own kept/killed ledger.
+- Whether opt-in deep cuts count toward a *second* designation tier.
+- Re-completion notification cadence (avoid it becoming a treadmill by the back
+  door).
+
+## Interacts with
+
+- `D-SUPPLY-LADDER-UNIFY-01` — now UNBLOCKED; rungs 2/3/5 rewrite against finite
+  sets (fill-once refill, complete-not-thin threshold, graduation-as-arc).
+- `D-AREA-EXPANSION-01` — graduation valence flips; revise with P2.
+- `B-CRAFTER-LIFECYCLE-01` — the authorship-invite and curation surfaces already
+  exist; this decision points real routing at them.
+- Mastery-v2 (`node_weight`) — reused as the set-size signal.
+- The paid AC-1 refill run / soak — still paused pending the P3 re-scope; refill
+  as it stands (infinite drain) is now the *wrong shape*, so do not run the
+  old-shape confirmation — rebuild it fill-once first.

--- a/docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md
+++ b/docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md
@@ -1,28 +1,17 @@
-# D-SUPPLY-FINITE-SET-01 — PENDING DECISION (not yet ratified)
+# D-SUPPLY-FINITE-SET-01 — RESOLVED (see the ratified doc)
 
-**Status:** ⏳ **PENDING** — a chat decision with Josh precedes the real D-doc; this is only the visible marker. **Not ratified. Do not build against it, and do not build against the things it blocks.**
+**Status:** ✅ **RATIFIED 2026-07-05.** This pending marker is closed. The real
+decision lives at `D-SUPPLY-FINITE-SET-01.md` (repo root).
 
-**Blocks:** the paid AC-1 refill confirmation run · the refill soak · any `D-SUPPLY-LADDER-UNIFY-01` build prompts.
+**The answers Josh gave:**
+1. **Finite completable sets ("trophy"), and completion invites authorship** —
+   ~15–30 fan-salient questions per topic; complete → designation → graduate AND
+   author your own; arcane questions opt-in only.
+2. **Cost-routed hybrid curation** — a human curates domains that are expensive/
+   unreliable to generate+verify (high demotion, needs web-search, low yield);
+   cheap reliable domains auto-fill. The expensive set and the authorship-invite
+   set coincide.
 
-## The question
-Are knowledge domains **infinite top-up pools** (the current supply-ladder premise — daily refill drains a backlog forever) or **finite completable sets** (a bounded body of ~15–30 fan-salient questions the player *completes*, earns a **designation** for, then **graduates/broadens** by choice — with **opt-in difficulty tiers** so arcane questions are generated rarely and only on demand)?
-
-## Why it matters (what the answer reshapes)
-- **Refill:** "daily backlog-draining cost" → "fill a set once, then stop."
-- **Depth threshold:** stops meaning "too thin to serve," starts meaning "set complete."
-- **Graduation (`D-AREA-EXPANSION-01`, rung 5):** flips from **fallback** (we ran out) to **intended arc** (you mastered it).
-- **Human curation:** Josh vetting ~50 → keeping ~35 may beat automated refill on both cost and quality for vettable domains.
-
-The driving feedback: *"answering ever deeper into one play leads to weirdness and frustration and boredom."* — i.e. infinite depth may be the wrong goal.
-
-## Two inputs Josh owes before ratification
-1. Does the **finite-set model feel right** as the game's direction?
-2. Does Josh want to **personally curate**, or should supply run **hands-off**?
-
-## Interacts with (do NOT build until resolved)
-- `D-SUPPLY-LADDER-UNIFY-01` — rungs 2, 3, and 5 all change.
-- `D-AREA-EXPANSION-01` — graduation's valence flips (fallback → intended arc). *(Do not edit that doc yet; its revision waits on this same decision.)*
-- The AC-1 refill confirmation run · the refill soak (`docs/retrieval-flip-checklist.md`, `B-SUPPLY-REFILL-EFFORT-REPORT.md`).
-
-## Does NOT block
-- The **batch-verify cost characterization** work (`docs/findings/batch-verify-cost-characterization.md`) — that cron is unrelated to this reframe and proceeds independently.
+See the ratified doc for mechanics, the per-domain curation-worthiness signal,
+the "finite ≠ frozen" growth model, and the phased build (P1 score → P2
+completion+trophy → P3 refill re-scope → P4 routing).

--- a/docs/findings/SCALE-READINESS-2026-07-05.md
+++ b/docs/findings/SCALE-READINESS-2026-07-05.md
@@ -1,0 +1,82 @@
+# Scale-readiness review — question generation & verification
+
+**Date:** 2026-07-05 · **Method:** live prod DB (read-only aggregates), Axiom `vercel` log drain, Vercel env/deploy state, docs pricing page, and a full code map of both pipelines. · **Companion fixes landed with this doc:** the Batch-API `custom_id` bug, the prefilter explanation-path tightening, and the one-time backlog blitz (see §7).
+
+## TL;DR
+
+Generation is healthy and cheap (~$0.014/question). **Verification was the scaling wall** — a ~50/day synchronous cap under a ~26/day inflow, a growing backlog, and the built escape hatch (Batch API mode) silently broken. As of this doc the wall is removed: the Batch path works (bug fixed, first real batches submitted), the prefilter routes 78.5% instead of 94.3%, and the actionable backlog is being cleared for ~$3. The remaining scale levers are pricing/caching hygiene and one strategic decision (`D-SUPPLY-FINITE-SET-01`) that sets whether cost stays linear in players.
+
+## 1. Baseline (2026-07-05)
+
+| Metric | Value |
+|---|---|
+| Users / weekly answerers | 18 / 6 |
+| Answers, last 7d | 167 |
+| GeneratedQuestion total / servable / fresh-unused | 1,270 / 760 / 177 |
+| Question total / human-authored | 766 / 139 |
+| LLM spend | wk 6/22: **$3.87** (908 calls) → wk 6/29: **~$16–21 list** (1,804 calls; experiment-driven, not player-driven) |
+| Cost per generated question | **$0.014** (weekly digest) |
+| `LLM_MONTHLY_USD_CEILING` | $42 — last week's pace annualizes past it; raise or expect throttling |
+
+## 2. Generation
+
+Paths: daily on-demand (3-pass cron, time-budgeted rounds, six inline gates + ask-to-answer), pool refill (grounded web-search, flag-gated), crafter/authored (gates-as-flags, decision ledger feedback), reference-grounded anchor (built, flag-off).
+
+**Findings:**
+- **Sonnet 5 wins the A/B on everything measured**: generation 10.5s vs 15.3s avg, verify 3.7s vs 7.8s, refill 41 domains/165s/0 timeouts (vs 65% timeout catastrophe on 4.6), demotion parity (13.2% vs 13.3%). **Intro pricing $2/$10 per MTok through 2026-08-31** (list $3/$15; new tokenizer ≈ +30% tokens → net ~13% cheaper at intro). Some scopes still run 4.6 (factual gate default, parts of verify/inside-joke/enrich) — finish the consolidation before the intro window closes.
+- **The refill "pause" is not real in telemetry**: 155 non-dry cron invocations in 7d, 16×200, **10×504 + 2×500 dying at the 300s `maxDuration`**, plus live `pool-refill-generate` ledger rows. Reconcile posture vs reality; if refill stays on, it needs the Batch API architecture (the 504s prove sync can't hold even at this scale).
+- **No `generated_by_model` on question rows** — provider only (mostly NULL). Model-level quality A/Bs are impossible until a column is added and stamped at persist.
+
+## 3. Verification
+
+Layers: inline gates at generation → ask-to-answer (`machine_verified` tier) → inline Haiku vet for authored keeps → daily batch-verify cron (demote-only) → crafter gate-calibration ledger.
+
+**The wall, quantified (pre-fix):**
+- Raw unverified: 833 GQ + 636 Q. **Correction:** 826 of the GQ rows are *expired* bank stock the cron rightly ignores — the actionable backlog was **643** (636 Q + 7 live GQ).
+- Sync capacity 25/store/day vs ~26/day GQ inflow → backlog structurally never drains; cron p95 already 97s of 300s.
+- ~$2/day (~$60/mo) — the single largest recurring LLM line, driven by a prefilter that routed 94.3% of rows (the `explanationCarriesClaims` length/any-signal heuristic) and frequent web search.
+
+**Why the Batch API mode never fired (two independent causes, both found today):**
+1. `BATCH_VERIFY_ASYNC_ENABLED=true` was added to prod env only hours before this review — env vars bind at deploy, and no flag-bearing deployment had served the 10:00 UTC cron yet.
+2. **The real bug:** `encodeVerifyCustomId` used `q:<uuid>` — the Batches API rejects `custom_id` outside `^[a-zA-Z0-9_-]{1,64}$`, so every submit would have thrown `invalid_request_error`, been caught, logged, and returned 200. Unit tests mocked the API and never saw the pattern. Fixed to `q_<uuid>` (decode tolerates the legacy form); regression test asserts the pattern.
+
+**Prefilter fix (this PR):** the explanation path now routes only *adjacent* claims — a signal **kind** absent from stem+answer, or a claim-dense (≥2 kinds) explainer; length alone never routes; the `count` regex no longer double-fires on years. Measured on 1,200 recent prod rows:
+
+| variant | skip | route | extra_fact |
+|---|---|---|---|
+| legacy (both hatches) | 5.7% | 94.3% | 94.1% |
+| answer-tightening only (prior default) | 5.9% | 94.1% | 93.8% |
+| **strict (new default)** | **21.5%** | **78.5%** | **63.3%** |
+
+190/1,200 rows flip route→skip; eyeballed flips are explainers restating the asked fact (no leaked checkable claims). Escape hatch: `PREFILTER_EXPLANATION_LEGACY=true` (no deploy needed).
+
+## 4. Infrastructure
+
+- **Vercel:** Pro; `maxDuration=300` is the binding constraint on all sync LLM batch jobs (refill 504s; verify p95 97s). Batch API sidesteps it. `daily-assignments` p95 75s is fine (soft-deadline pattern).
+- **Supabase:** `max:5` pool pins every concurrency knob at 4; becomes the next ceiling at ~10× users (daily-assignment fan-out). Not urgent.
+- **Axiom:** `vercel` drain only; `LlmUsageEvent` is the real telemetry (good). Aborted-call tokens still unledgered (self-heals on Sonnet 5).
+- Hygiene: web-search tool version drift (refill `20260209` vs verify `20250305`); `/api/cron/prompt-proposal` unscheduled; `VOYAGE_API_KEY` unprovisioned (semantic dedup off — deterministic guards only).
+
+## 5. Cost model & projection
+
+Current: ~$3/weekly-active/week, mostly experiment overhead. With the fixes in §7 plus Sonnet-5 consolidation and cache breakpoints on the Haiku gate prompts (quality/vet/grade/dedupe ran ~1.2M input tokens/14d with **zero** cache), the player-proportional core projects to **$0.30–0.50/weekly-active/week**. Verification capacity via Batch API is effectively unbounded (100k requests/batch; ~24h latency is fine for a demote-only background net).
+
+What bends the curve vs. moves it: **`D-SUPPLY-FINITE-SET-01`** (still unratified). Infinite top-up pools ⇒ cost scales with play-time forever; finite completable sets (~15–30/territory) cap per-domain cost at a constant. Every prerequisite now exists (authored graph, node weights, mastery-v2, fragmentation fixed, crafter pipeline).
+
+## 6. Ranked recommendations
+
+1. ~~Fire the Batch verify path + backlog blitz~~ **DONE with this PR** (§7).
+2. Finish Sonnet-5 consolidation before Aug 31 (intro pricing).
+3. ~~Tighten the prefilter explanation path~~ **DONE with this PR** (§3).
+4. Cache breakpoints on Haiku gate + remaining verify prompts (audit the 4,096-token Haiku cache minimum per prompt).
+5. Flip fandom-grounding Consumer B (verifier domain allowlist), then Consumer A after the finite-set call — attacks the 13% demotion rate at the source.
+6. Reconcile refill posture; if kept on, rebuild on Batch API.
+7. Hygiene batch: `generated_by_model` column, `VOYAGE_API_KEY`, web-search version unification, schedule-or-delete `prompt-proposal`, revisit the $42 ceiling.
+8. Ratify the finite-set decision.
+
+## 7. Actions taken alongside this doc (2026-07-05)
+
+- **`custom_id` bug fixed** (`verify-batch.ts`): colon → underscore; legacy-tolerant decode; pattern regression test.
+- **Prefilter explanation path tightened** (`verification-prefilter.ts`): adjacent-claims heuristic + `PREFILTER_EXPLANATION_LEGACY` hatch; measurement script extended to three variants (`scripts/measure-prefilter-skip-rate.ts`).
+- **Backlog blitz executed** (`scripts/verify-backlog-blitz.ts`, reusable): 643 actionable rows → 135 stamped `skipped` free, 508 submitted as two Batch-API batches (`msgbatch_01VXkDri…` ×500, `msgbatch_01KJpYCc…` ×8, ~$3 est.); harvested via `--harvest` or by the daily cron (its submit phase waits for in-flight runs, so no double-billing).
+- First real `VerifyBatchRun` rows recorded; the daily cron's async mode is now genuinely operational.

--- a/docs/findings/batch-verify-cost-characterization.md
+++ b/docs/findings/batch-verify-cost-characterization.md
@@ -1,5 +1,23 @@
 # batch-verify cron — cost characterization (read-only, no LLM calls)
 
+> **UPDATE (2026-07-05): the §5 "explanation path" lever landed and MOVED the
+> needle — and the Batch API mode had a submit-blocking bug, now fixed.**
+> 1. **Explanation-path tightening** (`explanationCarriesAdjacentClaims`): routes
+>    only NOVEL-kind or claim-dense (≥2 kinds) explainers; length alone never
+>    routes; the `count` signal no longer double-fires on years. Measured on
+>    1,200 recent rows: **skip 5.7% → 21.5%, extra_fact 94.1% → 63.3%**
+>    (190/1,200 route→skip; flips eyeballed — no leaked claims). Escape hatch
+>    `PREFILTER_EXPLANATION_LEGACY=true`.
+> 2. **Batch mode was silently broken**: `custom_id` used a colon (`q:<uuid>`),
+>    which the Batches API rejects (`^[a-zA-Z0-9_-]{1,64}$`) — every submit threw,
+>    was caught, and returned 200. Fixed to `q_<uuid>` (legacy-tolerant decode) +
+>    a pattern regression test. First real batches submitted 2026-07-05 via the
+>    backlog blitz (`scripts/verify-backlog-blitz.ts`).
+> 3. **Backlog correction:** of the 833 "unverified" GeneratedQuestion rows, 826
+>    were EXPIRED (never re-servable; the cron rightly ignores them). The
+>    actionable backlog was 643, now cleared/in-flight.
+> See docs/findings/SCALE-READINESS-2026-07-05.md for the full review.
+
 > **UPDATE (2026-07-02): the three cost dials this doc named have landed.**
 > 1. **System-prompt caching** — `buildVerifyRequestParams` now sends the system
 >    prompt with an ephemeral `cache_control` breakpoint (live in both modes).

--- a/drizzle/0114_set_completion.sql
+++ b/drizzle/0114_set_completion.sql
@@ -1,0 +1,26 @@
+-- 0114: finite-set completion (D-SUPPLY-FINITE-SET-01 P2).
+--
+-- Two additive/relaxing changes so a player who answers a domain's whole set
+-- earns a durable "designation" and an automatic invitation to author more:
+--
+--   1. PLAYER_MASTERY.designated_at — the durable recognition timestamp. The
+--      /invited trophy is currently ephemeral (computed live from an active
+--      AuthorInvitation); this is its missing permanent half. Mirrors the
+--      existing tier_reached_at "recognition timestamp" precedent. Nullable,
+--      additive — safe on a non-empty table, nothing reads it until P2 ships.
+--
+--   2. AuthorInvitation.invited_by — dropped NOT NULL. Until now every
+--      invitation had a human inviter (the crafter admin checkbox). A
+--      set-completion invitation is system-created and has no inviter, so the
+--      column becomes nullable (NULL = automatic). Relaxing a constraint is
+--      safe on existing rows.
+--
+-- Both statements are idempotent and mirrored by defensive guards in
+-- src/instrumentation.ts (precedent: 0105/0106 ADD COLUMN guards).
+--
+-- Rollback:
+--   ALTER TABLE "PLAYER_MASTERY" DROP COLUMN "designated_at";
+--   ALTER TABLE "AuthorInvitation" ALTER COLUMN "invited_by" SET NOT NULL;  -- only if no NULL rows exist
+ALTER TABLE "PLAYER_MASTERY" ADD COLUMN IF NOT EXISTS "designated_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "AuthorInvitation" ALTER COLUMN "invited_by" DROP NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,804 +1,811 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1777585453077,
-      "tag": "0000_material_lyja",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1777630800000,
-      "tag": "0001_add_ceremony_ready_sms_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1777654136670,
-      "tag": "0002_add_joshing_game_sms_types",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1777654800000,
-      "tag": "0003_question_rating",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1777662000000,
-      "tag": "0004_daily_preference_configuration",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1777671600000,
-      "tag": "0005_profile_domain_visibility_three_state",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1777737600000,
-      "tag": "0006_question_reactions_contexts",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1777780800000,
-      "tag": "0007_send_to_friend_note",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1777784400000,
-      "tag": "0008_add_to_bank_provenance",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1777771056661,
-      "tag": "0009_domain_merge_events",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1777771056661,
-      "tag": "0010_feed_submitted_answer",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1777771056661,
-      "tag": "0011_preview_schema_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1777839477000,
-      "tag": "0012_feed_friend_answered",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1777840000000,
-      "tag": "0013_onboarding_demographics",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1777840100000,
-      "tag": "0014_territory_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1777840200000,
-      "tag": "0015_declared_promoted_event_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1777840300000,
-      "tag": "0016_quip_columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1777840400000,
-      "tag": "0017_creator_notes",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1777840500000,
-      "tag": "0018_daily_generated_and_player_mastery_territory",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1778508000000,
-      "tag": "0019_feed_item_nullable_columns_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1778510000000,
-      "tag": "0020_question_critique_verification",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1778521283376,
-      "tag": "0021_feed_dismissed_domains_active_unique",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1778538800000,
-      "tag": "0022_player_mastery_territory_type_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1778540000000,
-      "tag": "0023_profile_domain_visibility_runtime_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1778616500000,
-      "tag": "0024_question_surface_priority_runtime_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1778616600000,
-      "tag": "0025_grade_dispute_recheck_details",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1778616700000,
-      "tag": "0026_friend_invitation_pre_profile",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "7",
-      "when": 1778616800000,
-      "tag": "0027_friendship_request_context",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "7",
-      "when": 1778616900000,
-      "tag": "0028_remove_other_question_category",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "7",
-      "when": 1778714100000,
-      "tag": "0029_correct_answer_social_feed",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "7",
-      "when": 1778714200000,
-      "tag": "0030_apply_general_knowledge_category",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "7",
-      "when": 1778806800000,
-      "tag": "0031_feed_answered_card_data",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "7",
-      "when": 1778888376122,
-      "tag": "0032_biweekly_ceremony_unique_cycle",
-      "breakpoints": true
-    },
-    {
-      "idx": 33,
-      "version": "7",
-      "when": 1778910000000,
-      "tag": "0033_feed_item_source_result_check",
-      "breakpoints": true
-    },
-    {
-      "idx": 34,
-      "version": "7",
-      "when": 1778952386715,
-      "tag": "0034_territory_type_enum",
-      "breakpoints": true
-    },
-    {
-      "idx": 35,
-      "version": "7",
-      "when": 1779580800000,
-      "tag": "0035_mastery_events_viewer_status_idx",
-      "breakpoints": true
-    },
-    {
-      "idx": 36,
-      "version": "7",
-      "when": 1779667200000,
-      "tag": "0036_domain_exclusion_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 37,
-      "version": "7",
-      "when": 1779753600000,
-      "tag": "0037_round_reminder_optin",
-      "breakpoints": true
-    },
-    {
-      "idx": 38,
-      "version": "7",
-      "when": 1779840000000,
-      "tag": "0038_feed_item_catchup_resolved",
-      "breakpoints": true
-    },
-    {
-      "idx": 39,
-      "version": "7",
-      "when": 1779926400000,
-      "tag": "0039_repair_short_canonical_subcategory",
-      "breakpoints": true
-    },
-    {
-      "idx": 40,
-      "version": "7",
-      "when": 1780012800000,
-      "tag": "0040_question_reaction_include_submitted_answer",
-      "breakpoints": true
-    },
-    {
-      "idx": 41,
-      "version": "7",
-      "when": 1780099200000,
-      "tag": "0041_question_inside_joke",
-      "breakpoints": true
-    },
-    {
-      "idx": 42,
-      "version": "7",
-      "when": 1780185600000,
-      "tag": "0042_seed_player_mastery_for_declared_interests",
-      "breakpoints": true
-    },
-    {
-      "idx": 43,
-      "version": "7",
-      "when": 1780272000000,
-      "tag": "0043_rename_season_points_to_lifetime_baseline",
-      "breakpoints": true
-    },
-    {
-      "idx": 44,
-      "version": "7",
-      "when": 1780358400000,
-      "tag": "0044_user_last_activity_bell_opened_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 45,
-      "version": "7",
-      "when": 1780444800000,
-      "tag": "0045_user_handle",
-      "breakpoints": true
-    },
-    {
-      "idx": 46,
-      "version": "7",
-      "when": 1780531200000,
-      "tag": "0046_user_avatar_color",
-      "breakpoints": true
-    },
-    {
-      "idx": 47,
-      "version": "7",
-      "when": 1780617600000,
-      "tag": "0047_user_profile_fields",
-      "breakpoints": true
-    },
-    {
-      "idx": 48,
-      "version": "7",
-      "when": 1780704000000,
-      "tag": "0048_friends_privacy_foundation",
-      "breakpoints": true
-    },
-    {
-      "idx": 49,
-      "version": "7",
-      "when": 1780790400000,
-      "tag": "0049_user_invite_token",
-      "breakpoints": true
-    },
-    {
-      "idx": 50,
-      "version": "7",
-      "when": 1780876800000,
-      "tag": "0050_user_phone_hash_discovery",
-      "breakpoints": true
-    },
-    {
-      "idx": 51,
-      "version": "7",
-      "when": 1780963200000,
-      "tag": "0051_generated_question_fact_key",
-      "breakpoints": true
-    },
-    {
-      "idx": 52,
-      "version": "7",
-      "when": 1781049600000,
-      "tag": "0052_profile_section_visibility",
-      "breakpoints": true
-    },
-    {
-      "idx": 53,
-      "version": "7",
-      "when": 1781136000000,
-      "tag": "0053_drop_legacy_profile_visibility",
-      "breakpoints": true
-    },
-    {
-      "idx": 54,
-      "version": "7",
-      "when": 1781222400000,
-      "tag": "0054_redesign_profile",
-      "breakpoints": true
-    },
-    {
-      "idx": 55,
-      "version": "7",
-      "when": 1781308800000,
-      "tag": "0055_question_sub_angles",
-      "breakpoints": true
-    },
-    {
-      "idx": 56,
-      "version": "7",
-      "when": 1781395200000,
-      "tag": "0056_area_top_up_prompt",
-      "breakpoints": true
-    },
-    {
-      "idx": 57,
-      "version": "7",
-      "when": 1781481600000,
-      "tag": "0057_retire_creator_notes_and_quips",
-      "breakpoints": true
-    },
-    {
-      "idx": 58,
-      "version": "7",
-      "when": 1781568000000,
-      "tag": "0058_follow_model",
-      "breakpoints": true
-    },
-    {
-      "idx": 59,
-      "version": "7",
-      "when": 1781654400000,
-      "tag": "0059_niche_match_discoverability",
-      "breakpoints": true
-    },
-    {
-      "idx": 60,
-      "version": "7",
-      "when": 1781740800000,
-      "tag": "0060_generated_question_inside_joke",
-      "breakpoints": true
-    },
-    {
-      "idx": 61,
-      "version": "7",
-      "when": 1781827200000,
-      "tag": "0061_email_verification_token",
-      "breakpoints": true
-    },
-    {
-      "idx": 62,
-      "version": "7",
-      "when": 1781913600000,
-      "tag": "0062_pool_substrate_trust_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 63,
-      "version": "7",
-      "when": 1782000000000,
-      "tag": "0063_pool_embeddings",
-      "breakpoints": true
-    },
-    {
-      "idx": 64,
-      "version": "7",
-      "when": 1782086400000,
-      "tag": "0064_domain_difficulty_freeze",
-      "breakpoints": true
-    },
-    {
-      "idx": 65,
-      "version": "7",
-      "when": 1782172800000,
-      "tag": "0065_daily_refine_decision",
-      "breakpoints": true
-    },
-    {
-      "idx": 66,
-      "version": "7",
-      "when": 1782259200000,
-      "tag": "0066_ask_to_answer_verified",
-      "breakpoints": true
-    },
-    {
-      "idx": 67,
-      "version": "7",
-      "when": 1782345600000,
-      "tag": "0067_human_validated_backfill",
-      "breakpoints": true
-    },
-    {
-      "idx": 68,
-      "version": "7",
-      "when": 1782432000000,
-      "tag": "0068_acceptable_variants",
-      "breakpoints": true
-    },
-    {
-      "idx": 69,
-      "version": "7",
-      "when": 1782518400000,
-      "tag": "0069_question_visibility_blocked",
-      "breakpoints": true
-    },
-    {
-      "idx": 70,
-      "version": "7",
-      "when": 1782604800000,
-      "tag": "0070_daily_domain_preference_frequency",
-      "breakpoints": true
-    },
-    {
-      "idx": 71,
-      "version": "7",
-      "when": 1782691200000,
-      "tag": "0071_pg_trgm_convergence",
-      "breakpoints": true
-    },
-    {
-      "idx": 72,
-      "version": "7",
-      "when": 1782777600000,
-      "tag": "0072_first_session_recap_seen",
-      "breakpoints": true
-    },
-    {
-      "idx": 73,
-      "version": "7",
-      "when": 1782864000000,
-      "tag": "0073_content_report",
-      "breakpoints": true
-    },
-    {
-      "idx": 74,
-      "version": "7",
-      "when": 1782950400000,
-      "tag": "0074_generated_question_domain_key",
-      "breakpoints": true
-    },
-    {
-      "idx": 75,
-      "version": "7",
-      "when": 1783036800000,
-      "tag": "0075_daily_queue_email_reminder",
-      "breakpoints": true
-    },
-    {
-      "idx": 76,
-      "version": "7",
-      "when": 1783123200000,
-      "tag": "0076_first_game_recap_seen",
-      "breakpoints": true
-    },
-    {
-      "idx": 77,
-      "version": "7",
-      "when": 1783209600000,
-      "tag": "0077_email_verification_opt_in_intent",
-      "breakpoints": true
-    },
-    {
-      "idx": 78,
-      "version": "7",
-      "when": 1783296000000,
-      "tag": "0078_perf_lookup_indexes",
-      "breakpoints": true
-    },
-    {
-      "idx": 79,
-      "version": "7",
-      "when": 1783382400000,
-      "tag": "0079_perf_fk_covering_indexes",
-      "breakpoints": true
-    },
-    {
-      "idx": 80,
-      "version": "7",
-      "when": 1783468800000,
-      "tag": "0080_question_author_deleted",
-      "breakpoints": true
-    },
-    {
-      "idx": 81,
-      "version": "7",
-      "when": 1783555200000,
-      "tag": "0081_enable_rls_public_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 82,
-      "version": "7",
-      "when": 1783641600000,
-      "tag": "0082_question_bank_added_at_idx",
-      "breakpoints": true
-    },
-    {
-      "idx": 83,
-      "version": "7",
-      "when": 1783728000000,
-      "tag": "0083_fk_covering_indexes",
-      "breakpoints": true
-    },
-    {
-      "idx": 84,
-      "version": "7",
-      "when": 1783814400000,
-      "tag": "0084_via_attribution",
-      "breakpoints": true
-    },
-    {
-      "idx": 85,
-      "version": "7",
-      "when": 1783900800000,
-      "tag": "0085_feed_item_answered_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 86,
-      "version": "7",
-      "when": 1783987200000,
-      "tag": "0086_subject_entity",
-      "breakpoints": true
-    },
-    {
-      "idx": 87,
-      "version": "7",
-      "when": 1784073600000,
-      "tag": "0087_app_settings",
-      "breakpoints": true
-    },
-    {
-      "idx": 88,
-      "version": "7",
-      "when": 1784160000000,
-      "tag": "0088_provider_provenance",
-      "breakpoints": true
-    },
-    {
-      "idx": 89,
-      "version": "7",
-      "when": 1784246400000,
-      "tag": "0089_domain_expansion_offer",
-      "breakpoints": true
-    },
-    {
-      "idx": 90,
-      "version": "7",
-      "when": 1784332800000,
-      "tag": "0090_llm_provider_change_log",
-      "breakpoints": true
-    },
-    {
-      "idx": 91,
-      "version": "7",
-      "when": 1784419200000,
-      "tag": "0091_llm_usage_event",
-      "breakpoints": true
-    },
-    {
-      "idx": 92,
-      "version": "7",
-      "when": 1784505600000,
-      "tag": "0092_llm_cost_report",
-      "breakpoints": true
-    },
-    {
-      "idx": 93,
-      "version": "7",
-      "when": 1784592000000,
-      "tag": "0093_recovered_set_aside",
-      "breakpoints": true
-    },
-    {
-      "idx": 94,
-      "version": "7",
-      "when": 1784678400000,
-      "tag": "0094_expansion_mastery_event_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 95,
-      "version": "7",
-      "when": 1784764800000,
-      "tag": "0095_player_mastery_rotation_eligible",
-      "breakpoints": true
-    },
-    {
-      "idx": 96,
-      "version": "7",
-      "when": 1784851200000,
-      "tag": "0096_question_verification",
-      "breakpoints": true
-    },
-    {
-      "idx": 97,
-      "version": "7",
-      "when": 1784937600000,
-      "tag": "0097_quality_report",
-      "breakpoints": true
-    },
-    {
-      "idx": 98,
-      "version": "7",
-      "when": 1785024000000,
-      "tag": "0098_retrieval_domain_health",
-      "breakpoints": true
-    },
-    {
-      "idx": 99,
-      "version": "7",
-      "when": 1785110400000,
-      "tag": "0099_domain_relation",
-      "breakpoints": true
-    },
-    {
-      "idx": 100,
-      "version": "7",
-      "when": 1785196800000,
-      "tag": "0100_verification_reason",
-      "breakpoints": true
-    },
-    {
-      "idx": 101,
-      "version": "7",
-      "when": 1785283200000,
-      "tag": "0101_author_invitation",
-      "breakpoints": true
-    },
-    {
-      "idx": 102,
-      "version": "7",
-      "when": 1785369600000,
-      "tag": "0102_knowledge_graph",
-      "breakpoints": true
-    },
-    {
-      "idx": 103,
-      "version": "7",
-      "when": 1785456000000,
-      "tag": "0103_crafter_draft_decision",
-      "breakpoints": true
-    },
-    {
-      "idx": 104,
-      "version": "7",
-      "when": 1785542400000,
-      "tag": "0104_knowledge_parent_mastery",
-      "breakpoints": true
-    },
-    {
-      "idx": 105,
-      "version": "7",
-      "when": 1785628800000,
-      "tag": "0105_llm_usage_web_search",
-      "breakpoints": true
-    },
-    {
-      "idx": 106,
-      "version": "7",
-      "when": 1785715200000,
-      "tag": "0106_verify_batch_run",
-      "breakpoints": true
-    },
-    {
-      "idx": 107,
-      "version": "7",
-      "when": 1785801600000,
-      "tag": "0107_knowledge_node_wikidata_qid",
-      "breakpoints": true
-    },
-    {
-      "idx": 108,
-      "version": "7",
-      "when": 1785888000000,
-      "tag": "0108_domain_reference_passage",
-      "breakpoints": true
-    },
-    {
-      "idx": 109,
-      "version": "7",
-      "when": 1785974400000,
-      "tag": "0109_knowledge_node_weight",
-      "breakpoints": true
-    },
-    {
-      "idx": 110,
-      "version": "7",
-      "when": 1786060800000,
-      "tag": "0110_drop_knowledge_edge_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 111,
-      "version": "7",
-      "when": 1786147200000,
-      "tag": "0111_knowledge_leaf_mastery",
-      "breakpoints": true
-    },
-    {
-      "idx": 112,
-      "version": "7",
-      "when": 1786233600000,
-      "tag": "0112_drop_node_weight",
-      "breakpoints": true
-    },
-    {
-      "idx": 113,
-      "version": "7",
-      "when": 1786320000000,
-      "tag": "0113_milestone_dismissed",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1777585453077,
+			"tag": "0000_material_lyja",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1777630800000,
+			"tag": "0001_add_ceremony_ready_sms_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1777654136670,
+			"tag": "0002_add_joshing_game_sms_types",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1777654800000,
+			"tag": "0003_question_rating",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1777662000000,
+			"tag": "0004_daily_preference_configuration",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1777671600000,
+			"tag": "0005_profile_domain_visibility_three_state",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1777737600000,
+			"tag": "0006_question_reactions_contexts",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1777780800000,
+			"tag": "0007_send_to_friend_note",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1777784400000,
+			"tag": "0008_add_to_bank_provenance",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1777771056661,
+			"tag": "0009_domain_merge_events",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1777771056661,
+			"tag": "0010_feed_submitted_answer",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1777771056661,
+			"tag": "0011_preview_schema_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1777839477000,
+			"tag": "0012_feed_friend_answered",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1777840000000,
+			"tag": "0013_onboarding_demographics",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1777840100000,
+			"tag": "0014_territory_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1777840200000,
+			"tag": "0015_declared_promoted_event_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1777840300000,
+			"tag": "0016_quip_columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1777840400000,
+			"tag": "0017_creator_notes",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1777840500000,
+			"tag": "0018_daily_generated_and_player_mastery_territory",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1778508000000,
+			"tag": "0019_feed_item_nullable_columns_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1778510000000,
+			"tag": "0020_question_critique_verification",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1778521283376,
+			"tag": "0021_feed_dismissed_domains_active_unique",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1778538800000,
+			"tag": "0022_player_mastery_territory_type_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1778540000000,
+			"tag": "0023_profile_domain_visibility_runtime_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1778616500000,
+			"tag": "0024_question_surface_priority_runtime_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1778616600000,
+			"tag": "0025_grade_dispute_recheck_details",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1778616700000,
+			"tag": "0026_friend_invitation_pre_profile",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1778616800000,
+			"tag": "0027_friendship_request_context",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1778616900000,
+			"tag": "0028_remove_other_question_category",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "7",
+			"when": 1778714100000,
+			"tag": "0029_correct_answer_social_feed",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1778714200000,
+			"tag": "0030_apply_general_knowledge_category",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1778806800000,
+			"tag": "0031_feed_answered_card_data",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "7",
+			"when": 1778888376122,
+			"tag": "0032_biweekly_ceremony_unique_cycle",
+			"breakpoints": true
+		},
+		{
+			"idx": 33,
+			"version": "7",
+			"when": 1778910000000,
+			"tag": "0033_feed_item_source_result_check",
+			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1778952386715,
+			"tag": "0034_territory_type_enum",
+			"breakpoints": true
+		},
+		{
+			"idx": 35,
+			"version": "7",
+			"when": 1779580800000,
+			"tag": "0035_mastery_events_viewer_status_idx",
+			"breakpoints": true
+		},
+		{
+			"idx": 36,
+			"version": "7",
+			"when": 1779667200000,
+			"tag": "0036_domain_exclusion_scope",
+			"breakpoints": true
+		},
+		{
+			"idx": 37,
+			"version": "7",
+			"when": 1779753600000,
+			"tag": "0037_round_reminder_optin",
+			"breakpoints": true
+		},
+		{
+			"idx": 38,
+			"version": "7",
+			"when": 1779840000000,
+			"tag": "0038_feed_item_catchup_resolved",
+			"breakpoints": true
+		},
+		{
+			"idx": 39,
+			"version": "7",
+			"when": 1779926400000,
+			"tag": "0039_repair_short_canonical_subcategory",
+			"breakpoints": true
+		},
+		{
+			"idx": 40,
+			"version": "7",
+			"when": 1780012800000,
+			"tag": "0040_question_reaction_include_submitted_answer",
+			"breakpoints": true
+		},
+		{
+			"idx": 41,
+			"version": "7",
+			"when": 1780099200000,
+			"tag": "0041_question_inside_joke",
+			"breakpoints": true
+		},
+		{
+			"idx": 42,
+			"version": "7",
+			"when": 1780185600000,
+			"tag": "0042_seed_player_mastery_for_declared_interests",
+			"breakpoints": true
+		},
+		{
+			"idx": 43,
+			"version": "7",
+			"when": 1780272000000,
+			"tag": "0043_rename_season_points_to_lifetime_baseline",
+			"breakpoints": true
+		},
+		{
+			"idx": 44,
+			"version": "7",
+			"when": 1780358400000,
+			"tag": "0044_user_last_activity_bell_opened_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 45,
+			"version": "7",
+			"when": 1780444800000,
+			"tag": "0045_user_handle",
+			"breakpoints": true
+		},
+		{
+			"idx": 46,
+			"version": "7",
+			"when": 1780531200000,
+			"tag": "0046_user_avatar_color",
+			"breakpoints": true
+		},
+		{
+			"idx": 47,
+			"version": "7",
+			"when": 1780617600000,
+			"tag": "0047_user_profile_fields",
+			"breakpoints": true
+		},
+		{
+			"idx": 48,
+			"version": "7",
+			"when": 1780704000000,
+			"tag": "0048_friends_privacy_foundation",
+			"breakpoints": true
+		},
+		{
+			"idx": 49,
+			"version": "7",
+			"when": 1780790400000,
+			"tag": "0049_user_invite_token",
+			"breakpoints": true
+		},
+		{
+			"idx": 50,
+			"version": "7",
+			"when": 1780876800000,
+			"tag": "0050_user_phone_hash_discovery",
+			"breakpoints": true
+		},
+		{
+			"idx": 51,
+			"version": "7",
+			"when": 1780963200000,
+			"tag": "0051_generated_question_fact_key",
+			"breakpoints": true
+		},
+		{
+			"idx": 52,
+			"version": "7",
+			"when": 1781049600000,
+			"tag": "0052_profile_section_visibility",
+			"breakpoints": true
+		},
+		{
+			"idx": 53,
+			"version": "7",
+			"when": 1781136000000,
+			"tag": "0053_drop_legacy_profile_visibility",
+			"breakpoints": true
+		},
+		{
+			"idx": 54,
+			"version": "7",
+			"when": 1781222400000,
+			"tag": "0054_redesign_profile",
+			"breakpoints": true
+		},
+		{
+			"idx": 55,
+			"version": "7",
+			"when": 1781308800000,
+			"tag": "0055_question_sub_angles",
+			"breakpoints": true
+		},
+		{
+			"idx": 56,
+			"version": "7",
+			"when": 1781395200000,
+			"tag": "0056_area_top_up_prompt",
+			"breakpoints": true
+		},
+		{
+			"idx": 57,
+			"version": "7",
+			"when": 1781481600000,
+			"tag": "0057_retire_creator_notes_and_quips",
+			"breakpoints": true
+		},
+		{
+			"idx": 58,
+			"version": "7",
+			"when": 1781568000000,
+			"tag": "0058_follow_model",
+			"breakpoints": true
+		},
+		{
+			"idx": 59,
+			"version": "7",
+			"when": 1781654400000,
+			"tag": "0059_niche_match_discoverability",
+			"breakpoints": true
+		},
+		{
+			"idx": 60,
+			"version": "7",
+			"when": 1781740800000,
+			"tag": "0060_generated_question_inside_joke",
+			"breakpoints": true
+		},
+		{
+			"idx": 61,
+			"version": "7",
+			"when": 1781827200000,
+			"tag": "0061_email_verification_token",
+			"breakpoints": true
+		},
+		{
+			"idx": 62,
+			"version": "7",
+			"when": 1781913600000,
+			"tag": "0062_pool_substrate_trust_scope",
+			"breakpoints": true
+		},
+		{
+			"idx": 63,
+			"version": "7",
+			"when": 1782000000000,
+			"tag": "0063_pool_embeddings",
+			"breakpoints": true
+		},
+		{
+			"idx": 64,
+			"version": "7",
+			"when": 1782086400000,
+			"tag": "0064_domain_difficulty_freeze",
+			"breakpoints": true
+		},
+		{
+			"idx": 65,
+			"version": "7",
+			"when": 1782172800000,
+			"tag": "0065_daily_refine_decision",
+			"breakpoints": true
+		},
+		{
+			"idx": 66,
+			"version": "7",
+			"when": 1782259200000,
+			"tag": "0066_ask_to_answer_verified",
+			"breakpoints": true
+		},
+		{
+			"idx": 67,
+			"version": "7",
+			"when": 1782345600000,
+			"tag": "0067_human_validated_backfill",
+			"breakpoints": true
+		},
+		{
+			"idx": 68,
+			"version": "7",
+			"when": 1782432000000,
+			"tag": "0068_acceptable_variants",
+			"breakpoints": true
+		},
+		{
+			"idx": 69,
+			"version": "7",
+			"when": 1782518400000,
+			"tag": "0069_question_visibility_blocked",
+			"breakpoints": true
+		},
+		{
+			"idx": 70,
+			"version": "7",
+			"when": 1782604800000,
+			"tag": "0070_daily_domain_preference_frequency",
+			"breakpoints": true
+		},
+		{
+			"idx": 71,
+			"version": "7",
+			"when": 1782691200000,
+			"tag": "0071_pg_trgm_convergence",
+			"breakpoints": true
+		},
+		{
+			"idx": 72,
+			"version": "7",
+			"when": 1782777600000,
+			"tag": "0072_first_session_recap_seen",
+			"breakpoints": true
+		},
+		{
+			"idx": 73,
+			"version": "7",
+			"when": 1782864000000,
+			"tag": "0073_content_report",
+			"breakpoints": true
+		},
+		{
+			"idx": 74,
+			"version": "7",
+			"when": 1782950400000,
+			"tag": "0074_generated_question_domain_key",
+			"breakpoints": true
+		},
+		{
+			"idx": 75,
+			"version": "7",
+			"when": 1783036800000,
+			"tag": "0075_daily_queue_email_reminder",
+			"breakpoints": true
+		},
+		{
+			"idx": 76,
+			"version": "7",
+			"when": 1783123200000,
+			"tag": "0076_first_game_recap_seen",
+			"breakpoints": true
+		},
+		{
+			"idx": 77,
+			"version": "7",
+			"when": 1783209600000,
+			"tag": "0077_email_verification_opt_in_intent",
+			"breakpoints": true
+		},
+		{
+			"idx": 78,
+			"version": "7",
+			"when": 1783296000000,
+			"tag": "0078_perf_lookup_indexes",
+			"breakpoints": true
+		},
+		{
+			"idx": 79,
+			"version": "7",
+			"when": 1783382400000,
+			"tag": "0079_perf_fk_covering_indexes",
+			"breakpoints": true
+		},
+		{
+			"idx": 80,
+			"version": "7",
+			"when": 1783468800000,
+			"tag": "0080_question_author_deleted",
+			"breakpoints": true
+		},
+		{
+			"idx": 81,
+			"version": "7",
+			"when": 1783555200000,
+			"tag": "0081_enable_rls_public_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 82,
+			"version": "7",
+			"when": 1783641600000,
+			"tag": "0082_question_bank_added_at_idx",
+			"breakpoints": true
+		},
+		{
+			"idx": 83,
+			"version": "7",
+			"when": 1783728000000,
+			"tag": "0083_fk_covering_indexes",
+			"breakpoints": true
+		},
+		{
+			"idx": 84,
+			"version": "7",
+			"when": 1783814400000,
+			"tag": "0084_via_attribution",
+			"breakpoints": true
+		},
+		{
+			"idx": 85,
+			"version": "7",
+			"when": 1783900800000,
+			"tag": "0085_feed_item_answered_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 86,
+			"version": "7",
+			"when": 1783987200000,
+			"tag": "0086_subject_entity",
+			"breakpoints": true
+		},
+		{
+			"idx": 87,
+			"version": "7",
+			"when": 1784073600000,
+			"tag": "0087_app_settings",
+			"breakpoints": true
+		},
+		{
+			"idx": 88,
+			"version": "7",
+			"when": 1784160000000,
+			"tag": "0088_provider_provenance",
+			"breakpoints": true
+		},
+		{
+			"idx": 89,
+			"version": "7",
+			"when": 1784246400000,
+			"tag": "0089_domain_expansion_offer",
+			"breakpoints": true
+		},
+		{
+			"idx": 90,
+			"version": "7",
+			"when": 1784332800000,
+			"tag": "0090_llm_provider_change_log",
+			"breakpoints": true
+		},
+		{
+			"idx": 91,
+			"version": "7",
+			"when": 1784419200000,
+			"tag": "0091_llm_usage_event",
+			"breakpoints": true
+		},
+		{
+			"idx": 92,
+			"version": "7",
+			"when": 1784505600000,
+			"tag": "0092_llm_cost_report",
+			"breakpoints": true
+		},
+		{
+			"idx": 93,
+			"version": "7",
+			"when": 1784592000000,
+			"tag": "0093_recovered_set_aside",
+			"breakpoints": true
+		},
+		{
+			"idx": 94,
+			"version": "7",
+			"when": 1784678400000,
+			"tag": "0094_expansion_mastery_event_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 95,
+			"version": "7",
+			"when": 1784764800000,
+			"tag": "0095_player_mastery_rotation_eligible",
+			"breakpoints": true
+		},
+		{
+			"idx": 96,
+			"version": "7",
+			"when": 1784851200000,
+			"tag": "0096_question_verification",
+			"breakpoints": true
+		},
+		{
+			"idx": 97,
+			"version": "7",
+			"when": 1784937600000,
+			"tag": "0097_quality_report",
+			"breakpoints": true
+		},
+		{
+			"idx": 98,
+			"version": "7",
+			"when": 1785024000000,
+			"tag": "0098_retrieval_domain_health",
+			"breakpoints": true
+		},
+		{
+			"idx": 99,
+			"version": "7",
+			"when": 1785110400000,
+			"tag": "0099_domain_relation",
+			"breakpoints": true
+		},
+		{
+			"idx": 100,
+			"version": "7",
+			"when": 1785196800000,
+			"tag": "0100_verification_reason",
+			"breakpoints": true
+		},
+		{
+			"idx": 101,
+			"version": "7",
+			"when": 1785283200000,
+			"tag": "0101_author_invitation",
+			"breakpoints": true
+		},
+		{
+			"idx": 102,
+			"version": "7",
+			"when": 1785369600000,
+			"tag": "0102_knowledge_graph",
+			"breakpoints": true
+		},
+		{
+			"idx": 103,
+			"version": "7",
+			"when": 1785456000000,
+			"tag": "0103_crafter_draft_decision",
+			"breakpoints": true
+		},
+		{
+			"idx": 104,
+			"version": "7",
+			"when": 1785542400000,
+			"tag": "0104_knowledge_parent_mastery",
+			"breakpoints": true
+		},
+		{
+			"idx": 105,
+			"version": "7",
+			"when": 1785628800000,
+			"tag": "0105_llm_usage_web_search",
+			"breakpoints": true
+		},
+		{
+			"idx": 106,
+			"version": "7",
+			"when": 1785715200000,
+			"tag": "0106_verify_batch_run",
+			"breakpoints": true
+		},
+		{
+			"idx": 107,
+			"version": "7",
+			"when": 1785801600000,
+			"tag": "0107_knowledge_node_wikidata_qid",
+			"breakpoints": true
+		},
+		{
+			"idx": 108,
+			"version": "7",
+			"when": 1785888000000,
+			"tag": "0108_domain_reference_passage",
+			"breakpoints": true
+		},
+		{
+			"idx": 109,
+			"version": "7",
+			"when": 1785974400000,
+			"tag": "0109_knowledge_node_weight",
+			"breakpoints": true
+		},
+		{
+			"idx": 110,
+			"version": "7",
+			"when": 1786060800000,
+			"tag": "0110_drop_knowledge_edge_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 111,
+			"version": "7",
+			"when": 1786147200000,
+			"tag": "0111_knowledge_leaf_mastery",
+			"breakpoints": true
+		},
+		{
+			"idx": 112,
+			"version": "7",
+			"when": 1786233600000,
+			"tag": "0112_drop_node_weight",
+			"breakpoints": true
+		},
+		{
+			"idx": 113,
+			"version": "7",
+			"when": 1786320000000,
+			"tag": "0113_milestone_dismissed",
+			"breakpoints": true
+		},
+		{
+			"idx": 114,
+			"version": "7",
+			"when": 1786406400000,
+			"tag": "0114_set_completion",
+			"breakpoints": true
+		}
+	]
 }

--- a/scripts/measure-prefilter-skip-rate.ts
+++ b/scripts/measure-prefilter-skip-rate.ts
@@ -33,10 +33,13 @@ type VariantTally = {
   extraFact: number;
 };
 
-function tallyVariant(rows: SampleRow[], legacyExtraFact: boolean): VariantTally {
+function tallyVariant(
+  rows: SampleRow[],
+  options: { legacyExtraFact?: boolean; legacyExplanation?: boolean },
+): VariantTally {
   const t: VariantTally = { skipped: 0, routed: 0, falsePremise: 0, extraFact: 0 };
   for (const row of rows) {
-    const d = prefilterForVerification(row, { legacyExtraFact });
+    const d = prefilterForVerification(row, options);
     if (!d.needsVerification) {
       t.skipped += 1;
       continue;
@@ -83,15 +86,19 @@ async function main() {
     ...generatedRows.map((r) => ({ ...r, store: 'GeneratedQuestion' as const })),
   ];
 
-  const legacy = tallyVariant(sample, true);
-  const strict = tallyVariant(sample, false);
+  // Three variants, cumulative: full legacy → answer tightening only (the
+  // 2026-07-03 near-no-op) → answer + explanation tightening (2026-07-05).
+  const legacy = tallyVariant(sample, { legacyExtraFact: true, legacyExplanation: true });
+  const answerOnly = tallyVariant(sample, { legacyExplanation: true });
+  const strict = tallyVariant(sample, {});
   const n = sample.length;
 
   console.log(`\nSample: ${n} rows (${questionRows.length} Question + ${generatedRows.length} GeneratedQuestion, most recent)\n`);
-  console.log('variant   skip           route          false_premise  extra_fact');
+  console.log('variant        skip           route          false_premise  extra_fact');
   for (const [name, t] of [
-    ['legacy ', legacy],
-    ['strict ', strict],
+    ['legacy      ', legacy],
+    ['answer-only ', answerOnly],
+    ['strict      ', strict],
   ] as const) {
     console.log(
       `${name}   ${String(t.skipped).padStart(4)} (${pct(t.skipped, n).padStart(6)})  ` +
@@ -103,19 +110,24 @@ async function main() {
 
   // Rows whose overall decision flipped route→skip: the spend actually saved.
   const flipped = sample.filter((row) => {
-    const wasRouted = prefilterForVerification(row, { legacyExtraFact: true }).needsVerification;
+    const wasRouted = prefilterForVerification(row, {
+      legacyExtraFact: true,
+      legacyExplanation: true,
+    }).needsVerification;
     const nowRouted = prefilterForVerification(row).needsVerification;
     return wasRouted && !nowRouted;
   });
   console.log(
     `\nroute→skip under tightening: ${flipped.length} rows (${pct(flipped.length, n)}) — ` +
-      `each was a paid verify call/day of demand; eyeball a few below for anything that LOOKS claim-bearing:`,
+      `each was a paid verify call/day of demand; eyeball for anything that LOOKS claim-bearing ` +
+      `(explainer shown — the tightened router's input):`,
   );
-  for (const row of flipped.slice(0, 10)) {
+  for (const row of flipped.slice(0, 15)) {
     console.log(`  [${row.store}] Q: ${row.questionText.slice(0, 90)}`);
     console.log(`      A: ${row.answer.slice(0, 90)}`);
+    if (row.explanation) console.log(`      E: ${row.explanation.slice(0, 110)}`);
   }
-  if (flipped.length > 10) console.log(`  … and ${flipped.length - 10} more`);
+  if (flipped.length > 15) console.log(`  … and ${flipped.length - 15} more`);
 }
 
 main()

--- a/scripts/verify-backlog-blitz.ts
+++ b/scripts/verify-backlog-blitz.ts
@@ -1,0 +1,180 @@
+/**
+ * One-time verification backlog blitz over the Message Batches API
+ * (scale-readiness follow-up, 2026-07-05: ~1,469 rows sat verifiedAt IS NULL
+ * against a 50/day sync cap — a wall-clock problem, not a cost problem).
+ *
+ * Reuses the EXACT production primitives — prefilterForVerification (tightened),
+ * submitVerifyBatch / harvestVerifyBatches, and the same verdict patch helpers —
+ * so semantics are identical to the cron's async mode; this script only removes
+ * the daily size cap. Runs it submits are recorded in VerifyBatchRun, so the
+ * daily cron sees them in flight, won't double-submit, and can itself harvest
+ * them (its submit phase is gated on runsStillProcessing === 0).
+ *
+ * Read-only by default. Run from repo root:
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/verify-backlog-blitz.ts            # dry-run census + cost estimate
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/verify-backlog-blitz.ts --submit   # stamp skips + submit routed rows in chunks
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/verify-backlog-blitz.ts --harvest  # harvest ended batches + stamp verdicts
+ *
+ * Fail-open contract preserved: an errored/expired/unparseable result stamps
+ * nothing and the row is re-picked by a later submission.
+ */
+import 'dotenv/config';
+
+import { and, eq, gt, isNull, ne } from 'drizzle-orm';
+
+import { getAnthropicClient } from '../src/lib/llm';
+import { db, generatedQuestions, pool, questions } from '../src/server/db';
+import {
+  prefilterForVerification,
+} from '../src/server/quality/verification-prefilter';
+import {
+  harvestVerifyBatches,
+  submitVerifyBatch,
+  type BatchRowInput,
+} from '../src/server/quality/verify-batch';
+import {
+  verdictToGeneratedPatch,
+  verdictToQuestionPatch,
+} from '../src/server/quality/verify-question';
+
+const SUBMIT = process.argv.includes('--submit');
+const HARVEST = process.argv.includes('--harvest');
+// Moderate chunks: a failed create loses one chunk, not the whole blitz.
+const CHUNK = 500;
+
+type PendingRow = {
+  id: string;
+  questionText: string;
+  answer: string;
+  explanation: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+};
+
+async function selectAllPending(now: Date): Promise<{ q: PendingRow[]; g: PendingRow[] }> {
+  const [q, g] = await Promise.all([
+    db
+      .select({
+        id: questions.id,
+        questionText: questions.questionText,
+        answer: questions.answerText,
+        explanation: questions.factualExplanation,
+        canonicalSubcategory: questions.canonicalSubcategory,
+        broadCategory: questions.broadCategory,
+      })
+      .from(questions)
+      .where(and(isNull(questions.verifiedAt), ne(questions.visibility, 'blocked'), isNull(questions.deletedAt))),
+    db
+      .select({
+        id: generatedQuestions.id,
+        questionText: generatedQuestions.questionText,
+        answer: generatedQuestions.answer,
+        explanation: generatedQuestions.explainer,
+        canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+        broadCategory: generatedQuestions.broadCategory,
+      })
+      .from(generatedQuestions)
+      .where(and(
+        isNull(generatedQuestions.verifiedAt),
+        eq(generatedQuestions.isDuplicate, false),
+        gt(generatedQuestions.expiresAt, now),
+      )),
+  ]);
+  return { q: q as PendingRow[], g: g as PendingRow[] };
+}
+
+async function main() {
+  const now = new Date();
+  const { q, g } = await selectAllPending(now);
+
+  // Prefilter census (tightened heuristics — this script runs the working tree).
+  const routed: BatchRowInput[] = [];
+  const skips: Array<{ store: 'q' | 'g'; id: string }> = [];
+  for (const [store, rows] of [['q', q], ['g', g]] as const) {
+    for (const row of rows) {
+      const d = prefilterForVerification(
+        { questionText: row.questionText, answer: row.answer, explanation: row.explanation },
+      );
+      if (!d.needsVerification) skips.push({ store, id: row.id });
+      else routed.push({ store, rowId: row.id, questionText: row.questionText, answer: row.answer, explanation: row.explanation, canonicalSubcategory: row.canonicalSubcategory, broadCategory: row.broadCategory, dimensions: d.dimensions });
+    }
+  }
+
+  console.log(`pending: Question=${q.length} GeneratedQuestion=${g.length} total=${q.length + g.length}`);
+  console.log(`prefilter: skip=${skips.length} route=${routed.length}`);
+  // ~4k input tok/row measured; batch = 50% off; Sonnet 5 intro $2/$10 → ~$1/$5 batched.
+  console.log(`rough batched cost estimate: $${((routed.length * 4000 * 1 + routed.length * 300 * 5) / 1e6).toFixed(2)} + web searches`);
+
+  if (HARVEST) {
+    const client = getAnthropicClient();
+    if (!client) throw new Error('no anthropic client');
+    const summary = await harvestVerifyBatches(client, now);
+    let stamped = 0;
+    let stampFailures = 0;
+    for (const v of summary.verdicts) {
+      try {
+        if (v.store === 'q') {
+          await db.update(questions).set(verdictToQuestionPatch(v.outcome, now, v.reason)).where(eq(questions.id, v.rowId));
+        } else {
+          await db.update(generatedQuestions).set(verdictToGeneratedPatch(v.outcome, now, v.reason)).where(eq(generatedQuestions.id, v.rowId));
+        }
+        stamped += 1;
+      } catch (error) {
+        stampFailures += 1;
+        console.warn('stamp failed', v.store, v.rowId, error instanceof Error ? error.message : error);
+      }
+    }
+    const byOutcome = summary.verdicts.reduce<Record<string, number>>((acc, v) => {
+      acc[v.outcome] = (acc[v.outcome] ?? 0) + 1;
+      return acc;
+    }, {});
+    console.log('harvest:', {
+      runsChecked: summary.runsChecked,
+      runsHarvested: summary.runsHarvested,
+      runsStillProcessing: summary.runsStillProcessing,
+      runsFailed: summary.runsFailed,
+      resultFailures: summary.resultFailures,
+      stamped,
+      stampFailures,
+      byOutcome,
+    });
+    return;
+  }
+
+  if (!SUBMIT) {
+    console.log('\nDRY RUN — pass --submit to stamp skips and submit batches, --harvest to collect verdicts.');
+    return;
+  }
+
+  // Stamp the free skips first (identical to the cron's skip handling).
+  let skipped = 0;
+  for (const s of skips) {
+    try {
+      if (s.store === 'q') {
+        await db.update(questions).set(verdictToQuestionPatch('skipped', now)).where(eq(questions.id, s.id));
+      } else {
+        await db.update(generatedQuestions).set(verdictToGeneratedPatch('skipped', now)).where(eq(generatedQuestions.id, s.id));
+      }
+      skipped += 1;
+    } catch (error) {
+      console.warn('skip stamp failed', s.store, s.id, error instanceof Error ? error.message : error);
+    }
+  }
+  console.log(`stamped ${skipped}/${skips.length} skips (zero LLM cost)`);
+
+  const client = getAnthropicClient();
+  if (!client) throw new Error('no anthropic client');
+  for (let i = 0; i < routed.length; i += CHUNK) {
+    const chunk = routed.slice(i, i + CHUNK);
+    const { providerBatchId, requestCount } = await submitVerifyBatch(client, chunk);
+    console.log(`submitted chunk ${1 + i / CHUNK}: ${requestCount} requests → ${providerBatchId}`);
+  }
+  console.log('\nAll batches submitted. Re-run with --harvest once ended (typically <1h), or let the daily cron harvest.');
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => void pool.end());

--- a/src/app/admin/crafter/CrafterClient.tsx
+++ b/src/app/admin/crafter/CrafterClient.tsx
@@ -257,6 +257,17 @@ function DomainRow({ row, onCraft }: { row: CrafterWorklistRow; onCraft: () => v
                 you love this
               </span>
             ) : null}
+            {/* D-SUPPLY-FINITE-SET-01: this subject crossed the "too expensive
+                for the machine" line — human curation beats auto-fill here. */}
+            {row.expensiveToMachine ? (
+              <span
+                className="rounded-sm border px-1.5 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.08em]"
+                style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
+                title={`Expensive for the machine — curate this (${row.expensiveReason ?? 'costly to generate'})`}
+              >
+                expensive · curate
+              </span>
+            ) : null}
             <span className="text-[0.65rem] uppercase tracking-[0.06em]" style={{ color: heatColor(row.heat) }}>
               {HEAT_LABEL[row.heat]}
             </span>

--- a/src/app/api/cron/batch-verify-questions/route.ts
+++ b/src/app/api/cron/batch-verify-questions/route.ts
@@ -37,12 +37,20 @@ const ASYNC_BATCH_SIZE = Math.max(1, Number(process.env.BATCH_VERIFY_ASYNC_BATCH
 // Each worker holds an LLM (and maybe a web-search) call in flight.
 const VERIFY_CONCURRENCY = 4;
 
-// Operational escape hatch for the 2026-07 extra_fact tightening: set
-// PREFILTER_EXTRA_FACT_LEGACY=true to restore the pre-tightening routing
-// (any comma/paren/"and" in the answer routes) without a deploy.
+// Operational escape hatches for the 2026-07 prefilter tightenings, both
+// restorable without a deploy: PREFILTER_EXTRA_FACT_LEGACY=true restores the
+// pre-tightening ANSWER routing (any comma/paren/"and" routes);
+// PREFILTER_EXPLANATION_LEGACY=true restores the pre-tightening EXPLANATION
+// routing (any one signal OR length ≥140 routes — the measured ~90% router).
 function prefilterOptions(): PrefilterOptions {
-  const raw = process.env.PREFILTER_EXTRA_FACT_LEGACY?.trim().toLowerCase();
-  return { legacyExtraFact: raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on' };
+  const flag = (name: string) => {
+    const raw = process.env[name]?.trim().toLowerCase();
+    return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+  };
+  return {
+    legacyExtraFact: flag('PREFILTER_EXTRA_FACT_LEGACY'),
+    legacyExplanation: flag('PREFILTER_EXPLANATION_LEGACY'),
+  };
 }
 
 type PendingRow = {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2067,6 +2067,16 @@ export async function register() {
       `);
       await db.execute(sql`ALTER TABLE "LlmCostReport" ENABLE ROW LEVEL SECURITY`);
       await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmCostReport_created_at_idx" ON "LlmCostReport" ("created_at")`);
+      // Migration 0114 (D-SUPPLY-FINITE-SET-01 P2): the durable set-completion
+      // designation + system-created (inviterless) author invitations. The daily
+      // summary evaluates completion and would error on the missing column /
+      // NOT NULL constraint if the migration recorded without these. Both
+      // idempotent (ADD COLUMN IF NOT EXISTS / DROP NOT NULL is a no-op if already
+      // relaxed). Same rationale as the 0105/0106 guards above.
+      await db.execute(sql`
+        ALTER TABLE "PLAYER_MASTERY" ADD COLUMN IF NOT EXISTS "designated_at" timestamp with time zone
+      `);
+      await db.execute(sql`ALTER TABLE "AuthorInvitation" ALTER COLUMN "invited_by" DROP NOT NULL`);
     } catch {
       // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
     }

--- a/src/server/daily/__tests__/enrich-variants.test.ts
+++ b/src/server/daily/__tests__/enrich-variants.test.ts
@@ -9,6 +9,7 @@ const llmMock = vi.hoisted(() => ({
 }));
 
 vi.mock('@/lib/llm', () => ({
+  ANTHROPIC_MODEL: 'claude-sonnet-4-6',
   INSTRUCTION_SCOPING_QUALIFIER: '',
   INSTRUCTION_USER_INPUT_GUIDANCE: '',
   extractTextContent: (content: unknown) => String((content as { text: string }).text),

--- a/src/server/daily/__tests__/set-completion.test.ts
+++ b/src/server/daily/__tests__/set-completion.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Distinct-answered comes from a db.select().from().where().groupBy() chain; the
+// pool depth + designation/invite writes are separate query modules. Mock all
+// three (via vi.hoisted, since vi.mock factories are hoisted above the file) so
+// the evaluator's orchestration is testable without a live DB.
+const {
+  state,
+  getDurablePoolDepthForDomains,
+  hasDesignation,
+  markDomainDesignated,
+  inviteToAuthorAutomatic,
+} = vi.hoisted(() => ({
+  state: { answeredRows: [] as Array<{ domain: string; answered: number }> },
+  getDurablePoolDepthForDomains: vi.fn(),
+  hasDesignation: vi.fn(),
+  markDomainDesignated: vi.fn(),
+  inviteToAuthorAutomatic: vi.fn(),
+}));
+
+vi.mock('@/server/db', () => {
+  const dbChain = {
+    from: () => dbChain,
+    where: () => dbChain,
+    groupBy: () => Promise.resolve(state.answeredRows),
+  };
+  return {
+    db: { select: () => dbChain },
+    masteryEvents: { canonicalSubcategory: 'cs', answeredByUserId: 'a', questionId: 'q' },
+  };
+});
+vi.mock('@/server/db/queries/retrieval-demand', () => ({ getDurablePoolDepthForDomains }));
+vi.mock('@/server/db/queries/author-invitations', () => ({
+  hasDesignation,
+  markDomainDesignated,
+  inviteToAuthorAutomatic,
+}));
+
+import {
+  evaluateSetCompletions,
+  isSetComplete,
+  SET_COMPLETION_MIN_SIZE,
+} from '@/server/daily/set-completion';
+
+describe('isSetComplete', () => {
+  it('is false below the floor even when fully answered', () => {
+    expect(isSetComplete({ distinctAnswered: 5, setSize: 5 })).toBe(false); // 5 < floor 8
+  });
+
+  it('is false when the set is big enough but not fully covered', () => {
+    expect(isSetComplete({ distinctAnswered: 9, setSize: 12 })).toBe(false);
+  });
+
+  it('is true at the floor when fully answered', () => {
+    expect(isSetComplete({ distinctAnswered: 8, setSize: 8 })).toBe(true);
+  });
+
+  it('is true when answered exceeds the set (over-coverage still completes)', () => {
+    expect(isSetComplete({ distinctAnswered: 20, setSize: 12 })).toBe(true);
+  });
+
+  it('honors an override floor', () => {
+    expect(isSetComplete({ distinctAnswered: 3, setSize: 3, minSize: 3 })).toBe(true);
+  });
+
+  it('exports the documented floor', () => {
+    expect(SET_COMPLETION_MIN_SIZE).toBe(8);
+  });
+});
+
+describe('evaluateSetCompletions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.answeredRows = [];
+    hasDesignation.mockResolvedValue(false);
+    getDurablePoolDepthForDomains.mockResolvedValue(new Map());
+    inviteToAuthorAutomatic.mockResolvedValue({ ok: true, action: 'invited' });
+  });
+
+  it('designates + invites a domain the player just completed', async () => {
+    state.answeredRows = [{ domain: 'Spy School', answered: 12 }];
+    getDurablePoolDepthForDomains.mockResolvedValue(new Map([['Spy School', 10]]));
+
+    const completed = await evaluateSetCompletions('u1', ['Spy School']);
+
+    expect(completed).toEqual(['Spy School']);
+    expect(markDomainDesignated).toHaveBeenCalledWith('u1', 'Spy School', expect.any(Date));
+    expect(inviteToAuthorAutomatic).toHaveBeenCalledWith({ userId: 'u1', domain: 'Spy School' });
+  });
+
+  it('does not designate a below-floor domain', async () => {
+    state.answeredRows = [{ domain: 'Tiny Topic', answered: 4 }];
+    getDurablePoolDepthForDomains.mockResolvedValue(new Map([['Tiny Topic', 4]]));
+
+    const completed = await evaluateSetCompletions('u1', ['Tiny Topic']);
+
+    expect(completed).toEqual([]);
+    expect(markDomainDesignated).not.toHaveBeenCalled();
+    expect(inviteToAuthorAutomatic).not.toHaveBeenCalled();
+  });
+
+  it('does not designate a not-yet-covered domain', async () => {
+    state.answeredRows = [{ domain: 'Big Topic', answered: 9 }];
+    getDurablePoolDepthForDomains.mockResolvedValue(new Map([['Big Topic', 30]]));
+
+    expect(await evaluateSetCompletions('u1', ['Big Topic'])).toEqual([]);
+    expect(inviteToAuthorAutomatic).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — already-designated domains are skipped without writes', async () => {
+    state.answeredRows = [{ domain: 'Spy School', answered: 12 }];
+    getDurablePoolDepthForDomains.mockResolvedValue(new Map([['Spy School', 10]]));
+    hasDesignation.mockResolvedValue(true);
+
+    const completed = await evaluateSetCompletions('u1', ['Spy School']);
+
+    expect(completed).toEqual([]);
+    expect(markDomainDesignated).not.toHaveBeenCalled();
+    expect(inviteToAuthorAutomatic).not.toHaveBeenCalled();
+  });
+
+  it('never throws — a query fault returns no completions', async () => {
+    getDurablePoolDepthForDomains.mockRejectedValue(new Error('db down'));
+    state.answeredRows = [{ domain: 'Spy School', answered: 12 }];
+    expect(await evaluateSetCompletions('u1', ['Spy School'])).toEqual([]);
+  });
+
+  it('returns early for an empty domain list (no queries)', async () => {
+    expect(await evaluateSetCompletions('u1', [])).toEqual([]);
+    expect(getDurablePoolDepthForDomains).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/daily/enrich-variants.ts
+++ b/src/server/daily/enrich-variants.ts
@@ -25,6 +25,7 @@
 // question still ships with its original key), it never blocks or drops.
 
 import {
+  ANTHROPIC_MODEL,
   INSTRUCTION_SCOPING_QUALIFIER,
   INSTRUCTION_USER_INPUT_GUIDANCE,
   extractTextContent,
@@ -40,12 +41,14 @@ export interface EnrichVariantsItem {
   explainer: string;
 }
 
-// Default to the generation tier (Sonnet) — judging answer equivalence needs the
-// same reasoning the generator and factual gate use; Haiku is too lenient/broad
-// here and would risk polluting keys. Overridable without a deploy, mirroring
-// FACTUAL_GATE_MODEL. Resolved lazily so tests can stub the model id.
+// Default to the generation tier — judging answer equivalence needs the same
+// reasoning the generator and factual gate use; Haiku is too lenient/broad here
+// and would risk polluting keys. Inherits ANTHROPIC_MODEL (Sonnet 5 in prod, the
+// central flag) rather than pinning a version, so a model flip carries here too;
+// overridable without a deploy, mirroring FACTUAL_GATE_MODEL. Resolved lazily so
+// tests can stub the model id.
 function enrichModel(): string {
-  return process.env.ENRICH_VARIANTS_MODEL?.trim() || 'claude-sonnet-4-6';
+  return process.env.ENRICH_VARIANTS_MODEL?.trim() || ANTHROPIC_MODEL;
 }
 
 function enrichEnabled(): boolean {

--- a/src/server/daily/set-completion.ts
+++ b/src/server/daily/set-completion.ts
@@ -1,0 +1,108 @@
+/**
+ * D-SUPPLY-FINITE-SET-01 P2 — set-completion detection.
+ *
+ * A domain is a finite completable SET (~the fan-salient questions it holds).
+ * When a player has answered the whole set, they earn a durable DESIGNATION
+ * (recognition only — no mechanical effect) and an AUTOMATIC invitation to
+ * author more, which lights the already-built /invited trophy takeover.
+ *
+ * Completion is COVERAGE-based (Josh, 2026-07-05): the player has answered at
+ * least as many DISTINCT questions as the set holds distinct facts. We compare
+ * distinct-answered (not the raw answer-event count — repeats/catch-up must not
+ * trophy a replay) against the durable pool depth (the set size at current
+ * scale), gated by a floor so a 3-question domain isn't called a "set".
+ *
+ * Fail-open and idempotent: a designation stamps once (guarded on
+ * designated_at IS NULL) and the invitation's partial unique index makes a
+ * re-fire a no-op, so an over-eager or repeated call is harmless; an error
+ * never breaks the summary it runs inside.
+ */
+import { and, eq, inArray, sql } from 'drizzle-orm';
+
+import { db, masteryEvents } from '@/server/db';
+import {
+  hasDesignation,
+  inviteToAuthorAutomatic,
+  markDomainDesignated,
+} from '@/server/db/queries/author-invitations';
+import { getDurablePoolDepthForDomains } from '@/server/db/queries/retrieval-demand';
+
+// Below this many distinct facts a domain isn't a "set" worth a trophy — a
+// thin domain a player exhausts is surfaced to the human via the crafter
+// worklist instead (the P1 expensive/thin signal), not celebrated. Tunable.
+export const SET_COMPLETION_MIN_SIZE = 8;
+
+/**
+ * Pure completion predicate (unit-tested): a set is complete when it is at least
+ * the floor size AND the player has answered every distinct question in it.
+ */
+export function isSetComplete(input: {
+  distinctAnswered: number;
+  setSize: number;
+  minSize?: number;
+}): boolean {
+  const minSize = input.minSize ?? SET_COMPLETION_MIN_SIZE;
+  return input.setSize >= minSize && input.distinctAnswered >= input.setSize;
+}
+
+// Distinct QUESTIONS a player has answered per domain (coverage) — deduped so
+// a re-answered question counts once, matching the distinct-fact set size.
+async function distinctAnsweredByDomain(
+  userId: string,
+  domains: string[],
+): Promise<Map<string, number>> {
+  if (domains.length === 0) return new Map();
+  const rows = await db
+    .select({
+      domain: masteryEvents.canonicalSubcategory,
+      answered: sql<number>`count(distinct ${masteryEvents.questionId})::int`,
+    })
+    .from(masteryEvents)
+    .where(
+      and(
+        eq(masteryEvents.answeredByUserId, userId),
+        inArray(masteryEvents.canonicalSubcategory, domains),
+      ),
+    )
+    .groupBy(masteryEvents.canonicalSubcategory);
+  return new Map(rows.filter((r) => r.domain).map((r) => [r.domain as string, Number(r.answered)]));
+}
+
+/**
+ * For the domains a player was active in this round, designate + invite the ones
+ * they've just completed. Returns the newly-completed domains (for logging).
+ * Side-effecting but idempotent; safe to call every summary.
+ */
+export async function evaluateSetCompletions(
+  userId: string,
+  domains: string[],
+): Promise<string[]> {
+  const unique = [...new Set(domains.filter(Boolean))];
+  if (unique.length === 0) return [];
+
+  const completed: string[] = [];
+  try {
+    const [answeredByDomain, poolDepthByDomain] = await Promise.all([
+      distinctAnsweredByDomain(userId, unique),
+      getDurablePoolDepthForDomains(unique),
+    ]);
+    const now = new Date();
+    for (const domain of unique) {
+      const setSize = poolDepthByDomain.get(domain) ?? 0;
+      const distinctAnswered = answeredByDomain.get(domain) ?? 0;
+      if (!isSetComplete({ distinctAnswered, setSize })) continue;
+      // Cheap guard first so a repeat call skips the writes entirely; the writes
+      // are themselves idempotent, so a race is harmless.
+      if (await hasDesignation(userId, domain)) continue;
+      await markDomainDesignated(userId, domain, now);
+      await inviteToAuthorAutomatic({ userId, domain });
+      completed.push(domain);
+    }
+  } catch (error) {
+    console.warn('[set-completion] evaluation failed (non-fatal)', {
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return completed;
+}

--- a/src/server/db/queries/__tests__/crafter-demand-clusters.test.ts
+++ b/src/server/db/queries/__tests__/crafter-demand-clusters.test.ts
@@ -21,7 +21,13 @@ vi.mock('@/server/knowledge/converge-domain', () => ({
   getConvergeTrgmThreshold: () => 0.55,
 }));
 
-import { buildLabelClusters, futilityScore, type ClusterLabel } from '@/server/db/queries/crafter-demand';
+import {
+  buildLabelClusters,
+  curationVerdict,
+  futilityScore,
+  CURATION_FUTILITY_THRESHOLD,
+  type ClusterLabel,
+} from '@/server/db/queries/crafter-demand';
 
 const THRESHOLD = 0.55;
 
@@ -86,5 +92,46 @@ describe('futilityScore', () => {
 
   it('below the sample floor (rate=null) the machine is presumed fine', () => {
     expect(futilityScore({ demotionRate: null, generationStruggling: false })).toBe(0);
+  });
+});
+
+// D-SUPPLY-FINITE-SET-01: the "too expensive → curate it" threshold that drives
+// the crafter dashboard badge and the weekly notification.
+describe('curationVerdict', () => {
+  it('a low-demotion, healthy domain is NOT expensive', () => {
+    const v = curationVerdict({ demotionRate: 0.1, generationStruggling: false });
+    expect(v.expensive).toBe(false);
+    expect(v.reason).toBeNull();
+  });
+
+  it('a high demotion rate crosses the line with a % reason', () => {
+    const v = curationVerdict({ demotionRate: 0.64, generationStruggling: false });
+    expect(v.expensive).toBe(true);
+    expect(v.reason).toBe('64% demoted');
+  });
+
+  it('generation timing out crosses the line on its own', () => {
+    // struggling bump (0.5) alone clears 0.34, even with no verdict sample.
+    const v = curationVerdict({ demotionRate: null, generationStruggling: true });
+    expect(v.expensive).toBe(true);
+    expect(v.reason).toBe('generation timing out');
+  });
+
+  it('names both causes when both fire', () => {
+    const v = curationVerdict({ demotionRate: 0.5, generationStruggling: true });
+    expect(v.expensive).toBe(true);
+    expect(v.reason).toBe('50% demoted; generation timing out');
+  });
+
+  it('does not fabricate a % reason when the rate is below the threshold but struggling pushes it over', () => {
+    // demotionRate 0.1 alone wouldn't cross; the 0.5 struggling bump does. The
+    // reason must not claim "10% demoted" as a cause — only the timeout.
+    const v = curationVerdict({ demotionRate: 0.1, generationStruggling: true });
+    expect(v.expensive).toBe(true);
+    expect(v.reason).toBe('generation timing out');
+  });
+
+  it('the threshold is the documented value', () => {
+    expect(CURATION_FUTILITY_THRESHOLD).toBe(0.34);
   });
 });

--- a/src/server/db/queries/author-invitations.ts
+++ b/src/server/db/queries/author-invitations.ts
@@ -1,6 +1,6 @@
 import { and, countDistinct, desc, eq, gte, inArray, isNull, max, min, sql } from 'drizzle-orm';
 
-import { authorInvitations, db, masteryEvents, users } from '@/server/db';
+import { authorInvitations, db, masteryEvents, playerMastery, users } from '@/server/db';
 
 // B-CRAFTER-LIFECYCLE-01 Phase 3 — the manual "invitation to author" state
 // (decision 2026-07-01: manual checkbox first; automatic exhaustion signals can
@@ -11,8 +11,11 @@ import { authorInvitations, db, masteryEvents, users } from '@/server/db';
 //   3. records which door they took (doorChoice: author | expand | wait).
 // 'domain_exhausted' is the first invitation reason of a couple — keep new
 // reasons as data, not new tables. No hard-delete: revoke = resolvedAt stamp.
+// 'set_completed' (D-SUPPLY-FINITE-SET-01 P2) is the AUTOMATIC reason: the
+// player answered a domain's whole finite set. Unlike the manual crafter flip
+// it has no human inviter (invited_by IS NULL).
 
-export type InvitationReason = 'domain_exhausted';
+export type InvitationReason = 'domain_exhausted' | 'set_completed';
 export type DoorChoice = 'author' | 'expand' | 'wait';
 
 const PG_UNIQUE_VIOLATION = '23505';
@@ -118,6 +121,61 @@ export async function inviteToAuthor(params: {
     if (isUniqueViolation(err)) return { ok: true, action: 'already_invited' };
     throw err;
   }
+}
+
+// The AUTOMATIC counterpart (D-SUPPLY-FINITE-SET-01 P2): a system-created
+// invitation with no human inviter (invited_by NULL, reason 'set_completed'),
+// fired when a player completes a domain's finite set. Same idempotent
+// unique-violation guard as inviteToAuthor.
+export async function inviteToAuthorAutomatic(params: {
+  userId: string;
+  domain: string;
+}): Promise<InviteResult> {
+  try {
+    await db.insert(authorInvitations).values({
+      userId: params.userId,
+      domain: params.domain,
+      invitedBy: null,
+      reason: 'set_completed',
+    });
+    return { ok: true, action: 'invited' };
+  } catch (err) {
+    if (isUniqueViolation(err)) return { ok: true, action: 'already_invited' };
+    throw err;
+  }
+}
+
+// ─── set-completion designation (recognition only, no mechanical effect) ─────
+
+// Has this player already earned the durable designation for this domain? Reads
+// PLAYER_MASTERY.designated_at — the completion guard so a set is trophied once.
+export async function hasDesignation(userId: string, domain: string): Promise<boolean> {
+  const [row] = await db
+    .select({ designatedAt: playerMastery.designatedAt })
+    .from(playerMastery)
+    .where(and(eq(playerMastery.userId, userId), eq(playerMastery.canonicalSubcategory, domain)))
+    .limit(1);
+  return row?.designatedAt != null;
+}
+
+// Stamp the designation on the player's existing mastery row (one always exists
+// once they've played the domain). Only stamps when currently NULL, so it never
+// moves an earlier recognition timestamp.
+export async function markDomainDesignated(
+  userId: string,
+  domain: string,
+  now: Date,
+): Promise<void> {
+  await db
+    .update(playerMastery)
+    .set({ designatedAt: now })
+    .where(
+      and(
+        eq(playerMastery.userId, userId),
+        eq(playerMastery.canonicalSubcategory, domain),
+        isNull(playerMastery.designatedAt),
+      ),
+    );
 }
 
 // Flip the checkbox OFF: soft-close (resolvedAt), never delete. A no-op when

--- a/src/server/db/queries/crafter-demand.ts
+++ b/src/server/db/queries/crafter-demand.ts
@@ -61,6 +61,15 @@ export type CrafterWorklistRow = {
   machineDemoted: number; // …of those, pulled as wrong
   demotionRate: number | null; // demoted/verified; null below the sample floor
   generationStruggling: boolean; // refill has been timing out here (health row)
+  /**
+   * D-SUPPLY-FINITE-SET-01 curation routing: TRUE when this subject has crossed
+   * the "too expensive for the machine" line (futility ≥ threshold) — it should
+   * be human-curated, not left to auto-fill. Drives the crafter dashboard badge
+   * and the weekly "subjects that got expensive" notification. `expensiveReason`
+   * is a short human string ('64% demoted' / 'generation timing out').
+   */
+  expensiveToMachine: boolean;
+  expensiveReason: string | null;
 };
 
 // Thresholds are deliberately small-scale (18-user era) and transparent — tune
@@ -88,6 +97,101 @@ export function futilityScore(row: {
   generationStruggling: boolean;
 }): number {
   return (row.demotionRate ?? 0) + (row.generationStruggling ? 0.5 : 0);
+}
+
+// The "too expensive for the machine → curate it" line (D-SUPPLY-FINITE-SET-01
+// cost-routed curation). Crossed by EITHER a high demotion rate (a third+ of the
+// machine's verified questions here are wrong — re-generating just re-mints
+// junk) OR generation timing out at all (the 0.5 struggling bump alone clears
+// it — the machine can't even produce here). Small-scale, tune by eye.
+export const CURATION_FUTILITY_THRESHOLD = 0.34;
+
+/**
+ * Whether a subject has crossed the curation line, with a short human reason.
+ * Pure and exported for tests + the weekly notification. Only speaks when there
+ * is a real signal: a demotion rate needs the sample floor (FUTILITY_MIN_VERIFIED),
+ * so a domain flagged solely on `generationStruggling` reads as a timeout, not a
+ * fabricated failure rate.
+ */
+export function curationVerdict(row: {
+  demotionRate: number | null;
+  generationStruggling: boolean;
+}): { expensive: boolean; reason: string | null } {
+  if (futilityScore(row) < CURATION_FUTILITY_THRESHOLD) return { expensive: false, reason: null };
+  const parts: string[] = [];
+  if (row.demotionRate != null && row.demotionRate >= CURATION_FUTILITY_THRESHOLD) {
+    parts.push(`${Math.round(row.demotionRate * 100)}% demoted`);
+  }
+  if (row.generationStruggling) parts.push('generation timing out');
+  return { expensive: true, reason: parts.join('; ') || 'costly to generate' };
+}
+
+export type ExpensiveDomain = {
+  domain: string;
+  reason: string;
+  demotionRate: number | null;
+  generationStruggling: boolean;
+};
+
+/**
+ * GLOBAL curation-worthiness scan (D-SUPPLY-FINITE-SET-01) — every subject that
+ * has crossed the "too expensive for the machine" line, corpus-wide (not scoped
+ * to one crafter's active domains like getCrafterWorklist). Powers the weekly
+ * "subjects that got expensive" notification in the LLM cost report. Read-only,
+ * pure threshold over the same two signals the worklist uses:
+ *   - per-domain machine demotion rate (needs the FUTILITY_MIN_VERIFIED sample),
+ *   - refill generation timing out (RetrievalDomainHealth).
+ * Sorted by futility, worst first.
+ */
+export async function getExpensiveDomains(): Promise<ExpensiveDomain[]> {
+  const [verdictRows, healthRows] = await Promise.all([
+    db
+      .select({
+        domain: generatedQuestions.canonicalSubcategory,
+        verified: sql<number>`count(*)::int`,
+        demoted: sql<number>`count(*) filter (where ${generatedQuestions.verificationVerdict} = 'demoted')::int`,
+      })
+      .from(generatedQuestions)
+      .where(isNotNull(generatedQuestions.verificationVerdict))
+      .groupBy(generatedQuestions.canonicalSubcategory),
+    db
+      .select({
+        domain: retrievalDomainHealth.domain,
+        consecutiveTimeouts: retrievalDomainHealth.consecutiveTimeouts,
+      })
+      .from(retrievalDomainHealth)
+      .where(gte(retrievalDomainHealth.consecutiveTimeouts, STRUGGLING_TIMEOUTS)),
+  ]);
+
+  const struggling = new Set(healthRows.map((r) => r.domain).filter(Boolean) as string[]);
+  const out: ExpensiveDomain[] = [];
+  const seen = new Set<string>();
+
+  for (const r of verdictRows) {
+    if (!r.domain) continue;
+    const verified = Number(r.verified);
+    const demoted = Number(r.demoted);
+    const demotionRate = verified >= FUTILITY_MIN_VERIFIED ? demoted / verified : null;
+    const generationStruggling = struggling.has(r.domain);
+    const v = curationVerdict({ demotionRate, generationStruggling });
+    if (v.expensive) {
+      out.push({ domain: r.domain, reason: v.reason ?? 'costly to generate', demotionRate, generationStruggling });
+      seen.add(r.domain);
+    }
+  }
+  // Domains that time out so hard they have no verdict rows at all (the machine
+  // can't even produce here) — the clearest curate case; include them too.
+  for (const domain of struggling) {
+    if (seen.has(domain)) continue;
+    const v = curationVerdict({ demotionRate: null, generationStruggling: true });
+    out.push({ domain, reason: v.reason ?? 'generation timing out', demotionRate: null, generationStruggling: true });
+  }
+
+  return out.sort(
+    (a, b) =>
+      futilityScore({ demotionRate: b.demotionRate, generationStruggling: b.generationStruggling }) -
+      futilityScore({ demotionRate: a.demotionRate, generationStruggling: a.generationStruggling }),
+  );
 }
 
 function heatFor(activePlayers: number, machineDepth: number, humanAuthored: number): CrafterWorklistHeat {
@@ -348,6 +452,10 @@ export async function getCrafterWorklist(
     const verdicts = verdictsByDomain.get(row.domain);
     const machineVerified = verdicts ? Number(verdicts.verified) : 0;
     const machineDemoted = verdicts ? Number(verdicts.demoted) : 0;
+    const demotionRate =
+      machineVerified >= FUTILITY_MIN_VERIFIED ? machineDemoted / machineVerified : null;
+    const generationStruggling = strugglingDomains.has(row.domain);
+    const verdict = curationVerdict({ demotionRate, generationStruggling });
     return {
       domain: row.domain,
       activePlayers: row.activePlayers,
@@ -361,9 +469,10 @@ export async function getCrafterWorklist(
       heat: heatFor(row.activePlayers, clusterMachineDepth, clusterHumanAuthored),
       machineVerified,
       machineDemoted,
-      demotionRate:
-        machineVerified >= FUTILITY_MIN_VERIFIED ? machineDemoted / machineVerified : null,
-      generationStruggling: strugglingDomains.has(row.domain),
+      demotionRate,
+      generationStruggling,
+      expensiveToMachine: verdict.expensive,
+      expensiveReason: verdict.reason,
     };
   });
 

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -23,6 +23,7 @@ import {
 } from '@/server/daily/kb-exhaustion';
 import type { AdjacentDomainSuggestion } from '@/server/llm/interests';
 import { suggestAdjacentDomains, suggestBroaderDomains } from '@/server/llm/interests';
+import { evaluateSetCompletions } from '@/server/daily/set-completion';
 import { getCachedDomainRungs } from '@/server/knowledge/nearness-tree';
 import { getHeldDomainKeys } from '@/server/db/queries/nearness-overlay';
 import { domainKey } from '@/lib/knowledge/domain-key';
@@ -355,6 +356,15 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
     territoryType: masteryByDomain.get(domain)?.territoryType ?? null,
   }));
   const expansionOffer = await buildExpansionOffer(userId, touchedForExpansion);
+
+  // D-SUPPLY-FINITE-SET-01 P2: designate + auto-invite domains this player just
+  // completed (answered the whole finite set). Side-effect only — it creates the
+  // AuthorInvitation that the summary's InvitationTakeoverGate then routes to
+  // /invited (the trophy). Fail-open; never blocks the summary.
+  await evaluateSetCompletions(
+    userId,
+    touchedForExpansion.map((t) => t.domain),
+  );
 
   return {
     date: dateString,

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -171,7 +171,7 @@ async function getPlayerMasteryRows(userId: string, orderByPoints = false): Prom
         .from(playerMastery)
         .where(eq(playerMastery.userId, userId));
 
-    return rows.map((row) => ({ ...row, territoryType: 'demonstrated' as const, rotationEligible: true }));
+    return rows.map((row) => ({ ...row, territoryType: 'demonstrated' as const, rotationEligible: true, designatedAt: null }));
   }
 }
 
@@ -213,7 +213,7 @@ async function getPlayerMasteryRowsBulk(
       .from(playerMastery)
       .where(inArray(playerMastery.userId, ids))
       .orderBy(desc(playerMastery.totalPoints));
-    rows = raw.map((row) => ({ ...row, territoryType: 'demonstrated' as const, rotationEligible: true }));
+    rows = raw.map((row) => ({ ...row, territoryType: 'demonstrated' as const, rotationEligible: true, designatedAt: null }));
   }
 
   for (const row of rows) {

--- a/src/server/db/queries/llm-cost-report.ts
+++ b/src/server/db/queries/llm-cost-report.ts
@@ -17,6 +17,7 @@ import { and, desc, gte, inArray, isNotNull, lt, sql } from 'drizzle-orm';
 
 import { adminUserIds } from '@/server/auth/admin';
 import { db, generatedQuestions, llmCostReport, llmUsageEvent, masteryEvents, users } from '@/server/db';
+import { getExpensiveDomains, type ExpensiveDomain } from '@/server/db/queries/crafter-demand';
 import { estimateCostUsd } from '@/server/llm/pricing';
 
 // ─── Decision A: the surface taxonomy ────────────────────────────────────────
@@ -301,6 +302,13 @@ export type CostLatencyReport = {
   answersGraded: number;
   costPerQuestionUsd: number | null;
   costPerAnswerGradedUsd: number | null;
+  /**
+   * D-SUPPLY-FINITE-SET-01 cost-routed curation: subjects that crossed the "too
+   * expensive for the machine" line (high demotion / generation timing out) and
+   * should be human-curated. The weekly notification half of the crafter
+   * dashboard badge. Worst first.
+   */
+  expensiveDomains: ExpensiveDomain[];
 };
 
 /**
@@ -311,14 +319,16 @@ export async function buildCostLatencyReport(windowDays = 7): Promise<CostLatenc
   const now = new Date();
   const periodStart = new Date(now.getTime() - windowDays * 86_400_000);
 
-  const [surfaces, prev, month, latency, questionsGenerated, answersGraded] = await Promise.all([
-    readSurfaceCost(windowDays, 0),
-    readSurfaceCost(windowDays * 2, windowDays),
-    readSurfaceCost(30, 0),
-    readSurfaceLatency(windowDays, 0),
-    countQuestionsGenerated(windowDays),
-    countAnswersGraded(windowDays),
-  ]);
+  const [surfaces, prev, month, latency, questionsGenerated, answersGraded, expensiveDomains] =
+    await Promise.all([
+      readSurfaceCost(windowDays, 0),
+      readSurfaceCost(windowDays * 2, windowDays),
+      readSurfaceCost(30, 0),
+      readSurfaceLatency(windowDays, 0),
+      countQuestionsGenerated(windowDays),
+      countAnswersGraded(windowDays),
+      getExpensiveDomains().catch(() => [] as ExpensiveDomain[]),
+    ]);
 
   const totalUsd = surfaces.reduce((a, s) => a + s.costUsd, 0);
   const prevTotalUsd = prev.reduce((a, s) => a + s.costUsd, 0);
@@ -350,6 +360,7 @@ export async function buildCostLatencyReport(windowDays = 7): Promise<CostLatenc
     answersGraded,
     costPerQuestionUsd: questionsGenerated > 0 ? generateUsd / questionsGenerated : null,
     costPerAnswerGradedUsd: answersGraded > 0 ? gradeUsd / answersGraded : null,
+    expensiveDomains,
   };
 }
 
@@ -453,6 +464,24 @@ export function renderCostLatencyReportMarkdown(r: CostLatencyReport): string {
     lines.push('| --- | --- | --- |');
     for (const l of timed) {
       lines.push(`| ${l.label} | ${ms(l.avgMs)} | ${ms(l.p95Ms)} |`);
+    }
+    lines.push('');
+  }
+
+  // Subjects that got expensive for the machine — the notification half of the
+  // crafter dashboard badge (D-SUPPLY-FINITE-SET-01 cost-routed curation). These
+  // are where human authoring beats paying to re-generate junk.
+  if (r.expensiveDomains.length > 0) {
+    lines.push('## Subjects too expensive for the machine — curate these');
+    lines.push('');
+    lines.push(
+      'The machine keeps producing wrong or unservable questions here (or can’t generate at all). Author them by hand instead of paying to re-generate — they’re flagged in the crafter worklist:',
+    );
+    for (const d of r.expensiveDomains.slice(0, 15)) {
+      lines.push(`- **${d.domain}** — ${d.reason}`);
+    }
+    if (r.expensiveDomains.length > 15) {
+      lines.push(`- …and ${r.expensiveDomains.length - 15} more`);
     }
     lines.push('');
   }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -496,6 +496,11 @@ export const playerMastery = pgTable(
     // friend's domain can't leak into the main five until the player adopts it
     // (a non-resting frequency) or declares it. See getKnowledgeBase.
     rotationEligible: boolean('rotation_eligible').notNull().default(true),
+    // D-SUPPLY-FINITE-SET-01 P2: the durable "you completed this set" recognition
+    // (designation). Set once a player has answered the domain's whole set; drives
+    // the /invited trophy's permanence. Recognition only — no mechanical effect.
+    // NULL = not yet designated. Mirrors tier_reached_at.
+    designatedAt: timestamp('designated_at', { withTimezone: true }),
     updatedAt: updatedAt(),
   },
   (table) => [
@@ -1203,7 +1208,9 @@ export const authorInvitations = pgTable(
     userId: text('user_id').notNull().references(() => users.id),
     domain: text('domain').notNull(),
     reason: text('reason').notNull().default('domain_exhausted'),
-    invitedBy: text('invited_by').notNull().references(() => users.id),
+    // Nullable since 0114: a set-completion invitation is system-created and has
+    // no human inviter (NULL = automatic). Human crafter invites still set it.
+    invitedBy: text('invited_by').references(() => users.id),
     createdAt: createdAt(),
     seenAt: timestamp('seen_at', { withTimezone: true }),
     doorChoice: text('door_choice'),

--- a/src/server/profile/multitudes.ts
+++ b/src/server/profile/multitudes.ts
@@ -1,9 +1,12 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { loggedMessagesCreate } from '@/lib/llm';
+import { ANTHROPIC_MODEL, loggedMessagesCreate } from '@/lib/llm';
 import type { MasteryTier } from '@/types/db';
 import type { PortraitState } from '@/server/profile/portrait';
 
-const MODEL = 'claude-sonnet-4-6';
+// Inherit the central generation model (Sonnet 5 in prod) rather than pinning a
+// version, so a model flip carries here too. Prose-only, no schema — the tier
+// doesn't matter much, but there's no reason to leave it stranded on 4.6.
+const MODEL = ANTHROPIC_MODEL;
 const SYSTEM_PROMPT = "You are writing a one-line identity statement for a player in a trivia game where knowledge is identity. Their strongest territories are listed. Write a single sentence — 12 to 25 words — that names their intellectual world with warmth and specificity. Tone: a well-written author bio, not a stats report. Never say 'you are' — the sentence should read like a caption. Specific nouns, not abstractions. The sentence should make the player feel recognized, not evaluated.";
 
 type CacheValue = {

--- a/src/server/quality/__tests__/verification-prefilter.test.ts
+++ b/src/server/quality/__tests__/verification-prefilter.test.ts
@@ -99,7 +99,8 @@ describe('prefilterForVerification — tightened extra_fact answer heuristic (20
   });
 
   it('claim-bearing explanations still route regardless of the answer shape', () => {
-    // The explanation path is untouched by the tightening.
+    // Survives BOTH tightenings: the explainer's year claim is a kind the
+    // question+answer never carried (novel adjacent claim).
     const d = decide(
       'Who painted the ceiling of the Sistine Chapel?',
       'Michelangelo',
@@ -113,6 +114,66 @@ describe('prefilterForVerification — tightened extra_fact answer heuristic (20
     const input = { questionText: 'What items does Ben buy at the store?', answer: 'Bread, eggs and milk' };
     const strict = prefilterForVerification(input);
     const legacy = prefilterForVerification(input, { legacyExtraFact: true });
+    expect(strict.needsVerification).toBe(false);
+    expect(legacy.needsVerification).toBe(true);
+    if (legacy.needsVerification) expect(legacy.dimensions).toContain('extra_fact');
+  });
+});
+
+describe('prefilterForVerification — tightened explanation heuristic (2026-07-05)', () => {
+  it('no longer routes an explanation that merely restates the asked fact-kind', () => {
+    // The stem/answer are ABOUT a year; the explainer's only signal is that same
+    // year. That's context, not an adjacent claim — under the legacy heuristic
+    // this routed to a paid verify (any one signal).
+    const d = decide(
+      'In what year did the Titanic sink?',
+      '1912',
+      'The Titanic sank in 1912 after striking an iceberg, and the disaster prompted sweeping changes to maritime safety law.',
+    );
+    expect(d.needsVerification).toBe(false);
+  });
+
+  it('no longer routes long pure-prose explanations (length is not a claim)', () => {
+    // ≥140 chars but zero assertion signals — legacy routed on length alone.
+    const d = decide(
+      'What is the capital of France?',
+      'Paris',
+      'Paris has long been celebrated as a global center of art, fashion, gastronomy and culture, and its cafe-lined boulevards draw countless visitors from far beyond its borders.',
+    );
+    expect(d.needsVerification).toBe(false);
+  });
+
+  it('still routes an explanation that volunteers a NOVEL claim kind', () => {
+    // Question asks a "who"; the explainer volunteers a date — a checkable
+    // adjacent claim the question never asked about.
+    const d = decide(
+      'Who wrote The Waste Land?',
+      'T. S. Eliot',
+      'T. S. Eliot published The Waste Land in 1922, and it quickly became one of the most influential poems of the modernist movement.',
+    );
+    expect(d.needsVerification).toBe(true);
+    if (d.needsVerification) expect(d.dimensions).toContain('extra_fact');
+  });
+
+  it('still routes a claim-dense explainer (two-plus signal kinds)', () => {
+    const d = decide(
+      "What is the title of Beethoven's Third Symphony?",
+      'Eroica',
+      'Beethoven composed the Eroica in 1804 and it was the first of his symphonies to break with classical convention.',
+    );
+    expect(d.needsVerification).toBe(true);
+    if (d.needsVerification) expect(d.dimensions).toContain('extra_fact');
+  });
+
+  it('the legacy explanation hatch restores the old routing', () => {
+    const input = {
+      questionText: 'In what year did the Titanic sink?',
+      answer: '1912',
+      explanation:
+        'The Titanic sank in 1912 after striking an iceberg, and the disaster prompted sweeping changes to maritime safety law.',
+    };
+    const strict = prefilterForVerification(input);
+    const legacy = prefilterForVerification(input, { legacyExplanation: true });
     expect(strict.needsVerification).toBe(false);
     expect(legacy.needsVerification).toBe(true);
     if (legacy.needsVerification) expect(legacy.dimensions).toContain('extra_fact');

--- a/src/server/quality/__tests__/verify-batch.test.ts
+++ b/src/server/quality/__tests__/verify-batch.test.ts
@@ -17,11 +17,25 @@ describe('verify custom_id codec', () => {
     }
   });
 
+  it('emits only characters the Batches API accepts (^[a-zA-Z0-9_-]{1,64}$)', () => {
+    // Regression for the 2026-07-05 prod finding: the original colon separator
+    // was REJECTED by the real API at submit — every async run silently no-oped.
+    for (const store of ['q', 'g'] as const) {
+      const encoded = encodeVerifyCustomId(store, 'a4f0c2de-1b3c-4d5e-8f90-0123456789ab');
+      expect(encoded).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+    }
+  });
+
+  it('still decodes the legacy colon form defensively', () => {
+    expect(decodeVerifyCustomId('q:row-1')).toEqual({ store: 'q', rowId: 'row-1' });
+  });
+
   it('rejects malformed custom_ids instead of guessing a store', () => {
     expect(decodeVerifyCustomId('x:abc')).toBeNull();
     expect(decodeVerifyCustomId('q')).toBeNull();
     expect(decodeVerifyCustomId('')).toBeNull();
     expect(decodeVerifyCustomId('q:')).toBeNull();
+    expect(decodeVerifyCustomId('q_')).toBeNull();
   });
 });
 

--- a/src/server/quality/verification-prefilter.ts
+++ b/src/server/quality/verification-prefilter.ts
@@ -99,17 +99,64 @@ function isOpinionAdjacent(text: string): boolean {
   return OPINION_RE.test(text);
 }
 
-// The explanation carries adjacent claims when it is more than a terse restatement
-// of the answer — long enough to assert something of its own, with assertion
-// signals or substantial independent prose.
-function explanationCarriesClaims(
+// LEGACY (pre-2026-07-05): substance ≈ claims — ≥60 chars AND (any one signal OR
+// ≥140 chars). MEASURED as the dominant ~90% router (cost-characterization §5
+// retraction): trivia explainers nearly always clear one of those bars — every
+// explainer mentions a year or runs long — so extra_fact routed almost every row
+// and the pre-filter skipped only ~9%. Kept callable for the escape hatch and
+// the before/after measurement script.
+export function explanationCarriesClaimsLegacy(
   explanation: string | null | undefined,
-  _answer: string,
 ): boolean {
   if (!explanation) return false;
   const trimmed = explanation.trim();
   if (trimmed.length < 60) return false; // too short to carry an independent claim
   return signalKinds(trimmed).size >= 1 || trimmed.length >= 140;
+}
+
+// TIGHTENED (2026-07-05): length is prose, not a claim — and a single signal of
+// the same KIND the question/answer already carries is context (restating the
+// asked fact), not an ADJACENT claim. Route only when the explanation asserts
+// something checkable BEYOND the question+answer:
+//   - a signal kind ABSENT from stem+answer (a genuinely new claim category —
+//     e.g. the question asks a "who" and the explainer volunteers a date), or
+//   - two-plus distinct signal kinds (a claim-dense explainer — where wrong
+//     adjacent facts live).
+// Kind-level comparison is deliberately coarse (stem 1804 / explainer 1799 both
+// read as 'year' and would skip) — this is a demote-only BACKGROUND net behind
+// the factual gate and ask-to-answer, and the spend guarantee only pays out on
+// skips. The measurement script prints route→skip flips for eyeballing.
+// signalKinds with the year/count double-fire collapsed: the 'count' pattern
+// greedily matches ANY number followed by a word — including the year itself
+// ("in 1912 after…") — so every explainer mentioning a year read as two kinds
+// (year + count) and looked claim-dense. Keep 'count' only when a NON-year
+// number (or word-number) also matches. Local to the explanation path — the
+// stem/premise router keeps the original, deliberately conservative behavior.
+function effectiveKinds(text: string): Set<string> {
+  const kinds = signalKinds(text);
+  if (kinds.has('year') && kinds.has('count')) {
+    const withoutYears = text.replace(/\b(1\d{3}|20\d{2})\b/g, ' ');
+    if (!new RegExp(`\\b(\\d+|${WORD_NUMBERS})\\s+\\w+`, 'i').test(withoutYears)) {
+      kinds.delete('count');
+    }
+  }
+  return kinds;
+}
+
+export function explanationCarriesAdjacentClaims(
+  explanation: string | null | undefined,
+  stem: string,
+  answer: string,
+): boolean {
+  if (!explanation) return false;
+  const trimmed = explanation.trim();
+  if (trimmed.length < 60) return false; // too short to carry an independent claim
+  const explKinds = effectiveKinds(trimmed);
+  if (explKinds.size === 0) return false; // pure prose — nothing checkable
+  if (explKinds.size >= 2) return true; // claim-dense
+  const contextKinds = effectiveKinds(`${stem} ${answer}`);
+  for (const kind of explKinds) if (!contextKinds.has(kind)) return true; // novel kind
+  return false;
 }
 
 // The answer bundles an extra descriptor ("Eroica (Beethoven's Third, dedicated to
@@ -145,6 +192,13 @@ export type PrefilterOptions = {
    * before/after comparison. Default false (tightened heuristic).
    */
   legacyExtraFact?: boolean;
+  /**
+   * Use the pre-2026-07-05 explanation heuristic (any one signal OR length ≥140
+   * routes — the measured ~90% router). Operational escape hatch only — the cron
+   * passes this from PREFILTER_EXPLANATION_LEGACY; the measurement script uses it
+   * for the before/after comparison. Default false (adjacent-claims heuristic).
+   */
+  legacyExplanation?: boolean;
 };
 
 /**
@@ -178,12 +232,16 @@ export function prefilterForVerification(
   if (premiseBearing) dimensions.push('false_premise');
 
   // extra_fact: the explanation or the answer carries adjacent claims. The answer
-  // side requires bundling + an assertion signal (tightened 2026-07) unless the
-  // legacy escape hatch is on.
+  // side requires bundling + an assertion signal (tightened 2026-07); the
+  // explanation side requires a NOVEL or claim-dense assertion (tightened
+  // 2026-07-05 — the measured ~90% router). Each has its own legacy hatch.
   const answerRoutes = options?.legacyExtraFact
     ? answerIsMultiFact(answer)
     : answerCarriesAdjacentClaim(answer);
-  if (explanationCarriesClaims(input.explanation, answer) || answerRoutes) {
+  const explanationRoutes = options?.legacyExplanation
+    ? explanationCarriesClaimsLegacy(input.explanation)
+    : explanationCarriesAdjacentClaims(input.explanation, stem, answer);
+  if (explanationRoutes || answerRoutes) {
     dimensions.push('extra_fact');
   }
 

--- a/src/server/quality/verify-batch.ts
+++ b/src/server/quality/verify-batch.ts
@@ -43,14 +43,19 @@ export function isBatchVerifyAsyncEnabled(): boolean {
 /** 'q' = Question, 'g' = GeneratedQuestion — encoded into the batch custom_id. */
 export type VerifyStore = 'q' | 'g';
 
+// The Batches API constrains custom_id to ^[a-zA-Z0-9_-]{1,64}$ — a colon
+// separator is REJECTED at submit (invalid_request_error), which is exactly how
+// the async mode silently no-oped in prod (submit threw on every run; the cron
+// caught, logged, and returned 200). Underscore is in the allowed class and
+// unambiguous before a UUID. Decode tolerates the legacy colon form defensively.
 export function encodeVerifyCustomId(store: VerifyStore, rowId: string): string {
-  return `${store}:${rowId}`;
+  return `${store}_${rowId}`;
 }
 
 export function decodeVerifyCustomId(
   customId: string,
 ): { store: VerifyStore; rowId: string } | null {
-  const match = /^([qg]):(.+)$/.exec(customId);
+  const match = /^([qg])[_:](.+)$/.exec(customId);
   if (!match) return null;
   return { store: match[1] as VerifyStore, rowId: match[2] };
 }


### PR DESCRIPTION
`D-SUPPLY-FINITE-SET-01` P2 — the automatic completion trigger for the already-built trophy.

## What existed vs. what's new
The player-facing surface (`/invited`: gold trophy, receipts, three doors — author / go-broader / wait) already shipped as `B-CRAFTER-LIFECYCLE-01`, but was only ever lit by a **manual crafter checkbox**. This adds the automatic set-completion trigger + a durable designation.

## Behavior
- **Completion = coverage** (Josh's call): a player has answered every **distinct** question the domain's finite set holds — `distinct-answered ≥ durable pool depth` — gated by a floor (`SET_COMPLETION_MIN_SIZE = 8`) so a thin domain isn't a "set". Distinct (not raw event count) so a replay can't trophy.
- `evaluateSetCompletions()` runs at daily-summary build over the domains touched that round. A newly-completed domain gets a durable **designation** (`PLAYER_MASTERY.designated_at`, recognition only — no mechanical effect) + a **system `AuthorInvitation`** (`reason='set_completed'`, `invited_by=NULL`). The existing `InvitationTakeoverGate` routes to `/invited`. **No new surface.** Fail-open, idempotent.
- Fires only at the completion **transition** (a fully-answered domain isn't re-served), so the **13 pre-P2 completions across 4 players don't retroactively fire** — no backfill.

## Migration 0114 (applied to prod)
- `PLAYER_MASTERY.designated_at` — the durable half of the (previously ephemeral) trophy.
- `AuthorInvitation.invited_by` DROP NOT NULL — system invites have no human inviter.
- Boot guards mirror both.

## Tests
`isSetComplete` (floor / coverage) + `evaluateSetCompletions` (designate+invite once, idempotent, below-floor skip, fail-open). Drive-by: fixed the `enrich-variants` test's `@/lib/llm` mock (missing the `ANTHROPIC_MODEL` export the #1422 consolidation added — 2 tests were red on main).

## Out of scope
P3 (fill-once refill), P4 (curate-vs-fill routing), unifying the difficulty-ceiling expansion offer, any mechanical effect of a designation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrEnXchnUG6EVzVsUEB63V