### PR TITLE
Conservative salvage pass for demoted questions (D-QUALITY-SALVAGE-01)

### DIFF
--- a/drizzle/0115_question_salvage_proposal.sql
+++ b/drizzle/0115_question_salvage_proposal.sql
@@ -1,0 +1,39 @@
+-- 0115: QuestionSalvageProposal (D-QUALITY-SALVAGE-01).
+--
+-- Stores a machine-proposed MINIMAL fix for a verifier-demoted question — a
+-- trimmed/corrected stem or explainer that has already been re-verified — so a
+-- human can approve it with one click in the review queue instead of hand-editing
+-- each demotion. Never applied automatically; approving copies the proposed text
+-- through the normal edit/approve path. One live ('ready') proposal per question.
+--
+-- Purely additive: no existing table is altered. RLS enabled with no policies
+-- (the app connects as the owner role, which bypasses RLS) per B-SECURITY-RLS-01
+-- / migration 0081 — without it the table is reachable over Supabase's public
+-- Data API. Every statement is idempotent and mirrored by a defensive guard in
+-- src/instrumentation.ts (precedent: 0103's CrafterDraftDecision guard).
+--
+-- NB: 0114 (set-completion) lands from a sibling branch; this migration is
+-- independent of it (different table, no ordering dependency).
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "QuestionSalvageProposal";
+CREATE TABLE IF NOT EXISTS "QuestionSalvageProposal" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "question_id" text NOT NULL,
+  "target_table" text NOT NULL,
+  "kind" text NOT NULL,
+  "proposed_stem" text,
+  "proposed_explanation" text,
+  "reverify_outcome" text NOT NULL,
+  "reverify_reason" text,
+  "status" text NOT NULL DEFAULT 'ready',
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "QuestionSalvageProposal" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "QuestionSalvageProposal_question_id_idx" ON "QuestionSalvageProposal" ("question_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "QuestionSalvageProposal_active_question_key"
+  ON "QuestionSalvageProposal" ("question_id")
+  WHERE "status" = 'ready';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,804 +1,811 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1777585453077,
-      "tag": "0000_material_lyja",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1777630800000,
-      "tag": "0001_add_ceremony_ready_sms_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1777654136670,
-      "tag": "0002_add_joshing_game_sms_types",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1777654800000,
-      "tag": "0003_question_rating",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1777662000000,
-      "tag": "0004_daily_preference_configuration",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1777671600000,
-      "tag": "0005_profile_domain_visibility_three_state",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1777737600000,
-      "tag": "0006_question_reactions_contexts",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1777780800000,
-      "tag": "0007_send_to_friend_note",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1777784400000,
-      "tag": "0008_add_to_bank_provenance",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1777771056661,
-      "tag": "0009_domain_merge_events",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1777771056661,
-      "tag": "0010_feed_submitted_answer",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1777771056661,
-      "tag": "0011_preview_schema_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1777839477000,
-      "tag": "0012_feed_friend_answered",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1777840000000,
-      "tag": "0013_onboarding_demographics",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1777840100000,
-      "tag": "0014_territory_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1777840200000,
-      "tag": "0015_declared_promoted_event_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1777840300000,
-      "tag": "0016_quip_columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1777840400000,
-      "tag": "0017_creator_notes",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1777840500000,
-      "tag": "0018_daily_generated_and_player_mastery_territory",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1778508000000,
-      "tag": "0019_feed_item_nullable_columns_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1778510000000,
-      "tag": "0020_question_critique_verification",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1778521283376,
-      "tag": "0021_feed_dismissed_domains_active_unique",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1778538800000,
-      "tag": "0022_player_mastery_territory_type_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1778540000000,
-      "tag": "0023_profile_domain_visibility_runtime_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1778616500000,
-      "tag": "0024_question_surface_priority_runtime_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1778616600000,
-      "tag": "0025_grade_dispute_recheck_details",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1778616700000,
-      "tag": "0026_friend_invitation_pre_profile",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "7",
-      "when": 1778616800000,
-      "tag": "0027_friendship_request_context",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "7",
-      "when": 1778616900000,
-      "tag": "0028_remove_other_question_category",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "7",
-      "when": 1778714100000,
-      "tag": "0029_correct_answer_social_feed",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "7",
-      "when": 1778714200000,
-      "tag": "0030_apply_general_knowledge_category",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "7",
-      "when": 1778806800000,
-      "tag": "0031_feed_answered_card_data",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "7",
-      "when": 1778888376122,
-      "tag": "0032_biweekly_ceremony_unique_cycle",
-      "breakpoints": true
-    },
-    {
-      "idx": 33,
-      "version": "7",
-      "when": 1778910000000,
-      "tag": "0033_feed_item_source_result_check",
-      "breakpoints": true
-    },
-    {
-      "idx": 34,
-      "version": "7",
-      "when": 1778952386715,
-      "tag": "0034_territory_type_enum",
-      "breakpoints": true
-    },
-    {
-      "idx": 35,
-      "version": "7",
-      "when": 1779580800000,
-      "tag": "0035_mastery_events_viewer_status_idx",
-      "breakpoints": true
-    },
-    {
-      "idx": 36,
-      "version": "7",
-      "when": 1779667200000,
-      "tag": "0036_domain_exclusion_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 37,
-      "version": "7",
-      "when": 1779753600000,
-      "tag": "0037_round_reminder_optin",
-      "breakpoints": true
-    },
-    {
-      "idx": 38,
-      "version": "7",
-      "when": 1779840000000,
-      "tag": "0038_feed_item_catchup_resolved",
-      "breakpoints": true
-    },
-    {
-      "idx": 39,
-      "version": "7",
-      "when": 1779926400000,
-      "tag": "0039_repair_short_canonical_subcategory",
-      "breakpoints": true
-    },
-    {
-      "idx": 40,
-      "version": "7",
-      "when": 1780012800000,
-      "tag": "0040_question_reaction_include_submitted_answer",
-      "breakpoints": true
-    },
-    {
-      "idx": 41,
-      "version": "7",
-      "when": 1780099200000,
-      "tag": "0041_question_inside_joke",
-      "breakpoints": true
-    },
-    {
-      "idx": 42,
-      "version": "7",
-      "when": 1780185600000,
-      "tag": "0042_seed_player_mastery_for_declared_interests",
-      "breakpoints": true
-    },
-    {
-      "idx": 43,
-      "version": "7",
-      "when": 1780272000000,
-      "tag": "0043_rename_season_points_to_lifetime_baseline",
-      "breakpoints": true
-    },
-    {
-      "idx": 44,
-      "version": "7",
-      "when": 1780358400000,
-      "tag": "0044_user_last_activity_bell_opened_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 45,
-      "version": "7",
-      "when": 1780444800000,
-      "tag": "0045_user_handle",
-      "breakpoints": true
-    },
-    {
-      "idx": 46,
-      "version": "7",
-      "when": 1780531200000,
-      "tag": "0046_user_avatar_color",
-      "breakpoints": true
-    },
-    {
-      "idx": 47,
-      "version": "7",
-      "when": 1780617600000,
-      "tag": "0047_user_profile_fields",
-      "breakpoints": true
-    },
-    {
-      "idx": 48,
-      "version": "7",
-      "when": 1780704000000,
-      "tag": "0048_friends_privacy_foundation",
-      "breakpoints": true
-    },
-    {
-      "idx": 49,
-      "version": "7",
-      "when": 1780790400000,
-      "tag": "0049_user_invite_token",
-      "breakpoints": true
-    },
-    {
-      "idx": 50,
-      "version": "7",
-      "when": 1780876800000,
-      "tag": "0050_user_phone_hash_discovery",
-      "breakpoints": true
-    },
-    {
-      "idx": 51,
-      "version": "7",
-      "when": 1780963200000,
-      "tag": "0051_generated_question_fact_key",
-      "breakpoints": true
-    },
-    {
-      "idx": 52,
-      "version": "7",
-      "when": 1781049600000,
-      "tag": "0052_profile_section_visibility",
-      "breakpoints": true
-    },
-    {
-      "idx": 53,
-      "version": "7",
-      "when": 1781136000000,
-      "tag": "0053_drop_legacy_profile_visibility",
-      "breakpoints": true
-    },
-    {
-      "idx": 54,
-      "version": "7",
-      "when": 1781222400000,
-      "tag": "0054_redesign_profile",
-      "breakpoints": true
-    },
-    {
-      "idx": 55,
-      "version": "7",
-      "when": 1781308800000,
-      "tag": "0055_question_sub_angles",
-      "breakpoints": true
-    },
-    {
-      "idx": 56,
-      "version": "7",
-      "when": 1781395200000,
-      "tag": "0056_area_top_up_prompt",
-      "breakpoints": true
-    },
-    {
-      "idx": 57,
-      "version": "7",
-      "when": 1781481600000,
-      "tag": "0057_retire_creator_notes_and_quips",
-      "breakpoints": true
-    },
-    {
-      "idx": 58,
-      "version": "7",
-      "when": 1781568000000,
-      "tag": "0058_follow_model",
-      "breakpoints": true
-    },
-    {
-      "idx": 59,
-      "version": "7",
-      "when": 1781654400000,
-      "tag": "0059_niche_match_discoverability",
-      "breakpoints": true
-    },
-    {
-      "idx": 60,
-      "version": "7",
-      "when": 1781740800000,
-      "tag": "0060_generated_question_inside_joke",
-      "breakpoints": true
-    },
-    {
-      "idx": 61,
-      "version": "7",
-      "when": 1781827200000,
-      "tag": "0061_email_verification_token",
-      "breakpoints": true
-    },
-    {
-      "idx": 62,
-      "version": "7",
-      "when": 1781913600000,
-      "tag": "0062_pool_substrate_trust_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 63,
-      "version": "7",
-      "when": 1782000000000,
-      "tag": "0063_pool_embeddings",
-      "breakpoints": true
-    },
-    {
-      "idx": 64,
-      "version": "7",
-      "when": 1782086400000,
-      "tag": "0064_domain_difficulty_freeze",
-      "breakpoints": true
-    },
-    {
-      "idx": 65,
-      "version": "7",
-      "when": 1782172800000,
-      "tag": "0065_daily_refine_decision",
-      "breakpoints": true
-    },
-    {
-      "idx": 66,
-      "version": "7",
-      "when": 1782259200000,
-      "tag": "0066_ask_to_answer_verified",
-      "breakpoints": true
-    },
-    {
-      "idx": 67,
-      "version": "7",
-      "when": 1782345600000,
-      "tag": "0067_human_validated_backfill",
-      "breakpoints": true
-    },
-    {
-      "idx": 68,
-      "version": "7",
-      "when": 1782432000000,
-      "tag": "0068_acceptable_variants",
-      "breakpoints": true
-    },
-    {
-      "idx": 69,
-      "version": "7",
-      "when": 1782518400000,
-      "tag": "0069_question_visibility_blocked",
-      "breakpoints": true
-    },
-    {
-      "idx": 70,
-      "version": "7",
-      "when": 1782604800000,
-      "tag": "0070_daily_domain_preference_frequency",
-      "breakpoints": true
-    },
-    {
-      "idx": 71,
-      "version": "7",
-      "when": 1782691200000,
-      "tag": "0071_pg_trgm_convergence",
-      "breakpoints": true
-    },
-    {
-      "idx": 72,
-      "version": "7",
-      "when": 1782777600000,
-      "tag": "0072_first_session_recap_seen",
-      "breakpoints": true
-    },
-    {
-      "idx": 73,
-      "version": "7",
-      "when": 1782864000000,
-      "tag": "0073_content_report",
-      "breakpoints": true
-    },
-    {
-      "idx": 74,
-      "version": "7",
-      "when": 1782950400000,
-      "tag": "0074_generated_question_domain_key",
-      "breakpoints": true
-    },
-    {
-      "idx": 75,
-      "version": "7",
-      "when": 1783036800000,
-      "tag": "0075_daily_queue_email_reminder",
-      "breakpoints": true
-    },
-    {
-      "idx": 76,
-      "version": "7",
-      "when": 1783123200000,
-      "tag": "0076_first_game_recap_seen",
-      "breakpoints": true
-    },
-    {
-      "idx": 77,
-      "version": "7",
-      "when": 1783209600000,
-      "tag": "0077_email_verification_opt_in_intent",
-      "breakpoints": true
-    },
-    {
-      "idx": 78,
-      "version": "7",
-      "when": 1783296000000,
-      "tag": "0078_perf_lookup_indexes",
-      "breakpoints": true
-    },
-    {
-      "idx": 79,
-      "version": "7",
-      "when": 1783382400000,
-      "tag": "0079_perf_fk_covering_indexes",
-      "breakpoints": true
-    },
-    {
-      "idx": 80,
-      "version": "7",
-      "when": 1783468800000,
-      "tag": "0080_question_author_deleted",
-      "breakpoints": true
-    },
-    {
-      "idx": 81,
-      "version": "7",
-      "when": 1783555200000,
-      "tag": "0081_enable_rls_public_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 82,
-      "version": "7",
-      "when": 1783641600000,
-      "tag": "0082_question_bank_added_at_idx",
-      "breakpoints": true
-    },
-    {
-      "idx": 83,
-      "version": "7",
-      "when": 1783728000000,
-      "tag": "0083_fk_covering_indexes",
-      "breakpoints": true
-    },
-    {
-      "idx": 84,
-      "version": "7",
-      "when": 1783814400000,
-      "tag": "0084_via_attribution",
-      "breakpoints": true
-    },
-    {
-      "idx": 85,
-      "version": "7",
-      "when": 1783900800000,
-      "tag": "0085_feed_item_answered_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 86,
-      "version": "7",
-      "when": 1783987200000,
-      "tag": "0086_subject_entity",
-      "breakpoints": true
-    },
-    {
-      "idx": 87,
-      "version": "7",
-      "when": 1784073600000,
-      "tag": "0087_app_settings",
-      "breakpoints": true
-    },
-    {
-      "idx": 88,
-      "version": "7",
-      "when": 1784160000000,
-      "tag": "0088_provider_provenance",
-      "breakpoints": true
-    },
-    {
-      "idx": 89,
-      "version": "7",
-      "when": 1784246400000,
-      "tag": "0089_domain_expansion_offer",
-      "breakpoints": true
-    },
-    {
-      "idx": 90,
-      "version": "7",
-      "when": 1784332800000,
-      "tag": "0090_llm_provider_change_log",
-      "breakpoints": true
-    },
-    {
-      "idx": 91,
-      "version": "7",
-      "when": 1784419200000,
-      "tag": "0091_llm_usage_event",
-      "breakpoints": true
-    },
-    {
-      "idx": 92,
-      "version": "7",
-      "when": 1784505600000,
-      "tag": "0092_llm_cost_report",
-      "breakpoints": true
-    },
-    {
-      "idx": 93,
-      "version": "7",
-      "when": 1784592000000,
-      "tag": "0093_recovered_set_aside",
-      "breakpoints": true
-    },
-    {
-      "idx": 94,
-      "version": "7",
-      "when": 1784678400000,
-      "tag": "0094_expansion_mastery_event_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 95,
-      "version": "7",
-      "when": 1784764800000,
-      "tag": "0095_player_mastery_rotation_eligible",
-      "breakpoints": true
-    },
-    {
-      "idx": 96,
-      "version": "7",
-      "when": 1784851200000,
-      "tag": "0096_question_verification",
-      "breakpoints": true
-    },
-    {
-      "idx": 97,
-      "version": "7",
-      "when": 1784937600000,
-      "tag": "0097_quality_report",
-      "breakpoints": true
-    },
-    {
-      "idx": 98,
-      "version": "7",
-      "when": 1785024000000,
-      "tag": "0098_retrieval_domain_health",
-      "breakpoints": true
-    },
-    {
-      "idx": 99,
-      "version": "7",
-      "when": 1785110400000,
-      "tag": "0099_domain_relation",
-      "breakpoints": true
-    },
-    {
-      "idx": 100,
-      "version": "7",
-      "when": 1785196800000,
-      "tag": "0100_verification_reason",
-      "breakpoints": true
-    },
-    {
-      "idx": 101,
-      "version": "7",
-      "when": 1785283200000,
-      "tag": "0101_author_invitation",
-      "breakpoints": true
-    },
-    {
-      "idx": 102,
-      "version": "7",
-      "when": 1785369600000,
-      "tag": "0102_knowledge_graph",
-      "breakpoints": true
-    },
-    {
-      "idx": 103,
-      "version": "7",
-      "when": 1785456000000,
-      "tag": "0103_crafter_draft_decision",
-      "breakpoints": true
-    },
-    {
-      "idx": 104,
-      "version": "7",
-      "when": 1785542400000,
-      "tag": "0104_knowledge_parent_mastery",
-      "breakpoints": true
-    },
-    {
-      "idx": 105,
-      "version": "7",
-      "when": 1785628800000,
-      "tag": "0105_llm_usage_web_search",
-      "breakpoints": true
-    },
-    {
-      "idx": 106,
-      "version": "7",
-      "when": 1785715200000,
-      "tag": "0106_verify_batch_run",
-      "breakpoints": true
-    },
-    {
-      "idx": 107,
-      "version": "7",
-      "when": 1785801600000,
-      "tag": "0107_knowledge_node_wikidata_qid",
-      "breakpoints": true
-    },
-    {
-      "idx": 108,
-      "version": "7",
-      "when": 1785888000000,
-      "tag": "0108_domain_reference_passage",
-      "breakpoints": true
-    },
-    {
-      "idx": 109,
-      "version": "7",
-      "when": 1785974400000,
-      "tag": "0109_knowledge_node_weight",
-      "breakpoints": true
-    },
-    {
-      "idx": 110,
-      "version": "7",
-      "when": 1786060800000,
-      "tag": "0110_drop_knowledge_edge_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 111,
-      "version": "7",
-      "when": 1786147200000,
-      "tag": "0111_knowledge_leaf_mastery",
-      "breakpoints": true
-    },
-    {
-      "idx": 112,
-      "version": "7",
-      "when": 1786233600000,
-      "tag": "0112_drop_node_weight",
-      "breakpoints": true
-    },
-    {
-      "idx": 113,
-      "version": "7",
-      "when": 1786320000000,
-      "tag": "0113_milestone_dismissed",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1777585453077,
+			"tag": "0000_material_lyja",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1777630800000,
+			"tag": "0001_add_ceremony_ready_sms_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1777654136670,
+			"tag": "0002_add_joshing_game_sms_types",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1777654800000,
+			"tag": "0003_question_rating",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1777662000000,
+			"tag": "0004_daily_preference_configuration",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1777671600000,
+			"tag": "0005_profile_domain_visibility_three_state",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1777737600000,
+			"tag": "0006_question_reactions_contexts",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1777780800000,
+			"tag": "0007_send_to_friend_note",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1777784400000,
+			"tag": "0008_add_to_bank_provenance",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1777771056661,
+			"tag": "0009_domain_merge_events",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1777771056661,
+			"tag": "0010_feed_submitted_answer",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1777771056661,
+			"tag": "0011_preview_schema_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1777839477000,
+			"tag": "0012_feed_friend_answered",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1777840000000,
+			"tag": "0013_onboarding_demographics",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1777840100000,
+			"tag": "0014_territory_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1777840200000,
+			"tag": "0015_declared_promoted_event_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1777840300000,
+			"tag": "0016_quip_columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1777840400000,
+			"tag": "0017_creator_notes",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1777840500000,
+			"tag": "0018_daily_generated_and_player_mastery_territory",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1778508000000,
+			"tag": "0019_feed_item_nullable_columns_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1778510000000,
+			"tag": "0020_question_critique_verification",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1778521283376,
+			"tag": "0021_feed_dismissed_domains_active_unique",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1778538800000,
+			"tag": "0022_player_mastery_territory_type_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1778540000000,
+			"tag": "0023_profile_domain_visibility_runtime_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1778616500000,
+			"tag": "0024_question_surface_priority_runtime_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1778616600000,
+			"tag": "0025_grade_dispute_recheck_details",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1778616700000,
+			"tag": "0026_friend_invitation_pre_profile",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1778616800000,
+			"tag": "0027_friendship_request_context",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1778616900000,
+			"tag": "0028_remove_other_question_category",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "7",
+			"when": 1778714100000,
+			"tag": "0029_correct_answer_social_feed",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1778714200000,
+			"tag": "0030_apply_general_knowledge_category",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1778806800000,
+			"tag": "0031_feed_answered_card_data",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "7",
+			"when": 1778888376122,
+			"tag": "0032_biweekly_ceremony_unique_cycle",
+			"breakpoints": true
+		},
+		{
+			"idx": 33,
+			"version": "7",
+			"when": 1778910000000,
+			"tag": "0033_feed_item_source_result_check",
+			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1778952386715,
+			"tag": "0034_territory_type_enum",
+			"breakpoints": true
+		},
+		{
+			"idx": 35,
+			"version": "7",
+			"when": 1779580800000,
+			"tag": "0035_mastery_events_viewer_status_idx",
+			"breakpoints": true
+		},
+		{
+			"idx": 36,
+			"version": "7",
+			"when": 1779667200000,
+			"tag": "0036_domain_exclusion_scope",
+			"breakpoints": true
+		},
+		{
+			"idx": 37,
+			"version": "7",
+			"when": 1779753600000,
+			"tag": "0037_round_reminder_optin",
+			"breakpoints": true
+		},
+		{
+			"idx": 38,
+			"version": "7",
+			"when": 1779840000000,
+			"tag": "0038_feed_item_catchup_resolved",
+			"breakpoints": true
+		},
+		{
+			"idx": 39,
+			"version": "7",
+			"when": 1779926400000,
+			"tag": "0039_repair_short_canonical_subcategory",
+			"breakpoints": true
+		},
+		{
+			"idx": 40,
+			"version": "7",
+			"when": 1780012800000,
+			"tag": "0040_question_reaction_include_submitted_answer",
+			"breakpoints": true
+		},
+		{
+			"idx": 41,
+			"version": "7",
+			"when": 1780099200000,
+			"tag": "0041_question_inside_joke",
+			"breakpoints": true
+		},
+		{
+			"idx": 42,
+			"version": "7",
+			"when": 1780185600000,
+			"tag": "0042_seed_player_mastery_for_declared_interests",
+			"breakpoints": true
+		},
+		{
+			"idx": 43,
+			"version": "7",
+			"when": 1780272000000,
+			"tag": "0043_rename_season_points_to_lifetime_baseline",
+			"breakpoints": true
+		},
+		{
+			"idx": 44,
+			"version": "7",
+			"when": 1780358400000,
+			"tag": "0044_user_last_activity_bell_opened_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 45,
+			"version": "7",
+			"when": 1780444800000,
+			"tag": "0045_user_handle",
+			"breakpoints": true
+		},
+		{
+			"idx": 46,
+			"version": "7",
+			"when": 1780531200000,
+			"tag": "0046_user_avatar_color",
+			"breakpoints": true
+		},
+		{
+			"idx": 47,
+			"version": "7",
+			"when": 1780617600000,
+			"tag": "0047_user_profile_fields",
+			"breakpoints": true
+		},
+		{
+			"idx": 48,
+			"version": "7",
+			"when": 1780704000000,
+			"tag": "0048_friends_privacy_foundation",
+			"breakpoints": true
+		},
+		{
+			"idx": 49,
+			"version": "7",
+			"when": 1780790400000,
+			"tag": "0049_user_invite_token",
+			"breakpoints": true
+		},
+		{
+			"idx": 50,
+			"version": "7",
+			"when": 1780876800000,
+			"tag": "0050_user_phone_hash_discovery",
+			"breakpoints": true
+		},
+		{
+			"idx": 51,
+			"version": "7",
+			"when": 1780963200000,
+			"tag": "0051_generated_question_fact_key",
+			"breakpoints": true
+		},
+		{
+			"idx": 52,
+			"version": "7",
+			"when": 1781049600000,
+			"tag": "0052_profile_section_visibility",
+			"breakpoints": true
+		},
+		{
+			"idx": 53,
+			"version": "7",
+			"when": 1781136000000,
+			"tag": "0053_drop_legacy_profile_visibility",
+			"breakpoints": true
+		},
+		{
+			"idx": 54,
+			"version": "7",
+			"when": 1781222400000,
+			"tag": "0054_redesign_profile",
+			"breakpoints": true
+		},
+		{
+			"idx": 55,
+			"version": "7",
+			"when": 1781308800000,
+			"tag": "0055_question_sub_angles",
+			"breakpoints": true
+		},
+		{
+			"idx": 56,
+			"version": "7",
+			"when": 1781395200000,
+			"tag": "0056_area_top_up_prompt",
+			"breakpoints": true
+		},
+		{
+			"idx": 57,
+			"version": "7",
+			"when": 1781481600000,
+			"tag": "0057_retire_creator_notes_and_quips",
+			"breakpoints": true
+		},
+		{
+			"idx": 58,
+			"version": "7",
+			"when": 1781568000000,
+			"tag": "0058_follow_model",
+			"breakpoints": true
+		},
+		{
+			"idx": 59,
+			"version": "7",
+			"when": 1781654400000,
+			"tag": "0059_niche_match_discoverability",
+			"breakpoints": true
+		},
+		{
+			"idx": 60,
+			"version": "7",
+			"when": 1781740800000,
+			"tag": "0060_generated_question_inside_joke",
+			"breakpoints": true
+		},
+		{
+			"idx": 61,
+			"version": "7",
+			"when": 1781827200000,
+			"tag": "0061_email_verification_token",
+			"breakpoints": true
+		},
+		{
+			"idx": 62,
+			"version": "7",
+			"when": 1781913600000,
+			"tag": "0062_pool_substrate_trust_scope",
+			"breakpoints": true
+		},
+		{
+			"idx": 63,
+			"version": "7",
+			"when": 1782000000000,
+			"tag": "0063_pool_embeddings",
+			"breakpoints": true
+		},
+		{
+			"idx": 64,
+			"version": "7",
+			"when": 1782086400000,
+			"tag": "0064_domain_difficulty_freeze",
+			"breakpoints": true
+		},
+		{
+			"idx": 65,
+			"version": "7",
+			"when": 1782172800000,
+			"tag": "0065_daily_refine_decision",
+			"breakpoints": true
+		},
+		{
+			"idx": 66,
+			"version": "7",
+			"when": 1782259200000,
+			"tag": "0066_ask_to_answer_verified",
+			"breakpoints": true
+		},
+		{
+			"idx": 67,
+			"version": "7",
+			"when": 1782345600000,
+			"tag": "0067_human_validated_backfill",
+			"breakpoints": true
+		},
+		{
+			"idx": 68,
+			"version": "7",
+			"when": 1782432000000,
+			"tag": "0068_acceptable_variants",
+			"breakpoints": true
+		},
+		{
+			"idx": 69,
+			"version": "7",
+			"when": 1782518400000,
+			"tag": "0069_question_visibility_blocked",
+			"breakpoints": true
+		},
+		{
+			"idx": 70,
+			"version": "7",
+			"when": 1782604800000,
+			"tag": "0070_daily_domain_preference_frequency",
+			"breakpoints": true
+		},
+		{
+			"idx": 71,
+			"version": "7",
+			"when": 1782691200000,
+			"tag": "0071_pg_trgm_convergence",
+			"breakpoints": true
+		},
+		{
+			"idx": 72,
+			"version": "7",
+			"when": 1782777600000,
+			"tag": "0072_first_session_recap_seen",
+			"breakpoints": true
+		},
+		{
+			"idx": 73,
+			"version": "7",
+			"when": 1782864000000,
+			"tag": "0073_content_report",
+			"breakpoints": true
+		},
+		{
+			"idx": 74,
+			"version": "7",
+			"when": 1782950400000,
+			"tag": "0074_generated_question_domain_key",
+			"breakpoints": true
+		},
+		{
+			"idx": 75,
+			"version": "7",
+			"when": 1783036800000,
+			"tag": "0075_daily_queue_email_reminder",
+			"breakpoints": true
+		},
+		{
+			"idx": 76,
+			"version": "7",
+			"when": 1783123200000,
+			"tag": "0076_first_game_recap_seen",
+			"breakpoints": true
+		},
+		{
+			"idx": 77,
+			"version": "7",
+			"when": 1783209600000,
+			"tag": "0077_email_verification_opt_in_intent",
+			"breakpoints": true
+		},
+		{
+			"idx": 78,
+			"version": "7",
+			"when": 1783296000000,
+			"tag": "0078_perf_lookup_indexes",
+			"breakpoints": true
+		},
+		{
+			"idx": 79,
+			"version": "7",
+			"when": 1783382400000,
+			"tag": "0079_perf_fk_covering_indexes",
+			"breakpoints": true
+		},
+		{
+			"idx": 80,
+			"version": "7",
+			"when": 1783468800000,
+			"tag": "0080_question_author_deleted",
+			"breakpoints": true
+		},
+		{
+			"idx": 81,
+			"version": "7",
+			"when": 1783555200000,
+			"tag": "0081_enable_rls_public_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 82,
+			"version": "7",
+			"when": 1783641600000,
+			"tag": "0082_question_bank_added_at_idx",
+			"breakpoints": true
+		},
+		{
+			"idx": 83,
+			"version": "7",
+			"when": 1783728000000,
+			"tag": "0083_fk_covering_indexes",
+			"breakpoints": true
+		},
+		{
+			"idx": 84,
+			"version": "7",
+			"when": 1783814400000,
+			"tag": "0084_via_attribution",
+			"breakpoints": true
+		},
+		{
+			"idx": 85,
+			"version": "7",
+			"when": 1783900800000,
+			"tag": "0085_feed_item_answered_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 86,
+			"version": "7",
+			"when": 1783987200000,
+			"tag": "0086_subject_entity",
+			"breakpoints": true
+		},
+		{
+			"idx": 87,
+			"version": "7",
+			"when": 1784073600000,
+			"tag": "0087_app_settings",
+			"breakpoints": true
+		},
+		{
+			"idx": 88,
+			"version": "7",
+			"when": 1784160000000,
+			"tag": "0088_provider_provenance",
+			"breakpoints": true
+		},
+		{
+			"idx": 89,
+			"version": "7",
+			"when": 1784246400000,
+			"tag": "0089_domain_expansion_offer",
+			"breakpoints": true
+		},
+		{
+			"idx": 90,
+			"version": "7",
+			"when": 1784332800000,
+			"tag": "0090_llm_provider_change_log",
+			"breakpoints": true
+		},
+		{
+			"idx": 91,
+			"version": "7",
+			"when": 1784419200000,
+			"tag": "0091_llm_usage_event",
+			"breakpoints": true
+		},
+		{
+			"idx": 92,
+			"version": "7",
+			"when": 1784505600000,
+			"tag": "0092_llm_cost_report",
+			"breakpoints": true
+		},
+		{
+			"idx": 93,
+			"version": "7",
+			"when": 1784592000000,
+			"tag": "0093_recovered_set_aside",
+			"breakpoints": true
+		},
+		{
+			"idx": 94,
+			"version": "7",
+			"when": 1784678400000,
+			"tag": "0094_expansion_mastery_event_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 95,
+			"version": "7",
+			"when": 1784764800000,
+			"tag": "0095_player_mastery_rotation_eligible",
+			"breakpoints": true
+		},
+		{
+			"idx": 96,
+			"version": "7",
+			"when": 1784851200000,
+			"tag": "0096_question_verification",
+			"breakpoints": true
+		},
+		{
+			"idx": 97,
+			"version": "7",
+			"when": 1784937600000,
+			"tag": "0097_quality_report",
+			"breakpoints": true
+		},
+		{
+			"idx": 98,
+			"version": "7",
+			"when": 1785024000000,
+			"tag": "0098_retrieval_domain_health",
+			"breakpoints": true
+		},
+		{
+			"idx": 99,
+			"version": "7",
+			"when": 1785110400000,
+			"tag": "0099_domain_relation",
+			"breakpoints": true
+		},
+		{
+			"idx": 100,
+			"version": "7",
+			"when": 1785196800000,
+			"tag": "0100_verification_reason",
+			"breakpoints": true
+		},
+		{
+			"idx": 101,
+			"version": "7",
+			"when": 1785283200000,
+			"tag": "0101_author_invitation",
+			"breakpoints": true
+		},
+		{
+			"idx": 102,
+			"version": "7",
+			"when": 1785369600000,
+			"tag": "0102_knowledge_graph",
+			"breakpoints": true
+		},
+		{
+			"idx": 103,
+			"version": "7",
+			"when": 1785456000000,
+			"tag": "0103_crafter_draft_decision",
+			"breakpoints": true
+		},
+		{
+			"idx": 104,
+			"version": "7",
+			"when": 1785542400000,
+			"tag": "0104_knowledge_parent_mastery",
+			"breakpoints": true
+		},
+		{
+			"idx": 105,
+			"version": "7",
+			"when": 1785628800000,
+			"tag": "0105_llm_usage_web_search",
+			"breakpoints": true
+		},
+		{
+			"idx": 106,
+			"version": "7",
+			"when": 1785715200000,
+			"tag": "0106_verify_batch_run",
+			"breakpoints": true
+		},
+		{
+			"idx": 107,
+			"version": "7",
+			"when": 1785801600000,
+			"tag": "0107_knowledge_node_wikidata_qid",
+			"breakpoints": true
+		},
+		{
+			"idx": 108,
+			"version": "7",
+			"when": 1785888000000,
+			"tag": "0108_domain_reference_passage",
+			"breakpoints": true
+		},
+		{
+			"idx": 109,
+			"version": "7",
+			"when": 1785974400000,
+			"tag": "0109_knowledge_node_weight",
+			"breakpoints": true
+		},
+		{
+			"idx": 110,
+			"version": "7",
+			"when": 1786060800000,
+			"tag": "0110_drop_knowledge_edge_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 111,
+			"version": "7",
+			"when": 1786147200000,
+			"tag": "0111_knowledge_leaf_mastery",
+			"breakpoints": true
+		},
+		{
+			"idx": 112,
+			"version": "7",
+			"when": 1786233600000,
+			"tag": "0112_drop_node_weight",
+			"breakpoints": true
+		},
+		{
+			"idx": 113,
+			"version": "7",
+			"when": 1786320000000,
+			"tag": "0113_milestone_dismissed",
+			"breakpoints": true
+		},
+		{
+			"idx": 115,
+			"version": "7",
+			"when": 1786492800000,
+			"tag": "0115_question_salvage_proposal",
+			"breakpoints": true
+		}
+	]
 }

