### PR TITLE
feat(cost-report): name unmapped scopes (verify / sizing / grounding) in the weekly digest

### DIFF
--- a/src/server/db/queries/__tests__/llm-cost-report-taxonomy.test.ts
+++ b/src/server/db/queries/__tests__/llm-cost-report-taxonomy.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The taxonomy exports are pure, but the module imports the db layer at top level.
+// Stub the heavy imports so we can test SURFACE_BUCKETS / bucketForScope in isolation.
+vi.mock('@/server/db', () => ({
+  db: {},
+  generatedQuestions: {},
+  llmCostReport: {},
+  llmUsageEvent: {},
+  masteryEvents: {},
+  users: {},
+}));
+vi.mock('@/server/db/queries/crafter-demand', () => ({ getExpensiveDomains: vi.fn() }));
+vi.mock('@/server/auth/admin', () => ({ adminUserIds: () => [] }));
+vi.mock('@/server/llm/pricing', () => ({ estimateCostUsd: () => ({ usd: 0, unpriced: false }) }));
+
+import {
+  ALL_BUCKETS,
+  OTHER_BUCKET,
+  SURFACE_BUCKETS,
+  bucketForScope,
+} from '@/server/db/queries/llm-cost-report';
+
+// Scopes observed in the live LlmUsageEvent ledger (30-day snapshot, 2026-07-06).
+// Every one must resolve to a NAMED bucket — none may fall into "Other / unmapped",
+// which is what let the whole verification pipeline + topic-sizing hide from the
+// weekly digest. A new scope added to the codebase should be added to a bucket
+// here (or this test flags that it's silently landing in Other).
+const LIVE_SCOPES = [
+  'batch-verify', 'ask-to-answer-cold', 'vet-question', 'generate-questions',
+  'audit:gate', 'inside-joke', 'grade', 'factual-gate', 'node-weight-depth',
+  'quality-gate', 'mastery-threshold-points', 'salvage-propose', 'history-dedupe',
+  'ask-to-answer-judge', 'batch-dedupe', 'enrich-variants', 'pool-refill-generate',
+  'questions-suggest-verify', 'questions-suggest', 'ceremony-narrative',
+  'interests-answerability', 'crafter-draft', 'recheck', 'interests-categorize-domain',
+  'knowledge-structure-proposal', 'critique', 'reconcile-subcategory', 'categorize',
+  'difficulty', 'interests-suggest-broader', 'interests-suggest-adjacent',
+  'interests-expand', 'interests-proofread', 'categorize-deleak',
+  // Flag-gated / lower-volume scopes that must still be named when they fire:
+  'domain-reference', 'nearness-tree',
+];
+
+describe('LLM cost-report surface taxonomy', () => {
+  it('maps every live scope to a NAMED bucket (nothing hides in Other)', () => {
+    const unmapped = LIVE_SCOPES.filter((s) => bucketForScope(s).key === OTHER_BUCKET.key);
+    expect(unmapped).toEqual([]);
+  });
+
+  it('surfaces the new named buckets', () => {
+    const keys = ALL_BUCKETS.map((b) => b.key);
+    expect(keys).toContain('verify');
+    expect(keys).toContain('sizing');
+    expect(keys).toContain('grounding');
+  });
+
+  it('lands the depth-sized-completion spend under "sizing"', () => {
+    expect(bucketForScope('node-weight-depth').key).toBe('sizing');
+    expect(bucketForScope('mastery-threshold-points').key).toBe('sizing');
+  });
+
+  it('names the verification pipeline (previously the biggest Other contributor)', () => {
+    expect(bucketForScope('batch-verify').key).toBe('verify');
+    expect(bucketForScope('ask-to-answer-cold').key).toBe('verify');
+  });
+
+  it('assigns each scope to exactly one bucket (no double-counting)', () => {
+    const seen = new Map<string, string>();
+    for (const b of SURFACE_BUCKETS) {
+      for (const scope of b.scopes) {
+        expect(seen.has(scope), `scope "${scope}" is in both ${seen.get(scope)} and ${b.key}`).toBe(false);
+        seen.set(scope, b.key);
+      }
+    }
+  });
+
+  it('keeps only genuinely player-facing surfaces flagged', () => {
+    const facing = SURFACE_BUCKETS.filter((b) => b.playerFacing).map((b) => b.key).sort();
+    expect(facing).toEqual(['grade', 'interests']);
+  });
+});

