### PR TITLE
feat(daily): raise short-queue yield — own-stock bank reuse + longer background build budget

### DIFF
--- a/src/app/api/cron/daily-assignments/route.ts
+++ b/src/app/api/cron/daily-assignments/route.ts
@@ -131,7 +131,10 @@ export async function GET(request: NextRequest) {
       // reminder — they're already playing today.
       let freshlyGenerated = false;
       if (!queue || existingSlots.length === 0) {
-        await fillDailyQueueForUser(user.id);
+        // Background build: use the longer top-up budget this 300s cron route
+        // allows, so a struggling build reaches DAILY_QUEUE_SIZE instead of
+        // persisting the 4-slot short queue the 90s sync ceiling forces.
+        await fillDailyQueueForUser(user.id, { background: true });
         queue = await getTodaysDailyQueue(user.id);
         results.generated += 1;
         freshlyGenerated = true;

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -116,6 +116,20 @@ const FUNCTION_DURATION_BUDGET_MS = Number(
   process.env.DAILY_BUILD_DURATION_BUDGET_MS ?? 90_000,
 );
 
+// Background builds (the daily cron) run under a route whose maxDuration is 300s,
+// so they can afford a LONGER top-up loop than the user-facing synchronous POST.
+// The 90s sync ceiling is why a struggling build stops at 4 instead of 5: after
+// the first pass (~50-70s) there isn't budget to START another top-up round
+// (elapsed + GENERATION_TIMEOUT_MS + margin > 90s), so it persists the short queue
+// (the measured "four questions" case). Giving the non-interactive build ~180s
+// lets that extra round run and reach DAILY_QUEUE_SIZE. The sync + pre-warm paths
+// keep the 90s budget for perceived latency; carry-forward means most users are
+// served the cron's pre-built (full) queue anyway. Env-tunable; keep it under the
+// cron route's maxDuration (300s) with margin for concurrency.
+const BACKGROUND_DURATION_BUDGET_MS = Number(
+  process.env.DAILY_BUILD_BG_DURATION_BUDGET_MS ?? 180_000,
+);
+
 // Headroom reserved AFTER the last LLM round for assembling + atomically
 // persisting the queue before the ceiling.
 const BUILD_PERSIST_MARGIN_MS = 8_000;
@@ -124,9 +138,8 @@ const BUILD_PERSIST_MARGIN_MS = 8_000;
 // to GENERATION_TIMEOUT_MS — plus persistence can still finish before the
 // platform kills the function. This is what keeps a short-but-served (≥ floor)
 // queue from degrading into a 504 + a "forever" wait on Hobby.
-const hasBudgetForAnotherRound = (elapsedMs: number) =>
-  elapsedMs + GENERATION_TIMEOUT_MS + BUILD_PERSIST_MARGIN_MS <=
-  FUNCTION_DURATION_BUDGET_MS;
+const hasBudgetForAnotherRound = (elapsedMs: number, budgetMs: number) =>
+  elapsedMs + GENERATION_TIMEOUT_MS + BUILD_PERSIST_MARGIN_MS <= budgetMs;
 
 // Hard cap on top-up rounds, independent of the time budget — a backstop against
 // a pathological domain that keeps generating questions the gates fully reject.
@@ -289,11 +302,20 @@ async function topUpAndCarryForwardPartialQueue(userId: string): Promise<boolean
   }
 }
 