--- a/scripts/salvage-demoted.ts
+++ b/scripts/salvage-demoted.ts
@@ -1,0 +1,155 @@
+/**
+ * Salvage pass over the demoted-question review queue (D-QUALITY-SALVAGE-01).
+ *
+ * A sample of the queue showed ~80% of demotions are not wrong answers — they
+ * are one removable/wrong fact (usually a decorative aside in the explainer)
+ * while the ask + headline answer are correct. For each demoted Question this
+ * proposes the MINIMAL fix (proposeSalvage), re-verifies the PROPOSED version
+ * (verifyQuestion directly — so we check our exact edit against the existing
+ * answer), and stores a proposal. Nothing is applied: a human approves each
+ * ready diff in the review queue (conservative). Broken cores → 'unsalvageable'.
+ *
+ * Read-only by default (proposes + prints a triage census). Run from repo root:
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/salvage-demoted.ts          # dry-run: propose + census, persist nothing
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/salvage-demoted.ts --write   # persist proposals to QuestionSalvageProposal
+ *
+ * --write only ever touches the QuestionSalvageProposal table; Question/
+ * GeneratedQuestion rows are never modified by this script.
+ */
+import 'dotenv/config';
+
+import { pool } from '../src/server/db';
+import { getMachineDemotionsForReview } from '../src/server/db/queries/machine-demotions';
+import {
+  questionIdsWithProposal,
+  upsertSalvageProposal,
+} from '../src/server/db/queries/salvage-proposals';
+import { proposeSalvage } from '../src/server/quality/salvage-question';
+import { verifyQuestion } from '../src/server/quality/verify-question';
+
+const WRITE = process.argv.includes('--write');
+const CONCURRENCY = 5;
+// --limit N: process only the first N of the queue (validation runs).
+const LIMIT_ARG = process.argv.find((a) => a.startsWith('--limit='));
+const LIMIT = LIMIT_ARG ? Math.max(1, Number(LIMIT_ARG.split('=')[1]) || 0) : Infinity;
+
+type Outcome = 'ready' | 'reverify_failed' | 'unsalvageable' | 'skipped_existing';
+
+async function processOne(item: {
+  questionId: string;
+  questionText: string;
+  correctAnswer: string;
+  explanation: string | null;
+  verificationReason: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+}): Promise<{ outcome: Outcome; note: string }> {
+  const proposal = await proposeSalvage({
+    questionText: item.questionText,
+    answer: item.correctAnswer,
+    explanation: item.explanation,
+    verificationReason: item.verificationReason ?? 'demoted (reason not captured)',
+    canonicalSubcategory: item.canonicalSubcategory,
+    broadCategory: item.broadCategory,
+  });
+
+  if (proposal.kind === 'unsalvageable') {
+    if (WRITE) {
+      await upsertSalvageProposal({
+        questionId: item.questionId,
+        targetTable: 'question',
+        kind: 'unsalvageable',
+        proposedStem: null,
+        proposedExplanation: null,
+        reverifyOutcome: 'demoted',
+        reverifyReason: proposal.note,
+        status: 'unsalvageable',
+      });
+    }
+    return { outcome: 'unsalvageable', note: proposal.note };
+  }
+
+  // Re-verify the PROPOSED version against the EXISTING answer (verifyQuestion
+  // directly — rerunQuestion would regenerate the answer + overwrite our
+  // proposed explainer). Fall back to originals for the field we didn't touch.
+  const reverify = await verifyQuestion({
+    questionText: proposal.proposedStem ?? item.questionText,
+    answer: item.correctAnswer,
+    explanation: proposal.proposedExplanation ?? item.explanation ?? undefined,
+    canonicalSubcategory: item.canonicalSubcategory ?? undefined,
+    broadCategory: item.broadCategory ?? undefined,
+    dimensions: ['false_premise', 'extra_fact'],
+  });
+
+  // Only a proposal that now PASSES becomes 'ready'; anything else is not shown.
+  const passed = reverify?.outcome === 'ok';
+  if (WRITE) {
+    await upsertSalvageProposal({
+      questionId: item.questionId,
+      targetTable: 'question',
+      kind: proposal.kind,
+      proposedStem: proposal.proposedStem,
+      proposedExplanation: proposal.proposedExplanation,
+      reverifyOutcome: reverify?.outcome ?? 'unverifiable',
+      reverifyReason: reverify?.reason ?? 'reverify unavailable',
+      status: passed ? 'ready' : 'unsalvageable',
+    });
+  }
+  return {
+    outcome: passed ? 'ready' : 'reverify_failed',
+    note: `${proposal.kind}: ${proposal.note}${passed ? '' : ` → reverify=${reverify?.outcome ?? 'none'}`}`,
+  };
+}
+
+async function main() {
+  const fullQueue = await getMachineDemotionsForReview();
+  const queue = Number.isFinite(LIMIT) ? fullQueue.slice(0, LIMIT) : fullQueue;
+  const already = await questionIdsWithProposal(queue.map((q) => q.questionId));
+  const todo = queue.filter((q) => !already.has(q.questionId));
+
+  console.log(
+    `[salvage] queue=${queue.length} already_proposed=${already.size} to_process=${todo.length} mode=${WRITE ? 'WRITE' : 'DRY-RUN'}`,
+  );
+
+  const tally: Record<Outcome, number> = {
+    ready: 0,
+    reverify_failed: 0,
+    unsalvageable: 0,
+    skipped_existing: already.size,
+  };
+
+  for (let i = 0; i < todo.length; i += CONCURRENCY) {
+    const chunk = todo.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(
+      chunk.map(async (item) => {
+        try {
+          return await processOne(item);
+        } catch (error) {
+          return {
+            outcome: 'reverify_failed' as Outcome,
+            note: `error: ${error instanceof Error ? error.message : String(error)}`,
+          };
+        }
+      }),
+    );
+    results.forEach((r, j) => {
+      tally[r.outcome]++;
+      const stem = chunk[j].questionText.slice(0, 60).replace(/\s+/g, ' ');
+      console.log(`  [${r.outcome}] ${stem}… — ${r.note}`);
+    });
+  }
+
+  console.log('\n[salvage] census:', JSON.stringify(tally));
+  const salvageable = tally.ready;
+  const pct = todo.length ? Math.round((salvageable / todo.length) * 100) : 0;
+  console.log(
+    `[salvage] ${salvageable}/${todo.length} processed became one-click-ready (${pct}%). ${WRITE ? 'Persisted.' : 'Dry-run — re-run with --write to persist.'}`,
+  );
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => pool.end());