--- a/src/server/db/queries/llm-cost-report.ts
+++ b/src/server/db/queries/llm-cost-report.ts
@@ -49,21 +49,40 @@ export const SURFACE_BUCKETS: SurfaceBucket[] = [
     key: 'generate',
     label: 'Generating questions',
     playerFacing: false,
-    scopes: ['generate-questions', 'pool-refill-generate', 'multitudes'],
+    scopes: ['generate-questions', 'pool-refill-generate', 'multitudes', 'crafter-draft'],
   },
   {
     key: 'quality',
     label: 'Checking question quality',
     playerFacing: false,
+    // Generation-time gates + quality repair (salvage/variants). Post-hoc
+    // fact-checking now lives in its own 'verify' bucket below.
     scopes: [
       'quality-gate',
       'factual-gate',
       'critique',
-      'vet-question',
-      'recheck',
       'difficulty',
       'batch-dedupe',
       'history-dedupe',
+      'salvage-propose',
+      'enrich-variants',
+    ],
+  },
+  {
+    key: 'verify',
+    label: 'Fact-checking questions',
+    playerFacing: false,
+    // The verification pipeline — the biggest single cost centre (batch-verify
+    // alone is the top scope by calls, and carries the web-search spend). Was
+    // entirely in "Other / unmapped" before, so the digest under-named it.
+    scopes: [
+      'vet-question',
+      'recheck',
+      'batch-verify',
+      'ask-to-answer-cold',
+      'ask-to-answer-judge',
+      'audit:gate',
+      'questions-suggest-verify',
     ],
   },
   {
@@ -84,7 +103,30 @@ export const SURFACE_BUCKETS: SurfaceBucket[] = [
       'interests-proofread',
       'interests-suggest',
       'interests-suggest-adjacent',
+      'interests-suggest-broader',
     ],
+  },
+  {
+    key: 'sizing',
+    label: 'Sizing & structuring topics',
+    playerFacing: false,
+    // Depth/size scoring + knowledge-graph structuring. This is where the
+    // depth-sized finite-set completion (D-DIFFICULTY-SIZE-COMPLETION-01) and
+    // mastery-v2 seeding spend lands; also the nearness/graduation adjacency.
+    scopes: [
+      'node-weight-depth',
+      'mastery-threshold-points',
+      'knowledge-structure-proposal',
+      'nearness-tree',
+    ],
+  },
+  {
+    key: 'grounding',
+    label: 'Grounding from wiki/web sources',
+    playerFacing: false,
+    // Reference-passage retrieval (D-FANDOM-GROUNDING-01). Flag-off today, so this
+    // reads $0 until the wiki-anchor flips — then its cost is named, not hidden.
+    scopes: ['domain-reference'],
   },
   {
     key: 'tagging',
@@ -98,6 +140,7 @@ export const SURFACE_BUCKETS: SurfaceBucket[] = [
       'reconcile-subcategory',
       'clean-question',
       'categorize',
+      'categorize-deleak',
     ],
   },
   {


### PR DESCRIPTION
## What & why

Answers "are we tracking the cost of all this?" — **yes, in the totals** (the `LlmUsageEvent` ledger is append-only and captures every call through `loggedMessagesCreate`, priced at read time). But the weekly digest's *named* per-surface breakdown had a big hole: a live 30-day snapshot showed the largest cost centres landing in **"Other / unmapped"** instead of a labeled line.

**What was hiding in "Other":**
- The entire **verification pipeline** — `batch-verify` (the #1 scope by calls, 825, and the one carrying the ~400 web searches), `ask-to-answer-cold` (551), `ask-to-answer-judge`, `audit:gate`, `questions-suggest-verify`.
- **Topic sizing** — `node-weight-depth` (145) and `mastery-threshold-points` (116) — i.e. the depth-sized finite-set completion + mastery-v2 seeding.
- Strays: `salvage-propose`, `enrich-variants`, `crafter-draft`, `knowledge-structure-proposal`, a few `interests-*`.

## Change

Purely a **taxonomy edit** in `llm-cost-report.ts` (the file's own "this constant IS the mapping" seam) — no ledger change, no backfill, read-time rollup:

- **new `verify`** — "Fact-checking questions" (the verification pipeline; surfaces its web-search cost).
- **new `sizing`** — "Sizing & structuring topics" (where `D-DIFFICULTY-SIZE-COMPLETION-01`'s depth calls + mastery seeding land).
- **new `grounding`** — "Grounding from wiki/web sources" (`domain-reference`; $0 today, named the moment the Fandom wiki-anchor flips).
- remaining strays folded into existing buckets.

Adds a guard test asserting every live scope maps out of "Other" and each scope is in exactly one bucket — so a future scope can't silently vanish from the digest again.

## Notes
- Net effect on the digest: the same total, but "Where the money went" now names the verification + sizing + (future) grounding spend instead of a lump "Other."
- The background-budget change (#1433) shows up automatically under "Generating questions"; own-stock reuse shows as *lower* generation spend.
- 6 taxonomy tests pass; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
