### PR TITLE
Results addendum on D-SUPPLY-FINITE-SET-01 (P1/P2 findings)

### DIFF
--- a/D-SUPPLY-FINITE-SET-01.md
+++ b/D-SUPPLY-FINITE-SET-01.md
@@ -116,3 +116,52 @@ A set is bounded *at any moment*, not permanently sealed:
 - The paid AC-1 refill run / soak — still paused pending the P3 re-scope; refill
   as it stands (infinite drain) is now the *wrong shape*, so do not run the
   old-shape confirmation — rebuild it fill-once first.
+
+## Results (addendum, 2026-07-05)
+
+P1 and P2 shipped the same day this was ratified; building them + the parallel
+demoted-question work surfaced findings that **partly overtake the plan above.**
+The decision holds as *direction*; three corrections to what's written:
+
+- **P1 (curation-worthiness score) — shipped (#1422), but the signal is INERT.**
+  `curationVerdict` + `CURATION_FUTILITY_THRESHOLD=0.34` are live in the crafter
+  worklist + weekly cost email. **Nothing crosses the line in prod:** the worst
+  domain is ~25% demotion (under 0.34) and refill is off so nothing is
+  "generation-struggling." The router is built ahead of anything to route.
+
+- **The cost-routing premise (§2) is weaker than assumed — and this session
+  eroded it further.** §2 keys "curate this domain" on **demotion rate** as a
+  proxy for intrinsic domain difficulty. But the salvage pass (`D-QUALITY-
+  SALVAGE-01`, #1426) found **~70% of demotions are one-off *extra-fact* errors**
+  (a wrong year/count/attribution, usually in the explainer) scattered across
+  otherwise-fine domains — fixable with a one-line trim, **not** a signal the
+  domain is hard. Worse, the salvage pass + the generation tightening (#1425)
+  **drive demotion rates down broadly**, hollowing out the exact signal P4's
+  routing depends on. **Correction:** if cost-routing is revived, do NOT key it on
+  raw demotion rate. Use the signals salvage can't explain away — **verify
+  web-search rate** and **draft-kill rate** — or **post-salvage *residual*
+  demotion** (a domain that still demotes *after* the trim is the genuinely-hard
+  one). That residual is the real "expensive domain."
+
+- **P2 (set-completion) — shipped (#1427), but it does NOT use `node_weight`.**
+  Contrary to "set size is seeded from `node_weight`" (§"What finite changes"),
+  completion was implemented as **distinct-answered ≥ durable pool depth, floored
+  at `SET_COMPLETION_MIN_SIZE=8`** — because at current scale pool depth *is* the
+  set, and weight-based target sizing is really a P3/generation-cap concern that
+  doesn't exist yet. Do not build P3 assuming P2 already sizes sets by weight.
+
+- **At ~6 weekly players the whole model is LATENT, not load-bearing.** Only 13
+  pre-P2 completions across 4 players exist, and they don't retroactively fire —
+  so the trophy/authorship arc will rarely trigger for now. **P3 (fill-once
+  refill) and P4 (routing) are scale-gated, not next-up:** normal generation +
+  human authoring already fills sets faster than 6 people drain them, and P4 has
+  no cost-variance to route on yet. Revisit both when player count grows enough
+  that (a) players actually complete sets and (b) a residual-demotion signal has
+  real spread.
+
+- **What held up:** the completion-as-trophy reframe (the driving fix for the
+  "answering ever deeper leads to boredom" feedback) is correct regardless of
+  scale, and the phasing ("each independently mergeable") is what let P1/P2 ship
+  while P3/P4 wait. The §2 convergence idea (expensive domain == ideal-author
+  domain) stays elegant — *if* cost-variance ever materializes under a
+  salvage-corrected signal.

--- a/docs/Codex-suggestions-July-5.md
+++ b/docs/Codex-suggestions-July-5.md
@@ -1,0 +1,342 @@
+# Codex Suggestions — July 5
+
+## Overview
+
+This is a read-only architectural review of the current question-generation, serving, verification, and gating code as of July 5, 2026. The implementation has moved significantly beyond a PRD-level version in a good way: it is no longer just “generate five questions,” but a layered supply chain for producing, reusing, validating, and serving trivia.
+
+The current architecture includes:
+
+- prompt-time constraints to make generated questions safer before they exist;
+- write-time and batch-time gates to catch poor machine output;
+- reuse-first bank selection to avoid unnecessary LLM generation;
+- queue-level gates for diversity, repeat avoidance, and cooldowns;
+- background verification to sweep already-created stock;
+- trust-tier machinery that can eventually decide which surfaces get which quality bar.
+
+The overall recommendation is **not** to simplify this aggressively. The shape is good. The main room for improvement is operational and product-policy clarity:
+
+1. make fail-open / fail-closed policy explicit per surface;
+2. surface machine demotions into a real review loop;
+3. separate player-serving quality gates from long-term pool-trust gates more cleanly;
+4. turn logs into a small dashboard or report so these gates can be operated, not just admired in code.
+
+---
+
+## 1. The generation path is much more robust than a PRD-level implementation would usually be
+
+The generator prompt is doing useful editorial prevention up front: open-recall only, no answer leaks, no gratuitous false-premise scaffolding, fan-salience by tier, strip-the-domain, one clean answer, single ask, named-authority caution, fact keys, subject entities, and shape variety.
+
+The important part is that the prompt is not only style guidance. It is explicitly trying to prevent the same production defects the downstream gates later check for. For example, the prompt bans unnecessary asserted side-facts because those are identified as a major false-premise source.
+
+That is the right posture. The best gate is still: **do not ask the model to produce risky artifacts in the first place.** The downstream checks should be insurance, not the primary author.
+
+The generator also fetches the user’s knowledge base, preferences, previous question texts, previous fact keys, recent domain counts, recent skips, cultural anchor, and answered canonical texts before generation. That means generation is not blind; it adapts to declared interests and recent play history.
+
+The strongest design choice here is the combination of **fact-level identity** and **semantic history** machinery. `fact_key` handles exact conceptual duplicates when it works; recent-history and embedding checks catch phrasing variants. Either one alone would be brittle. Together, they make repeat avoidance much more reliable.
+
+---
+
+## 2. The serving ladder is doing the right thing: bank first, generate second
+
+The daily generation path now tries durable bank stock before falling through to fresh generation. For each requested domain and difficulty, it builds a tier ladder, attempts a bank pick, logs hit/fall-through telemetry, and only continues to LLM generation when no source is found.
+
+The bank query itself is mature. It:
+
+- matches on folded `domain_key`, with exact-string fallback for legacy rows;
+- excludes the current user’s own generated stock;
+- excludes duplicates;
+- excludes content-report-suppressed rows;
+- applies trust-tier gating in shadow/enforced mode;
+- ranks and filters likely duds before serving.
+
+That “verify once, reuse many” posture is exactly where this product should go.
+
+The code also preserves verification and trust metadata when copying a bank row into a serving `GeneratedQuestion` row, including trust tier, ask-to-answer verification, acceptable variants, source refs, perishable flag, and provider provenance. That prevents bank reuse from becoming a provenance or grading regression.
+
+### Suggested improvement
+
+Treat bank-hit telemetry as an operational metric, not just a debug log. The raw signal already exists: domain, hit vs fall-through, requested tier, served tier, fallback use. The missing piece is a small report answering:
+
+- Which domains are always falling through?
+- Which tiers are under-stocked?
+- How many bank hits are below the intended trust tier while gating is still off?
+- Which domains generate repeatedly but never build durable stock?
+
+---
+
+## 3. The queue-level gates are product-aware, not just quality-aware
+
+The queue orchestrator has a whole-queue diversity gate that applies across authored, house, and generated sources, not per source. That matters because otherwise the system could produce a technically valid queue that still feels repetitive.
+
+It also correctly treats generation as a lossy process. The code acknowledges that quality, factual, and history gates can drop half or more of a batch, so it over-requests and trims survivors.
+
+The top-up loop is the right kind of complexity: it does **not** relax gates just to hit five. It spends additional bounded rounds trying to find more good questions, stops under time/round budgets, and broadens the palette away from already-filled domains to avoid re-mining exhausted favorites.
+
+That is a very good product decision. A short high-quality queue is better than a padded bad queue, but a full high-quality queue is worth an extra round if budget allows.
+
+### Suggested improvement
+
+Make degraded cases more visible to admins. The code has nuanced reasons for shortfall — generic drops, duplicates, answer cooldown, subject cooldown, diversity deflections, gate losses, top-up recovered nothing — but those are mostly internal counters and logs.
+
+If a player repeatedly gets 3–4 questions, the system should be able to say which reason dominates for that user/domain without spelunking logs.
+
+---
+
+## 4. The generation gates are layered well
+
+The generated-question screening phase is comprehensive. It runs multiple gates against the same batch and unions the drop sets:
+
+- intra-batch duplicate detection;
+- recent-history duplicate detection;
+- quality gate;
+- factual gate;
+- answered-history semantic duplicate detection;
+- deterministic answer-leak backstop;
+- answer cooldown;
+- subject cooldown.
+
+The independent checks run in parallel, which matters because otherwise the gate stack would destroy latency.
+
+### Quality gate
+
+The quality gate checks for answer leakage, opinion/vagueness, false premise, self-answering, generic-at-tier, multipart questions, and misleading setup.
+
+The tier nuance is important: `GENERIC_AT_TIER` is only judged for moderate/specialist questions, not accessible ones. That prevents “accessible” from becoming artificially ornate while still keeping moderate/specialist questions from collapsing into generic trivia.
+
+### Factual gate
+
+The factual gate is correctly scoped to the two highest-risk factual failures:
+
+- the stated answer is wrong;
+- the setup contains a false factual claim even when the answer is right.
+
+The model-tier decision also makes sense. The comments indicate that Haiku missed subtle false-premise cases and Sonnet recovered the major-defect lift, so the factual gate defaults to the stronger model while remaining overridable by `FACTUAL_GATE_MODEL`.
+
+The `max_tokens` truncation guard is a sign the code has been hardened against real failures. Previously, truncated JSON could silently produce an empty drop set and let bad questions through. Now the gate logs loudly if the response hits `max_tokens`.
+
+### Ask-to-answer gate
+
+The ask-to-answer gate is well conceived. It strips the stored answer, asks a cheaper independent model to answer cold several times, then judges whether those cold attempts agree with each other and the stored answer.
+
+Passing earns machine verification; clear contradiction drops the question; ambiguity does not falsely verify.
+
+That is exactly the right role for this gate: it catches “the generator’s answer key is not what a solver would produce,” but it does not pretend to be full factual grounding.
+
+### Suggested improvement
+
+Track the percentage of served generated questions that were served after one or more gates failed open. The system mostly avoids falsely minting trust when a gate fails, but operationally it should be easy to answer:
+
+> How many questions reached players because availability won over verification on this run?
+
+---
+
+## 5. Trust tiers are the right abstraction, but the rollout is intentionally unfinished
+
+The trust-tier gate is a clean boundary:
+
+- self-practice can eventually require `machine_verified` or better;
+- friend-facing / convergence / house can require `human_validated` or `author_confirmed`;
+- enforcement is behind `VERIFICATION_TIER_GATING_ENABLED`, off by default, and currently shadow-logs what it would filter.
+
+This is exactly how to avoid a dangerous flag flip. The system can measure blast radius before turning enforcement on.
+
+### Suggested improvement
+
+Formalize the pre-flip checklist. Before enabling tier gating, require a concrete report with:
+
+- candidate counts before/after by surface;
+- bank hit rate before/after by domain/tier;
+- expected Daily shortfall rate;
+- top domains that would become under-stocked;
+- number of friend-facing items that would disappear.
+
+---
+
+## 6. User-authored questions have a different, sensible gate profile
+
+The authored-question route has a different and reasonable posture from generated questions. It:
+
+- validates payload and rejects answer-in-question at request level;
+- categorizes the question;
+- rejects generic categories;
+- reconciles authored domains against existing domains;
+- assesses difficulty;
+- vets the question;
+- hard-blocks safety failures from fan-out.
+
+The authored vetter is broader than the generated factual gate. It checks factual correctness, quality, safety, and answer leakage, then maps the result onto public eligibility.
+
+The failure posture is also better for authored content than for generated content: if vetting fails, the route falls back to `needs_review`, not auto-publish.
+
+That distinction makes sense:
+
+- generated content is system-owned, so fail-open may be acceptable to keep the Daily queue alive, as long as trust tier stays low;
+- user-authored content can be saved for the author but should not silently enter stranger-facing surfaces if vetting is uncertain.
+
+Safety failures are especially strict: the route overrides visibility to blocked and skips all fan-out.
+
+### Suggested improvement
+
+Revisit whether factual failures should remain friend-shareable.
+
+Currently, safety failures are hard-blocked from every surface, while factual, quality, and answer-leaked rejections are public-pool signals and can remain shareable to friends. That may be right for a friend-game product, but it is a product policy that deserves explicit ratification.
+
+A possible policy split:
+
+- **Safety fail:** blocked everywhere.
+- **Answer leak:** author can save, but do not fan out automatically.
+- **Factual fail:** do not fan out unless the author explicitly overrides after seeing a warning.
+- **Quality fail:** lower severity; maybe still shareable.
+
+---
+
+## 7. Background verification is the strongest second net
+
+The batch verifier is demote-only, not write-time. It sweeps both `Question` and `GeneratedQuestion` rows that have not been stamped, skips rows the pure prefilter says do not need verification, and verifies routed rows with a grounded verifier.
+
+This is good architecture because it separates **serving latency** from **long-term supply hygiene**. The player path can stay responsive, while the background verifier gradually improves the pool.
+
+### Prefilter
+
+The prefilter is pure and deterministic. Its goal is to avoid spending LLM/web calls on bare stable facts while routing premise-bearing or adjacent-claim-bearing questions to verification.
+
+It looks for assertion signals such as years, dates, counts, ordinals, superlatives, recurrence, attribution, relationships, and work-location claims.
+
+It then routes to:
+
+- `false_premise` if the stem has a setup clause with assertion signals or multiple signals;
+- `extra_fact` if the explanation or answer carries adjacent claims;
+- `skipped` if neither applies.
+
+This is a cost-aware design. It is the right “cheap deterministic router before expensive verifier” shape.
+
+### Verifier
+
+The verifier itself is grounded but not web-happy. It resolves from model knowledge first, then uses web search only when knowledge cannot confidently settle a claim.
+
+It supports optional domain restrictions for web search via `VERIFY_WEB_SEARCH_ALLOWED_DOMAINS`, which is useful if the verifier should read reference-style sources rather than arbitrary web results.
+
+Demotion semantics are conservative:
+
+- `Question` demotion sets `publicStatus = 'needs_review'`, never overwriting the author’s answer.
+- `GeneratedQuestion` demotion sets `isDuplicate = true`, the suppression flag the bank honors.
+
+### Suggested improvement
+
+Demotions need a first-class human review surface. A demote-only background verifier is much more powerful if reviewers can see, clear, uphold, and learn from demotions.
+
+Machine demotions should become part of the same operational loop as player reports, or at least a parallel queue with equivalent ergonomics.
+
+---
+
+## 8. Deduplication is multi-layered and generally well designed
+
+There are at least four dedup layers:
+
+1. prompt-level avoid lists, which are advisory;
+2. recent-history LLM gate for semantic same-fact detection;
+3. fact-key persistence guard for recent history and same-batch duplicates;
+4. embedding dedup, which marks pool collisions as duplicate so bank selection will not serve them.
+
+This is the right level of redundancy because LLM-produced identifiers are imperfect and text similarity alone can over-collapse distinct facts.
+
+### Suggested improvement
+
+Watch for false suppression in embedding dedup. The code already passes `factKey` into dedup to avoid collapsing distinct facts about the same work based on shared vocabulary. That is good, but it means dedup quality depends heavily on fact-key quality.
+
+If bank under-supply appears in dense domains, inspect whether embedding dedup is over-suppressing or fact keys are too coarse.
+
+---
+
+## 9. Main improvement list
+
+### A. Make gate outcomes inspectable as a single artifact
+
+The information exists, but it is spread across logs and columns. A compact per-generated-batch record would make the system much easier to operate:
+
+```ts
+{
+  requested: 10,
+  parsed: 9,
+  dropped: {
+    quality: 2,
+    factual: 1,
+    answerLeak: 0,
+    recentHistory: 1,
+    answeredHistory: 0,
+    askToAnswer: 1,
+    genericDomain: 0,
+    underDifficulty: 1
+  },
+  persisted: 4,
+  machineVerified: 3,
+  unverified: 1,
+  gateFailures: {
+    quality: false,
+    factual: false,
+    embeddings: true
+  }
+}
+```
+
+The improvement is aggregation. It would make it much easier to answer whether short queues are caused by model quality, exhausted knowledge bases, over-dropping factual gates, or thin bank supply.
+
+### B. Decide whether factual failures should be friend-shareable
+
+For authored questions, safety failures are hard-blocked, but factual/quality/answer-leak issues affect public status while remaining potentially shareable to friends. That may be correct, but it should be an explicit product decision rather than an implicit behavior.
+
+### C. Human review is the missing closure loop
+
+Machine demotion without a review queue risks becoming invisible debt. The batch verifier can demote generated questions and user questions, but the product needs a place where those demotions are triaged, corrected, restored, or used to improve prompts.
+
+### D. Make trust-tier flip criteria concrete
+
+Before enabling `VERIFICATION_TIER_GATING_ENABLED`, require a concrete report:
+
+- candidate counts before/after by surface;
+- bank hit rate before/after by domain/tier;
+- expected Daily shortfall rate;
+- top domains that would become under-stocked;
+- number of friend-facing items that would disappear.
+
+### E. Separate “availability fail-open” from “trust fail-open”
+
+A lot of gates fail open to avoid blocking the daily queue. That is defensible. But there are two meanings of fail-open:
+
+1. serve it because otherwise the player gets nothing;
+2. treat it as verified.
+
+The code mostly avoids the second. That invariant should be made explicit everywhere:
+
+> Gate outage may preserve availability, but must never mint trust.
+
+### F. Use verifier findings to tune the generator
+
+The batch verifier’s reasons can become a feedback source. If demotions cluster around dates/counts, fandom episode placement, relationship claims, quote completions, or named-authority rules questions, those clusters should feed back into the generator prompt and supply strategy.
+
+---
+
+## 10. Overall judgment
+
+The code has moved past the PRD in a good way. The PRD likely described “generate questions, verify them, serve a daily set.” The implementation now has a real supply pipeline:
+
+1. bank-first serving to reuse existing stock;
+2. LLM generation only on fall-through;
+3. prompt-level prevention;
+4. batch quality/factual/history gates;
+5. deterministic answer-leak, answer-cooldown, subject-cooldown, and generic-domain guards;
+6. ask-to-answer machine verification;
+7. embedding/fact-key dedup;
+8. background verification with pure prefilter and web fallback;
+9. trust tiers with shadow-mode enforcement;
+10. queue top-up loops that preserve quality rather than padding.
+
+The remaining work is mostly operational/product closure:
+
+- expose gate health;
+- triage machine demotions;
+- formalize trust-tier flip criteria;
+- decide social policy for flawed authored questions;
+- turn verification reasons into prompt/supply improvements.
+
+That is a very solid place to be.

--- a/drizzle/0115_question_salvage_proposal.sql
+++ b/drizzle/0115_question_salvage_proposal.sql
@@ -1,0 +1,39 @@
+-- 0115: QuestionSalvageProposal (D-QUALITY-SALVAGE-01).
+--
+-- Stores a machine-proposed MINIMAL fix for a verifier-demoted question — a
+-- trimmed/corrected stem or explainer that has already been re-verified — so a
+-- human can approve it with one click in the review queue instead of hand-editing
+-- each demotion. Never applied automatically; approving copies the proposed text
+-- through the normal edit/approve path. One live ('ready') proposal per question.
+--
+-- Purely additive: no existing table is altered. RLS enabled with no policies
+-- (the app connects as the owner role, which bypasses RLS) per B-SECURITY-RLS-01
+-- / migration 0081 — without it the table is reachable over Supabase's public
+-- Data API. Every statement is idempotent and mirrored by a defensive guard in
+-- src/instrumentation.ts (precedent: 0103's CrafterDraftDecision guard).
+--
+-- NB: 0114 (set-completion) lands from a sibling branch; this migration is
+-- independent of it (different table, no ordering dependency).
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "QuestionSalvageProposal";
+CREATE TABLE IF NOT EXISTS "QuestionSalvageProposal" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "question_id" text NOT NULL,
+  "target_table" text NOT NULL,
+  "kind" text NOT NULL,
+  "proposed_stem" text,
+  "proposed_explanation" text,
+  "reverify_outcome" text NOT NULL,
+  "reverify_reason" text,
+  "status" text NOT NULL DEFAULT 'ready',
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "QuestionSalvageProposal" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "QuestionSalvageProposal_question_id_idx" ON "QuestionSalvageProposal" ("question_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "QuestionSalvageProposal_active_question_key"
+  ON "QuestionSalvageProposal" ("question_id")
+  WHERE "status" = 'ready';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,804 +1,811 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1777585453077,
-      "tag": "0000_material_lyja",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1777630800000,
-      "tag": "0001_add_ceremony_ready_sms_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1777654136670,
-      "tag": "0002_add_joshing_game_sms_types",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1777654800000,
-      "tag": "0003_question_rating",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1777662000000,
-      "tag": "0004_daily_preference_configuration",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1777671600000,
-      "tag": "0005_profile_domain_visibility_three_state",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1777737600000,
-      "tag": "0006_question_reactions_contexts",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1777780800000,
-      "tag": "0007_send_to_friend_note",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1777784400000,
-      "tag": "0008_add_to_bank_provenance",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1777771056661,
-      "tag": "0009_domain_merge_events",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1777771056661,
-      "tag": "0010_feed_submitted_answer",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1777771056661,
-      "tag": "0011_preview_schema_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1777839477000,
-      "tag": "0012_feed_friend_answered",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1777840000000,
-      "tag": "0013_onboarding_demographics",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1777840100000,
-      "tag": "0014_territory_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1777840200000,
-      "tag": "0015_declared_promoted_event_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1777840300000,
-      "tag": "0016_quip_columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1777840400000,
-      "tag": "0017_creator_notes",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1777840500000,
-      "tag": "0018_daily_generated_and_player_mastery_territory",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1778508000000,
-      "tag": "0019_feed_item_nullable_columns_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1778510000000,
-      "tag": "0020_question_critique_verification",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1778521283376,
-      "tag": "0021_feed_dismissed_domains_active_unique",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1778538800000,
-      "tag": "0022_player_mastery_territory_type_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1778540000000,
-      "tag": "0023_profile_domain_visibility_runtime_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1778616500000,
-      "tag": "0024_question_surface_priority_runtime_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1778616600000,
-      "tag": "0025_grade_dispute_recheck_details",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1778616700000,
-      "tag": "0026_friend_invitation_pre_profile",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "7",
-      "when": 1778616800000,
-      "tag": "0027_friendship_request_context",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "7",
-      "when": 1778616900000,
-      "tag": "0028_remove_other_question_category",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "7",
-      "when": 1778714100000,
-      "tag": "0029_correct_answer_social_feed",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "7",
-      "when": 1778714200000,
-      "tag": "0030_apply_general_knowledge_category",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "7",
-      "when": 1778806800000,
-      "tag": "0031_feed_answered_card_data",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "7",
-      "when": 1778888376122,
-      "tag": "0032_biweekly_ceremony_unique_cycle",
-      "breakpoints": true
-    },
-    {
-      "idx": 33,
-      "version": "7",
-      "when": 1778910000000,
-      "tag": "0033_feed_item_source_result_check",
-      "breakpoints": true
-    },
-    {
-      "idx": 34,
-      "version": "7",
-      "when": 1778952386715,
-      "tag": "0034_territory_type_enum",
-      "breakpoints": true
-    },
-    {
-      "idx": 35,
-      "version": "7",
-      "when": 1779580800000,
-      "tag": "0035_mastery_events_viewer_status_idx",
-      "breakpoints": true
-    },
-    {
-      "idx": 36,
-      "version": "7",
-      "when": 1779667200000,
-      "tag": "0036_domain_exclusion_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 37,
-      "version": "7",
-      "when": 1779753600000,
-      "tag": "0037_round_reminder_optin",
-      "breakpoints": true
-    },
-    {
-      "idx": 38,
-      "version": "7",
-      "when": 1779840000000,
-      "tag": "0038_feed_item_catchup_resolved",
-      "breakpoints": true
-    },
-    {
-      "idx": 39,
-      "version": "7",
-      "when": 1779926400000,
-      "tag": "0039_repair_short_canonical_subcategory",
-      "breakpoints": true
-    },
-    {
-      "idx": 40,
-      "version": "7",
-      "when": 1780012800000,
-      "tag": "0040_question_reaction_include_submitted_answer",
-      "breakpoints": true
-    },
-    {
-      "idx": 41,
-      "version": "7",
-      "when": 1780099200000,
-      "tag": "0041_question_inside_joke",
-      "breakpoints": true
-    },
-    {
-      "idx": 42,
-      "version": "7",
-      "when": 1780185600000,
-      "tag": "0042_seed_player_mastery_for_declared_interests",
-      "breakpoints": true
-    },
-    {
-      "idx": 43,
-      "version": "7",
-      "when": 1780272000000,
-      "tag": "0043_rename_season_points_to_lifetime_baseline",
-      "breakpoints": true
-    },
-    {
-      "idx": 44,
-      "version": "7",
-      "when": 1780358400000,
-      "tag": "0044_user_last_activity_bell_opened_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 45,
-      "version": "7",
-      "when": 1780444800000,
-      "tag": "0045_user_handle",
-      "breakpoints": true
-    },
-    {
-      "idx": 46,
-      "version": "7",
-      "when": 1780531200000,
-      "tag": "0046_user_avatar_color",
-      "breakpoints": true
-    },
-    {
-      "idx": 47,
-      "version": "7",
-      "when": 1780617600000,
-      "tag": "0047_user_profile_fields",
-      "breakpoints": true
-    },
-    {
-      "idx": 48,
-      "version": "7",
-      "when": 1780704000000,
-      "tag": "0048_friends_privacy_foundation",
-      "breakpoints": true
-    },
-    {
-      "idx": 49,
-      "version": "7",
-      "when": 1780790400000,
-      "tag": "0049_user_invite_token",
-      "breakpoints": true
-    },
-    {
-      "idx": 50,
-      "version": "7",
-      "when": 1780876800000,
-      "tag": "0050_user_phone_hash_discovery",
-      "breakpoints": true
-    },
-    {
-      "idx": 51,
-      "version": "7",
-      "when": 1780963200000,
-      "tag": "0051_generated_question_fact_key",
-      "breakpoints": true
-    },
-    {
-      "idx": 52,
-      "version": "7",
-      "when": 1781049600000,
-      "tag": "0052_profile_section_visibility",
-      "breakpoints": true
-    },
-    {
-      "idx": 53,
-      "version": "7",
-      "when": 1781136000000,
-      "tag": "0053_drop_legacy_profile_visibility",
-      "breakpoints": true
-    },
-    {
-      "idx": 54,
-      "version": "7",
-      "when": 1781222400000,
-      "tag": "0054_redesign_profile",
-      "breakpoints": true
-    },
-    {
-      "idx": 55,
-      "version": "7",
-      "when": 1781308800000,
-      "tag": "0055_question_sub_angles",
-      "breakpoints": true
-    },
-    {
-      "idx": 56,
-      "version": "7",
-      "when": 1781395200000,
-      "tag": "0056_area_top_up_prompt",
-      "breakpoints": true
-    },
-    {
-      "idx": 57,
-      "version": "7",
-      "when": 1781481600000,
-      "tag": "0057_retire_creator_notes_and_quips",
-      "breakpoints": true
-    },
-    {
-      "idx": 58,
-      "version": "7",
-      "when": 1781568000000,
-      "tag": "0058_follow_model",
-      "breakpoints": true
-    },
-    {
-      "idx": 59,
-      "version": "7",
-      "when": 1781654400000,
-      "tag": "0059_niche_match_discoverability",
-      "breakpoints": true
-    },
-    {
-      "idx": 60,
-      "version": "7",
-      "when": 1781740800000,
-      "tag": "0060_generated_question_inside_joke",
-      "breakpoints": true
-    },
-    {
-      "idx": 61,
-      "version": "7",
-      "when": 1781827200000,
-      "tag": "0061_email_verification_token",
-      "breakpoints": true
-    },
-    {
-      "idx": 62,
-      "version": "7",
-      "when": 1781913600000,
-      "tag": "0062_pool_substrate_trust_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 63,
-      "version": "7",
-      "when": 1782000000000,
-      "tag": "0063_pool_embeddings",
-      "breakpoints": true
-    },
-    {
-      "idx": 64,
-      "version": "7",
-      "when": 1782086400000,
-      "tag": "0064_domain_difficulty_freeze",
-      "breakpoints": true
-    },
-    {
-      "idx": 65,
-      "version": "7",
-      "when": 1782172800000,
-      "tag": "0065_daily_refine_decision",
-      "breakpoints": true
-    },
-    {
-      "idx": 66,
-      "version": "7",
-      "when": 1782259200000,
-      "tag": "0066_ask_to_answer_verified",
-      "breakpoints": true
-    },
-    {
-      "idx": 67,
-      "version": "7",
-      "when": 1782345600000,
-      "tag": "0067_human_validated_backfill",
-      "breakpoints": true
-    },
-    {
-      "idx": 68,
-      "version": "7",
-      "when": 1782432000000,
-      "tag": "0068_acceptable_variants",
-      "breakpoints": true
-    },
-    {
-      "idx": 69,
-      "version": "7",
-      "when": 1782518400000,
-      "tag": "0069_question_visibility_blocked",
-      "breakpoints": true
-    },
-    {
-      "idx": 70,
-      "version": "7",
-      "when": 1782604800000,
-      "tag": "0070_daily_domain_preference_frequency",
-      "breakpoints": true
-    },
-    {
-      "idx": 71,
-      "version": "7",
-      "when": 1782691200000,
-      "tag": "0071_pg_trgm_convergence",
-      "breakpoints": true
-    },
-    {
-      "idx": 72,
-      "version": "7",
-      "when": 1782777600000,
-      "tag": "0072_first_session_recap_seen",
-      "breakpoints": true
-    },
-    {
-      "idx": 73,
-      "version": "7",
-      "when": 1782864000000,
-      "tag": "0073_content_report",
-      "breakpoints": true
-    },
-    {
-      "idx": 74,
-      "version": "7",
-      "when": 1782950400000,
-      "tag": "0074_generated_question_domain_key",
-      "breakpoints": true
-    },
-    {
-      "idx": 75,
-      "version": "7",
-      "when": 1783036800000,
-      "tag": "0075_daily_queue_email_reminder",
-      "breakpoints": true
-    },
-    {
-      "idx": 76,
-      "version": "7",
-      "when": 1783123200000,
-      "tag": "0076_first_game_recap_seen",
-      "breakpoints": true
-    },
-    {
-      "idx": 77,
-      "version": "7",
-      "when": 1783209600000,
-      "tag": "0077_email_verification_opt_in_intent",
-      "breakpoints": true
-    },
-    {
-      "idx": 78,
-      "version": "7",
-      "when": 1783296000000,
-      "tag": "0078_perf_lookup_indexes",
-      "breakpoints": true
-    },
-    {
-      "idx": 79,
-      "version": "7",
-      "when": 1783382400000,
-      "tag": "0079_perf_fk_covering_indexes",
-      "breakpoints": true
-    },
-    {
-      "idx": 80,
-      "version": "7",
-      "when": 1783468800000,
-      "tag": "0080_question_author_deleted",
-      "breakpoints": true
-    },
-    {
-      "idx": 81,
-      "version": "7",
-      "when": 1783555200000,
-      "tag": "0081_enable_rls_public_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 82,
-      "version": "7",
-      "when": 1783641600000,
-      "tag": "0082_question_bank_added_at_idx",
-      "breakpoints": true
-    },
-    {
-      "idx": 83,
-      "version": "7",
-      "when": 1783728000000,
-      "tag": "0083_fk_covering_indexes",
-      "breakpoints": true
-    },
-    {
-      "idx": 84,
-      "version": "7",
-      "when": 1783814400000,
-      "tag": "0084_via_attribution",
-      "breakpoints": true
-    },
-    {
-      "idx": 85,
-      "version": "7",
-      "when": 1783900800000,
-      "tag": "0085_feed_item_answered_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 86,
-      "version": "7",
-      "when": 1783987200000,
-      "tag": "0086_subject_entity",
-      "breakpoints": true
-    },
-    {
-      "idx": 87,
-      "version": "7",
-      "when": 1784073600000,
-      "tag": "0087_app_settings",
-      "breakpoints": true
-    },
-    {
-      "idx": 88,
-      "version": "7",
-      "when": 1784160000000,
-      "tag": "0088_provider_provenance",
-      "breakpoints": true
-    },
-    {
-      "idx": 89,
-      "version": "7",
-      "when": 1784246400000,
-      "tag": "0089_domain_expansion_offer",
-      "breakpoints": true
-    },
-    {
-      "idx": 90,
-      "version": "7",
-      "when": 1784332800000,
-      "tag": "0090_llm_provider_change_log",
-      "breakpoints": true
-    },
-    {
-      "idx": 91,
-      "version": "7",
-      "when": 1784419200000,
-      "tag": "0091_llm_usage_event",
-      "breakpoints": true
-    },
-    {
-      "idx": 92,
-      "version": "7",
-      "when": 1784505600000,
-      "tag": "0092_llm_cost_report",
-      "breakpoints": true
-    },
-    {
-      "idx": 93,
-      "version": "7",
-      "when": 1784592000000,
-      "tag": "0093_recovered_set_aside",
-      "breakpoints": true
-    },
-    {
-      "idx": 94,
-      "version": "7",
-      "when": 1784678400000,
-      "tag": "0094_expansion_mastery_event_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 95,
-      "version": "7",
-      "when": 1784764800000,
-      "tag": "0095_player_mastery_rotation_eligible",
-      "breakpoints": true
-    },
-    {
-      "idx": 96,
-      "version": "7",
-      "when": 1784851200000,
-      "tag": "0096_question_verification",
-      "breakpoints": true
-    },
-    {
-      "idx": 97,
-      "version": "7",
-      "when": 1784937600000,
-      "tag": "0097_quality_report",
-      "breakpoints": true
-    },
-    {
-      "idx": 98,
-      "version": "7",
-      "when": 1785024000000,
-      "tag": "0098_retrieval_domain_health",
-      "breakpoints": true
-    },
-    {
-      "idx": 99,
-      "version": "7",
-      "when": 1785110400000,
-      "tag": "0099_domain_relation",
-      "breakpoints": true
-    },
-    {
-      "idx": 100,
-      "version": "7",
-      "when": 1785196800000,
-      "tag": "0100_verification_reason",
-      "breakpoints": true
-    },
-    {
-      "idx": 101,
-      "version": "7",
-      "when": 1785283200000,
-      "tag": "0101_author_invitation",
-      "breakpoints": true
-    },
-    {
-      "idx": 102,
-      "version": "7",
-      "when": 1785369600000,
-      "tag": "0102_knowledge_graph",
-      "breakpoints": true
-    },
-    {
-      "idx": 103,
-      "version": "7",
-      "when": 1785456000000,
-      "tag": "0103_crafter_draft_decision",
-      "breakpoints": true
-    },
-    {
-      "idx": 104,
-      "version": "7",
-      "when": 1785542400000,
-      "tag": "0104_knowledge_parent_mastery",
-      "breakpoints": true
-    },
-    {
-      "idx": 105,
-      "version": "7",
-      "when": 1785628800000,
-      "tag": "0105_llm_usage_web_search",
-      "breakpoints": true
-    },
-    {
-      "idx": 106,
-      "version": "7",
-      "when": 1785715200000,
-      "tag": "0106_verify_batch_run",
-      "breakpoints": true
-    },
-    {
-      "idx": 107,
-      "version": "7",
-      "when": 1785801600000,
-      "tag": "0107_knowledge_node_wikidata_qid",
-      "breakpoints": true
-    },
-    {
-      "idx": 108,
-      "version": "7",
-      "when": 1785888000000,
-      "tag": "0108_domain_reference_passage",
-      "breakpoints": true
-    },
-    {
-      "idx": 109,
-      "version": "7",
-      "when": 1785974400000,
-      "tag": "0109_knowledge_node_weight",
-      "breakpoints": true
-    },
-    {
-      "idx": 110,
-      "version": "7",
-      "when": 1786060800000,
-      "tag": "0110_drop_knowledge_edge_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 111,
-      "version": "7",
-      "when": 1786147200000,
-      "tag": "0111_knowledge_leaf_mastery",
-      "breakpoints": true
-    },
-    {
-      "idx": 112,
-      "version": "7",
-      "when": 1786233600000,
-      "tag": "0112_drop_node_weight",
-      "breakpoints": true
-    },
-    {
-      "idx": 113,
-      "version": "7",
-      "when": 1786320000000,
-      "tag": "0113_milestone_dismissed",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1777585453077,
+			"tag": "0000_material_lyja",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1777630800000,
+			"tag": "0001_add_ceremony_ready_sms_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1777654136670,
+			"tag": "0002_add_joshing_game_sms_types",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1777654800000,
+			"tag": "0003_question_rating",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1777662000000,
+			"tag": "0004_daily_preference_configuration",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1777671600000,
+			"tag": "0005_profile_domain_visibility_three_state",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1777737600000,
+			"tag": "0006_question_reactions_contexts",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1777780800000,
+			"tag": "0007_send_to_friend_note",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1777784400000,
+			"tag": "0008_add_to_bank_provenance",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1777771056661,
+			"tag": "0009_domain_merge_events",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1777771056661,
+			"tag": "0010_feed_submitted_answer",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1777771056661,
+			"tag": "0011_preview_schema_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1777839477000,
+			"tag": "0012_feed_friend_answered",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1777840000000,
+			"tag": "0013_onboarding_demographics",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1777840100000,
+			"tag": "0014_territory_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1777840200000,
+			"tag": "0015_declared_promoted_event_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1777840300000,
+			"tag": "0016_quip_columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1777840400000,
+			"tag": "0017_creator_notes",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1777840500000,
+			"tag": "0018_daily_generated_and_player_mastery_territory",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1778508000000,
+			"tag": "0019_feed_item_nullable_columns_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1778510000000,
+			"tag": "0020_question_critique_verification",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1778521283376,
+			"tag": "0021_feed_dismissed_domains_active_unique",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1778538800000,
+			"tag": "0022_player_mastery_territory_type_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1778540000000,
+			"tag": "0023_profile_domain_visibility_runtime_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1778616500000,
+			"tag": "0024_question_surface_priority_runtime_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1778616600000,
+			"tag": "0025_grade_dispute_recheck_details",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1778616700000,
+			"tag": "0026_friend_invitation_pre_profile",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1778616800000,
+			"tag": "0027_friendship_request_context",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1778616900000,
+			"tag": "0028_remove_other_question_category",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "7",
+			"when": 1778714100000,
+			"tag": "0029_correct_answer_social_feed",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1778714200000,
+			"tag": "0030_apply_general_knowledge_category",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1778806800000,
+			"tag": "0031_feed_answered_card_data",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "7",
+			"when": 1778888376122,
+			"tag": "0032_biweekly_ceremony_unique_cycle",
+			"breakpoints": true
+		},
+		{
+			"idx": 33,
+			"version": "7",
+			"when": 1778910000000,
+			"tag": "0033_feed_item_source_result_check",
+			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1778952386715,
+			"tag": "0034_territory_type_enum",
+			"breakpoints": true
+		},
+		{
+			"idx": 35,
+			"version": "7",
+			"when": 1779580800000,
+			"tag": "0035_mastery_events_viewer_status_idx",
+			"breakpoints": true
+		},
+		{
+			"idx": 36,
+			"version": "7",
+			"when": 1779667200000,
+			"tag": "0036_domain_exclusion_scope",
+			"breakpoints": true
+		},
+		{
+			"idx": 37,
+			"version": "7",
+			"when": 1779753600000,
+			"tag": "0037_round_reminder_optin",
+			"breakpoints": true
+		},
+		{
+			"idx": 38,
+			"version": "7",
+			"when": 1779840000000,
+			"tag": "0038_feed_item_catchup_resolved",
+			"breakpoints": true
+		},
+		{
+			"idx": 39,
+			"version": "7",
+			"when": 1779926400000,
+			"tag": "0039_repair_short_canonical_subcategory",
+			"breakpoints": true
+		},
+		{
+			"idx": 40,
+			"version": "7",
+			"when": 1780012800000,
+			"tag": "0040_question_reaction_include_submitted_answer",
+			"breakpoints": true
+		},
+		{
+			"idx": 41,
+			"version": "7",
+			"when": 1780099200000,
+			"tag": "0041_question_inside_joke",
+			"breakpoints": true
+		},
+		{
+			"idx": 42,
+			"version": "7",
+			"when": 1780185600000,
+			"tag": "0042_seed_player_mastery_for_declared_interests",
+			"breakpoints": true
+		},
+		{
+			"idx": 43,
+			"version": "7",
+			"when": 1780272000000,
+			"tag": "0043_rename_season_points_to_lifetime_baseline",
+			"breakpoints": true
+		},
+		{
+			"idx": 44,
+			"version": "7",
+			"when": 1780358400000,
+			"tag": "0044_user_last_activity_bell_opened_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 45,
+			"version": "7",
+			"when": 1780444800000,
+			"tag": "0045_user_handle",
+			"breakpoints": true
+		},
+		{
+			"idx": 46,
+			"version": "7",
+			"when": 1780531200000,
+			"tag": "0046_user_avatar_color",
+			"breakpoints": true
+		},
+		{
+			"idx": 47,
+			"version": "7",
+			"when": 1780617600000,
+			"tag": "0047_user_profile_fields",
+			"breakpoints": true
+		},
+		{
+			"idx": 48,
+			"version": "7",
+			"when": 1780704000000,
+			"tag": "0048_friends_privacy_foundation",
+			"breakpoints": true
+		},
+		{
+			"idx": 49,
+			"version": "7",
+			"when": 1780790400000,
+			"tag": "0049_user_invite_token",
+			"breakpoints": true
+		},
+		{
+			"idx": 50,
+			"version": "7",
+			"when": 1780876800000,
+			"tag": "0050_user_phone_hash_discovery",
+			"breakpoints": true
+		},
+		{
+			"idx": 51,
+			"version": "7",
+			"when": 1780963200000,
+			"tag": "0051_generated_question_fact_key",
+			"breakpoints": true
+		},
+		{
+			"idx": 52,
+			"version": "7",
+			"when": 1781049600000,
+			"tag": "0052_profile_section_visibility",
+			"breakpoints": true
+		},
+		{
+			"idx": 53,
+			"version": "7",
+			"when": 1781136000000,
+			"tag": "0053_drop_legacy_profile_visibility",
+			"breakpoints": true
+		},
+		{
+			"idx": 54,
+			"version": "7",
+			"when": 1781222400000,
+			"tag": "0054_redesign_profile",
+			"breakpoints": true
+		},
+		{
+			"idx": 55,
+			"version": "7",
+			"when": 1781308800000,
+			"tag": "0055_question_sub_angles",
+			"breakpoints": true
+		},
+		{
+			"idx": 56,
+			"version": "7",
+			"when": 1781395200000,
+			"tag": "0056_area_top_up_prompt",
+			"breakpoints": true
+		},
+		{
+			"idx": 57,
+			"version": "7",
+			"when": 1781481600000,
+			"tag": "0057_retire_creator_notes_and_quips",
+			"breakpoints": true
+		},
+		{
+			"idx": 58,
+			"version": "7",
+			"when": 1781568000000,
+			"tag": "0058_follow_model",
+			"breakpoints": true
+		},
+		{
+			"idx": 59,
+			"version": "7",
+			"when": 1781654400000,
+			"tag": "0059_niche_match_discoverability",
+			"breakpoints": true
+		},
+		{
+			"idx": 60,
+			"version": "7",
+			"when": 1781740800000,
+			"tag": "0060_generated_question_inside_joke",
+			"breakpoints": true
+		},
+		{
+			"idx": 61,
+			"version": "7",
+			"when": 1781827200000,
+			"tag": "0061_email_verification_token",
+			"breakpoints": true
+		},
+		{
+			"idx": 62,
+			"version": "7",
+			"when": 1781913600000,
+			"tag": "0062_pool_substrate_trust_scope",
+			"breakpoints": true
+		},
+		{
+			"idx": 63,
+			"version": "7",
+			"when": 1782000000000,
+			"tag": "0063_pool_embeddings",
+			"breakpoints": true
+		},
+		{
+			"idx": 64,
+			"version": "7",
+			"when": 1782086400000,
+			"tag": "0064_domain_difficulty_freeze",
+			"breakpoints": true
+		},
+		{
+			"idx": 65,
+			"version": "7",
+			"when": 1782172800000,
+			"tag": "0065_daily_refine_decision",
+			"breakpoints": true
+		},
+		{
+			"idx": 66,
+			"version": "7",
+			"when": 1782259200000,
+			"tag": "0066_ask_to_answer_verified",
+			"breakpoints": true
+		},
+		{
+			"idx": 67,
+			"version": "7",
+			"when": 1782345600000,
+			"tag": "0067_human_validated_backfill",
+			"breakpoints": true
+		},
+		{
+			"idx": 68,
+			"version": "7",
+			"when": 1782432000000,
+			"tag": "0068_acceptable_variants",
+			"breakpoints": true
+		},
+		{
+			"idx": 69,
+			"version": "7",
+			"when": 1782518400000,
+			"tag": "0069_question_visibility_blocked",
+			"breakpoints": true
+		},
+		{
+			"idx": 70,
+			"version": "7",
+			"when": 1782604800000,
+			"tag": "0070_daily_domain_preference_frequency",
+			"breakpoints": true
+		},
+		{
+			"idx": 71,
+			"version": "7",
+			"when": 1782691200000,
+			"tag": "0071_pg_trgm_convergence",
+			"breakpoints": true
+		},
+		{
+			"idx": 72,
+			"version": "7",
+			"when": 1782777600000,
+			"tag": "0072_first_session_recap_seen",
+			"breakpoints": true
+		},
+		{
+			"idx": 73,
+			"version": "7",
+			"when": 1782864000000,
+			"tag": "0073_content_report",
+			"breakpoints": true
+		},
+		{
+			"idx": 74,
+			"version": "7",
+			"when": 1782950400000,
+			"tag": "0074_generated_question_domain_key",
+			"breakpoints": true
+		},
+		{
+			"idx": 75,
+			"version": "7",
+			"when": 1783036800000,
+			"tag": "0075_daily_queue_email_reminder",
+			"breakpoints": true
+		},
+		{
+			"idx": 76,
+			"version": "7",
+			"when": 1783123200000,
+			"tag": "0076_first_game_recap_seen",
+			"breakpoints": true
+		},
+		{
+			"idx": 77,
+			"version": "7",
+			"when": 1783209600000,
+			"tag": "0077_email_verification_opt_in_intent",
+			"breakpoints": true
+		},
+		{
+			"idx": 78,
+			"version": "7",
+			"when": 1783296000000,
+			"tag": "0078_perf_lookup_indexes",
+			"breakpoints": true
+		},
+		{
+			"idx": 79,
+			"version": "7",
+			"when": 1783382400000,
+			"tag": "0079_perf_fk_covering_indexes",
+			"breakpoints": true
+		},
+		{
+			"idx": 80,
+			"version": "7",
+			"when": 1783468800000,
+			"tag": "0080_question_author_deleted",
+			"breakpoints": true
+		},
+		{
+			"idx": 81,
+			"version": "7",
+			"when": 1783555200000,
+			"tag": "0081_enable_rls_public_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 82,
+			"version": "7",
+			"when": 1783641600000,
+			"tag": "0082_question_bank_added_at_idx",
+			"breakpoints": true
+		},
+		{
+			"idx": 83,
+			"version": "7",
+			"when": 1783728000000,
+			"tag": "0083_fk_covering_indexes",
+			"breakpoints": true
+		},
+		{
+			"idx": 84,
+			"version": "7",
+			"when": 1783814400000,
+			"tag": "0084_via_attribution",
+			"breakpoints": true
+		},
+		{
+			"idx": 85,
+			"version": "7",
+			"when": 1783900800000,
+			"tag": "0085_feed_item_answered_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 86,
+			"version": "7",
+			"when": 1783987200000,
+			"tag": "0086_subject_entity",
+			"breakpoints": true
+		},
+		{
+			"idx": 87,
+			"version": "7",
+			"when": 1784073600000,
+			"tag": "0087_app_settings",
+			"breakpoints": true
+		},
+		{
+			"idx": 88,
+			"version": "7",
+			"when": 1784160000000,
+			"tag": "0088_provider_provenance",
+			"breakpoints": true
+		},
+		{
+			"idx": 89,
+			"version": "7",
+			"when": 1784246400000,
+			"tag": "0089_domain_expansion_offer",
+			"breakpoints": true
+		},
+		{
+			"idx": 90,
+			"version": "7",
+			"when": 1784332800000,
+			"tag": "0090_llm_provider_change_log",
+			"breakpoints": true
+		},
+		{
+			"idx": 91,
+			"version": "7",
+			"when": 1784419200000,
+			"tag": "0091_llm_usage_event",
+			"breakpoints": true
+		},
+		{
+			"idx": 92,
+			"version": "7",
+			"when": 1784505600000,
+			"tag": "0092_llm_cost_report",
+			"breakpoints": true
+		},
+		{
+			"idx": 93,
+			"version": "7",
+			"when": 1784592000000,
+			"tag": "0093_recovered_set_aside",
+			"breakpoints": true
+		},
+		{
+			"idx": 94,
+			"version": "7",
+			"when": 1784678400000,
+			"tag": "0094_expansion_mastery_event_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 95,
+			"version": "7",
+			"when": 1784764800000,
+			"tag": "0095_player_mastery_rotation_eligible",
+			"breakpoints": true
+		},
+		{
+			"idx": 96,
+			"version": "7",
+			"when": 1784851200000,
+			"tag": "0096_question_verification",
+			"breakpoints": true
+		},
+		{
+			"idx": 97,
+			"version": "7",
+			"when": 1784937600000,
+			"tag": "0097_quality_report",
+			"breakpoints": true
+		},
+		{
+			"idx": 98,
+			"version": "7",
+			"when": 1785024000000,
+			"tag": "0098_retrieval_domain_health",
+			"breakpoints": true
+		},
+		{
+			"idx": 99,
+			"version": "7",
+			"when": 1785110400000,
+			"tag": "0099_domain_relation",
+			"breakpoints": true
+		},
+		{
+			"idx": 100,
+			"version": "7",
+			"when": 1785196800000,
+			"tag": "0100_verification_reason",
+			"breakpoints": true
+		},
+		{
+			"idx": 101,
+			"version": "7",
+			"when": 1785283200000,
+			"tag": "0101_author_invitation",
+			"breakpoints": true
+		},
+		{
+			"idx": 102,
+			"version": "7",
+			"when": 1785369600000,
+			"tag": "0102_knowledge_graph",
+			"breakpoints": true
+		},
+		{
+			"idx": 103,
+			"version": "7",
+			"when": 1785456000000,
+			"tag": "0103_crafter_draft_decision",
+			"breakpoints": true
+		},
+		{
+			"idx": 104,
+			"version": "7",
+			"when": 1785542400000,
+			"tag": "0104_knowledge_parent_mastery",
+			"breakpoints": true
+		},
+		{
+			"idx": 105,
+			"version": "7",
+			"when": 1785628800000,
+			"tag": "0105_llm_usage_web_search",
+			"breakpoints": true
+		},
+		{
+			"idx": 106,
+			"version": "7",
+			"when": 1785715200000,
+			"tag": "0106_verify_batch_run",
+			"breakpoints": true
+		},
+		{
+			"idx": 107,
+			"version": "7",
+			"when": 1785801600000,
+			"tag": "0107_knowledge_node_wikidata_qid",
+			"breakpoints": true
+		},
+		{
+			"idx": 108,
+			"version": "7",
+			"when": 1785888000000,
+			"tag": "0108_domain_reference_passage",
+			"breakpoints": true
+		},
+		{
+			"idx": 109,
+			"version": "7",
+			"when": 1785974400000,
+			"tag": "0109_knowledge_node_weight",
+			"breakpoints": true
+		},
+		{
+			"idx": 110,
+			"version": "7",
+			"when": 1786060800000,
+			"tag": "0110_drop_knowledge_edge_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 111,
+			"version": "7",
+			"when": 1786147200000,
+			"tag": "0111_knowledge_leaf_mastery",
+			"breakpoints": true
+		},
+		{
+			"idx": 112,
+			"version": "7",
+			"when": 1786233600000,
+			"tag": "0112_drop_node_weight",
+			"breakpoints": true
+		},
+		{
+			"idx": 113,
+			"version": "7",
+			"when": 1786320000000,
+			"tag": "0113_milestone_dismissed",
+			"breakpoints": true
+		},
+		{
+			"idx": 115,
+			"version": "7",
+			"when": 1786492800000,
+			"tag": "0115_question_salvage_proposal",
+			"breakpoints": true
+		}
+	]
 }

--- a/scripts/salvage-demoted.ts
+++ b/scripts/salvage-demoted.ts
@@ -1,0 +1,155 @@
+/**
+ * Salvage pass over the demoted-question review queue (D-QUALITY-SALVAGE-01).
+ *
+ * A sample of the queue showed ~80% of demotions are not wrong answers — they
+ * are one removable/wrong fact (usually a decorative aside in the explainer)
+ * while the ask + headline answer are correct. For each demoted Question this
+ * proposes the MINIMAL fix (proposeSalvage), re-verifies the PROPOSED version
+ * (verifyQuestion directly — so we check our exact edit against the existing
+ * answer), and stores a proposal. Nothing is applied: a human approves each
+ * ready diff in the review queue (conservative). Broken cores → 'unsalvageable'.
+ *
+ * Read-only by default (proposes + prints a triage census). Run from repo root:
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/salvage-demoted.ts          # dry-run: propose + census, persist nothing
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/salvage-demoted.ts --write   # persist proposals to QuestionSalvageProposal
+ *
+ * --write only ever touches the QuestionSalvageProposal table; Question/
+ * GeneratedQuestion rows are never modified by this script.
+ */
+import 'dotenv/config';
+
+import { pool } from '../src/server/db';
+import { getMachineDemotionsForReview } from '../src/server/db/queries/machine-demotions';
+import {
+  questionIdsWithProposal,
+  upsertSalvageProposal,
+} from '../src/server/db/queries/salvage-proposals';
+import { proposeSalvage } from '../src/server/quality/salvage-question';
+import { verifyQuestion } from '../src/server/quality/verify-question';
+
+const WRITE = process.argv.includes('--write');
+const CONCURRENCY = 5;
+// --limit N: process only the first N of the queue (validation runs).
+const LIMIT_ARG = process.argv.find((a) => a.startsWith('--limit='));
+const LIMIT = LIMIT_ARG ? Math.max(1, Number(LIMIT_ARG.split('=')[1]) || 0) : Infinity;
+
+type Outcome = 'ready' | 'reverify_failed' | 'unsalvageable' | 'skipped_existing';
+
+async function processOne(item: {
+  questionId: string;
+  questionText: string;
+  correctAnswer: string;
+  explanation: string | null;
+  verificationReason: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+}): Promise<{ outcome: Outcome; note: string }> {
+  const proposal = await proposeSalvage({
+    questionText: item.questionText,
+    answer: item.correctAnswer,
+    explanation: item.explanation,
+    verificationReason: item.verificationReason ?? 'demoted (reason not captured)',
+    canonicalSubcategory: item.canonicalSubcategory,
+    broadCategory: item.broadCategory,
+  });
+
+  if (proposal.kind === 'unsalvageable') {
+    if (WRITE) {
+      await upsertSalvageProposal({
+        questionId: item.questionId,
+        targetTable: 'question',
+        kind: 'unsalvageable',
+        proposedStem: null,
+        proposedExplanation: null,
+        reverifyOutcome: 'demoted',
+        reverifyReason: proposal.note,
+        status: 'unsalvageable',
+      });
+    }
+    return { outcome: 'unsalvageable', note: proposal.note };
+  }
+
+  // Re-verify the PROPOSED version against the EXISTING answer (verifyQuestion
+  // directly — rerunQuestion would regenerate the answer + overwrite our
+  // proposed explainer). Fall back to originals for the field we didn't touch.
+  const reverify = await verifyQuestion({
+    questionText: proposal.proposedStem ?? item.questionText,
+    answer: item.correctAnswer,
+    explanation: proposal.proposedExplanation ?? item.explanation ?? undefined,
+    canonicalSubcategory: item.canonicalSubcategory ?? undefined,
+    broadCategory: item.broadCategory ?? undefined,
+    dimensions: ['false_premise', 'extra_fact'],
+  });
+
+  // Only a proposal that now PASSES becomes 'ready'; anything else is not shown.
+  const passed = reverify?.outcome === 'ok';
+  if (WRITE) {
+    await upsertSalvageProposal({
+      questionId: item.questionId,
+      targetTable: 'question',
+      kind: proposal.kind,
+      proposedStem: proposal.proposedStem,
+      proposedExplanation: proposal.proposedExplanation,
+      reverifyOutcome: reverify?.outcome ?? 'unverifiable',
+      reverifyReason: reverify?.reason ?? 'reverify unavailable',
+      status: passed ? 'ready' : 'unsalvageable',
+    });
+  }
+  return {
+    outcome: passed ? 'ready' : 'reverify_failed',
+    note: `${proposal.kind}: ${proposal.note}${passed ? '' : ` → reverify=${reverify?.outcome ?? 'none'}`}`,
+  };
+}
+
+async function main() {
+  const fullQueue = await getMachineDemotionsForReview();
+  const queue = Number.isFinite(LIMIT) ? fullQueue.slice(0, LIMIT) : fullQueue;
+  const already = await questionIdsWithProposal(queue.map((q) => q.questionId));
+  const todo = queue.filter((q) => !already.has(q.questionId));
+
+  console.log(
+    `[salvage] queue=${queue.length} already_proposed=${already.size} to_process=${todo.length} mode=${WRITE ? 'WRITE' : 'DRY-RUN'}`,
+  );
+
+  const tally: Record<Outcome, number> = {
+    ready: 0,
+    reverify_failed: 0,
+    unsalvageable: 0,
+    skipped_existing: already.size,
+  };
+
+  for (let i = 0; i < todo.length; i += CONCURRENCY) {
+    const chunk = todo.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(
+      chunk.map(async (item) => {
+        try {
+          return await processOne(item);
+        } catch (error) {
+          return {
+            outcome: 'reverify_failed' as Outcome,
+            note: `error: ${error instanceof Error ? error.message : String(error)}`,
+          };
+        }
+      }),
+    );
+    results.forEach((r, j) => {
+      tally[r.outcome]++;
+      const stem = chunk[j].questionText.slice(0, 60).replace(/\s+/g, ' ');
+      console.log(`  [${r.outcome}] ${stem}… — ${r.note}`);
+    });
+  }
+
+  console.log('\n[salvage] census:', JSON.stringify(tally));
+  const salvageable = tally.ready;
+  const pct = todo.length ? Math.round((salvageable / todo.length) * 100) : 0;
+  console.log(
+    `[salvage] ${salvageable}/${todo.length} processed became one-click-ready (${pct}%). ${WRITE ? 'Persisted.' : 'Dry-run — re-run with --write to persist.'}`,
+  );
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => pool.end());

--- a/src/app/admin/reports/AdminReportsClient.tsx
+++ b/src/app/admin/reports/AdminReportsClient.tsx
@@ -161,6 +161,10 @@ export function AdminReportsClient({
       })),
   ].sort((a, b) => a.at - b.at);
   const openCount = inappropriate.length + rest.length;
+  // D-QUALITY-SALVAGE-01: how many demotions have a ready one-click fix waiting.
+  const readyFixCount = demotions.filter(
+    (item) => item.proposal && !hiddenKey(`demotion:${item.questionId}`),
+  ).length;
 
   return (
     <main className="mx-auto min-h-dvh max-w-3xl px-4 pt-6 pb-24">
@@ -173,6 +177,12 @@ export function AdminReportsClient({
           Two streams, one queue: players reported these, or the verifier pulled them pending your
           call. Nothing here is deleted — flagged questions sit out of circulation until you act.
         </p>
+        {readyFixCount > 0 ? (
+          <p className="mt-2 text-sm font-medium text-[var(--success)]">
+            {readyFixCount} {readyFixCount === 1 ? 'has' : 'have'} a suggested fix that re-verifies
+            clean — look for “Review fix”.
+          </p>
+        ) : null}
         <div className="mt-3 flex gap-2">
           <TabButton active={view === 'open'} onClick={() => setView('open')}>
             Needing review ({openCount})
@@ -913,6 +923,9 @@ function DemotionRow({
 }) {
   const router = useRouter();
   const [editing, setEditing] = useState(false);
+  // Opened from the "Review fix" button → EditPanel pre-fills the machine's
+  // proposed edit (D-QUALITY-SALVAGE-01). The human still re-runs + approves.
+  const [fixMode, setFixMode] = useState(false);
 
   function resolved() {
     onCleared();
@@ -925,6 +938,20 @@ function DemotionRow({
       label: action === 'restore_demoted' ? 'Restored to circulation' : 'Retired (recoverable)',
       body: { action, questionId: item.questionId },
     });
+  }
+
+  function rejectFix() {
+    onStage({
+      key: `demotion:${item.questionId}`,
+      label: 'Suggested fix dismissed',
+      body: { action: 'reject_salvage', questionId: item.questionId },
+    });
+  }
+
+  const proposal = item.proposal;
+  function openFix() {
+    setFixMode(true);
+    setEditing(true);
   }
 
   const authorLabel = item.authorIsHouse
@@ -970,24 +997,63 @@ function DemotionRow({
         {item.verificationReason ?? 'reason not captured (demoted before reasons were stored)'}
       </p>
 
+      {/* D-QUALITY-SALVAGE-01: a machine-proposed minimal fix that already
+          re-verified clean. Conservative — "Review fix" opens the same edit panel
+          pre-filled; the human still re-runs + approves. Nothing auto-applies. */}
+      {proposal && !editing ? (
+        <div
+          className="mt-2 rounded-md border px-3 py-2 text-[13px]"
+          style={{ borderColor: 'var(--success)', background: 'var(--success-surface, transparent)' }}
+        >
+          <p className="font-semibold text-[var(--success)]">
+            Suggested fix — verifier re-checked, now passes
+          </p>
+          <p className="text-muted-foreground mt-0.5">
+            {proposal.kind === 'extra_fact_explainer' ? 'Explainer' : 'Question'} · {proposal.reverifyReason ?? 'minimal edit'}
+          </p>
+          {proposal.proposedStem ? (
+            <p className="mt-1 text-[var(--brand-ink)]">
+              <span className="text-muted-foreground">Proposed question: </span>
+              {proposal.proposedStem}
+            </p>
+          ) : null}
+          {proposal.proposedExplanation ? (
+            <p className="mt-1 text-[var(--brand-ink-700)]">
+              <span className="text-muted-foreground">Proposed explainer: </span>
+              {proposal.proposedExplanation}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
       {editing ? (
-        <Modal title="Edit &amp; re-run" onClose={() => setEditing(false)}>
+        <Modal title="Edit &amp; re-run" onClose={() => { setEditing(false); setFixMode(false); }}>
           <EditPanel
             target={{ table: 'question', id: item.questionId }}
-            initialQuestion={item.questionText}
+            initialQuestion={fixMode && proposal?.proposedStem ? proposal.proposedStem : item.questionText}
             initialAnswer={item.correctAnswer}
-            initialExplanation={item.explanation}
+            initialExplanation={fixMode && proposal?.proposedExplanation ? proposal.proposedExplanation : item.explanation}
             showExplanation
             canonicalSubcategory={item.canonicalSubcategory}
             broadCategory={item.broadCategory}
             concern={item.verificationReason ?? 'demoted by the verifier (reason not captured)'}
             onDone={resolved}
-            onCancel={() => setEditing(false)}
+            onCancel={() => { setEditing(false); setFixMode(false); }}
           />
         </Modal>
       ) : null}
       {!editing ? (
         <div className="mt-3 flex flex-wrap items-center gap-2">
+          {proposal ? (
+            <button
+              type="button"
+              onClick={openFix}
+              className="rounded-md border px-3 py-1.5 text-sm font-semibold"
+              style={{ borderColor: 'var(--success)', background: 'var(--success)', color: 'var(--on-accent, #fff)' }}
+            >
+              Review fix →
+            </button>
+          ) : null}
           <button
             type="button"
             onClick={() => act('restore_demoted')}
@@ -1012,6 +1078,16 @@ function DemotionRow({
           >
             Retire (recoverable)
           </button>
+          {proposal ? (
+            <button
+              type="button"
+              onClick={rejectFix}
+              className="rounded-md px-2 py-1.5 text-xs font-medium"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              Not a fix
+            </button>
+          ) : null}
         </div>
       ) : null}
     </article>

--- a/src/app/api/admin/content-reports/__tests__/route.test.ts
+++ b/src/app/api/admin/content-reports/__tests__/route.test.ts
@@ -51,6 +51,9 @@ vi.mock('@/server/db/queries/machine-demotions', () => ({
   approveEditedQuestion: approveMock,
 }));
 vi.mock('@/server/quality/rerun-question', () => ({ rerunQuestion: rerunMock }));
+vi.mock('@/server/db/queries/salvage-proposals', () => ({
+  resolveSalvageProposal: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { POST } from '@/app/api/admin/content-reports/route';
 

--- a/src/app/api/admin/content-reports/route.ts
+++ b/src/app/api/admin/content-reports/route.ts
@@ -15,6 +15,7 @@ import {
   restoreDemotedQuestion,
   retireDemotedQuestion,
 } from '@/server/db/queries/machine-demotions';
+import { resolveSalvageProposal } from '@/server/db/queries/salvage-proposals';
 import { rerunQuestion } from '@/server/quality/rerun-question';
 
 export const dynamic = 'force-dynamic';
@@ -40,6 +41,9 @@ const bodySchema = z.discriminatedUnion('action', [
   }),
   z.object({ action: z.literal('restore_demoted'), questionId: z.string().trim().min(1) }),
   z.object({ action: z.literal('retire_demoted'), questionId: z.string().trim().min(1) }),
+  // D-QUALITY-SALVAGE-01: dismiss a machine-proposed salvage fix ("Not a fix");
+  // the demotion card falls back to the manual restore/edit/retire buttons.
+  z.object({ action: z.literal('reject_salvage'), questionId: z.string().trim().min(1) }),
   z.object({
     action: z.literal('edit'),
     questionId: z.string().trim().min(1),
@@ -104,7 +108,15 @@ export async function POST(request: NextRequest) {
     if (!result.ok) {
       return NextResponse.json({ error: result.reason }, { status: 404 });
     }
+    // If this approval consumed a salvage proposal, mark it applied (best-effort;
+    // a no-op when the edit didn't come from one).
+    await resolveSalvageProposal(data.target.id, 'applied');
     return NextResponse.json(result);
+  }
+
+  if (data.action === 'reject_salvage') {
+    await resolveSalvageProposal(data.questionId, 'rejected');
+    return NextResponse.json({ ok: true });
   }
 
   if (data.action === 'edit') {
@@ -148,6 +160,12 @@ export async function POST(request: NextRequest) {
       { error: result.reason },
       { status: result.reason === 'not_found' ? 404 : 409 },
     );
+  }
+
+  // A manual restore/retire settles the demotion, so retire any live salvage
+  // proposal too (it can't apply to a row that has left the queue).
+  if (data.action === 'restore_demoted' || data.action === 'retire_demoted') {
+    await resolveSalvageProposal(data.questionId, 'rejected');
   }
 
   return NextResponse.json(result);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2067,6 +2067,27 @@ export async function register() {
       `);
       await db.execute(sql`ALTER TABLE "LlmCostReport" ENABLE ROW LEVEL SECURITY`);
       await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmCostReport_created_at_idx" ON "LlmCostReport" ("created_at")`);
+      // Migration 0115 (D-QUALITY-SALVAGE-01): machine-proposed salvage fixes for
+      // demoted questions. The salvage batch + review queue read/insert here and
+      // would 42P01 if the migration recorded without the table. Self-contained;
+      // same rationale as the 0103 CrafterDraftDecision guard.
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "QuestionSalvageProposal" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "question_id" text NOT NULL,
+          "target_table" text NOT NULL,
+          "kind" text NOT NULL,
+          "proposed_stem" text,
+          "proposed_explanation" text,
+          "reverify_outcome" text NOT NULL,
+          "reverify_reason" text,
+          "status" text NOT NULL DEFAULT 'ready',
+          "created_at" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "QuestionSalvageProposal" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "QuestionSalvageProposal_question_id_idx" ON "QuestionSalvageProposal" ("question_id")`);
+      await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "QuestionSalvageProposal_active_question_key" ON "QuestionSalvageProposal" ("question_id") WHERE "status" = 'ready'`);
     } catch {
       // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
     }

--- a/src/server/daily/__tests__/enrich-variants.test.ts
+++ b/src/server/daily/__tests__/enrich-variants.test.ts
@@ -9,6 +9,7 @@ const llmMock = vi.hoisted(() => ({
 }));
 
 vi.mock('@/lib/llm', () => ({
+  ANTHROPIC_MODEL: 'claude-sonnet-4-6',
   INSTRUCTION_SCOPING_QUALIFIER: '',
   INSTRUCTION_USER_INPUT_GUIDANCE: '',
   extractTextContent: (content: unknown) => String((content as { text: string }).text),

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -158,6 +158,7 @@ The single largest source of broken questions is a FALSE CLAIM smuggled into the
 RULE: assert in the setup ONLY what the question actually needs the player to lean on, and only what you are certain is true. If a fact is not essential to the ask, CUT it. When you must include framing, prefer evocative, atmospheric description (which carries no factual claim) over a pile of stated counts, superlatives, and attributions. Setup length is not the problem — asserted side-facts are; a long atmospheric question is safe, a short one with a wrong number is not.
 - BAD (false, unnecessary superlative): "Dumbledore makes last-minute point awards that overturn Slytherin's lead. Which student receives fifty points — the largest single award in that sequence — for standing up to his friends?" → the "fifty points / largest single award" claim is both decorative and false (it was ten points, and the largest award went to someone else); the question works without it.
 - GOOD (same answer, no asserted side-fact): "At the end-of-year feast in Harry's first year, which student does Dumbledore award points to 'for standing up to his friends'?" → "Neville Longbottom"
+THE SAME FLOOR APPLIES TO THE EXPLAINER, NOT JUST THE SETUP: the explainer is fact-checked exactly like the question, and one wrong decorative aside in it — a date, a count, an adjacent work, an attribution the answer never needed — demotes the WHOLE question even when the ask and answer are perfect. Every factual claim you put in the explainer must be load-bearing to understanding the answer AND independently checkable. If you are not certain of an incidental detail (the exact year, "the first", who directed the adaptation, what else the author wrote), leave it OUT — a short explainer that only restates why the answer is right is safer than a rich one that smuggles in a wrong "1973". Prefer under-claiming to a decorative aside.
 
 FAN-SALIENCE RULE (Rule 1 — tier-dependent):
 Do NOT default to the most nameable entity in a work — the character roster, the title, the principal location. Those are wiki-salient (easy to look up, dull to be asked). Chase fan-salient facts instead: the thing a devoted fan of THIS specific work would be delighted to be recognized for knowing — the rewatch-catch, the running joke, the exact wording of a famous line, the specific beat or object fans hold onto. Apply by difficulty tier:
@@ -276,7 +277,7 @@ Return format:
       "broad_category": "string",
       "question_text": "string",
       "answer": "string",
-      "explainer": "string, 2-3 sentences of educational context",
+      "explainer": "string, 2-3 sentences of educational context — every factual claim in it must be load-bearing and checkable (see the side-facts floor); omit any incidental date/count/attribution you are not certain of rather than risk a wrong aside",
       "difficulty_estimate": "accessible | moderate | specialist",
       "fact_key": "string, short hyphenated lowercase identifier for the underlying fact (see REPETITION RULES)",
       "subject_entity": "string, the single primary subject the question is about (see above) — coarser than fact_key",
@@ -873,7 +874,8 @@ For each question decide:
   - the question's clearly-correct answer is a different thing/person than the stated answer, OR
   - the question and answer come from mismatched subjects (e.g. a literature question answered with an unrelated political figure), OR
   - the question's SETUP asserts a false fact — a wrong count, date, attribution, authorship, or relationship — EVEN WHEN the stated answer is correct. E.g. "Bach composed six works for unaccompanied strings — three for solo violin and three for solo cello — what collective title is given to the cello set?" answered "Cello Suites": the answer is correct, but the premise is false (Bach wrote six of each, not three), so this is WRONG.
-- OK — the stated answer is correct (or a reasonable equivalent/alternate form) AND the setup contains no false factual claim.
+  - the EXPLAINER (e=) asserts a false incidental fact — a wrong date, count, attribution, or adjacent-work claim — EVEN WHEN the question, answer, and setup are all correct. The explainer is fact-checked downstream exactly like the question, so a decorative wrong aside there (e.g. calling a 1979 anthology "the 1973 anthology") demotes the whole item. Judge only clear factual errors, not phrasing.
+- OK — the stated answer is correct (or a reasonable equivalent/alternate form) AND neither the setup nor the explainer contains a false factual claim.
 - UNVERIFIABLE — you genuinely cannot verify the fact (extremely niche, recent, or personal). Treat these as OK; do NOT flag them.
 
 Flag (drop) ONLY questions you judge WRONG with high confidence. A high bar applies — when in doubt, leave it. Do not flag for style, difficulty, phrasing, or ambiguity; only for a factually incorrect stated answer or a factually false premise.
@@ -966,7 +968,7 @@ export async function findFactualFailures(generated: LlmQuestion[]): Promise<{
   const body = generated
     .map(
       (q, i) =>
-        `[${i}] domain=${q.canonical_subcategory}\n    q=${q.question_text}\n    a=${q.answer}`,
+        `[${i}] domain=${q.canonical_subcategory}\n    q=${q.question_text}\n    a=${q.answer}\n    e=${q.explainer}`,
     )
     .join('\n\n');
   const userMessage = wrapUserInput('batch', body);

--- a/src/server/db/queries/machine-demotions.ts
+++ b/src/server/db/queries/machine-demotions.ts
@@ -6,6 +6,7 @@ import {
   resolveActiveIncorrectReportsForGenerated,
   resolveActiveIncorrectReportsForQuestion,
 } from '@/server/db/queries/content-reports';
+import { getReadyProposalsForQuestions, type SalvageProposalRow } from '@/server/db/queries/salvage-proposals';
 import { type QuestionSource, resolveAuthorDisplay } from '@/lib/questions-types';
 
 // B-CRAFTER-LIFECYCLE-01 Phase 1 — the MACHINE stream of the admin review queue.
@@ -44,6 +45,9 @@ export type MachineDemotionReviewItem = {
   creatorId: string | null;
   authorName: string | null;
   authorIsHouse: boolean;
+  // D-QUALITY-SALVAGE-01: a machine-proposed, pre-re-verified minimal fix awaiting
+  // one-click approval. Present only when a 'ready' proposal exists for this row.
+  proposal: SalvageProposalRow | null;
 };
 
 // Demoted canonical questions awaiting a human call, oldest demotion first
@@ -81,6 +85,8 @@ export async function getMachineDemotionsForReview(): Promise<MachineDemotionRev
     )
     .orderBy(asc(questions.verifiedAt));
 
+  const proposals = await getReadyProposalsForQuestions(rows.map((r) => r.questionId));
+
   return rows.map((row) => ({
     questionId: row.questionId,
     questionText: row.questionText,
@@ -92,6 +98,7 @@ export async function getMachineDemotionsForReview(): Promise<MachineDemotionRev
     broadCategory: row.broadCategory,
     source: row.source,
     creatorId: row.creatorId,
+    proposal: proposals.get(row.questionId) ?? null,
     ...resolveAuthorDisplay(row.creatorId, row.source, row.authorName),
   }));
 }

--- a/src/server/db/queries/salvage-proposals.ts
+++ b/src/server/db/queries/salvage-proposals.ts
@@ -1,0 +1,95 @@
+import { and, desc, eq, inArray } from 'drizzle-orm';
+
+import { db, questionSalvageProposals } from '@/server/db';
+
+export type SalvageProposalRow = {
+  questionId: string;
+  kind: 'extra_fact_stem' | 'extra_fact_explainer' | 'unsalvageable';
+  proposedStem: string | null;
+  proposedExplanation: string | null;
+  reverifyReason: string | null;
+};
+
+type InsertSalvageProposal = {
+  questionId: string;
+  targetTable: 'question' | 'generated';
+  kind: 'extra_fact_stem' | 'extra_fact_explainer' | 'unsalvageable';
+  proposedStem: string | null;
+  proposedExplanation: string | null;
+  reverifyOutcome: 'ok' | 'demoted' | 'unverifiable';
+  reverifyReason: string | null;
+  status: 'ready' | 'unsalvageable';
+};
+
+/**
+ * Record a fresh proposal for a question, retiring any prior live ('ready') one
+ * first so the partial-unique index holds (a re-run supersedes, not stacks).
+ */
+export async function upsertSalvageProposal(row: InsertSalvageProposal): Promise<void> {
+  await db
+    .update(questionSalvageProposals)
+    .set({ status: 'rejected' })
+    .where(
+      and(
+        eq(questionSalvageProposals.questionId, row.questionId),
+        eq(questionSalvageProposals.status, 'ready'),
+      ),
+    );
+  await db.insert(questionSalvageProposals).values(row);
+}
+
+/** The latest live proposal per question id — for the review-queue join. */
+export async function getReadyProposalsForQuestions(
+  questionIds: string[],
+): Promise<Map<string, SalvageProposalRow>> {
+  if (questionIds.length === 0) return new Map();
+  const rows = await db
+    .select({
+      questionId: questionSalvageProposals.questionId,
+      kind: questionSalvageProposals.kind,
+      proposedStem: questionSalvageProposals.proposedStem,
+      proposedExplanation: questionSalvageProposals.proposedExplanation,
+      reverifyReason: questionSalvageProposals.reverifyReason,
+    })
+    .from(questionSalvageProposals)
+    .where(
+      and(
+        inArray(questionSalvageProposals.questionId, questionIds),
+        eq(questionSalvageProposals.status, 'ready'),
+      ),
+    )
+    .orderBy(desc(questionSalvageProposals.createdAt));
+  const out = new Map<string, SalvageProposalRow>();
+  for (const r of rows) if (!out.has(r.questionId)) out.set(r.questionId, r);
+  return out;
+}
+
+/**
+ * Which of these question ids already have ANY proposal (ready/applied/rejected/
+ * unsalvageable) — the batch skips them so it never re-spends on a question it
+ * has already judged. (Re-processing a rejected one is a future --force concern.)
+ */
+export async function questionIdsWithProposal(questionIds: string[]): Promise<Set<string>> {
+  if (questionIds.length === 0) return new Set();
+  const rows = await db
+    .select({ questionId: questionSalvageProposals.questionId })
+    .from(questionSalvageProposals)
+    .where(inArray(questionSalvageProposals.questionId, questionIds));
+  return new Set(rows.map((r) => r.questionId));
+}
+
+/** Terminal-state a question's live proposal once the human acts on it. */
+export async function resolveSalvageProposal(
+  questionId: string,
+  status: 'applied' | 'rejected',
+): Promise<void> {
+  await db
+    .update(questionSalvageProposals)
+    .set({ status })
+    .where(
+      and(
+        eq(questionSalvageProposals.questionId, questionId),
+        eq(questionSalvageProposals.status, 'ready'),
+      ),
+    );
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1250,6 +1250,37 @@ export const crafterDraftDecisions = pgTable(
   ],
 );
 
+// D-QUALITY-SALVAGE-01: a machine-proposed minimal fix for a verifier-demoted
+// question, pre-re-verified, awaiting a human's one-click approval in the review
+// queue. Never applied automatically — approving copies the proposed text into
+// the real edit/approve path. Append-only-ish: one live ('ready') proposal per
+// question; superseded/decided proposals keep their terminal status for record.
+export const questionSalvageProposals = pgTable(
+  'QuestionSalvageProposal',
+  {
+    id: id(),
+    // The demoted row's id, in whichever store it lives (see targetTable).
+    questionId: text('question_id').notNull(),
+    targetTable: text('target_table').$type<'question' | 'generated'>().notNull(),
+    kind: text('kind').$type<'extra_fact_stem' | 'extra_fact_explainer' | 'unsalvageable'>().notNull(),
+    proposedStem: text('proposed_stem'),
+    proposedExplanation: text('proposed_explanation'),
+    // Outcome of re-verifying the PROPOSED version. A proposal is only surfaced
+    // when this is 'ok' — the human never sees a fix that didn't actually pass.
+    reverifyOutcome: text('reverify_outcome').$type<'ok' | 'demoted' | 'unverifiable'>().notNull(),
+    reverifyReason: text('reverify_reason'),
+    status: text('status').$type<'ready' | 'applied' | 'rejected' | 'unsalvageable'>().notNull().default('ready'),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    index('QuestionSalvageProposal_question_id_idx').on(table.questionId),
+    // At most one live proposal per question — a re-run supersedes, not stacks.
+    uniqueIndex('QuestionSalvageProposal_active_question_key')
+      .on(table.questionId)
+      .where(sql`${table.status} = 'ready'`),
+  ],
+);
+
 export const friendships = pgTable(
   'Friendship',
   {

--- a/src/server/quality/__tests__/salvage-question.test.ts
+++ b/src/server/quality/__tests__/salvage-question.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSalvageResponse } from '@/server/quality/salvage-question';
+
+describe('parseSalvageResponse', () => {
+  it('parses a stem fix', () => {
+    const out = parseSalvageResponse(
+      JSON.stringify({
+        kind: 'extra_fact_stem',
+        proposed_stem: 'Which anthology, edited by Barbara Smith, is a landmark of Black lesbian feminism?',
+        proposed_explanation: null,
+        note: 'removed the wrong "1973"',
+      }),
+    );
+    expect(out).toEqual({
+      kind: 'extra_fact_stem',
+      proposedStem: 'Which anthology, edited by Barbara Smith, is a landmark of Black lesbian feminism?',
+      proposedExplanation: null,
+      note: 'removed the wrong "1973"',
+    });
+  });
+
+  it('parses an explainer-only fix', () => {
+    const out = parseSalvageResponse(
+      JSON.stringify({
+        kind: 'extra_fact_explainer',
+        proposed_stem: null,
+        proposed_explanation: 'Corrected context without the wrong date.',
+        note: 'fixed the airlift duration',
+      }),
+    );
+    expect(out?.kind).toBe('extra_fact_explainer');
+    expect(out?.proposedStem).toBeNull();
+    expect(out?.proposedExplanation).toBe('Corrected context without the wrong date.');
+  });
+
+  it('passes through unsalvageable with no proposed text', () => {
+    const out = parseSalvageResponse(
+      JSON.stringify({ kind: 'unsalvageable', proposed_stem: null, proposed_explanation: null, note: 'answer is wrong' }),
+    );
+    expect(out).toEqual({
+      kind: 'unsalvageable',
+      proposedStem: null,
+      proposedExplanation: null,
+      note: 'answer is wrong',
+    });
+  });
+
+  it('demotes a "fix" that proposes NO changed text to unsalvageable', () => {
+    // A salvage with a salvageable kind but no stem AND no explainer is a no-op —
+    // never surface it as a fix.
+    const out = parseSalvageResponse(
+      JSON.stringify({ kind: 'extra_fact_stem', proposed_stem: '  ', proposed_explanation: null, note: 'x' }),
+    );
+    expect(out?.kind).toBe('unsalvageable');
+  });
+
+  it('rejects an unknown kind', () => {
+    expect(
+      parseSalvageResponse(JSON.stringify({ kind: 'whatever', proposed_stem: 'x' })),
+    ).toBeNull();
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(parseSalvageResponse('not json')).toBeNull();
+  });
+
+  it('caps the note length', () => {
+    const out = parseSalvageResponse(
+      JSON.stringify({ kind: 'extra_fact_stem', proposed_stem: 'ok', proposed_explanation: null, note: 'z'.repeat(500) }),
+    );
+    expect((out?.note.length ?? 0) <= 300).toBe(true);
+  });
+});

--- a/src/server/quality/salvage-question.ts
+++ b/src/server/quality/salvage-question.ts
@@ -1,0 +1,153 @@
+/**
+ * Salvage proposer (D-QUALITY-SALVAGE-01) — the counterpart to the verifier.
+ *
+ * Most verifier demotions are not wrong answers: they are ONE non-load-bearing
+ * fact — a decorative wrong year/count/attribution in the stem, or (more often)
+ * in the explainer — while the ask and the headline answer are perfectly right.
+ * Given the demoted question plus the verifier's own reason (which localizes the
+ * bad fact), this proposes the MINIMAL edit that removes or corrects it while
+ * leaving the answer untouched, and classifies whether the question is salvageable
+ * at all. The proposal is never applied here — it is re-verified and then a human
+ * approves it in the review queue (conservative).
+ *
+ * Fail-closed toward SAFETY: on any client/parse/uncertainty fault the result is
+ * `unsalvageable` with no proposed text, so a fault can never fabricate a "fix".
+ * Anthropic only; usage logged under scope 'salvage-propose'.
+ */
+
+import {
+  ANTHROPIC_MODEL,
+  INSTRUCTION_SCOPING_QUALIFIER,
+  INSTRUCTION_USER_INPUT_GUIDANCE,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+  wrapUserInput,
+} from '@/lib/llm';
+
+export type SalvageKind = 'extra_fact_stem' | 'extra_fact_explainer' | 'unsalvageable';
+
+export type SalvageInput = {
+  questionText: string;
+  answer: string;
+  explanation?: string | null;
+  verificationReason: string;
+  canonicalSubcategory?: string | null;
+  broadCategory?: string | null;
+};
+
+export type SalvageProposal = {
+  kind: SalvageKind;
+  /** Full proposed stem (null when the stem is unchanged or unsalvageable). */
+  proposedStem: string | null;
+  /** Full proposed explainer (null when unchanged or unsalvageable). */
+  proposedExplanation: string | null;
+  /** One short line of what was changed / why it can't be salvaged. */
+  note: string;
+};
+
+const UNSALVAGEABLE: SalvageProposal = {
+  kind: 'unsalvageable',
+  proposedStem: null,
+  proposedExplanation: null,
+  note: 'no safe minimal fix',
+};
+
+const SALVAGE_TIMEOUT_MS = 30_000;
+
+const SYSTEM_PROMPT = `You repair trivia questions that a fact-checker demoted. Most demotions are NOT a wrong answer — they are a single non-load-bearing fact ("smuggled" scaffolding: a decorative date, count, ordinal, superlative, attribution, or adjacent-work claim) that is wrong, usually in the explainer, while the actual ask and its headline answer are correct. Your job: propose the SMALLEST edit that makes the fact-checker pass, or declare the question unsalvageable.
+
+You are given the question, its stated answer, its explainer, and the fact-checker's reason (which names the offending claim).
+
+HARD RULES:
+- NEVER change the stated answer, and never change what the question asks. If the fix would require changing the answer or the thing being asked, it is UNSALVAGEABLE.
+- Prefer REMOVAL over correction: if the offending fact is not needed to identify the answer, delete that clause and stop. Correct it (using the fact-checker's stated correct value) ONLY when the fact is load-bearing to the ask.
+- Change as little as possible. Do not rewrite, re-tone, or "improve" anything the fact-checker did not flag. Keep the rest verbatim.
+- If the demotion is because the ANSWER itself is wrong, the premise the question hinges on is false, or you are not confident a minimal edit fixes it, return UNSALVAGEABLE. Do not guess.
+
+Classify:
+- "extra_fact_stem": you edited the stem (removed/corrected a bad fact there). Return the full proposed stem.
+- "extra_fact_explainer": the stem is fine; you edited only the explainer. Return the full proposed explainer.
+- "unsalvageable": no safe minimal fix.
+
+(If both stem and explainer need trimming, edit both and use "extra_fact_stem".)
+
+Return JSON only, nothing else:
+{ "kind": "extra_fact_stem" | "extra_fact_explainer" | "unsalvageable",
+  "proposed_stem": "<full edited stem, or null if unchanged/unsalvageable>",
+  "proposed_explanation": "<full edited explainer, or null if unchanged/unsalvageable>",
+  "note": "<short: what you removed/corrected, or why it can't be salvaged>" }${INSTRUCTION_USER_INPUT_GUIDANCE}${INSTRUCTION_SCOPING_QUALIFIER}`;
+
+function buildUserMessage(input: SalvageInput): string {
+  return [
+    wrapUserInput('question', input.questionText),
+    wrapUserInput('stated_answer', input.answer),
+    input.explanation ? wrapUserInput('explainer', input.explanation) : '',
+    input.canonicalSubcategory
+      ? wrapUserInput(
+          'subject',
+          `${input.canonicalSubcategory}${input.broadCategory ? ` (${input.broadCategory})` : ''}`,
+        )
+      : '',
+    wrapUserInput('fact_checker_reason', input.verificationReason),
+    'Propose the minimal fix or declare it unsalvageable. Return JSON only.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+/** Pure: parse + validate the proposer's JSON. Exported for unit tests. */
+export function parseSalvageResponse(raw: string): SalvageProposal | null {
+  const parsed = parseJsonObject(raw);
+  if (!parsed) return null;
+  const kind = parsed.kind;
+  if (kind !== 'extra_fact_stem' && kind !== 'extra_fact_explainer' && kind !== 'unsalvageable') {
+    return null;
+  }
+  const str = (v: unknown): string | null =>
+    typeof v === 'string' && v.trim().length > 0 ? v.trim() : null;
+  const note = typeof parsed.note === 'string' ? parsed.note.trim().slice(0, 300) : '';
+
+  if (kind === 'unsalvageable') {
+    return { kind, proposedStem: null, proposedExplanation: null, note: note || 'unsalvageable' };
+  }
+
+  const proposedStem = str(parsed.proposed_stem);
+  const proposedExplanation = str(parsed.proposed_explanation);
+  // A salvage MUST actually propose replacement text; a "fix" with no changed
+  // text is meaningless, so treat it as unsalvageable rather than a no-op edit.
+  if (!proposedStem && !proposedExplanation) return { ...UNSALVAGEABLE, note: note || UNSALVAGEABLE.note };
+  return { kind, proposedStem, proposedExplanation, note: note || 'minimal fix' };
+}
+
+/**
+ * Propose a minimal salvage edit for one demoted question. Never applies it.
+ * Returns `unsalvageable` (never throws) on any fault, so a proposer outage can
+ * only ever mean "no fix offered", never a bad auto-edit.
+ */
+export async function proposeSalvage(input: SalvageInput): Promise<SalvageProposal> {
+  const client = getAnthropicClient();
+  if (!client) return UNSALVAGEABLE;
+
+  try {
+    const response = await loggedMessagesCreate(
+      client,
+      'salvage-propose',
+      {
+        model: ANTHROPIC_MODEL,
+        max_tokens: 1024,
+        temperature: 0,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: buildUserMessage(input) }],
+      },
+      { timeoutMs: SALVAGE_TIMEOUT_MS },
+    );
+    return parseSalvageResponse(extractTextContent(response.content)) ?? UNSALVAGEABLE;
+  } catch (error) {
+    console.warn('[proposeSalvage] request_failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return UNSALVAGEABLE;
+  }
+}


### PR DESCRIPTION
Docs-only. Records what building P1 + P2 (and the parallel demoted-question work) revealed — the decision holds as direction, but three mechanics/premises need correcting:

1. **P1's cost signal is inert** — nothing crosses the 0.34 line in prod.
2. **The §2 cost-routing premise is undermined by the salvage pass** — ~70% of demotions are one-off extra-fact trims, not domain-level difficulty, and salvage (#1426) + gen-tightening (#1425) drive demotion rates down, eroding the signal. If routing is revived, key it on verify-web-rate / kill-rate / **residual post-salvage demotion**, not raw demotion rate.
3. **P2 sizes completion by pool-depth + floor 8, not `node_weight`** as §"What finite changes" states.
4. **At ~6 WAU the model is latent** — P3/P4 are scale-gated, not next-up.

What held up: the completion-as-trophy reframe and the phasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrEnXchnUG6EVzVsUEB63V