-export function fillDailyQueueForUser(userId: string): Promise<void> {
+export function fillDailyQueueForUser(
+  userId: string,
+  options?: { background?: boolean },
+): Promise<void> {
   const inFlight = inFlightFills.get(userId);
   if (inFlight) return inFlight;
 
-  const promise = buildDailyQueueForUser(userId).finally(() => {
+  // Background (cron) builds get the longer top-up budget their 300s route allows;
+  // the synchronous POST / pre-warm keep the 90s budget for perceived latency.
+  const durationBudgetMs = options?.background
+    ? BACKGROUND_DURATION_BUDGET_MS
+    : FUNCTION_DURATION_BUDGET_MS;
+
+  const promise = buildDailyQueueForUser(userId, durationBudgetMs).finally(() => {
     // Clear on settle (success OR failure) so the next genuine build for this
     // user isn't blocked by a stale entry — a rejected build must be retryable.
     inFlightFills.delete(userId);
@@ -302,7 +324,10 @@ export function fillDailyQueueForUser(userId: string): Promise<void> {
   return promise;
 }
 
-async function buildDailyQueueForUser(userId: string): Promise<void> {
+async function buildDailyQueueForUser(
+  userId: string,
+  durationBudgetMs: number,
+): Promise<void> {
   const startedAt = Date.now();
 
   // Commit point for Refine Your Game: staged decisions from the prior daily's
@@ -645,7 +670,7 @@ async function buildDailyQueueForUser(userId: string): Promise<void> {
       (authored.length + housePicks.length + dedupedGenerated.length + topUpGenerated.length) >
       0 &&
     topUpRounds < MAX_TOP_UP_ROUNDS &&
-    hasBudgetForAnotherRound(Date.now() - startedAt)
+    hasBudgetForAnotherRound(Date.now() - startedAt, durationBudgetMs)
   ) {
     topUpRounds += 1;
     const roundShortfall =
@@ -938,7 +963,7 @@ async function buildDailyQueueForUser(userId: string): Promise<void> {
     // additive, so when little time is left (e.g. a slow core build near the
     // ceiling) skipping it lets the core queue still persist instead of risking a
     // mid-bonus kill that would lose the whole build.
-    if (bonusDomains.length > 0 && hasBudgetForAnotherRound(Date.now() - startedAt)) {
+    if (bonusDomains.length > 0 && hasBudgetForAnotherRound(Date.now() - startedAt, durationBudgetMs)) {
       const presenceByDomain = new Map(
         bonusDomains.map((candidate) => [candidate.domain.toLowerCase(), candidate]),
       );

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1801,6 +1801,20 @@ export function rankAndFilterBankCandidates<
   return { ranked, dudsExcluded };
 }
 
+// Own-unused bank reuse (kill-switch, default ON). By default the bank serves
+// only OTHER users' stock (cross-user reuse). At small scale with niche interests
+// that pool is thin, so a queue burns fresh Sonnet calls even though the viewer's
+// OWN over-provisioned / unfinished stock — rows persisted but never placed
+// (used_in_queue = false) — sits serveable in the pool. Including them cuts fresh
+// generation (fewer short queues, faster builds). Repeat-safe: used_in_queue flips
+// true the instant a row is placed (persistDailyQueue), and the fact-key /
+// question-text avoid sets below dedup anything already seen. Disable with
+// BANK_INCLUDE_OWN_UNUSED=false.
+function isBankIncludeOwnUnusedEnabled(): boolean {
+  const raw = process.env.BANK_INCLUDE_OWN_UNUSED?.trim().toLowerCase();
+  return !(raw === 'false' || raw === '0' || raw === 'no' || raw === 'off');
+}
+
 export async function pickBankSource(
   userId: string,
   domain: string,
@@ -1808,6 +1822,17 @@ export async function pickBankSource(
   avoidFactKeys: ReadonlySet<string>,
   avoidQuestionTexts: ReadonlySet<string> = new Set(),
 ): Promise<BankSource | null> {
+  // Cross-user stock, plus (when enabled) the viewer's own never-served rows.
+  const viewerClause = isBankIncludeOwnUnusedEnabled()
+    ? or(
+        sql`${generatedQuestions.userId} <> ${userId}`,
+        and(
+          eq(generatedQuestions.userId, userId),
+          eq(generatedQuestions.usedInQueue, false),
+        ),
+      )
+    : sql`${generatedQuestions.userId} <> ${userId}`;
+
   let candidates: Array<typeof generatedQuestions.$inferSelect>;
   try {
     candidates = await db
@@ -1825,7 +1850,7 @@ export async function pickBankSource(
         ),
         eq(generatedQuestions.difficultyEstimate, difficulty),
         isNotNull(generatedQuestions.factKey),
-        sql`${generatedQuestions.userId} <> ${userId}`,
+        viewerClause,
         eq(generatedQuestions.isDuplicate, false),
         // B-Report-3: skip generated questions under an open/upheld report.
         notSuppressedByContentReport(generatedQuestions.id, 'generated'),


### PR DESCRIPTION
## What & why

The **"only four questions"** half of the Marcellus/Buttkicker report. (The difficulty/completion half shipped in #1432.)

**Root cause (measured in prod logs):** short queues aren't over-filtering or too-few-domains — Joshua P has 12 interests and still went short. They're **generation under-yield × the 90s build budget**. The gates drop legitimately (a false-premise "gimer stick", a Shelob answer-leak, a self-answering He-Man question), so survival is ~30–40%; builds run p50 ≈ 60s / p90 ≈ 74s, and once a struggling build has spent ~50–68s it can't afford another top-up round (`elapsed + GENERATION_TIMEOUT_MS + margin > 90s`) — so it persists 4. The *slowest* builds are the *short* ones (3-slot p50 = 68s vs 7-slot = 41s), confirming budget exhaustion.

## Changes

**Lever 1 — own-stock bank reuse** (`pickBankSource`)
By default the bank serves only *other* users' rows — thin at ~18 users with niche interests. Now also draw the viewer's **own never-served stock** (`used_in_queue = false`): over-provisioned / unfinished rows already in the pool (Buttkicker has **12 serveable**). Cuts fresh generation → fewer short queues + faster builds. **Repeat-safe:** `used_in_queue` flips true on placement (`persistDailyQueue`), and the fact-key/question-text avoid-sets dedup anything already seen. Kill-switch `BANK_INCLUDE_OWN_UNUSED=false`.

**Lever 2 — longer background build budget** (`queue-orchestrator`)
The daily cron runs under a 300s route, but the top-up loop capped itself at the 90s sync budget — so background builds stopped at 4 with time to spare. Thread a per-build budget; the cron passes `background: true` → `DAILY_BUILD_BG_DURATION_BUDGET_MS` (default **180s**) so the extra round runs and reaches `DAILY_QUEUE_SIZE`. Sync POST + pre-warm keep 90s for perceived latency (carry-forward serves the cron's full queue anyway).

## Notes
- Lever 1 helps **returning** users (accumulated stock); lever 2 helps **first** builds (Marcellus had 0 leftover) — complementary.
- No migration. `pickBankSource` predicate widening is the only serving-behavior change (flag-guarded).
- 484 daily/queries tests pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
