### PR TITLE
feat(difficulty): size-bounded difficulty + completion (D-DIFFICULTY-SIZE-COMPLETION-01)

### DIFF
--- a/D-DIFFICULTY-SIZE-COMPLETION-01.md
+++ b/D-DIFFICULTY-SIZE-COMPLETION-01.md
@@ -1,0 +1,92 @@
+# D-DIFFICULTY-SIZE-COMPLETION-01 — Size-bounded difficulty + completion
+
+**Status:** 🟡 **RATIFIED IN CHAT** 2026-07-06 (Josh). Build in progress.
+Reconciles the ratified `D-SUPPLY-FINITE-SET-01` (completion = trophy) with the
+live per-domain difficulty ladder (`PRD-D-5`, `src/server/adaptive-difficulty.ts`)
+and mastery-v2 depth sizing (`src/server/llm/domain-depth.ts`). Supersedes the
+"always inject a harder stretch into every queue" framing (never canon; off the
+finite-set direction). Does **not** adopt the un-ratified human-authored pivot
+(`docs/thinking/CONCEPT-master-authored-canonical-sets.md`).
+
+## Why (the trigger)
+
+Two real friends played and it was **too easy + too short**:
+- **Marcellus** (new adult; declared Star Wars/LOTR): served tourist-level trivia
+  on domains he explicitly chose because he knows them. Root cause: a persisted
+  per-domain difficulty row **fully overrides** the global adaptive level
+  (`getDomainDifficultyOverrides`, `known.get(domain) ?? seed`), so demonstrated
+  skill never reaches already-played domains — the *earned* climb is disconnected.
+- **Buttkicker** (thin domain — Spy School — aces everything): difficulty can't
+  climb (thin domain can't field harder → supply-recalibration claws it back), so
+  he's stuck on easy forever with no escalation and no exit.
+
+## The model (decided)
+
+A topic is a **finite set sized by its real depth**. The player keeps playing,
+**difficulty climbing as earned**, until they cover the sized set — that *is*
+completion → **trophy → graduate + author**.
+
+1. **Size = a depth-derived TARGET QUESTION COUNT.** Each topic's target number of
+   distinct fan-salient questions comes from the LLM/Wikidata depth score (thin
+   topic ≈ small set; deep topic ≈ large). Completion = distinct good questions
+   answered ≥ target. (Chosen over the mastery-points threshold: a points target
+   punishes thin domains that can't climb with a slow 10-pt-per-easy-Q grind.)
+2. **Difficulty is a PARALLEL earned ladder**, not tied to the count. It climbs on
+   demonstrated skill and must actually reach already-played domains (Phase 0).
+   Deep topics (long runway) keep getting harder; thin topics reach their small
+   size and graduate before the "stuck easy" feeling sets in.
+3. **Good easy questions are kept — the mix is the point.** We never discard a
+   quality easy question for being easy; we just don't mine a topic past its
+   fan-salient size (`D-SUPPLY-FINITE-SET-01`: "stop mining past the core").
+4. **Deep cuts stay opt-in.** No automatic arcane grinding; harder = *earned*,
+   bounded by the topic's real size.
+
+## Fandom / grounding posture
+
+- **Now:** flip the **verifier** source allowlist to `wikipedia.org,fandom.com`
+  (`VERIFY_WEB_SEARCH_ALLOWED_DOMAINS`) — cost-neutral, strengthens fact-checking
+  of the deeper questions topics will surface as they climb. This is the documented
+  first flip (`D-FANDOM-GROUNDING-01`).
+- **Deferred:** generation-time wiki anchor (`GENERATION_WIKI_ANCHOR_ENABLED`) —
+  only if we observe fabrication in deeper questions the verifier can't catch.
+  Consistent with grounding being demoted to an anti-fabrication guard, not a
+  primary supply lever.
+
+## Build phases
+
+- **Phase 0 — earned-difficulty reconnect** ✅ DONE (`adaptive-difficulty.ts`).
+  `liftServedToGlobalSkill()` raises an already-played domain's requested tier up
+  to the player's demonstrated global skill (max-only; suppressed on an incorrect
+  streak in that domain). Wired into `getDomainDifficultyOverrides`. Unit-tested.
+  No migration. NB: changes requested difficulty for every adaptive-mode user
+  whose global level exceeds their per-domain rows — intended; review before deploy.
+- **Phase 1 — size-based completion** ✅ DONE (sizing + re-key).
+  - New `DomainDepthEstimate` cache (migration **0116**), keyed on `domain_key` so
+    every played `canonical_subcategory` is sizable (the ~dozens of authored
+    `KnowledgeNode`s don't cover them — the resolved integration gap). Caches the
+    DEPTH score; the count is derived at read time.
+  - `src/server/daily/domain-size.ts`: `depthToTargetCount` (`count = coeff·depth²`,
+    env-tunable — `DOMAIN_SIZE_COUNT_COEFFICIENT` default 2, clamp [12, 200]) +
+    `getTargetQuestionCountForDomains` (fold → cache → score-on-miss, fail-open).
+  - `set-completion.ts`: `setSize` now = depth target (was durable pool depth).
+    LLM sizing gated to candidates the player has answered ≥ min-target distinct in.
+    Kill-switch `DEPTH_SIZED_COMPLETION_ENABLED=0` + fail-open to the old pool-depth.
+- **Phase 1b — graduate-on-completion wiring** ✅ DONE. `markDomainExpansionEligible()`
+  (`adaptive-difficulty.ts`) stamps `expansionEligibleSince` on a completed domain, so
+  it flows through the EXISTING expansion funnel (getPendingExpansionDomains →
+  selectExpansionSource → buildExpansionOffer → ExpandDomainOfferCard) — reusing the
+  adjacency, card, accept/dismiss route, and once-per-area suppression with no UI
+  change (`trigger` is telemetry-only, not in the card). `evaluateSetCompletions` now
+  runs BEFORE `buildExpansionOffer` in the summary so the graduation card surfaces the
+  SAME day as completion. Copy valence ("you mastered X → branch out" vs the generic
+  "related areas") is a separate owed refinement (D-SUPPLY-FINITE-SET-01 §graduation).
+- **Phase 2 — verifier allowlist flip** ⏳ (env; Josh applies):
+  `VERIFY_WEB_SEARCH_ALLOWED_DOMAINS=wikipedia.org,fandom.com`.
+
+## Notes
+- **Sizing vs supply:** a target above what the topic can actually supply won't
+  complete (player exhausts the material first). Mitigation: the coefficient tunes
+  down with no re-seed, and completion fails open to pool-depth. Watch for topics
+  that never complete → coefficient too high for supply.
+- **To apply:** migration 0116 must be applied to prod (`npm run db:migrate` /
+  Josh's usual path); the instrumentation guard also creates it defensively.

--- a/drizzle/0116_domain_depth_estimate.sql
+++ b/drizzle/0116_domain_depth_estimate.sql
@@ -1,0 +1,34 @@
+-- 0116: DomainDepthEstimate (D-DIFFICULTY-SIZE-COMPLETION-01).
+--
+-- Caches the LLM/Wikidata DEPTH SCORE (1-10) for a topic, keyed on its folded
+-- domain_key so it covers every played canonical_subcategory (not just the few
+-- authored KnowledgeNodes). Set-completion derives a depth-sized TARGET QUESTION
+-- COUNT from this at read time (count = coefficient x depth^2, env-tunable), so
+-- bumping the target curve later is a config change with no re-seed.
+--
+-- One row per domain_key. depth_score NULL is a negative cache: sizing ran and
+-- the LLM returned nothing, so readers fall back to the default depth without
+-- re-billing until a deliberate re-score. Cheap (one Haiku call per topic ever,
+-- gated behind "player answered >= floor distinct in the domain").
+--
+-- Purely additive: no existing table is altered. RLS enabled with no policies
+-- (the app connects as the owner role, which bypasses RLS) per B-SECURITY-RLS-01
+-- / migration 0081 — without it the table is reachable over Supabase's public
+-- Data API. Every statement is idempotent and mirrored by a defensive guard in
+-- src/instrumentation.ts (precedent: 0108's DomainReferencePassage guard).
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "DomainDepthEstimate";
+CREATE TABLE IF NOT EXISTS "DomainDepthEstimate" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "domain_key" text NOT NULL,
+  "depth_score" integer,
+  "sample_label" text,
+  "source" text NOT NULL DEFAULT 'llm',
+  "computed_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "DomainDepthEstimate" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "DomainDepthEstimate_domain_key" ON "DomainDepthEstimate" ("domain_key");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -813,6 +813,13 @@
 			"when": 1786492800000,
 			"tag": "0115_question_salvage_proposal",
 			"breakpoints": true
+		},
+		{
+			"idx": 116,
+			"version": "7",
+			"when": 1786579200000,
+			"tag": "0116_domain_depth_estimate",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2098,6 +2098,23 @@ export async function register() {
       await db.execute(sql`ALTER TABLE "QuestionSalvageProposal" ENABLE ROW LEVEL SECURITY`);
       await db.execute(sql`CREATE INDEX IF NOT EXISTS "QuestionSalvageProposal_question_id_idx" ON "QuestionSalvageProposal" ("question_id")`);
       await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "QuestionSalvageProposal_active_question_key" ON "QuestionSalvageProposal" ("question_id") WHERE "status" = 'ready'`);
+      // Migration 0116 (D-DIFFICULTY-SIZE-COMPLETION-01): cached topic depth score
+      // that set-completion sizes the completable set from. evaluateSetCompletions
+      // would 42P01 on read if the migration recorded without the table. Self-
+      // contained; same rationale as the 0108 DomainReferencePassage guard.
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "DomainDepthEstimate" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "domain_key" text NOT NULL,
+          "depth_score" integer,
+          "sample_label" text,
+          "source" text NOT NULL DEFAULT 'llm',
+          "computed_at" timestamp with time zone NOT NULL DEFAULT now(),
+          "created_at" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "DomainDepthEstimate_domain_key" ON "DomainDepthEstimate" ("domain_key")`);
     } catch {
       // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
     }

--- a/src/server/__tests__/adaptive-difficulty.test.ts
+++ b/src/server/__tests__/adaptive-difficulty.test.ts
@@ -14,6 +14,7 @@ import {
   computeDomainDifficultyStep,
   computeStarvationStepDown,
   computeSupplyCorrection,
+  liftServedToGlobalSkill,
   focusDomainMinDifficulty,
   mapAdaptiveLevelToDifficultyHint,
   type DomainDifficultyState,
@@ -42,6 +43,32 @@ describe('applyAdaptiveLevelAdjustment — global adaptive level', () => {
 
   it('clamps at MAX_ADAPTIVE_LEVEL (4.0) — cannot exceed ceiling', () => {
     expect(applyAdaptiveLevelAdjustment(4.0, 1.0)).toBe(4.0);
+  });
+});
+
+describe('liftServedToGlobalSkill — earned-skill lift on played domains (Phase 0)', () => {
+  it('lifts a played domain UP to the global skill tier when not struggling', () => {
+    // Marcellus: global level demonstrates moderate/specialist skill, but the
+    // played domain is pinned at its accessible first-contact tier.
+    expect(liftServedToGlobalSkill('accessible', 'moderate', 0)).toBe('moderate');
+    expect(liftServedToGlobalSkill('accessible', 'specialist', 0)).toBe('specialist');
+    expect(liftServedToGlobalSkill('moderate', 'specialist', 0)).toBe('specialist');
+  });
+
+  it('never LOWERS: a domain already above global skill is left alone', () => {
+    expect(liftServedToGlobalSkill('specialist', 'accessible', 0)).toBe('specialist');
+    expect(liftServedToGlobalSkill('moderate', 'accessible', 0)).toBe('moderate');
+  });
+
+  it('is a no-op when the domain already sits at the global skill tier', () => {
+    expect(liftServedToGlobalSkill('moderate', 'moderate', 0)).toBe('moderate');
+  });
+
+  it('is SUPPRESSED while the player is on an incorrect streak in this domain', () => {
+    // An earned step-down on a domain they're currently missing must be respected,
+    // even if their global skill is higher.
+    expect(liftServedToGlobalSkill('accessible', 'specialist', 1)).toBe('accessible');
+    expect(liftServedToGlobalSkill('moderate', 'specialist', 2)).toBe('moderate');
   });
 });
 

--- a/src/server/adaptive-difficulty.ts
+++ b/src/server/adaptive-difficulty.ts
@@ -472,6 +472,39 @@ export function computeStarvationStepDown(
 }
 
 /**
+ * Earned-skill lift (D-DIFFICULTY-SIZE-COMPLETION-01, Phase 0). Raise an
+ * already-played domain's REQUESTED tier up to the player's demonstrated global
+ * skill tier, so a levelled-up player's existing domains climb in parallel with
+ * the finite-set count instead of being pinned at their first-contact tier. This
+ * is the counterpart to the disconnect where a persisted per-domain row fully
+ * overrode the global adaptiveLevel.
+ *
+ * - Never LOWERS (max only): the demand-side step-down (two wrong) and the
+ *   supply-side corrections stay the only things that ease a domain off.
+ * - SUPPRESSED while the player is on an incorrect streak in THIS domain
+ *   (consecutiveIncorrect > 0): an earned step-down on a domain they're currently
+ *   missing must be respected — global skill elsewhere shouldn't re-harden a
+ *   domain that's actively fighting them.
+ *
+ * A thin domain lifted above what it can field is self-correcting: the queue
+ * still fills from the under-difficulty reserve, supply recalibration eases the
+ * persisted row back down, and the topic reaches its (small) size and graduates —
+ * so the lift can't strand a narrow KB below the served floor.
+ */
+export function liftServedToGlobalSkill(
+  persisted: ServedDifficulty,
+  globalSkillTier: ServedDifficulty,
+  consecutiveIncorrect: number,
+): ServedDifficulty {
+  if (consecutiveIncorrect > 0) return persisted;
+  const idx = Math.max(
+    DIFFICULTY_LADDER.indexOf(persisted),
+    DIFFICULTY_LADDER.indexOf(globalSkillTier),
+  );
+  return DIFFICULTY_LADDER[idx];
+}
+
+/**
  * Supply-side difficulty correction — the counterpart to the demand-side streak
  * ladder in updateDomainDifficultyOnAnswer. A streak step-up is *optimistic*: it can
  * raise a domain to a tier the generator can't actually field (there is, for example,
@@ -725,6 +758,45 @@ export async function markDomainExpansionOffered(
 }
 
 /**
+ * Mark a domain eligible for the post-daily-Five expansion offer because the
+ * player just COMPLETED its finite set (D-DIFFICULTY-SIZE-COMPLETION-01, Phase 1b:
+ * completion → graduate). This reuses the exact `expansionEligibleSince` funnel the
+ * supply-ceiling trigger already drives — getPendingExpansionDomains →
+ * selectExpansionSource → buildExpansionOffer — so a completed set surfaces the
+ * neighbor/parent "branch out" card with no separate path, and the once-per-area
+ * suppression (expansionOfferedAt, filtered by getPendingExpansionDomains) holds.
+ *
+ * COALESCE preserves any existing eligibility timestamp so re-completion doesn't
+ * reset it, and it never touches expansionOfferedAt — a domain already offered and
+ * resolved stays suppressed. Upserts (a completed domain always has a row, but the
+ * insert branch is a harmless guard). Idempotent; best-effort by contract.
+ */
+export async function markDomainExpansionEligible(
+  userId: string,
+  canonicalSubcategory: string,
+): Promise<void> {
+  if (!canonicalSubcategory) return;
+  const now = new Date();
+  await db
+    .insert(userDomainDifficulties)
+    .values({
+      userId,
+      canonicalSubcategory,
+      servedDifficulty: seedDifficultyFromAdaptiveLevel(MIN_ADAPTIVE_LEVEL),
+      consecutiveCorrect: 0,
+      consecutiveIncorrect: 0,
+      lastUpdated: now,
+      expansionEligibleSince: now,
+    })
+    .onConflictDoUpdate({
+      target: [userDomainDifficulties.userId, userDomainDifficulties.canonicalSubcategory],
+      set: {
+        expansionEligibleSince: sql`COALESCE(${userDomainDifficulties.expansionEligibleSince}, ${now})`,
+      },
+    });
+}
+
+/**
  * Of the given domains, which already have an expansion offer stamped
  * (expansionOfferedAt set) — i.e. were already offered once. Used by the thinness
  * trigger to honor the once-per-area rule (B-AREA-EXPANSION-01).
@@ -817,6 +889,7 @@ export async function getDomainDifficultyOverrides(
     .select({
       canonicalSubcategory: userDomainDifficulties.canonicalSubcategory,
       servedDifficulty: userDomainDifficulties.servedDifficulty,
+      consecutiveIncorrect: userDomainDifficulties.consecutiveIncorrect,
     })
     .from(userDomainDifficulties)
     .where(and(
@@ -824,26 +897,35 @@ export async function getDomainDifficultyOverrides(
       inArray(userDomainDifficulties.canonicalSubcategory, domains),
     ));
 
-  const known = new Map<string, ServedDifficulty>();
+  const known = new Map<string, { served: ServedDifficulty; consecutiveIncorrect: number }>();
   for (const row of rows) {
-    known.set(row.canonicalSubcategory, row.servedDifficulty as ServedDifficulty);
+    known.set(row.canonicalSubcategory, {
+      served: row.servedDifficulty as ServedDifficulty,
+      consecutiveIncorrect: row.consecutiveIncorrect ?? 0,
+    });
   }
 
-  // Only domains without a persisted row need a first-contact seed. Pull the
-  // user's adaptive level and which of those domains are opted-in focus areas
-  // so we can floor the seed to "Familiar" for the latter (declared OR
-  // demonstrated — the erosion-floor split is applied later, on answer).
+  // Read the global adaptive level for BOTH jobs: the first-contact seed (domains
+  // with no persisted row) AND the earned-skill lift on ALREADY-PLAYED domains
+  // (D-DIFFICULTY-SIZE-COMPLETION-01, Phase 0). A persisted per-domain row used to
+  // FULLY override the global level, so a player who demonstrably levelled up kept
+  // being served their old (often accessible) first-contact tier on domains they
+  // had already played — the "aces every question but it never gets harder"
+  // disconnect (Marcellus). The focus-set lookup only needs the unseeded domains
+  // (its sole job is flooring their first-contact seed; the erosion-floor split is
+  // applied later, on answer).
   const domainsNeedingSeed = domains.filter((domain) => !known.has(domain));
-  const [seedLevel, focusDomains] = domainsNeedingSeed.length === 0
-    ? [MIN_ADAPTIVE_LEVEL, new Set<string>()]
-    : await Promise.all([
-        readCurrentAdaptiveLevel(userId),
-        getFocusDomainSet(userId, domainsNeedingSeed),
-      ]);
+  const [seedLevel, focusDomains] = await Promise.all([
+    readCurrentAdaptiveLevel(userId),
+    getFocusDomainSet(userId, domainsNeedingSeed),
+  ]);
+  const globalSkillTier = seedDifficultyFromAdaptiveLevel(seedLevel);
 
   for (const domain of domains) {
-    const served = known.get(domain)
-      ?? applyFocusFloor(seedDifficultyFromAdaptiveLevel(seedLevel), focusDomains.has(domain));
+    const row = known.get(domain);
+    const served = row
+      ? liftServedToGlobalSkill(row.served, globalSkillTier, row.consecutiveIncorrect)
+      : applyFocusFloor(seedDifficultyFromAdaptiveLevel(seedLevel), focusDomains.has(domain));
     overrides.set(domain, SERVED_TO_PREFERENCE[served]);
   }
 

--- a/src/server/daily/__tests__/domain-size.test.ts
+++ b/src/server/daily/__tests__/domain-size.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { depthToTargetCount } from '@/server/daily/domain-size';
+
+// Explicit opts so the curve is tested independent of env knobs.
+const OPTS = { coefficient: 2, min: 12, max: 200 };
+
+describe('depthToTargetCount — depth (1-10) → target distinct-question count', () => {
+  it('matches the agreed anchors (count ≈ 2·depth²)', () => {
+    expect(depthToTargetCount(3, OPTS)).toBe(18); // Spy School (thin) → graduate fast
+    expect(depthToTargetCount(4, OPTS)).toBe(32);
+    expect(depthToTargetCount(6, OPTS)).toBe(72);
+    expect(depthToTargetCount(8, OPTS)).toBe(128); // Star Wars (deep) → long runway
+  });
+
+  it('clamps to the min for shallow topics', () => {
+    expect(depthToTargetCount(1, OPTS)).toBe(12); // 2·1 = 2 → floored to 12
+    expect(depthToTargetCount(2, OPTS)).toBe(12); // 2·4 = 8 → floored to 12
+  });
+
+  it('clamps to the max for the deepest topics', () => {
+    expect(depthToTargetCount(10, OPTS)).toBe(200); // 2·100 = 200 (at cap)
+    expect(depthToTargetCount(10, { ...OPTS, coefficient: 3 })).toBe(200); // 300 → capped
+  });
+
+  it('rounds the depth and clamps out-of-range inputs', () => {
+    expect(depthToTargetCount(3.4, OPTS)).toBe(18); // rounds to 3
+    expect(depthToTargetCount(0, OPTS)).toBe(12); // clamped up to depth 1 → 2 → floor 12
+    expect(depthToTargetCount(99, OPTS)).toBe(200); // clamped down to depth 10
+  });
+
+  it('scales the whole curve when the coefficient is raised (the "expand later" lever)', () => {
+    expect(depthToTargetCount(3, { ...OPTS, coefficient: 3 })).toBe(27); // 3·9
+    expect(depthToTargetCount(8, { ...OPTS, coefficient: 3 })).toBe(192); // 3·64
+  });
+});

--- a/src/server/daily/__tests__/set-completion.test.ts
+++ b/src/server/daily/__tests__/set-completion.test.ts
@@ -7,15 +7,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   state,
   getDurablePoolDepthForDomains,
+  getTargetQuestionCountForDomains,
   hasDesignation,
   markDomainDesignated,
   inviteToAuthorAutomatic,
+  markDomainExpansionEligible,
 } = vi.hoisted(() => ({
   state: { answeredRows: [] as Array<{ domain: string; answered: number }> },
   getDurablePoolDepthForDomains: vi.fn(),
+  getTargetQuestionCountForDomains: vi.fn(),
   hasDesignation: vi.fn(),
   markDomainDesignated: vi.fn(),
   inviteToAuthorAutomatic: vi.fn(),
+  markDomainExpansionEligible: vi.fn(),
 }));
 
 vi.mock('@/server/db', () => {
@@ -30,11 +34,18 @@ vi.mock('@/server/db', () => {
   };
 });
 vi.mock('@/server/db/queries/retrieval-demand', () => ({ getDurablePoolDepthForDomains }));
+// Depth sizing is the default completion size source; mock it (minPossibleTargetCount
+// is the candidate gate floor).
+vi.mock('@/server/daily/domain-size', () => ({
+  getTargetQuestionCountForDomains,
+  minPossibleTargetCount: () => 12,
+}));
 vi.mock('@/server/db/queries/author-invitations', () => ({
   hasDesignation,
   markDomainDesignated,
   inviteToAuthorAutomatic,
 }));
+vi.mock('@/server/adaptive-difficulty', () => ({ markDomainExpansionEligible }));
 
 import {
   evaluateSetCompletions,
@@ -74,42 +85,48 @@ describe('evaluateSetCompletions', () => {
     state.answeredRows = [];
     hasDesignation.mockResolvedValue(false);
     getDurablePoolDepthForDomains.mockResolvedValue(new Map());
+    getTargetQuestionCountForDomains.mockResolvedValue(new Map());
     inviteToAuthorAutomatic.mockResolvedValue({ ok: true, action: 'invited' });
+    markDomainExpansionEligible.mockResolvedValue(undefined);
   });
 
-  it('designates + invites a domain the player just completed', async () => {
-    state.answeredRows = [{ domain: 'Spy School', answered: 12 }];
-    getDurablePoolDepthForDomains.mockResolvedValue(new Map([['Spy School', 10]]));
+  it('designates + invites a domain whose depth-sized set the player just covered', async () => {
+    // Spy School depth-sized target = 18; the player has answered 18 distinct.
+    state.answeredRows = [{ domain: 'Spy School', answered: 18 }];
+    getTargetQuestionCountForDomains.mockResolvedValue(new Map([['Spy School', 18]]));
 
     const completed = await evaluateSetCompletions('u1', ['Spy School']);
 
     expect(completed).toEqual(['Spy School']);
     expect(markDomainDesignated).toHaveBeenCalledWith('u1', 'Spy School', expect.any(Date));
     expect(inviteToAuthorAutomatic).toHaveBeenCalledWith({ userId: 'u1', domain: 'Spy School' });
+    // Phase 1b: completing the set makes the domain eligible for the graduation offer.
+    expect(markDomainExpansionEligible).toHaveBeenCalledWith('u1', 'Spy School');
   });
 
-  it('does not designate a below-floor domain', async () => {
+  it('does not even size a domain below the candidate gate floor', async () => {
     state.answeredRows = [{ domain: 'Tiny Topic', answered: 4 }];
-    getDurablePoolDepthForDomains.mockResolvedValue(new Map([['Tiny Topic', 4]]));
 
     const completed = await evaluateSetCompletions('u1', ['Tiny Topic']);
 
     expect(completed).toEqual([]);
+    // Below the gate (12) → never pays the depth sizing call.
+    expect(getTargetQuestionCountForDomains).not.toHaveBeenCalled();
     expect(markDomainDesignated).not.toHaveBeenCalled();
-    expect(inviteToAuthorAutomatic).not.toHaveBeenCalled();
   });
 
-  it('does not designate a not-yet-covered domain', async () => {
-    state.answeredRows = [{ domain: 'Big Topic', answered: 9 }];
-    getDurablePoolDepthForDomains.mockResolvedValue(new Map([['Big Topic', 30]]));
+  it('does not designate a deep topic still short of its (large) target', async () => {
+    // Star Wars depth-sized target = 128; 40 distinct answered → long runway left.
+    state.answeredRows = [{ domain: 'Star Wars', answered: 40 }];
+    getTargetQuestionCountForDomains.mockResolvedValue(new Map([['Star Wars', 128]]));
 
-    expect(await evaluateSetCompletions('u1', ['Big Topic'])).toEqual([]);
+    expect(await evaluateSetCompletions('u1', ['Star Wars'])).toEqual([]);
     expect(inviteToAuthorAutomatic).not.toHaveBeenCalled();
   });
 
   it('is idempotent — already-designated domains are skipped without writes', async () => {
-    state.answeredRows = [{ domain: 'Spy School', answered: 12 }];
-    getDurablePoolDepthForDomains.mockResolvedValue(new Map([['Spy School', 10]]));
+    state.answeredRows = [{ domain: 'Spy School', answered: 18 }];
+    getTargetQuestionCountForDomains.mockResolvedValue(new Map([['Spy School', 18]]));
     hasDesignation.mockResolvedValue(true);
 
     const completed = await evaluateSetCompletions('u1', ['Spy School']);
@@ -119,14 +136,27 @@ describe('evaluateSetCompletions', () => {
     expect(inviteToAuthorAutomatic).not.toHaveBeenCalled();
   });
 
+  it('falls back to pool depth when depth sizing faults (never blocks the trophy)', async () => {
+    // A sizing outage must not silently stop every completion from firing.
+    state.answeredRows = [{ domain: 'Spy School', answered: 18 }];
+    getTargetQuestionCountForDomains.mockRejectedValue(new Error('haiku down'));
+    getDurablePoolDepthForDomains.mockResolvedValue(new Map([['Spy School', 15]]));
+
+    const completed = await evaluateSetCompletions('u1', ['Spy School']);
+
+    expect(completed).toEqual(['Spy School']); // 18 >= pool depth 15
+    expect(getDurablePoolDepthForDomains).toHaveBeenCalled();
+  });
+
   it('never throws — a query fault returns no completions', async () => {
+    getTargetQuestionCountForDomains.mockRejectedValue(new Error('down'));
     getDurablePoolDepthForDomains.mockRejectedValue(new Error('db down'));
-    state.answeredRows = [{ domain: 'Spy School', answered: 12 }];
+    state.answeredRows = [{ domain: 'Spy School', answered: 18 }];
     expect(await evaluateSetCompletions('u1', ['Spy School'])).toEqual([]);
   });
 
   it('returns early for an empty domain list (no queries)', async () => {
     expect(await evaluateSetCompletions('u1', [])).toEqual([]);
-    expect(getDurablePoolDepthForDomains).not.toHaveBeenCalled();
+    expect(getTargetQuestionCountForDomains).not.toHaveBeenCalled();
   });
 });

--- a/src/server/daily/domain-size.ts
+++ b/src/server/daily/domain-size.ts
@@ -1,0 +1,110 @@
+/**
+ * D-DIFFICULTY-SIZE-COMPLETION-01 — depth-sized completion targets.
+ *
+ * A topic is a finite completable SET whose size is its real DEPTH, not whatever
+ * questions happen to exist. Each topic's target distinct-question count is
+ * derived from an LLM depth score (1-10) via `count = coefficient x depth^2`,
+ * clamped. Deep topics get large targets (a long runway that rarely completes —
+ * "keep going"); thin topics get small targets (reached fast → trophy →
+ * graduate). See set-completion.ts for the consumer.
+ *
+ * The DEPTH score is what's cached (DomainDepthEstimate, one Haiku call per topic
+ * ever); the COUNT is derived here at read time from env knobs, so re-tuning the
+ * curve later is a config change with NO re-seed and NO migration.
+ */
+import { domainKey } from '@/lib/knowledge/domain-key';
+import { scoreDomainDepth } from '@/server/llm/domain-depth';
+import {
+  getDepthEstimates,
+  upsertDepthEstimate,
+} from '@/server/db/queries/domain-depth-estimate';
+
+function numEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+// Env-tunable depth→count curve. Defaults chosen with Josh (2026-07-06):
+// count ≈ 2·depth² → Spy School (depth ~3) ≈ 18, Star Wars (depth ~8) ≈ 128.
+// Bump DOMAIN_SIZE_COUNT_COEFFICIENT to make every set larger without a re-seed.
+export const depthCountCoefficient = (): number => numEnv('DOMAIN_SIZE_COUNT_COEFFICIENT', 2);
+export const depthTargetMin = (): number => Math.round(numEnv('DOMAIN_SIZE_TARGET_MIN', 12));
+export const depthTargetMax = (): number => Math.round(numEnv('DOMAIN_SIZE_TARGET_MAX', 200));
+// Fallback depth when the LLM can't score a topic (negative cache) — a modest
+// middle value so an unsizable topic still completes at a sane count.
+export const defaultDepth = (): number => Math.round(numEnv('DOMAIN_SIZE_DEFAULT_DEPTH', 4));
+
+/**
+ * Pure: depth (1-10) → target distinct-question count for completion.
+ * count = coefficient · depth², clamped to [min, max]. Exported for unit tests.
+ */
+export function depthToTargetCount(
+  depth: number,
+  opts?: { coefficient?: number; min?: number; max?: number },
+): number {
+  const coefficient = opts?.coefficient ?? depthCountCoefficient();
+  const min = opts?.min ?? depthTargetMin();
+  const max = opts?.max ?? depthTargetMax();
+  const d = Math.max(1, Math.min(10, Math.round(depth)));
+  const raw = Math.round(coefficient * d * d);
+  return Math.max(min, Math.min(max, raw));
+}
+
+/** The smallest target any topic can have — the "is this even a set" floor. */
+export function minPossibleTargetCount(): number {
+  return depthTargetMin();
+}
+
+/**
+ * For each canonical_subcategory, the depth-sized target distinct-question count
+ * for set completion. Folds each topic to its domain_key, reads the cached depth
+ * (computing + caching on miss via one Haiku call), and derives the count. Fully
+ * fail-open: any read/scoring error falls back to the default depth so a sizing
+ * miss never blocks completion evaluation.
+ */
+export async function getTargetQuestionCountForDomains(
+  canonicalSubcategories: string[],
+): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const unique = [...new Set(canonicalSubcategories.filter(Boolean))];
+  if (unique.length === 0) return out;
+
+  const keyByCanonical = new Map(unique.map((canonical) => [canonical, domainKey(canonical)]));
+  const keys = [...new Set(keyByCanonical.values())];
+
+  const cached = await getDepthEstimates(keys).catch(() => new Map());
+
+  const depthByKey = new Map<string, number>();
+  for (const key of keys) {
+    const row = cached.get(key);
+    if (row) {
+      depthByKey.set(key, row.depthScore ?? defaultDepth());
+      continue;
+    }
+    // Cache miss — score once (Haiku) and cache. A representative label is any
+    // canonical string that folds to this key.
+    const sampleLabel = unique.find((canonical) => keyByCanonical.get(canonical) === key) ?? key;
+    let depth: number | null = null;
+    try {
+      depth = await scoreDomainDepth(sampleLabel);
+    } catch {
+      depth = null;
+    }
+    depthByKey.set(key, depth ?? defaultDepth());
+    // Best-effort cache write (negative-cache on null); never block on it.
+    void upsertDepthEstimate({
+      domainKey: key,
+      depthScore: depth,
+      sampleLabel,
+      source: depth == null ? 'default' : 'llm',
+    }).catch(() => {});
+  }
+
+  for (const canonical of unique) {
+    const key = keyByCanonical.get(canonical)!;
+    out.set(canonical, depthToTargetCount(depthByKey.get(key) ?? defaultDepth()));
+  }
+  return out;
+}

--- a/src/server/daily/set-completion.ts
+++ b/src/server/daily/set-completion.ts
@@ -7,10 +7,16 @@
  * author more, which lights the already-built /invited trophy takeover.
  *
  * Completion is COVERAGE-based (Josh, 2026-07-05): the player has answered at
- * least as many DISTINCT questions as the set holds distinct facts. We compare
- * distinct-answered (not the raw answer-event count — repeats/catch-up must not
- * trophy a replay) against the durable pool depth (the set size at current
- * scale), gated by a floor so a 3-question domain isn't called a "set".
+ * least as many DISTINCT questions as the set's size (not the raw answer-event
+ * count — repeats/catch-up must not trophy a replay).
+ *
+ * The set SIZE is the topic's depth-derived target question count
+ * (D-DIFFICULTY-SIZE-COMPLETION-01, Josh 2026-07-06): a thin topic reaches its
+ * small size fast → trophy → graduate; a deep topic has a long runway and rarely
+ * completes. This replaced the earlier "durable pool depth" stopgap (which sized
+ * completion by whatever questions happened to exist rather than the topic's real
+ * size). The old behaviour is still reachable via DEPTH_SIZED_COMPLETION_ENABLED=0
+ * as a kill-switch; depth sizing also fails open to it.
  *
  * Fail-open and idempotent: a designation stamps once (guarded on
  * designated_at IS NULL) and the invitation's partial unique index makes a
@@ -20,17 +26,45 @@
 import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import { db, masteryEvents } from '@/server/db';
+import { markDomainExpansionEligible } from '@/server/adaptive-difficulty';
 import {
   hasDesignation,
   inviteToAuthorAutomatic,
   markDomainDesignated,
 } from '@/server/db/queries/author-invitations';
 import { getDurablePoolDepthForDomains } from '@/server/db/queries/retrieval-demand';
+import {
+  getTargetQuestionCountForDomains,
+  minPossibleTargetCount,
+} from '@/server/daily/domain-size';
 
 // Below this many distinct facts a domain isn't a "set" worth a trophy — a
 // thin domain a player exhausts is surfaced to the human via the crafter
-// worklist instead (the P1 expensive/thin signal), not celebrated. Tunable.
+// worklist instead (the P1 expensive/thin signal), not celebrated. Only binds
+// when depth sizing is OFF; the depth path uses minPossibleTargetCount(). Tunable.
 export const SET_COMPLETION_MIN_SIZE = 8;
+
+function isDepthSizedCompletionEnabled(): boolean {
+  const raw = process.env.DEPTH_SIZED_COMPLETION_ENABLED?.trim().toLowerCase();
+  return !(raw === 'false' || raw === '0' || raw === 'no' || raw === 'off');
+}
+
+// Resolve each candidate domain's set SIZE: the depth-derived target count, or
+// (kill-switch / on error) the legacy durable-pool-depth. Fail-open to the legacy
+// path so a sizing outage can't silently stop every trophy from ever firing.
+async function getSetSizesForDomains(domains: string[]): Promise<Map<string, number>> {
+  if (!isDepthSizedCompletionEnabled()) {
+    return getDurablePoolDepthForDomains(domains);
+  }
+  try {
+    return await getTargetQuestionCountForDomains(domains);
+  } catch (error) {
+    console.warn('[set-completion] depth sizing failed; falling back to pool depth', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return getDurablePoolDepthForDomains(domains);
+  }
+}
 
 /**
  * Pure completion predicate (unit-tested): a set is complete when it is at least
@@ -82,13 +116,21 @@ export async function evaluateSetCompletions(
 
   const completed: string[] = [];
   try {
-    const [answeredByDomain, poolDepthByDomain] = await Promise.all([
-      distinctAnsweredByDomain(userId, unique),
-      getDurablePoolDepthForDomains(unique),
-    ]);
+    const answeredByDomain = await distinctAnsweredByDomain(userId, unique);
+    // Only a domain the player has answered enough DISTINCT questions in can be a
+    // completed set — gate the (LLM) depth sizing to those, so we never sprinkle
+    // depth calls across every touched-but-nowhere-near-complete domain. The floor
+    // is the smallest target any topic can have.
+    const gateFloor = isDepthSizedCompletionEnabled()
+      ? minPossibleTargetCount()
+      : SET_COMPLETION_MIN_SIZE;
+    const candidates = unique.filter((domain) => (answeredByDomain.get(domain) ?? 0) >= gateFloor);
+    if (candidates.length === 0) return [];
+
+    const setSizeByDomain = await getSetSizesForDomains(candidates);
     const now = new Date();
-    for (const domain of unique) {
-      const setSize = poolDepthByDomain.get(domain) ?? 0;
+    for (const domain of candidates) {
+      const setSize = setSizeByDomain.get(domain) ?? 0;
       const distinctAnswered = answeredByDomain.get(domain) ?? 0;
       if (!isSetComplete({ distinctAnswered, setSize })) continue;
       // Cheap guard first so a repeat call skips the writes entirely; the writes
@@ -96,6 +138,16 @@ export async function evaluateSetCompletions(
       if (await hasDesignation(userId, domain)) continue;
       await markDomainDesignated(userId, domain, now);
       await inviteToAuthorAutomatic({ userId, domain });
+      // Phase 1b: completing the set makes the domain eligible for the graduation
+      // ("branch out to a neighbor topic") offer built later in this same summary.
+      // Best-effort — a graduation-eligibility miss must not drop the trophy.
+      await markDomainExpansionEligible(userId, domain).catch((error) => {
+        console.warn('[set-completion] markDomainExpansionEligible failed (non-fatal)', {
+          userId,
+          domain,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
       completed.push(domain);
     }
   } catch (error) {

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -355,16 +355,18 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
     domain,
     territoryType: masteryByDomain.get(domain)?.territoryType ?? null,
   }));
-  const expansionOffer = await buildExpansionOffer(userId, touchedForExpansion);
-
   // D-SUPPLY-FINITE-SET-01 P2: designate + auto-invite domains this player just
-  // completed (answered the whole finite set). Side-effect only — it creates the
-  // AuthorInvitation that the summary's InvitationTakeoverGate then routes to
-  // /invited (the trophy). Fail-open; never blocks the summary.
+  // completed (answered the whole finite set). Creates the AuthorInvitation the
+  // summary's InvitationTakeoverGate routes to /invited (the trophy), AND marks the
+  // completed domain expansion-eligible. Runs BEFORE buildExpansionOffer so a
+  // just-completed set surfaces the graduation ("branch out") card in the SAME
+  // summary (D-DIFFICULTY-SIZE-COMPLETION-01 Phase 1b). Fail-open; never blocks.
   await evaluateSetCompletions(
     userId,
     touchedForExpansion.map((t) => t.domain),
   );
+
+  const expansionOffer = await buildExpansionOffer(userId, touchedForExpansion);
 
   return {
     date: dateString,

--- a/src/server/db/queries/domain-depth-estimate.ts
+++ b/src/server/db/queries/domain-depth-estimate.ts
@@ -1,0 +1,59 @@
+// D-DIFFICULTY-SIZE-COMPLETION-01 — read/write for the cached topic depth score
+// (DomainDepthEstimate, migration 0116). Keyed on the folded domain_key so it
+// covers every played canonical_subcategory, not just authored KnowledgeNodes.
+import { inArray } from 'drizzle-orm';
+
+import { db, domainDepthEstimates } from '@/server/db';
+
+export type DepthEstimateRow = {
+  domainKey: string;
+  depthScore: number | null;
+  source: string;
+};
+
+/** Cached depth estimates for the given folded domain keys. */
+export async function getDepthEstimates(
+  domainKeys: string[],
+): Promise<Map<string, DepthEstimateRow>> {
+  if (domainKeys.length === 0) return new Map();
+  const rows = await db
+    .select({
+      domainKey: domainDepthEstimates.domainKey,
+      depthScore: domainDepthEstimates.depthScore,
+      source: domainDepthEstimates.source,
+    })
+    .from(domainDepthEstimates)
+    .where(inArray(domainDepthEstimates.domainKey, domainKeys));
+  return new Map(rows.map((row) => [row.domainKey, row]));
+}
+
+/**
+ * Cache a depth estimate. depthScore null is a negative cache (sizing ran, the
+ * LLM returned nothing) — readers fall back to the default depth without
+ * re-billing until a deliberate re-score. First-writer-agnostic: an upsert so a
+ * concurrent org-wide sizing of the same topic converges.
+ */
+export async function upsertDepthEstimate(input: {
+  domainKey: string;
+  depthScore: number | null;
+  sampleLabel: string;
+  source: 'llm' | 'default';
+}): Promise<void> {
+  await db
+    .insert(domainDepthEstimates)
+    .values({
+      domainKey: input.domainKey,
+      depthScore: input.depthScore,
+      sampleLabel: input.sampleLabel,
+      source: input.source,
+    })
+    .onConflictDoUpdate({
+      target: domainDepthEstimates.domainKey,
+      set: {
+        depthScore: input.depthScore,
+        sampleLabel: input.sampleLabel,
+        source: input.source,
+        computedAt: new Date(),
+      },
+    });
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1739,6 +1739,32 @@ export const domainReferencePassage = pgTable(
   ],
 );
 
+// D-DIFFICULTY-SIZE-COMPLETION-01 (0116): cached topic DEPTH SCORE (1-10), keyed
+// on the folded domain_key so it covers every played canonical_subcategory, not
+// just the few authored KnowledgeNodes. Set-completion derives a depth-sized
+// target question count from this at read time (count = coefficient x depth^2),
+// so the target curve is env-tunable with no re-seed. depth_score NULL is a
+// negative cache (sizing ran, LLM returned nothing → readers use the default
+// depth). One row per domain_key. Removable as a unit.
+export const domainDepthEstimates = pgTable(
+  'DomainDepthEstimate',
+  {
+    id: id(),
+    domainKey: text('domain_key').notNull(),
+    // 1-10 breadth/depth (scoreDomainDepth). NULL = negative cache.
+    depthScore: integer('depth_score'),
+    // A canonical_subcategory that folded to this key — for debugging only.
+    sampleLabel: text('sample_label'),
+    // 'llm' (scored) | 'default' (LLM unavailable/null; using the code default).
+    source: text('source').notNull().default('llm'),
+    computedAt: timestamp('computed_at', { withTimezone: true }).notNull().defaultNow(),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    uniqueIndex('DomainDepthEstimate_domain_key').on(table.domainKey),
+  ],
+);
+
 // Batch-verify async mode (0106): one row per Anthropic Message Batch of
 // verification requests submitted by /api/cron/batch-verify-questions when
 // BATCH_VERIFY_ASYNC_ENABLED is on. The daily cron harvests 'submitted' runs


### PR DESCRIPTION
## What & why

Fixes the "the questions were really simple — and there were only four of them" report (Marcellus & Buttkicker). Two root causes, addressed here plus a supply follow-up:

- **Earned difficulty never reached already-played domains.** A persisted per-domain `USER_DOMAIN_DIFFICULTY` row *fully* overrode the global adaptive level, so a player who levelled up kept being served their first-contact (often `accessible`) tier on the very domains they play. Marcellus (new adult, declared Star Wars/LOTR) got tourist trivia.
- **Thin topics dead-ended on easy** instead of completing and graduating.

Ratified-in-chat model (Josh, 2026-07-06): a topic is a **finite set sized by its real depth**; the player keeps going (difficulty a **parallel earned ladder**) until they cover the depth-sized set → **trophy → graduate + author**. Spec: `D-DIFFICULTY-SIZE-COMPLETION-01.md`.

## Changes

**Phase 0 — earned-difficulty reconnect** (`adaptive-difficulty.ts`)
`liftServedToGlobalSkill()` raises an already-played domain's *requested* tier up to the player's demonstrated global skill — max-only, and suppressed while they're on an incorrect streak in that specific domain.

**Phase 1 — depth-sized completion**
- Migration **0116 `DomainDepthEstimate`** — caches the depth score keyed on `domain_key` (played `canonical_subcategory`s don't map to the ~dozen authored `KnowledgeNode`s).
- `domain-size.ts` — `depthToTargetCount = coeff·depth²`, clamped, **env-tunable** (`DOMAIN_SIZE_COUNT_COEFFICIENT`, default 2). Depth is cached; count derived at read-time, so re-tuning is a config change with no re-seed.
- `set-completion.ts` — completion size = the depth target (was durable pool depth). LLM sizing gated to real candidates. Kill-switch `DEPTH_SIZED_COMPLETION_ENABLED=0`, fails open to pool depth.

**Phase 1b — graduate-on-completion**
`markDomainExpansionEligible()` routes a completed set into the *existing* expansion-offer funnel (adjacency, card, accept/dismiss, once-per-area suppression — no UI change). `evaluateSetCompletions` now runs before `buildExpansionOffer` so the graduation card surfaces the same summary.

## Tests
New pure-fn coverage (`liftServedToGlobalSkill`, `depthToTargetCount`) + updated `set-completion` (depth sizing, candidate gate, graduation-eligibility, fail-open). 484 daily/queries tests pass; lint + typecheck clean.

## Reviewer notes / follow-ups
- ⚠️ Phase 0 changes requested difficulty for **every** adaptive-mode user whose global level exceeds their per-domain rows — intended, but worth a look.
- **Apply migration 0116 to prod** (the instrumentation guard also creates it defensively).
- **Flip** `VERIFY_WEB_SEARCH_ALLOWED_DOMAINS=wikipedia.org,fandom.com` (env; the approved Fandom step).
- Graduation-card **copy valence** ("you mastered X → branch out") is an owed refinement.
- **Sizing vs supply:** a target above what a topic can supply won't complete; mitigations = tunable coefficient (no re-seed) + fail-open to pool depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
