### PR TITLE
fix(dedup): stop repeated questions — answered-fact dedup + fact_key backfill

### DIFF
--- a/scripts/backfill-fact-key.ts
+++ b/scripts/backfill-fact-key.ts
@@ -1,0 +1,140 @@
+/**
+ * Repair GeneratedQuestion.fact_key on legacy rows (Josh's repeated-question
+ * report, 2026-07-06).
+ *
+ * fact_key is the dedup handle: getRecentFactKeys / pickBankSource / the
+ * generator's avoid-list all key on it, and a NULL fact_key is INVISIBLE to every
+ * one of them — so a fact answered via a null-keyed row keeps getting regenerated
+ * and re-surfaced (the "Star Trek flute three times" case). ~23% of the bank
+ * (303/1303 rows at time of writing) carries a NULL fact_key from before fact_key
+ * population was reliable; new generation (last 7 days) sets it correctly.
+ *
+ * Every null row still carries subject_entity AND answer, so we rebuild the same
+ * shape the generator emits — "<domain> <subject> <answer>" → normalizeFactKey —
+ * DETERMINISTICALLY (no LLM), using the SAME normalizer the live path uses
+ * (imported, not re-implemented). This is a best-effort floor: it makes the legacy
+ * rows dedup-VISIBLE (registered when answered, excluded from bank re-serve). The
+ * structural cross-surface fix — dedup on ANSWERED facts with a normalized-text
+ * fallback — is the follow-up (part B); this backfill stands on its own.
+ *
+ * Touches ONLY fact_key, ONLY where it is currently NULL and a key is derivable.
+ * Never rewrites an existing key, question content, subject_entity, or answer.
+ *
+ * Read-only by default. Run from repo root (Node 24):
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-fact-key.ts             # dry-run report
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-fact-key.ts --print-sql # emit UPDATEs for the SQL editor
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-fact-key.ts --apply      # write, in one transaction
+ *
+ * Idempotent: re-running after --apply reports 0 changes (the rows are no longer NULL).
+ */
+import pg from 'pg';
+
+import { normalizeFactKey } from '../src/server/questions/fact-key';
+
+const DB_URL = process.env.DIRECT_URL || process.env.DATABASE_URL;
+if (!DB_URL) {
+  console.error('No DIRECT_URL/DATABASE_URL in env');
+  process.exit(1);
+}
+
+const APPLY = process.argv.includes('--apply');
+const PRINT_SQL = process.argv.includes('--print-sql');
+
+function sqlLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+type Row = {
+  id: string;
+  canonical_subcategory: string | null;
+  subject_entity: string | null;
+  answer: string | null;
+};
+
+/** The same "<domain> <subject> <answer>" shape the generator emits, slugged. */
+function deriveFactKey(r: Row): string | null {
+  const parts = [r.canonical_subcategory, r.subject_entity, r.answer]
+    .map((p) => (p ?? '').trim())
+    .filter(Boolean);
+  if (parts.length === 0) return null;
+  return normalizeFactKey(parts.join(' '));
+}
+
+async function main() {
+  const client = new pg.Client({ connectionString: DB_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query<Row>(`
+      SELECT id, canonical_subcategory, subject_entity, answer
+      FROM "GeneratedQuestion"
+      WHERE fact_key IS NULL
+    `);
+
+    const derivable: Array<{ id: string; key: string; label: string }> = [];
+    let underivable = 0;
+    for (const r of rows) {
+      const key = deriveFactKey(r);
+      if (!key) {
+        underivable += 1;
+        continue;
+      }
+      derivable.push({
+        id: r.id,
+        key,
+        label: `${(r.canonical_subcategory ?? '?').slice(0, 24)} | ${(r.subject_entity ?? '?').slice(0, 22)} → ${(r.answer ?? '?').slice(0, 20)}`,
+      });
+    }
+
+    console.log('\n=== fact_key backfill — DRY RUN ===');
+    console.log(`null fact_key rows:    ${rows.length}`);
+    console.log(`derivable (will set):  ${derivable.length}`);
+    console.log(`underivable (skipped): ${underivable}`);
+    console.log('\n--- sample of proposed keys ---');
+    for (const d of derivable.slice(0, 12)) {
+      console.log(`  ${d.key}\n      ${d.label}`);
+    }
+
+    if (PRINT_SQL) {
+      console.log('\n--- SQL (paste into Supabase SQL editor) ---');
+      console.log('BEGIN;');
+      for (const d of derivable) {
+        console.log(
+          `UPDATE "GeneratedQuestion" SET fact_key = ${sqlLiteral(d.key)} ` +
+            `WHERE id = ${sqlLiteral(d.id)} AND fact_key IS NULL;`,
+        );
+      }
+      console.log('COMMIT;');
+    }
+
+    if (APPLY) {
+      console.log('\n--- APPLYING ---');
+      await client.query('BEGIN');
+      let changed = 0;
+      for (const d of derivable) {
+        const res = await client.query(
+          `UPDATE "GeneratedQuestion" SET fact_key = $1 WHERE id = $2 AND fact_key IS NULL`,
+          [d.key, d.id],
+        );
+        changed += res.rowCount ?? 0;
+      }
+      await client.query('COMMIT');
+      console.log(`updated ${changed} rows.`);
+    } else {
+      console.log('\n(no writes — pass --apply to execute, or --print-sql to emit SQL)');
+    }
+  } catch (err) {
+    try {
+      await client.query('ROLLBACK');
+    } catch {
+      /* not in a txn */
+    }
+    throw err;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -2227,24 +2227,61 @@ export async function getRecentFactKeys(
   userId: string,
   limit = 200,
 ): Promise<RecentFactKeyEntry[]> {
-  const rows = await db
-    .select({
-      factKey: generatedQuestions.factKey,
-      domain: generatedQuestions.canonicalSubcategory,
-    })
-    .from(generatedQuestions)
-    .where(and(
-      eq(generatedQuestions.userId, userId),
-      isNotNull(generatedQuestions.factKey),
-    ))
-    .orderBy(sql`${generatedQuestions.createdAt} desc`)
-    .limit(limit);
+  // Two sources, unioned (B-DEDUP-ANSWERED-FACTS, 2026-07-06). This is the ONE
+  // durable (non-windowed) dedup — the answer/subject cooldowns are short windows,
+  // so a fact answered >window days ago can still repeat unless it lives here.
+  //  (1) Facts the viewer ANSWERED on ANY surface (daily / feed / catch-up),
+  //      resolved to the answered row's fact_key — INCLUDING questions ANOTHER
+  //      user generated (a friend's question surfaced in the feed). The
+  //      "generated-for-you" source alone misses those, which is how a feed-
+  //      answered fact came back as a +2 bonus (the Optimus report). This is the
+  //      "never re-serve a fact I've already answered" guarantee.
+  //  (2) Facts GENERATED for the viewer (served but maybe unanswered) — the prior
+  //      behavior, so we still avoid re-creating something already put in front of
+  //      them. Answered facts are listed first so they win the cap.
+  const [answered, generated] = await Promise.all([
+    db
+      .select({
+        factKey: generatedQuestions.factKey,
+        domain: generatedQuestions.canonicalSubcategory,
+      })
+      .from(masteryEvents)
+      // MASTERY_EVENTS.question_id references the canonical Question twin, not the
+      // GeneratedQuestion — bridge via the twin's generated_question_id to read the
+      // fact_key. This is what makes a feed-answered question whose GENERATED row
+      // another user owns still land in the viewer's avoid set.
+      .innerJoin(canonicalQuestions, eq(masteryEvents.questionId, canonicalQuestions.id))
+      .innerJoin(
+        generatedQuestions,
+        eq(canonicalQuestions.generatedQuestionId, generatedQuestions.id),
+      )
+      .where(and(
+        eq(masteryEvents.answeredByUserId, userId),
+        isNotNull(generatedQuestions.factKey),
+      ))
+      .orderBy(sql`${masteryEvents.createdAt} desc`)
+      .limit(limit),
+    db
+      .select({
+        factKey: generatedQuestions.factKey,
+        domain: generatedQuestions.canonicalSubcategory,
+      })
+      .from(generatedQuestions)
+      .where(and(
+        eq(generatedQuestions.userId, userId),
+        isNotNull(generatedQuestions.factKey),
+      ))
+      .orderBy(sql`${generatedQuestions.createdAt} desc`)
+      .limit(limit),
+  ]);
 
   const out: RecentFactKeyEntry[] = [];
-  for (const row of rows) {
-    if (row.factKey) {
-      out.push({ domain: row.domain ?? 'unknown', factKey: row.factKey });
-    }
+  const seen = new Set<string>();
+  for (const row of [...answered, ...generated]) {
+    if (!row.factKey || seen.has(row.factKey)) continue;
+    seen.add(row.factKey);
+    out.push({ domain: row.domain ?? 'unknown', factKey: row.factKey });
+    if (out.length >= limit) break;
   }
   return out;
 }


### PR DESCRIPTION
## What & why

Fixes the repeated-question report: the "Star Trek flute ~3×" and a **+2 bonus** re-serving the Transformers/Optimus fact you'd **answered on the feed**.

**Diagnosis (from prod):** `fact_key` is the durable dedup handle, and it had two holes:
1. **23% of legacy bank rows had a NULL `fact_key`** (303/1303) — invisible to every dedup path (new generation sets it; this is legacy-only). Every flute/Optimus instance you answered was null-keyed.
2. **`getRecentFactKeys` read only rows generated *for you*** — so a friend's question you answered on the **feed** (owned by the friend) never entered your avoid-set, and the short answer/subject *cooldown windows* let a >window-old fact (flute answered 06-06, re-served 07-06 = 30 days) return.

## Part A — backfill null fact_keys (`scripts/backfill-fact-key.ts`) — already applied to prod
Rebuilds `fact_key` **deterministically** from `"<domain> <subject> <answer>"` (the shape the generator emits, via the same `normalizeFactKey`) for the 303 null rows — all had `subject_entity` + `answer`. Dry-run default, `--apply`, idempotent. Verified: 0 null fact_keys remain.

## Part B — dedup on *answered* facts (`getRecentFactKeys`)
Now UNIONs two sources:
1. **Facts you ANSWERED on any surface** (daily/feed/catch-up), resolved via the canonical `Question` twin's `generated_question_id → GeneratedQuestion.fact_key` — **including questions another user generated**. This is the durable, non-windowed "never re-serve a fact I've answered" guarantee.
2. Facts generated for you (prior behavior).

Verified against prod that Josh's flute (**both** the backfilled and LLM keys) and the Optimus-bonus fact now resolve into his avoid-set — so neither can come back via generation *or* the bank *or* the +2 bonus.

## Notes
- Complementary: A makes legacy rows dedup-visible; B closes the cross-surface/cross-owner hole and makes answered-dedup durable (window-independent).
- Strictly *additive* to the avoid-set (stricter dedup). Minor interaction with short-queue supply, bounded by the same `limit`.
- 490 daily/queries tests pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