--- a/src/app/admin/reports/AdminReportsClient.tsx
+++ b/src/app/admin/reports/AdminReportsClient.tsx
@@ -161,6 +161,10 @@ export function AdminReportsClient({
       })),
   ].sort((a, b) => a.at - b.at);
   const openCount = inappropriate.length + rest.length;
+  // D-QUALITY-SALVAGE-01: how many demotions have a ready one-click fix waiting.
+  const readyFixCount = demotions.filter(
+    (item) => item.proposal && !hiddenKey(`demotion:${item.questionId}`),
+  ).length;
 
   return (
     <main className="mx-auto min-h-dvh max-w-3xl px-4 pt-6 pb-24">
@@ -173,6 +177,12 @@ export function AdminReportsClient({
           Two streams, one queue: players reported these, or the verifier pulled them pending your
           call. Nothing here is deleted — flagged questions sit out of circulation until you act.
         </p>
+        {readyFixCount > 0 ? (
+          <p className="mt-2 text-sm font-medium text-[var(--success)]">
+            {readyFixCount} {readyFixCount === 1 ? 'has' : 'have'} a suggested fix that re-verifies
+            clean — look for “Review fix”.
+          </p>
+        ) : null}
         <div className="mt-3 flex gap-2">
           <TabButton active={view === 'open'} onClick={() => setView('open')}>
             Needing review ({openCount})
@@ -913,6 +923,9 @@ function DemotionRow({
 }) {
   const router = useRouter();
   const [editing, setEditing] = useState(false);
+  // Opened from the "Review fix" button → EditPanel pre-fills the machine's
+  // proposed edit (D-QUALITY-SALVAGE-01). The human still re-runs + approves.
+  const [fixMode, setFixMode] = useState(false);
 
   function resolved() {
     onCleared();
@@ -925,6 +938,20 @@ function DemotionRow({
       label: action === 'restore_demoted' ? 'Restored to circulation' : 'Retired (recoverable)',
       body: { action, questionId: item.questionId },
     });
+  }
+
+  function rejectFix() {
+    onStage({
+      key: `demotion:${item.questionId}`,
+      label: 'Suggested fix dismissed',
+      body: { action: 'reject_salvage', questionId: item.questionId },
+    });
+  }
+
+  const proposal = item.proposal;
+  function openFix() {
+    setFixMode(true);
+    setEditing(true);
   }
 
   const authorLabel = item.authorIsHouse
@@ -970,24 +997,63 @@ function DemotionRow({
         {item.verificationReason ?? 'reason not captured (demoted before reasons were stored)'}
       </p>
 
+      {/* D-QUALITY-SALVAGE-01: a machine-proposed minimal fix that already
+          re-verified clean. Conservative — "Review fix" opens the same edit panel
+          pre-filled; the human still re-runs + approves. Nothing auto-applies. */}
+      {proposal && !editing ? (
+        <div
+          className="mt-2 rounded-md border px-3 py-2 text-[13px]"
+          style={{ borderColor: 'var(--success)', background: 'var(--success-surface, transparent)' }}
+        >
+          <p className="font-semibold text-[var(--success)]">
+            Suggested fix — verifier re-checked, now passes
+          </p>
+          <p className="text-muted-foreground mt-0.5">
+            {proposal.kind === 'extra_fact_explainer' ? 'Explainer' : 'Question'} · {proposal.reverifyReason ?? 'minimal edit'}
+          </p>
+          {proposal.proposedStem ? (
+            <p className="mt-1 text-[var(--brand-ink)]">
+              <span className="text-muted-foreground">Proposed question: </span>
+              {proposal.proposedStem}
+            </p>
+          ) : null}
+          {proposal.proposedExplanation ? (
+            <p className="mt-1 text-[var(--brand-ink-700)]">
+              <span className="text-muted-foreground">Proposed explainer: </span>
+              {proposal.proposedExplanation}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
       {editing ? (
-        <Modal title="Edit &amp; re-run" onClose={() => setEditing(false)}>
+        <Modal title="Edit &amp; re-run" onClose={() => { setEditing(false); setFixMode(false); }}>
           <EditPanel
             target={{ table: 'question', id: item.questionId }}
-            initialQuestion={item.questionText}
+            initialQuestion={fixMode && proposal?.proposedStem ? proposal.proposedStem : item.questionText}
             initialAnswer={item.correctAnswer}
-            initialExplanation={item.explanation}
+            initialExplanation={fixMode && proposal?.proposedExplanation ? proposal.proposedExplanation : item.explanation}
             showExplanation
             canonicalSubcategory={item.canonicalSubcategory}
             broadCategory={item.broadCategory}
             concern={item.verificationReason ?? 'demoted by the verifier (reason not captured)'}
             onDone={resolved}
-            onCancel={() => setEditing(false)}
+            onCancel={() => { setEditing(false); setFixMode(false); }}
           />
         </Modal>
       ) : null}
       {!editing ? (
         <div className="mt-3 flex flex-wrap items-center gap-2">
+          {proposal ? (
+            <button
+              type="button"
+              onClick={openFix}
+              className="rounded-md border px-3 py-1.5 text-sm font-semibold"
+              style={{ borderColor: 'var(--success)', background: 'var(--success)', color: 'var(--on-accent, #fff)' }}
+            >
+              Review fix →
+            </button>
+          ) : null}
           <button
             type="button"
             onClick={() => act('restore_demoted')}
@@ -1012,6 +1078,16 @@ function DemotionRow({
           >
             Retire (recoverable)
           </button>
+          {proposal ? (
+            <button
+              type="button"
+              onClick={rejectFix}
+              className="rounded-md px-2 py-1.5 text-xs font-medium"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              Not a fix
+            </button>
+          ) : null}
         </div>
       ) : null}
     </article>

--- a/src/app/api/admin/content-reports/__tests__/route.test.ts
+++ b/src/app/api/admin/content-reports/__tests__/route.test.ts
@@ -51,6 +51,9 @@ vi.mock('@/server/db/queries/machine-demotions', () => ({
   approveEditedQuestion: approveMock,
 }));
 vi.mock('@/server/quality/rerun-question', () => ({ rerunQuestion: rerunMock }));
+vi.mock('@/server/db/queries/salvage-proposals', () => ({
+  resolveSalvageProposal: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { POST } from '@/app/api/admin/content-reports/route';
 

--- a/src/app/api/admin/content-reports/route.ts
+++ b/src/app/api/admin/content-reports/route.ts
@@ -15,6 +15,7 @@ import {
   restoreDemotedQuestion,
   retireDemotedQuestion,
 } from '@/server/db/queries/machine-demotions';
+import { resolveSalvageProposal } from '@/server/db/queries/salvage-proposals';
 import { rerunQuestion } from '@/server/quality/rerun-question';
 
 export const dynamic = 'force-dynamic';
@@ -40,6 +41,9 @@ const bodySchema = z.discriminatedUnion('action', [
   }),
   z.object({ action: z.literal('restore_demoted'), questionId: z.string().trim().min(1) }),
   z.object({ action: z.literal('retire_demoted'), questionId: z.string().trim().min(1) }),
+  // D-QUALITY-SALVAGE-01: dismiss a machine-proposed salvage fix ("Not a fix");
+  // the demotion card falls back to the manual restore/edit/retire buttons.
+  z.object({ action: z.literal('reject_salvage'), questionId: z.string().trim().min(1) }),
   z.object({
     action: z.literal('edit'),
     questionId: z.string().trim().min(1),
@@ -104,7 +108,15 @@ export async function POST(request: NextRequest) {
     if (!result.ok) {
       return NextResponse.json({ error: result.reason }, { status: 404 });
     }
+    // If this approval consumed a salvage proposal, mark it applied (best-effort;
+    // a no-op when the edit didn't come from one).
+    await resolveSalvageProposal(data.target.id, 'applied');
     return NextResponse.json(result);
+  }
+
+  if (data.action === 'reject_salvage') {
+    await resolveSalvageProposal(data.questionId, 'rejected');
+    return NextResponse.json({ ok: true });
   }
 
   if (data.action === 'edit') {
@@ -148,6 +160,12 @@ export async function POST(request: NextRequest) {
       { error: result.reason },
       { status: result.reason === 'not_found' ? 404 : 409 },
     );
+  }
+
+  // A manual restore/retire settles the demotion, so retire any live salvage
+  // proposal too (it can't apply to a row that has left the queue).
+  if (data.action === 'restore_demoted' || data.action === 'retire_demoted') {
+    await resolveSalvageProposal(data.questionId, 'rejected');
   }
 
   return NextResponse.json(result);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2067,6 +2067,27 @@ export async function register() {
       `);
       await db.execute(sql`ALTER TABLE "LlmCostReport" ENABLE ROW LEVEL SECURITY`);
       await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmCostReport_created_at_idx" ON "LlmCostReport" ("created_at")`);
+      // Migration 0115 (D-QUALITY-SALVAGE-01): machine-proposed salvage fixes for
+      // demoted questions. The salvage batch + review queue read/insert here and
+      // would 42P01 if the migration recorded without the table. Self-contained;
+      // same rationale as the 0103 CrafterDraftDecision guard.
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "QuestionSalvageProposal" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "question_id" text NOT NULL,
+          "target_table" text NOT NULL,
+          "kind" text NOT NULL,
+          "proposed_stem" text,
+          "proposed_explanation" text,
+          "reverify_outcome" text NOT NULL,
+          "reverify_reason" text,
+          "status" text NOT NULL DEFAULT 'ready',
+          "created_at" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "QuestionSalvageProposal" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "QuestionSalvageProposal_question_id_idx" ON "QuestionSalvageProposal" ("question_id")`);
+      await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "QuestionSalvageProposal_active_question_key" ON "QuestionSalvageProposal" ("question_id") WHERE "status" = 'ready'`);
     } catch {
       // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
     }

--- a/src/server/daily/__tests__/enrich-variants.test.ts
+++ b/src/server/daily/__tests__/enrich-variants.test.ts
@@ -9,6 +9,7 @@ const llmMock = vi.hoisted(() => ({
 }));
 
 vi.mock('@/lib/llm', () => ({
+  ANTHROPIC_MODEL: 'claude-sonnet-4-6',
   INSTRUCTION_SCOPING_QUALIFIER: '',
   INSTRUCTION_USER_INPUT_GUIDANCE: '',
   extractTextContent: (content: unknown) => String((content as { text: string }).text),

--- a/src/server/db/queries/machine-demotions.ts
+++ b/src/server/db/queries/machine-demotions.ts
@@ -6,6 +6,7 @@ import {
   resolveActiveIncorrectReportsForGenerated,
   resolveActiveIncorrectReportsForQuestion,
 } from '@/server/db/queries/content-reports';
+import { getReadyProposalsForQuestions, type SalvageProposalRow } from '@/server/db/queries/salvage-proposals';
 import { type QuestionSource, resolveAuthorDisplay } from '@/lib/questions-types';
 
 // B-CRAFTER-LIFECYCLE-01 Phase 1 — the MACHINE stream of the admin review queue.
@@ -44,6 +45,9 @@ export type MachineDemotionReviewItem = {
   creatorId: string | null;
   authorName: string | null;
   authorIsHouse: boolean;
+  // D-QUALITY-SALVAGE-01: a machine-proposed, pre-re-verified minimal fix awaiting
+  // one-click approval. Present only when a 'ready' proposal exists for this row.
+  proposal: SalvageProposalRow | null;
 };
 
 // Demoted canonical questions awaiting a human call, oldest demotion first
@@ -81,6 +85,8 @@ export async function getMachineDemotionsForReview(): Promise<MachineDemotionRev
     )
     .orderBy(asc(questions.verifiedAt));
 
+  const proposals = await getReadyProposalsForQuestions(rows.map((r) => r.questionId));
+
   return rows.map((row) => ({
     questionId: row.questionId,
     questionText: row.questionText,
@@ -92,6 +98,7 @@ export async function getMachineDemotionsForReview(): Promise<MachineDemotionRev
     broadCategory: row.broadCategory,
     source: row.source,
     creatorId: row.creatorId,
+    proposal: proposals.get(row.questionId) ?? null,
     ...resolveAuthorDisplay(row.creatorId, row.source, row.authorName),
   }));
 }

--- a/src/server/db/queries/salvage-proposals.ts
+++ b/src/server/db/queries/salvage-proposals.ts
@@ -1,0 +1,95 @@
+import { and, desc, eq, inArray } from 'drizzle-orm';
+
+import { db, questionSalvageProposals } from '@/server/db';
+
+export type SalvageProposalRow = {
+  questionId: string;
+  kind: 'extra_fact_stem' | 'extra_fact_explainer' | 'unsalvageable';
+  proposedStem: string | null;
+  proposedExplanation: string | null;
+  reverifyReason: string | null;
+};
+
+type InsertSalvageProposal = {
+  questionId: string;
+  targetTable: 'question' | 'generated';
+  kind: 'extra_fact_stem' | 'extra_fact_explainer' | 'unsalvageable';
+  proposedStem: string | null;
+  proposedExplanation: string | null;
+  reverifyOutcome: 'ok' | 'demoted' | 'unverifiable';
+  reverifyReason: string | null;
+  status: 'ready' | 'unsalvageable';
+};
+
+/**
+ * Record a fresh proposal for a question, retiring any prior live ('ready') one
+ * first so the partial-unique index holds (a re-run supersedes, not stacks).
+ */
+export async function upsertSalvageProposal(row: InsertSalvageProposal): Promise<void> {
+  await db
+    .update(questionSalvageProposals)
+    .set({ status: 'rejected' })
+    .where(
+      and(
+        eq(questionSalvageProposals.questionId, row.questionId),
+        eq(questionSalvageProposals.status, 'ready'),
+      ),
+    );
+  await db.insert(questionSalvageProposals).values(row);
+}
+
+/** The latest live proposal per question id — for the review-queue join. */
+export async function getReadyProposalsForQuestions(
+  questionIds: string[],
+): Promise<Map<string, SalvageProposalRow>> {
+  if (questionIds.length === 0) return new Map();
+  const rows = await db
+    .select({
+      questionId: questionSalvageProposals.questionId,
+      kind: questionSalvageProposals.kind,
+      proposedStem: questionSalvageProposals.proposedStem,
+      proposedExplanation: questionSalvageProposals.proposedExplanation,
+      reverifyReason: questionSalvageProposals.reverifyReason,
+    })
+    .from(questionSalvageProposals)
+    .where(
+      and(
+        inArray(questionSalvageProposals.questionId, questionIds),
+        eq(questionSalvageProposals.status, 'ready'),
+      ),
+    )
+    .orderBy(desc(questionSalvageProposals.createdAt));
+  const out = new Map<string, SalvageProposalRow>();
+  for (const r of rows) if (!out.has(r.questionId)) out.set(r.questionId, r);
+  return out;
+}
+
+/**
+ * Which of these question ids already have ANY proposal (ready/applied/rejected/
+ * unsalvageable) — the batch skips them so it never re-spends on a question it
+ * has already judged. (Re-processing a rejected one is a future --force concern.)
+ */
+export async function questionIdsWithProposal(questionIds: string[]): Promise<Set<string>> {
+  if (questionIds.length === 0) return new Set();
+  const rows = await db
+    .select({ questionId: questionSalvageProposals.questionId })
+    .from(questionSalvageProposals)
+    .where(inArray(questionSalvageProposals.questionId, questionIds));
+  return new Set(rows.map((r) => r.questionId));
+}
+
+/** Terminal-state a question's live proposal once the human acts on it. */
+export async function resolveSalvageProposal(
+  questionId: string,
+  status: 'applied' | 'rejected',
+): Promise<void> {
+  await db
+    .update(questionSalvageProposals)
+    .set({ status })
+    .where(
+      and(
+        eq(questionSalvageProposals.questionId, questionId),
+        eq(questionSalvageProposals.status, 'ready'),
+      ),
+    );
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1250,6 +1250,37 @@ export const crafterDraftDecisions = pgTable(
   ],
 );
 
+// D-QUALITY-SALVAGE-01: a machine-proposed minimal fix for a verifier-demoted
+// question, pre-re-verified, awaiting a human's one-click approval in the review
+// queue. Never applied automatically — approving copies the proposed text into
+// the real edit/approve path. Append-only-ish: one live ('ready') proposal per
+// question; superseded/decided proposals keep their terminal status for record.
+export const questionSalvageProposals = pgTable(
+  'QuestionSalvageProposal',
+  {
+    id: id(),
+    // The demoted row's id, in whichever store it lives (see targetTable).
+    questionId: text('question_id').notNull(),
+    targetTable: text('target_table').$type<'question' | 'generated'>().notNull(),
+    kind: text('kind').$type<'extra_fact_stem' | 'extra_fact_explainer' | 'unsalvageable'>().notNull(),
+    proposedStem: text('proposed_stem'),
+    proposedExplanation: text('proposed_explanation'),
+    // Outcome of re-verifying the PROPOSED version. A proposal is only surfaced
+    // when this is 'ok' — the human never sees a fix that didn't actually pass.
+    reverifyOutcome: text('reverify_outcome').$type<'ok' | 'demoted' | 'unverifiable'>().notNull(),
+    reverifyReason: text('reverify_reason'),
+    status: text('status').$type<'ready' | 'applied' | 'rejected' | 'unsalvageable'>().notNull().default('ready'),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    index('QuestionSalvageProposal_question_id_idx').on(table.questionId),
+    // At most one live proposal per question — a re-run supersedes, not stacks.
+    uniqueIndex('QuestionSalvageProposal_active_question_key')
+      .on(table.questionId)
+      .where(sql`${table.status} = 'ready'`),
+  ],
+);
+
 export const friendships = pgTable(
   'Friendship',
   {

--- a/src/server/quality/__tests__/salvage-question.test.ts
+++ b/src/server/quality/__tests__/salvage-question.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSalvageResponse } from '@/server/quality/salvage-question';
+
+describe('parseSalvageResponse', () => {
+  it('parses a stem fix', () => {
+    const out = parseSalvageResponse(
+      JSON.stringify({
+        kind: 'extra_fact_stem',
+        proposed_stem: 'Which anthology, edited by Barbara Smith, is a landmark of Black lesbian feminism?',
+        proposed_explanation: null,
+        note: 'removed the wrong "1973"',
+      }),
+    );
+    expect(out).toEqual({
+      kind: 'extra_fact_stem',
+      proposedStem: 'Which anthology, edited by Barbara Smith, is a landmark of Black lesbian feminism?',
+      proposedExplanation: null,
+      note: 'removed the wrong "1973"',
+    });
+  });
+
+  it('parses an explainer-only fix', () => {
+    const out = parseSalvageResponse(
+      JSON.stringify({
+        kind: 'extra_fact_explainer',
+        proposed_stem: null,
+        proposed_explanation: 'Corrected context without the wrong date.',
+        note: 'fixed the airlift duration',
+      }),
+    );
+    expect(out?.kind).toBe('extra_fact_explainer');
+    expect(out?.proposedStem).toBeNull();
+    expect(out?.proposedExplanation).toBe('Corrected context without the wrong date.');
+  });
+
+  it('passes through unsalvageable with no proposed text', () => {
+    const out = parseSalvageResponse(
+      JSON.stringify({ kind: 'unsalvageable', proposed_stem: null, proposed_explanation: null, note: 'answer is wrong' }),
+    );
+    expect(out).toEqual({
+      kind: 'unsalvageable',
+      proposedStem: null,
+      proposedExplanation: null,
+      note: 'answer is wrong',
+    });
+  });
+
+  it('demotes a "fix" that proposes NO changed text to unsalvageable', () => {
+    // A salvage with a salvageable kind but no stem AND no explainer is a no-op —
+    // never surface it as a fix.
+    const out = parseSalvageResponse(
+      JSON.stringify({ kind: 'extra_fact_stem', proposed_stem: '  ', proposed_explanation: null, note: 'x' }),
+    );
+    expect(out?.kind).toBe('unsalvageable');
+  });
+
+  it('rejects an unknown kind', () => {
+    expect(
+      parseSalvageResponse(JSON.stringify({ kind: 'whatever', proposed_stem: 'x' })),
+    ).toBeNull();
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(parseSalvageResponse('not json')).toBeNull();
+  });
+
+  it('caps the note length', () => {
+    const out = parseSalvageResponse(
+      JSON.stringify({ kind: 'extra_fact_stem', proposed_stem: 'ok', proposed_explanation: null, note: 'z'.repeat(500) }),
+    );
+    expect((out?.note.length ?? 0) <= 300).toBe(true);
+  });
+});

--- a/src/server/quality/salvage-question.ts
+++ b/src/server/quality/salvage-question.ts
@@ -1,0 +1,153 @@
+/**
+ * Salvage proposer (D-QUALITY-SALVAGE-01) — the counterpart to the verifier.
+ *
+ * Most verifier demotions are not wrong answers: they are ONE non-load-bearing
+ * fact — a decorative wrong year/count/attribution in the stem, or (more often)
+ * in the explainer — while the ask and the headline answer are perfectly right.
+ * Given the demoted question plus the verifier's own reason (which localizes the
+ * bad fact), this proposes the MINIMAL edit that removes or corrects it while
+ * leaving the answer untouched, and classifies whether the question is salvageable
+ * at all. The proposal is never applied here — it is re-verified and then a human
+ * approves it in the review queue (conservative).
+ *
+ * Fail-closed toward SAFETY: on any client/parse/uncertainty fault the result is
+ * `unsalvageable` with no proposed text, so a fault can never fabricate a "fix".
+ * Anthropic only; usage logged under scope 'salvage-propose'.
+ */
+
+import {
+  ANTHROPIC_MODEL,
+  INSTRUCTION_SCOPING_QUALIFIER,
+  INSTRUCTION_USER_INPUT_GUIDANCE,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+  wrapUserInput,
+} from '@/lib/llm';
+
+export type SalvageKind = 'extra_fact_stem' | 'extra_fact_explainer' | 'unsalvageable';
+
+export type SalvageInput = {
+  questionText: string;
+  answer: string;
+  explanation?: string | null;
+  verificationReason: string;
+  canonicalSubcategory?: string | null;
+  broadCategory?: string | null;
+};
+
+export type SalvageProposal = {
+  kind: SalvageKind;
+  /** Full proposed stem (null when the stem is unchanged or unsalvageable). */
+  proposedStem: string | null;
+  /** Full proposed explainer (null when unchanged or unsalvageable). */
+  proposedExplanation: string | null;
+  /** One short line of what was changed / why it can't be salvaged. */
+  note: string;
+};
+
+const UNSALVAGEABLE: SalvageProposal = {
+  kind: 'unsalvageable',
+  proposedStem: null,
+  proposedExplanation: null,
+  note: 'no safe minimal fix',
+};
+
+const SALVAGE_TIMEOUT_MS = 30_000;
+
+const SYSTEM_PROMPT = `You repair trivia questions that a fact-checker demoted. Most demotions are NOT a wrong answer — they are a single non-load-bearing fact ("smuggled" scaffolding: a decorative date, count, ordinal, superlative, attribution, or adjacent-work claim) that is wrong, usually in the explainer, while the actual ask and its headline answer are correct. Your job: propose the SMALLEST edit that makes the fact-checker pass, or declare the question unsalvageable.
+
+You are given the question, its stated answer, its explainer, and the fact-checker's reason (which names the offending claim).
+
+HARD RULES:
+- NEVER change the stated answer, and never change what the question asks. If the fix would require changing the answer or the thing being asked, it is UNSALVAGEABLE.
+- Prefer REMOVAL over correction: if the offending fact is not needed to identify the answer, delete that clause and stop. Correct it (using the fact-checker's stated correct value) ONLY when the fact is load-bearing to the ask.
+- Change as little as possible. Do not rewrite, re-tone, or "improve" anything the fact-checker did not flag. Keep the rest verbatim.
+- If the demotion is because the ANSWER itself is wrong, the premise the question hinges on is false, or you are not confident a minimal edit fixes it, return UNSALVAGEABLE. Do not guess.
+
+Classify:
+- "extra_fact_stem": you edited the stem (removed/corrected a bad fact there). Return the full proposed stem.
+- "extra_fact_explainer": the stem is fine; you edited only the explainer. Return the full proposed explainer.
+- "unsalvageable": no safe minimal fix.
+
+(If both stem and explainer need trimming, edit both and use "extra_fact_stem".)
+
+Return JSON only, nothing else:
+{ "kind": "extra_fact_stem" | "extra_fact_explainer" | "unsalvageable",
+  "proposed_stem": "<full edited stem, or null if unchanged/unsalvageable>",
+  "proposed_explanation": "<full edited explainer, or null if unchanged/unsalvageable>",
+  "note": "<short: what you removed/corrected, or why it can't be salvaged>" }${INSTRUCTION_USER_INPUT_GUIDANCE}${INSTRUCTION_SCOPING_QUALIFIER}`;
+
+function buildUserMessage(input: SalvageInput): string {
+  return [
+    wrapUserInput('question', input.questionText),
+    wrapUserInput('stated_answer', input.answer),
+    input.explanation ? wrapUserInput('explainer', input.explanation) : '',
+    input.canonicalSubcategory
+      ? wrapUserInput(
+          'subject',
+          `${input.canonicalSubcategory}${input.broadCategory ? ` (${input.broadCategory})` : ''}`,
+        )
+      : '',
+    wrapUserInput('fact_checker_reason', input.verificationReason),
+    'Propose the minimal fix or declare it unsalvageable. Return JSON only.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+/** Pure: parse + validate the proposer's JSON. Exported for unit tests. */
+export function parseSalvageResponse(raw: string): SalvageProposal | null {
+  const parsed = parseJsonObject(raw);
+  if (!parsed) return null;
+  const kind = parsed.kind;
+  if (kind !== 'extra_fact_stem' && kind !== 'extra_fact_explainer' && kind !== 'unsalvageable') {
+    return null;
+  }
+  const str = (v: unknown): string | null =>
+    typeof v === 'string' && v.trim().length > 0 ? v.trim() : null;
+  const note = typeof parsed.note === 'string' ? parsed.note.trim().slice(0, 300) : '';
+
+  if (kind === 'unsalvageable') {
+    return { kind, proposedStem: null, proposedExplanation: null, note: note || 'unsalvageable' };
+  }
+
+  const proposedStem = str(parsed.proposed_stem);
+  const proposedExplanation = str(parsed.proposed_explanation);
+  // A salvage MUST actually propose replacement text; a "fix" with no changed
+  // text is meaningless, so treat it as unsalvageable rather than a no-op edit.
+  if (!proposedStem && !proposedExplanation) return { ...UNSALVAGEABLE, note: note || UNSALVAGEABLE.note };
+  return { kind, proposedStem, proposedExplanation, note: note || 'minimal fix' };
+}
+
+/**
+ * Propose a minimal salvage edit for one demoted question. Never applies it.
+ * Returns `unsalvageable` (never throws) on any fault, so a proposer outage can
+ * only ever mean "no fix offered", never a bad auto-edit.
+ */
+export async function proposeSalvage(input: SalvageInput): Promise<SalvageProposal> {
+  const client = getAnthropicClient();
+  if (!client) return UNSALVAGEABLE;
+
+  try {
+    const response = await loggedMessagesCreate(
+      client,
+      'salvage-propose',
+      {
+        model: ANTHROPIC_MODEL,
+        max_tokens: 1024,
+        temperature: 0,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: buildUserMessage(input) }],
+      },
+      { timeoutMs: SALVAGE_TIMEOUT_MS },
+    );
+    return parseSalvageResponse(extractTextContent(response.content)) ?? UNSALVAGEABLE;
+  } catch (error) {
+    console.warn('[proposeSalvage] request_failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return UNSALVAGEABLE;
+  }
+}


### PR DESCRIPTION
Turns the review queue from "read + diagnose + hand-edit each demotion" into "approve a ready, passing diff in one click." ~80% of demotions aren't wrong answers — they're one removable/wrong fact (usually a decorative aside in the explainer). **Nothing is auto-applied** — conservative by request.

## Result on the live backlog
Ran `scripts/salvage-demoted.ts --write` over the ~105-question queue:
- **74 (70%) became one-click-ready** — minimal, re-verified fixes ("baritone" not "bass" soloist; removed "co-" from "co-founded"; dropped a wrong "Lake Lucerne" aside).
- **20 proposed fixes that didn't re-verify were withheld** (the safety gate — the human never sees a "fix" that didn't actually pass).
- **11 wrong-answer / broken-core cases correctly declined** as unsalvageable.

## Part A — machinery
- `salvage-question.ts`: `proposeSalvage()` — LLM proposes the smallest edit (remove/correct the flagged fact, **never** touch the answer) or declares unsalvageable. Fail-closed; pure parser unit-tested.
- Re-verify the **proposed** version via `verifyQuestion` directly (our exact edit vs the existing answer). 'ready' only if it now passes.
- `QuestionSalvageProposal` table — **migration 0115 + boot guard, applied to prod**. Query helpers in `salvage-proposals.ts`.
- `scripts/salvage-demoted.ts` — dry-run-default batch (`--write` only ever touches the proposal table).

## Part B — conservative surfacing
- `getMachineDemotionsForReview` joins the ready proposal per row.
- `DemotionRow`: a "Suggested fix — verifier re-checked, now passes" banner + a **Review fix** button that opens the **existing** edit panel pre-filled with the proposed text — the human still re-runs + approves. "Not a fix" falls back to manual. Header shows the ready count.
- Approve marks the proposal `applied`; restore/retire retire it.

## Notes
- Migration is `0115` because `0114` (set-completion, #1424) is a sibling branch already applied to prod; independent tables, no ordering dependency.
- Complements the generation-side inflow fix (#1425).
- Also fixes the `enrich-variants` mock red on main since #1422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrEnXchnUG6EVzVsUEB63V