### PR TITLE
Add admin questions audit table (B-ADMIN-QUESTIONS-OVERVIEW-01)

### DIFF
--- a/src/app/admin/AdminTabs.tsx
+++ b/src/app/admin/AdminTabs.tsx
@@ -10,7 +10,7 @@ export function AdminTabs({
   active,
   needingReviewCount,
 }: {
-  active: 'crafter' | 'reports' | 'knowledge';
+  active: 'crafter' | 'reports' | 'knowledge' | 'questions';
   needingReviewCount?: number;
 }) {
   const tabClass = 'rounded-md border px-3 py-1.5 text-sm font-medium';
@@ -45,6 +45,14 @@ export function AdminTabs({
         aria-current={active === 'knowledge' ? 'page' : undefined}
       >
         Knowledge graph
+      </Link>
+      <Link
+        href="/admin/questions"
+        className={tabClass}
+        style={active === 'questions' ? activeStyle : idleStyle}
+        aria-current={active === 'questions' ? 'page' : undefined}
+      >
+        Questions
       </Link>
     </nav>
   );

--- a/src/app/admin/questions/AdminQuestionsClient.tsx
+++ b/src/app/admin/questions/AdminQuestionsClient.tsx
@@ -172,7 +172,202 @@ function Group({ title, children }: { title: string; children: ReactNode }) {
   );
 }
 
+const EDITABLE_VISIBILITIES = ['public', 'friends', 'private'];
+
+// Phase 4 edit form. Minimal ratified field set (Decision B). answerText and
+// acceptedAlternatives are grading-adjacent — a change to either requires an
+// explicit confirm before persisting (grading must fail toward the player).
+function EditForm({
+  detail,
+  onDone,
+  onCancel,
+}: {
+  detail: AdminQuestionDetail;
+  onDone: () => void;
+  onCancel: () => void;
+}) {
+  const [questionText, setQuestionText] = useState(detail.questionText);
+  const [answerText, setAnswerText] = useState(detail.answerText);
+  const [acceptedAlternatives, setAcceptedAlternatives] = useState(detail.acceptedAlternatives.join('\n'));
+  const [factualExplanation, setFactualExplanation] = useState(detail.factualExplanation ?? '');
+  const [category, setCategory] = useState(detail.category);
+  const [visibility, setVisibility] = useState(detail.visibility);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    const altsArray = acceptedAlternatives
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    // Build a patch of only the fields that actually changed.
+    const patch: Record<string, unknown> = {};
+    if (questionText.trim() !== detail.questionText) patch.questionText = questionText.trim();
+    if (answerText.trim() !== detail.answerText) patch.answerText = answerText.trim();
+    if (JSON.stringify(altsArray) !== JSON.stringify(detail.acceptedAlternatives)) {
+      patch.acceptedAlternatives = altsArray;
+    }
+    if ((factualExplanation.trim() || null) !== (detail.factualExplanation ?? null)) {
+      patch.factualExplanation = factualExplanation.trim() || null;
+    }
+    if (category !== detail.category) patch.category = category;
+    if (visibility !== detail.visibility) patch.visibility = visibility;
+
+    if (Object.keys(patch).length === 0) {
+      setError('No changes to save.');
+      return;
+    }
+
+    // Grading-adjacent guard: confirm before changing how answers grade.
+    const gradingChanged = 'answerText' in patch || 'acceptedAlternatives' in patch;
+    if (gradingChanged) {
+      const ok = window.confirm(
+        'This changes the answer key or accepted alternatives, which changes how past and future answers grade. Save?',
+      );
+      if (!ok) return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/questions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action: 'edit', id: detail.id, ...patch }),
+      });
+      if (!res.ok) {
+        setError(`Save failed (${res.status}).`);
+        setBusy(false);
+        return;
+      }
+      onDone();
+    } catch {
+      setError('Save failed.');
+      setBusy(false);
+    }
+  }
+
+  const inputClass = 'w-full rounded-md border px-2 py-1.5 text-[13px]';
+  const inputStyle = { borderColor: 'var(--border)', background: 'var(--brand-field)', color: 'var(--brand-ink)' };
+  const labelClass = 'mb-1 block text-[11px] uppercase tracking-[0.04em]';
+  const labelStyle = { color: 'var(--text-muted)' };
+
+  return (
+    <div className="mb-4">
+      <div className="mb-3">
+        <label className={labelClass} style={labelStyle}>
+          Question
+        </label>
+        <textarea rows={3} className={inputClass} style={inputStyle} value={questionText} onChange={(e) => setQuestionText(e.target.value)} />
+      </div>
+      <div className="mb-3">
+        <label className={labelClass} style={labelStyle}>
+          Answer (grading key)
+        </label>
+        <input className={inputClass} style={inputStyle} value={answerText} onChange={(e) => setAnswerText(e.target.value)} />
+      </div>
+      <div className="mb-3">
+        <label className={labelClass} style={labelStyle}>
+          Accepted alternatives (one per line)
+        </label>
+        <textarea rows={3} className={inputClass} style={inputStyle} value={acceptedAlternatives} onChange={(e) => setAcceptedAlternatives(e.target.value)} />
+      </div>
+      <div className="mb-3">
+        <label className={labelClass} style={labelStyle}>
+          Factual explanation
+        </label>
+        <textarea rows={3} className={inputClass} style={inputStyle} value={factualExplanation} onChange={(e) => setFactualExplanation(e.target.value)} />
+      </div>
+      <div className="mb-3 flex gap-3">
+        <div className="flex-1">
+          <label className={labelClass} style={labelStyle}>
+            Category
+          </label>
+          <select className={inputClass} style={inputStyle} value={category} onChange={(e) => setCategory(e.target.value)}>
+            {CATEGORIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex-1">
+          <label className={labelClass} style={labelStyle}>
+            Visibility
+          </label>
+          <select className={inputClass} style={inputStyle} value={visibility} onChange={(e) => setVisibility(e.target.value)}>
+            {EDITABLE_VISIBILITIES.map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+            {/* A blocked row keeps its value visible but can't be re-selected. */}
+            {detail.visibility === 'blocked' ? <option value="blocked">blocked</option> : null}
+          </select>
+        </div>
+      </div>
+
+      {error ? (
+        <p className="mb-2 text-[13px]" style={{ color: 'var(--danger)' }}>
+          {error}
+        </p>
+      ) : null}
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={save}
+          className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+          style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+        >
+          {busy ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onCancel}
+          className="rounded-md border px-3 py-1.5 text-sm"
+          style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function DetailSheet({ detail, onClose }: { detail: AdminQuestionDetail; onClose: () => void }) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  async function mutate(action: 'delete' | 'restore') {
+    if (action === 'delete' && !window.confirm('Soft-delete this question? It stays inspectable under "show deleted" and can be restored.')) {
+      return;
+    }
+    setBusy(true);
+    setActionError(null);
+    try {
+      const res = await fetch('/api/admin/questions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action, id: detail.id }),
+      });
+      if (!res.ok) {
+        setActionError(`${action === 'delete' ? 'Delete' : 'Restore'} failed (${res.status}).`);
+        setBusy(false);
+        return;
+      }
+      router.refresh();
+    } catch {
+      setActionError(`${action === 'delete' ? 'Delete' : 'Restore'} failed.`);
+      setBusy(false);
+    }
+  }
+
   return (
     <div
       className="fixed inset-0 z-50 flex justify-end"
@@ -206,6 +401,64 @@ function DetailSheet({ detail, onClose }: { detail: AdminQuestionDetail; onClose
             Close
           </button>
         </div>
+
+        {/* Phase 4 actions. Deleted rows offer Restore instead of Edit/Delete. */}
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          {detail.deletedAt ? (
+            <>
+              <span className="text-[13px]" style={{ color: 'var(--danger)' }}>
+                Deleted {detail.deletedAt.slice(0, 10)}
+              </span>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => mutate('restore')}
+                className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+                style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+              >
+                Restore
+              </button>
+            </>
+          ) : (
+            <>
+              {!editing ? (
+                <button
+                  type="button"
+                  onClick={() => setEditing(true)}
+                  className="rounded-md border px-3 py-1.5 text-sm font-medium"
+                  style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+                >
+                  Edit
+                </button>
+              ) : null}
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => mutate('delete')}
+                className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+                style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
+              >
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+        {actionError ? (
+          <p className="mb-3 text-[13px]" style={{ color: 'var(--danger)' }}>
+            {actionError}
+          </p>
+        ) : null}
+
+        {editing ? (
+          <EditForm
+            detail={detail}
+            onDone={() => {
+              setEditing(false);
+              router.refresh();
+            }}
+            onCancel={() => setEditing(false)}
+          />
+        ) : null}
 
         <Group title="Content">
           <Field label="Question" value={detail.questionText} />
@@ -613,7 +866,7 @@ export function AdminQuestionsClient({
         </div>
       </div>
 
-      {detail ? <DetailSheet detail={detail} onClose={closeDetail} /> : null}
+      {detail ? <DetailSheet key={detail.id} detail={detail} onClose={closeDetail} /> : null}
     </main>
   );
 }

--- a/src/app/admin/questions/AdminQuestionsClient.tsx
+++ b/src/app/admin/questions/AdminQuestionsClient.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { AdminTabs } from '@/app/admin/AdminTabs';
+import type { AdminQuestionRow, AdminQuestionsPage } from '@/server/db/queries/admin-questions';
+
+// B-ADMIN-QUESTIONS-OVERVIEW-01 Phase 1 — the read-only pool audit table.
+// Deliberately plain (an internal ops tool): a wide, horizontally-scrollable
+// table with a show-deleted toggle and pagination. Interface quiet, content loud.
+// Canon: house/tombstone rows carry the neutral "House" label resolved server-
+// side (never a person); every flag is a TEXT badge, never color alone.
+
+function fmtDate(iso: string): string {
+  // YYYY-MM-DD — compact and sortable-looking for an audit table.
+  return iso.slice(0, 10);
+}
+
+function fmtRate(row: AdminQuestionRow): string {
+  if (row.correctRate !== null && row.correctRate !== undefined) {
+    return `${Math.round(row.correctRate * 100)}%`;
+  }
+  if (row.askedCount > 0) return `${Math.round((row.correctCount / row.askedCount) * 100)}%`;
+  return '—';
+}
+
+// A text-labelled badge. Callers pass a semantic token for tone; the LABEL always
+// carries the meaning so nothing is conveyed by color alone.
+function Badge({ label, tone }: { label: string; tone?: 'muted' | 'danger' | 'navy' | 'warning' }) {
+  const style =
+    tone === 'danger'
+      ? { color: 'var(--danger)', borderColor: 'var(--danger)' }
+      : tone === 'navy'
+        ? { color: 'var(--brand-navy)', borderColor: 'var(--brand-navy)' }
+        : tone === 'warning'
+          ? { color: 'var(--warning)', borderColor: 'var(--warning)' }
+          : { color: 'var(--text-muted)', borderColor: 'var(--border)' };
+  return (
+    <span
+      className="inline-block whitespace-nowrap rounded border px-1.5 py-0.5 text-[11px] font-medium"
+      style={style}
+    >
+      {label}
+    </span>
+  );
+}
+
+function FlagBadges({ row }: { row: AdminQuestionRow }) {
+  const flags: { label: string; tone: 'danger' | 'warning' | 'muted' }[] = [];
+  if (row.deletedAt) flags.push({ label: 'deleted', tone: 'danger' });
+  if (row.authorDeleted) flags.push({ label: 'tombstone', tone: 'muted' });
+  if (row.nobodyCorrectFlag) flags.push({ label: 'nobody-correct', tone: 'warning' });
+  if (row.isDuplicate) flags.push({ label: 'duplicate', tone: 'warning' });
+  if (row.perishable) flags.push({ label: 'perishable', tone: 'muted' });
+  if (flags.length === 0) return <span style={{ color: 'var(--text-muted)' }}>—</span>;
+  return (
+    <span className="flex flex-wrap gap-1">
+      {flags.map((f) => (
+        <Badge key={f.label} label={f.label} tone={f.tone} />
+      ))}
+    </span>
+  );
+}
+
+const CELL = 'px-2 py-1.5 align-top text-[13px]';
+const HEAD = 'px-2 py-1.5 text-left text-[11px] font-semibold uppercase tracking-[0.04em]';
+
+export function AdminQuestionsClient({ result }: { result: AdminQuestionsPage }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const totalPages = Math.max(1, Math.ceil(result.total / result.pageSize));
+
+  function navigate(next: Record<string, string | null>) {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [key, value] of Object.entries(next)) {
+      if (value === null) params.delete(key);
+      else params.set(key, value);
+    }
+    router.push(`/admin/questions?${params.toString()}`);
+  }
+
+  function toggleDeleted() {
+    navigate({ showDeleted: result.showDeleted ? null : '1', page: '1' });
+  }
+
+  function goToPage(page: number) {
+    navigate({ page: String(page) });
+  }
+
+  return (
+    <main className="mx-auto max-w-[1600px] px-4 py-6">
+      <h1 className="mb-3 font-serif text-2xl font-semibold text-[var(--brand-ink)]">Questions</h1>
+      <div className="mb-4">
+        <AdminTabs active="questions" />
+      </div>
+
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+          {result.total.toLocaleString()} question{result.total === 1 ? '' : 's'}
+          {result.showDeleted ? ' (including deleted)' : ''}
+        </p>
+        <label className="flex items-center gap-2 text-sm" style={{ color: 'var(--brand-ink-700)' }}>
+          <input type="checkbox" checked={result.showDeleted} onChange={toggleDeleted} />
+          Show deleted
+        </label>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border" style={{ borderColor: 'var(--border)' }}>
+        <table className="w-full border-collapse text-left">
+          <thead>
+            <tr style={{ background: 'var(--surface-2)', color: 'var(--text-muted)' }}>
+              <th className={HEAD}>Question</th>
+              <th className={HEAD}>Answer</th>
+              <th className={HEAD}>Category</th>
+              <th className={HEAD}>Author</th>
+              <th className={HEAD}>Source</th>
+              <th className={HEAD}>Trust</th>
+              <th className={HEAD}>Visibility</th>
+              <th className={HEAD}>Public status</th>
+              <th className={HEAD}>Verdict</th>
+              <th className={HEAD}>Asked</th>
+              <th className={HEAD}>Correct</th>
+              <th className={HEAD}>Rate</th>
+              <th className={HEAD}>Flags</th>
+              <th className={HEAD}>Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.rows.length === 0 ? (
+              <tr>
+                <td className={CELL} colSpan={14} style={{ color: 'var(--text-muted)' }}>
+                  No questions match.
+                </td>
+              </tr>
+            ) : (
+              result.rows.map((row) => (
+                <tr
+                  key={row.id}
+                  className="border-t"
+                  style={{
+                    borderColor: 'var(--border)',
+                    opacity: row.deletedAt ? 0.6 : 1,
+                    color: 'var(--brand-ink)',
+                  }}
+                >
+                  <td className={`${CELL} min-w-[280px] max-w-[360px]`}>
+                    <span className="line-clamp-2">{row.questionText}</span>
+                  </td>
+                  <td className={`${CELL} min-w-[120px] max-w-[200px]`}>
+                    <span className="line-clamp-2">{row.answerText}</span>
+                  </td>
+                  <td className={`${CELL} whitespace-nowrap`}>
+                    {row.category}
+                    {row.broadCategory ? (
+                      <span className="block text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                        {row.broadCategory}
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className={`${CELL} whitespace-nowrap`}>
+                    {row.authorIsPerson ? (
+                      row.authorLabel
+                    ) : (
+                      <Badge label={row.authorLabel} tone="muted" />
+                    )}
+                  </td>
+                  <td className={`${CELL} whitespace-nowrap`}>{row.source}</td>
+                  <td className={`${CELL} whitespace-nowrap`}>{row.trustTier}</td>
+                  <td className={`${CELL} whitespace-nowrap`}>{row.visibility}</td>
+                  <td className={`${CELL} whitespace-nowrap`}>{row.publicStatus}</td>
+                  <td className={`${CELL} whitespace-nowrap`}>{row.verificationVerdict ?? '—'}</td>
+                  <td className={`${CELL} text-right tabular-nums`}>{row.askedCount}</td>
+                  <td className={`${CELL} text-right tabular-nums`}>{row.correctCount}</td>
+                  <td className={`${CELL} text-right tabular-nums`}>{fmtRate(row)}</td>
+                  <td className={`${CELL} min-w-[140px]`}>
+                    <FlagBadges row={row} />
+                  </td>
+                  <td className={`${CELL} whitespace-nowrap`} style={{ color: 'var(--text-muted)' }}>
+                    {fmtDate(row.createdAt)}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between text-sm">
+        <span style={{ color: 'var(--text-muted)' }}>
+          Page {result.page} of {totalPages}
+        </span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="rounded-md border px-3 py-1.5 disabled:opacity-40"
+            style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+            disabled={result.page <= 1}
+            onClick={() => goToPage(result.page - 1)}
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            className="rounded-md border px-3 py-1.5 disabled:opacity-40"
+            style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+            disabled={result.page >= totalPages}
+            onClick={() => goToPage(result.page + 1)}
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/admin/questions/AdminQuestionsClient.tsx
+++ b/src/app/admin/questions/AdminQuestionsClient.tsx
@@ -1,18 +1,32 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { AdminTabs } from '@/app/admin/AdminTabs';
-import type { AdminQuestionRow, AdminQuestionsPage } from '@/server/db/queries/admin-questions';
+import { CATEGORIES } from '@/lib/questions-types';
+import type {
+  AdminQuestionRow,
+  AdminQuestionSortDir,
+  AdminQuestionSortKey,
+  AdminQuestionsPage,
+} from '@/server/db/queries/admin-questions';
 
-// B-ADMIN-QUESTIONS-OVERVIEW-01 Phase 1 — the read-only pool audit table.
-// Deliberately plain (an internal ops tool): a wide, horizontally-scrollable
-// table with a show-deleted toggle and pagination. Interface quiet, content loud.
-// Canon: house/tombstone rows carry the neutral "House" label resolved server-
-// side (never a person); every flag is a TEXT badge, never color alone.
+// B-ADMIN-QUESTIONS-OVERVIEW-01 Phase 1+2 — the read-only pool audit table with
+// server-driven sort & filter (URL search params → server re-query, so sort and
+// filter apply across the WHOLE pool, not just the loaded page). Deliberately
+// plain (an internal ops tool). Interface quiet, content loud. Canon:
+// house/tombstone rows carry the neutral "House" label resolved server-side
+// (never a person); every flag is a TEXT badge, never color alone.
+
+// Filter option lists. Sourced from the schema pgEnums (TrustTier,
+// QuestionVisibility, QuestionVerificationVerdict) and CATEGORIES — kept as plain
+// constants here so this client module pulls in no server-only schema import.
+const TRUST_TIERS = ['unverified', 'machine_verified', 'human_validated', 'author_confirmed'];
+const VISIBILITIES = ['public', 'friends', 'private', 'blocked'];
+const VERDICTS = ['ok', 'demoted', 'unverifiable', 'skipped'];
 
 function fmtDate(iso: string): string {
-  // YYYY-MM-DD — compact and sortable-looking for an audit table.
   return iso.slice(0, 10);
 }
 
@@ -64,29 +78,99 @@ function FlagBadges({ row }: { row: AdminQuestionRow }) {
 
 const CELL = 'px-2 py-1.5 align-top text-[13px]';
 const HEAD = 'px-2 py-1.5 text-left text-[11px] font-semibold uppercase tracking-[0.04em]';
+const CONTROL = 'rounded-md border px-2 py-1.5 text-sm';
 
-export function AdminQuestionsClient({ result }: { result: AdminQuestionsPage }) {
+// A sortable column header. A <button> so it is keyboard-operable; aria-sort
+// exposes the current direction to assistive tech.
+function SortHeader({
+  label,
+  columnKey,
+  sortKey,
+  sortDir,
+  onToggle,
+}: {
+  label: string;
+  columnKey: AdminQuestionSortKey;
+  sortKey: AdminQuestionSortKey;
+  sortDir: AdminQuestionSortDir;
+  onToggle: (key: AdminQuestionSortKey) => void;
+}) {
+  const active = sortKey === columnKey;
+  const arrow = active ? (sortDir === 'asc' ? '↑' : '↓') : '';
+  return (
+    <th className={HEAD} aria-sort={active ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+      <button
+        type="button"
+        onClick={() => onToggle(columnKey)}
+        className="inline-flex items-center gap-1 uppercase tracking-[0.04em] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        style={{ color: active ? 'var(--brand-navy)' : 'inherit' }}
+      >
+        {label}
+        {arrow ? <span aria-hidden>{arrow}</span> : null}
+      </button>
+    </th>
+  );
+}
+
+export function AdminQuestionsClient({
+  result,
+  sortKey,
+  sortDir,
+}: {
+  result: AdminQuestionsPage;
+  sortKey: AdminQuestionSortKey;
+  sortDir: AdminQuestionSortDir;
+}) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
+  const [search, setSearch] = useState(searchParams.get('q') ?? '');
+
   const totalPages = Math.max(1, Math.ceil(result.total / result.pageSize));
 
-  function navigate(next: Record<string, string | null>) {
+  // Update the given params (null deletes), always resetting to page 1 for any
+  // filter/sort change so a narrowed result set never lands on an empty page.
+  function navigate(next: Record<string, string | null>, { keepPage = false } = {}) {
     const params = new URLSearchParams(searchParams.toString());
     for (const [key, value] of Object.entries(next)) {
-      if (value === null) params.delete(key);
+      if (value === null || value === '') params.delete(key);
       else params.set(key, value);
     }
+    if (!keepPage) params.delete('page');
     router.push(`/admin/questions?${params.toString()}`);
   }
 
-  function toggleDeleted() {
-    navigate({ showDeleted: result.showDeleted ? null : '1', page: '1' });
+  function setFilter(key: string, value: string | null) {
+    navigate({ [key]: value });
+  }
+
+  function toggleFlag(key: string, on: boolean) {
+    navigate({ [key]: on ? '1' : null });
+  }
+
+  function toggleSort(key: AdminQuestionSortKey) {
+    // Same column → flip direction; new column → default to desc.
+    const nextDir: AdminQuestionSortDir = sortKey === key && sortDir === 'desc' ? 'asc' : 'desc';
+    navigate({ sort: key, dir: nextDir });
   }
 
   function goToPage(page: number) {
-    navigate({ page: String(page) });
+    navigate({ page: String(page) }, { keepPage: true });
   }
+
+  function resetFilters() {
+    setSearch('');
+    router.push('/admin/questions');
+  }
+
+  const isDeleted = result.showDeleted;
+
+  const boolFilters: { key: string; label: string }[] = [
+    { key: 'nobodyCorrect', label: 'Nobody correct' },
+    { key: 'duplicate', label: 'Duplicate' },
+    { key: 'tombstone', label: 'Tombstone' },
+    { key: 'perishable', label: 'Perishable' },
+  ];
 
   return (
     <main className="mx-auto max-w-[1600px] px-4 py-6">
@@ -95,16 +179,133 @@ export function AdminQuestionsClient({ result }: { result: AdminQuestionsPage })
         <AdminTabs active="questions" />
       </div>
 
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
-          {result.total.toLocaleString()} question{result.total === 1 ? '' : 's'}
-          {result.showDeleted ? ' (including deleted)' : ''}
-        </p>
-        <label className="flex items-center gap-2 text-sm" style={{ color: 'var(--brand-ink-700)' }}>
-          <input type="checkbox" checked={result.showDeleted} onChange={toggleDeleted} />
+      {/* Filter bar. Every control combines (AND) with the others server-side. */}
+      <form
+        className="mb-3 flex flex-wrap items-end gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          setFilter('q', search.trim() || null);
+        }}
+      >
+        <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.04em]" style={{ color: 'var(--text-muted)' }}>
+          Search
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="question or answer"
+            className={CONTROL}
+            style={{ borderColor: 'var(--border)', minWidth: '200px' }}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.04em]" style={{ color: 'var(--text-muted)' }}>
+          Category
+          <select
+            value={searchParams.get('category') ?? ''}
+            onChange={(e) => setFilter('category', e.target.value || null)}
+            className={CONTROL}
+            style={{ borderColor: 'var(--border)' }}
+          >
+            <option value="">All</option>
+            {CATEGORIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.04em]" style={{ color: 'var(--text-muted)' }}>
+          Trust tier
+          <select
+            value={searchParams.get('trustTier') ?? ''}
+            onChange={(e) => setFilter('trustTier', e.target.value || null)}
+            className={CONTROL}
+            style={{ borderColor: 'var(--border)' }}
+          >
+            <option value="">All</option>
+            {TRUST_TIERS.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.04em]" style={{ color: 'var(--text-muted)' }}>
+          Visibility
+          <select
+            value={searchParams.get('visibility') ?? ''}
+            onChange={(e) => setFilter('visibility', e.target.value || null)}
+            className={CONTROL}
+            style={{ borderColor: 'var(--border)' }}
+          >
+            <option value="">All</option>
+            {VISIBILITIES.map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.04em]" style={{ color: 'var(--text-muted)' }}>
+          Verdict
+          <select
+            value={searchParams.get('verdict') ?? ''}
+            onChange={(e) => setFilter('verdict', e.target.value || null)}
+            className={CONTROL}
+            style={{ borderColor: 'var(--border)' }}
+          >
+            <option value="">All</option>
+            {VERDICTS.map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <button
+          type="submit"
+          className="rounded-md border px-3 py-1.5 text-sm font-medium"
+          style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+        >
+          Apply search
+        </button>
+        <button
+          type="button"
+          onClick={resetFilters}
+          className="rounded-md border px-3 py-1.5 text-sm"
+          style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+        >
+          Reset
+        </button>
+      </form>
+
+      {/* Boolean flag filters — each carries a text label (no color-alone). */}
+      <div className="mb-3 flex flex-wrap items-center gap-4 text-sm" style={{ color: 'var(--brand-ink-700)' }}>
+        {boolFilters.map((f) => (
+          <label key={f.key} className="flex items-center gap-1.5">
+            <input
+              type="checkbox"
+              checked={searchParams.get(f.key) === '1'}
+              onChange={(e) => toggleFlag(f.key, e.target.checked)}
+            />
+            {f.label}
+          </label>
+        ))}
+        <label className="flex items-center gap-1.5">
+          <input type="checkbox" checked={isDeleted} onChange={(e) => toggleFlag('showDeleted', e.target.checked)} />
           Show deleted
         </label>
       </div>
+
+      <p className="mb-3 text-sm" style={{ color: 'var(--text-muted)' }}>
+        {result.total.toLocaleString()} question{result.total === 1 ? '' : 's'}
+        {isDeleted ? ' (including deleted)' : ''}
+      </p>
 
       <div className="overflow-x-auto rounded-md border" style={{ borderColor: 'var(--border)' }}>
         <table className="w-full border-collapse text-left">
@@ -112,18 +313,18 @@ export function AdminQuestionsClient({ result }: { result: AdminQuestionsPage })
             <tr style={{ background: 'var(--surface-2)', color: 'var(--text-muted)' }}>
               <th className={HEAD}>Question</th>
               <th className={HEAD}>Answer</th>
-              <th className={HEAD}>Category</th>
+              <SortHeader label="Category" columnKey="category" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} />
               <th className={HEAD}>Author</th>
               <th className={HEAD}>Source</th>
               <th className={HEAD}>Trust</th>
               <th className={HEAD}>Visibility</th>
               <th className={HEAD}>Public status</th>
               <th className={HEAD}>Verdict</th>
-              <th className={HEAD}>Asked</th>
+              <SortHeader label="Asked" columnKey="askedCount" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} />
               <th className={HEAD}>Correct</th>
-              <th className={HEAD}>Rate</th>
+              <SortHeader label="Rate" columnKey="correctRate" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} />
               <th className={HEAD}>Flags</th>
-              <th className={HEAD}>Created</th>
+              <SortHeader label="Created" columnKey="createdAt" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} />
             </tr>
           </thead>
           <tbody>
@@ -159,11 +360,7 @@ export function AdminQuestionsClient({ result }: { result: AdminQuestionsPage })
                     ) : null}
                   </td>
                   <td className={`${CELL} whitespace-nowrap`}>
-                    {row.authorIsPerson ? (
-                      row.authorLabel
-                    ) : (
-                      <Badge label={row.authorLabel} tone="muted" />
-                    )}
+                    {row.authorIsPerson ? row.authorLabel : <Badge label={row.authorLabel} tone="muted" />}
                   </td>
                   <td className={`${CELL} whitespace-nowrap`}>{row.source}</td>
                   <td className={`${CELL} whitespace-nowrap`}>{row.trustTier}</td>

--- a/src/app/admin/questions/AdminQuestionsClient.tsx
+++ b/src/app/admin/questions/AdminQuestionsClient.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { AdminTabs } from '@/app/admin/AdminTabs';
 import { CATEGORIES } from '@/lib/questions-types';
 import type {
+  AdminQuestionDetail,
   AdminQuestionRow,
   AdminQuestionSortDir,
   AdminQuestionSortKey,
@@ -112,14 +113,196 @@ function SortHeader({
   );
 }
 
+// ── Phase 3 detail view ──────────────────────────────────────────────────────
+// Read-only "look before you edit" surface. Every non-embedding column is
+// inspectable. Rendered as a side sheet driven by the ?detail=<id> param.
+
+function scalar(value: string | number | boolean | null): string {
+  if (value === null || value === '') return '—';
+  if (typeof value === 'boolean') return value ? 'yes' : 'no';
+  return String(value);
+}
+
+function Field({ label, value }: { label: string; value: string | number | boolean | null }) {
+  return (
+    <div className="grid grid-cols-[minmax(120px,180px)_1fr] gap-2 py-1">
+      <span className="text-[11px] uppercase tracking-[0.04em]" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </span>
+      <span className="whitespace-pre-wrap break-words text-[13px]" style={{ color: 'var(--brand-ink)' }}>
+        {scalar(value)}
+      </span>
+    </div>
+  );
+}
+
+function ListField({ label, values }: { label: string; values: string[] }) {
+  return (
+    <div className="grid grid-cols-[minmax(120px,180px)_1fr] gap-2 py-1">
+      <span className="text-[11px] uppercase tracking-[0.04em]" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </span>
+      {values.length === 0 ? (
+        <span className="text-[13px]" style={{ color: 'var(--text-muted)' }}>
+          —
+        </span>
+      ) : (
+        <ul className="list-disc pl-4 text-[13px]" style={{ color: 'var(--brand-ink)' }}>
+          {values.map((v, i) => (
+            <li key={i} className="break-words">
+              {v}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function Group({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="mb-4">
+      <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-[0.06em]" style={{ color: 'var(--brand-navy)' }}>
+        {title}
+      </h3>
+      <div className="divide-y" style={{ borderColor: 'var(--border)' }}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function DetailSheet({ detail, onClose }: { detail: AdminQuestionDetail; onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-end"
+      style={{ background: 'rgba(0,0,0,0.3)' }}
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="h-full w-full overflow-y-auto border-l p-5 sm:max-w-xl"
+        style={{ background: 'var(--brand-card)', borderColor: 'var(--border)' }}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Question detail"
+      >
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="font-serif text-lg font-semibold" style={{ color: 'var(--brand-ink)' }}>
+              Question detail
+            </h2>
+            <p className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+              {detail.id}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm"
+            style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+          >
+            Close
+          </button>
+        </div>
+
+        <Group title="Content">
+          <Field label="Question" value={detail.questionText} />
+          <Field label="Answer" value={detail.answerText} />
+          <ListField label="Accepted alt." values={detail.acceptedAlternatives} />
+          <Field label="Factual explanation" value={detail.factualExplanation} />
+          <Field label="Breadcrumb" value={detail.breadcrumbContext} />
+          <Field label="Creator note" value={detail.creatorNote} />
+          <Field label="Inside joke" value={detail.insideJoke} />
+          <Field label="Short label" value={detail.shortLabel} />
+          <Field label="LLM suggested" value={detail.llmSuggestedAnswer} />
+          <Field label="Answer source" value={detail.answerSource} />
+        </Group>
+
+        <Group title="Provenance">
+          <Field label="Author" value={detail.authorIsPerson ? detail.authorLabel : `${detail.authorLabel} (non-person)`} />
+          <Field label="Creator id" value={detail.creatorId} />
+          <Field label="Source" value={detail.source} />
+          <Field label="Generated question id" value={detail.generatedQuestionId} />
+          <Field label="Source question id" value={detail.sourceQuestionId} />
+          <Field label="Source creator id" value={detail.sourceCreatorId} />
+          <Field label="Suppressed by" value={detail.suppressedBy} />
+          <Field label="Subject entity" value={detail.subjectEntity} />
+          <Field label="Categorize provider" value={detail.categorizeProvider} />
+          <ListField label="Source refs" values={detail.sourceRefs} />
+        </Group>
+
+        <Group title="Categorization">
+          <Field label="Category" value={detail.category} />
+          <Field label="Broad category" value={detail.broadCategory} />
+          <Field label="Subcategory" value={detail.subcategory} />
+          <Field label="Canonical subcat." value={detail.canonicalSubcategory} />
+          <Field label="Category overridden" value={detail.categoryOverridden} />
+          <Field label="Question type" value={detail.questionType} />
+          <Field label="Minimum required" value={detail.minimumRequired} />
+          <Field label="Difficulty (est.)" value={detail.difficultyEstimate} />
+          <Field label="Difficulty (LLM)" value={detail.llmDifficulty} />
+          <Field label="Difficulty (calib.)" value={detail.calibratedDifficulty} />
+        </Group>
+
+        <Group title="Explainers">
+          <Field label="Brief" value={detail.explainerBrief} />
+          <Field label="Full" value={detail.explainerFull} />
+          <Field label="Brief (correct)" value={detail.explainerBriefCorrect} />
+          <Field label="Full (correct)" value={detail.explainerFullCorrect} />
+          <Field label="Brief (wrong)" value={detail.explainerBriefWrong} />
+          <Field label="Full (wrong)" value={detail.explainerFullWrong} />
+          <Field label="Brief (expired)" value={detail.explainerBriefExpired} />
+          <Field label="Full (expired)" value={detail.explainerFullExpired} />
+        </Group>
+
+        <Group title="Grading & lifecycle state">
+          <Field label="Status" value={detail.status} />
+          <Field label="Verified" value={detail.verified} />
+          <Field label="Trust tier" value={detail.trustTier} />
+          <Field label="Visibility" value={detail.visibility} />
+          <Field label="Public status" value={detail.publicStatus} />
+          <Field label="Public elig. score" value={detail.publicEligibilityScore} />
+          <Field label="Public elig. reason" value={detail.publicEligibilityReason} />
+          <Field label="Shared to friends" value={detail.sharedToFriendsFeed} />
+          <Field label="Verification verdict" value={detail.verificationVerdict} />
+          <Field label="Verification reason" value={detail.verificationReason} />
+          <Field label="Critique iterations" value={detail.critiqueIterations} />
+        </Group>
+
+        <Group title="Signals & flags">
+          <Field label="Asked count" value={detail.askedCount} />
+          <Field label="Correct count" value={detail.correctCount} />
+          <Field label="Correct rate" value={detail.correctRate} />
+          <Field label="Surface priority" value={detail.surfacePriorityScore} />
+          <Field label="Perishable" value={detail.perishable} />
+          <Field label="Nobody correct" value={detail.nobodyCorrectFlag} />
+          <Field label="Duplicate" value={detail.isDuplicate} />
+          <Field label="Author deleted" value={detail.authorDeleted} />
+        </Group>
+
+        <Group title="Timestamps">
+          <Field label="Created" value={detail.createdAt} />
+          <Field label="Updated" value={detail.updatedAt} />
+          <Field label="Verified at" value={detail.verifiedAt} />
+          <Field label="Deleted at" value={detail.deletedAt} />
+        </Group>
+      </div>
+    </div>
+  );
+}
+
 export function AdminQuestionsClient({
   result,
   sortKey,
   sortDir,
+  detail,
 }: {
   result: AdminQuestionsPage;
   sortKey: AdminQuestionSortKey;
   sortDir: AdminQuestionSortDir;
+  detail: AdminQuestionDetail | null;
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -156,6 +339,14 @@ export function AdminQuestionsClient({
 
   function goToPage(page: number) {
     navigate({ page: String(page) }, { keepPage: true });
+  }
+
+  function openDetail(id: string) {
+    navigate({ detail: id }, { keepPage: true });
+  }
+
+  function closeDetail() {
+    navigate({ detail: null }, { keepPage: true });
   }
 
   function resetFilters() {
@@ -311,6 +502,9 @@ export function AdminQuestionsClient({
         <table className="w-full border-collapse text-left">
           <thead>
             <tr style={{ background: 'var(--surface-2)', color: 'var(--text-muted)' }}>
+              <th className={HEAD}>
+                <span className="sr-only">Inspect</span>
+              </th>
               <th className={HEAD}>Question</th>
               <th className={HEAD}>Answer</th>
               <SortHeader label="Category" columnKey="category" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} />
@@ -330,7 +524,7 @@ export function AdminQuestionsClient({
           <tbody>
             {result.rows.length === 0 ? (
               <tr>
-                <td className={CELL} colSpan={14} style={{ color: 'var(--text-muted)' }}>
+                <td className={CELL} colSpan={15} style={{ color: 'var(--text-muted)' }}>
                   No questions match.
                 </td>
               </tr>
@@ -345,6 +539,16 @@ export function AdminQuestionsClient({
                     color: 'var(--brand-ink)',
                   }}
                 >
+                  <td className={`${CELL} whitespace-nowrap`}>
+                    <button
+                      type="button"
+                      onClick={() => openDetail(row.id)}
+                      className="rounded border px-2 py-0.5 text-[11px] font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      style={{ borderColor: 'var(--border)', color: 'var(--brand-navy)' }}
+                    >
+                      Inspect
+                    </button>
+                  </td>
                   <td className={`${CELL} min-w-[280px] max-w-[360px]`}>
                     <span className="line-clamp-2">{row.questionText}</span>
                   </td>
@@ -408,6 +612,8 @@ export function AdminQuestionsClient({
           </button>
         </div>
       </div>
+
+      {detail ? <DetailSheet detail={detail} onClose={closeDetail} /> : null}
     </main>
   );
 }

--- a/src/app/admin/questions/__tests__/page.test.tsx
+++ b/src/app/admin/questions/__tests__/page.test.tsx
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// B-ADMIN-QUESTIONS-OVERVIEW-01 Phase 1 — gating test. Mirrors the admin-gate
+// contract used across the admin rooms: a non-admin (or unauthenticated) session
+// must 404 via notFound(), and the pool query must never run for them. Admins get
+// the query and a rendered client.
+
+const { getSessionMock, isAdminUserMock, getAllQuestionsMock, notFoundMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn<() => Promise<{ userId: string } | null>>(),
+  isAdminUserMock: vi.fn<(userId: string | null | undefined) => boolean>(),
+  getAllQuestionsMock: vi.fn(async () => ({
+    rows: [],
+    total: 0,
+    page: 1,
+    pageSize: 50,
+    showDeleted: false,
+  })),
+  notFoundMock: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
+
+vi.mock('next/navigation', () => ({ notFound: notFoundMock }));
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/auth/admin', () => ({ isAdminUser: isAdminUserMock }));
+vi.mock('@/server/db/queries/admin-questions', () => ({ getAllQuestionsForAdmin: getAllQuestionsMock }));
+vi.mock('../AdminQuestionsClient', () => ({
+  AdminQuestionsClient: () => null,
+}));
+
+import AdminQuestionsPage from '@/app/admin/questions/page';
+
+const searchParams = Promise.resolve({});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AdminQuestionsPage gating', () => {
+  it('404s for an unauthenticated session and never queries the pool', async () => {
+    getSessionMock.mockResolvedValue(null);
+    isAdminUserMock.mockReturnValue(false);
+
+    await expect(AdminQuestionsPage({ searchParams })).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFoundMock).toHaveBeenCalled();
+    expect(getAllQuestionsMock).not.toHaveBeenCalled();
+  });
+
+  it('404s for an authenticated non-admin and never queries the pool', async () => {
+    getSessionMock.mockResolvedValue({ userId: 'not-admin' });
+    isAdminUserMock.mockReturnValue(false);
+
+    await expect(AdminQuestionsPage({ searchParams })).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFoundMock).toHaveBeenCalled();
+    expect(getAllQuestionsMock).not.toHaveBeenCalled();
+  });
+
+  it('renders and queries the pool for an admin', async () => {
+    getSessionMock.mockResolvedValue({ userId: 'admin-1' });
+    isAdminUserMock.mockReturnValue(true);
+
+    await AdminQuestionsPage({ searchParams });
+
+    expect(notFoundMock).not.toHaveBeenCalled();
+    expect(getAllQuestionsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/admin/questions/page.tsx
+++ b/src/app/admin/questions/page.tsx
@@ -2,11 +2,42 @@ import { notFound } from 'next/navigation';
 
 import { getSession } from '@/server/auth/session';
 import { isAdminUser } from '@/server/auth/admin';
-import { getAllQuestionsForAdmin } from '@/server/db/queries/admin-questions';
+import {
+  getAllQuestionsForAdmin,
+  type AdminQuestionSortDir,
+  type AdminQuestionSortKey,
+} from '@/server/db/queries/admin-questions';
 
 import { AdminQuestionsClient } from './AdminQuestionsClient';
 
 export const dynamic = 'force-dynamic';
+
+const SORT_KEYS: AdminQuestionSortKey[] = ['createdAt', 'askedCount', 'correctRate', 'category'];
+
+function parseSortKey(value: string | undefined): AdminQuestionSortKey {
+  return SORT_KEYS.includes(value as AdminQuestionSortKey) ? (value as AdminQuestionSortKey) : 'createdAt';
+}
+
+function trimmed(value: string | undefined): string | undefined {
+  const v = value?.trim();
+  return v ? v : undefined;
+}
+
+type AdminQuestionsSearchParams = {
+  page?: string;
+  showDeleted?: string;
+  sort?: string;
+  dir?: string;
+  q?: string;
+  category?: string;
+  trustTier?: string;
+  visibility?: string;
+  verdict?: string;
+  nobodyCorrect?: string;
+  duplicate?: string;
+  tombstone?: string;
+  perishable?: string;
+};
 
 // B-ADMIN-QUESTIONS-OVERVIEW-01 — the FOURTH admin room: an audit view of every
 // question in the pool (all creators, house + LLM, and soft-deleted rows). Same
@@ -16,19 +47,31 @@ export const dynamic = 'force-dynamic';
 export default async function AdminQuestionsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ page?: string; showDeleted?: string }>;
+  searchParams: Promise<AdminQuestionsSearchParams>;
 }) {
   const session = await getSession();
   if (!session || !isAdminUser(session.userId)) notFound();
 
   const params = await searchParams;
   const page = Number.parseInt(params.page ?? '1', 10);
-  const showDeleted = params.showDeleted === '1';
 
   const result = await getAllQuestionsForAdmin({
     page: Number.isFinite(page) ? page : 1,
-    showDeleted,
+    showDeleted: params.showDeleted === '1',
+    sortKey: parseSortKey(params.sort),
+    sortDir: (params.dir === 'asc' ? 'asc' : 'desc') as AdminQuestionSortDir,
+    filters: {
+      search: trimmed(params.q),
+      category: trimmed(params.category),
+      trustTier: trimmed(params.trustTier),
+      visibility: trimmed(params.visibility),
+      verificationVerdict: trimmed(params.verdict),
+      nobodyCorrectFlag: params.nobodyCorrect === '1',
+      isDuplicate: params.duplicate === '1',
+      authorDeleted: params.tombstone === '1',
+      perishable: params.perishable === '1',
+    },
   });
 
-  return <AdminQuestionsClient result={result} />;
+  return <AdminQuestionsClient result={result} sortKey={parseSortKey(params.sort)} sortDir={params.dir === 'asc' ? 'asc' : 'desc'} />;
 }

--- a/src/app/admin/questions/page.tsx
+++ b/src/app/admin/questions/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from 'next/navigation';
+
+import { getSession } from '@/server/auth/session';
+import { isAdminUser } from '@/server/auth/admin';
+import { getAllQuestionsForAdmin } from '@/server/db/queries/admin-questions';
+
+import { AdminQuestionsClient } from './AdminQuestionsClient';
+
+export const dynamic = 'force-dynamic';
+
+// B-ADMIN-QUESTIONS-OVERVIEW-01 — the FOURTH admin room: an audit view of every
+// question in the pool (all creators, house + LLM, and soft-deleted rows). Same
+// gate contract as the other admin pages: ADMIN_USER_IDS or Next's 404 — the
+// route's existence is not revealed to non-admins. This is NOT the player-facing
+// Questions tab.
+export default async function AdminQuestionsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string; showDeleted?: string }>;
+}) {
+  const session = await getSession();
+  if (!session || !isAdminUser(session.userId)) notFound();
+
+  const params = await searchParams;
+  const page = Number.parseInt(params.page ?? '1', 10);
+  const showDeleted = params.showDeleted === '1';
+
+  const result = await getAllQuestionsForAdmin({
+    page: Number.isFinite(page) ? page : 1,
+    showDeleted,
+  });
+
+  return <AdminQuestionsClient result={result} />;
+}

--- a/src/app/admin/questions/page.tsx
+++ b/src/app/admin/questions/page.tsx
@@ -3,7 +3,9 @@ import { notFound } from 'next/navigation';
 import { getSession } from '@/server/auth/session';
 import { isAdminUser } from '@/server/auth/admin';
 import {
+  getAdminQuestionDetail,
   getAllQuestionsForAdmin,
+  type AdminQuestionDetail,
   type AdminQuestionSortDir,
   type AdminQuestionSortKey,
 } from '@/server/db/queries/admin-questions';
@@ -37,6 +39,7 @@ type AdminQuestionsSearchParams = {
   duplicate?: string;
   tombstone?: string;
   perishable?: string;
+  detail?: string;
 };
 
 // B-ADMIN-QUESTIONS-OVERVIEW-01 — the FOURTH admin room: an audit view of every
@@ -73,5 +76,16 @@ export default async function AdminQuestionsPage({
     },
   });
 
-  return <AdminQuestionsClient result={result} sortKey={parseSortKey(params.sort)} sortDir={params.dir === 'asc' ? 'asc' : 'desc'} />;
+  const detail: AdminQuestionDetail | null = params.detail
+    ? await getAdminQuestionDetail(params.detail)
+    : null;
+
+  return (
+    <AdminQuestionsClient
+      result={result}
+      sortKey={parseSortKey(params.sort)}
+      sortDir={params.dir === 'asc' ? 'asc' : 'desc'}
+      detail={detail}
+    />
+  );
 }

--- a/src/app/api/admin/questions/__tests__/route.test.ts
+++ b/src/app/api/admin/questions/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NextRequest } from 'next/server';
+
+// B-ADMIN-QUESTIONS-OVERVIEW-01 Phase 4 — mutation route tests. The gate is
+// re-checked on the SERVER for every mutation (never trust the client); non-admins
+// (and the unauthenticated) get 404, not 403 — the route's existence is hidden.
+
+const { getSessionMock, isAdminUserMock, editMock, deleteMock, restoreMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn<() => Promise<{ userId: string } | null>>(),
+  isAdminUserMock: vi.fn<(userId: string | null | undefined) => boolean>(),
+  editMock: vi.fn(async () => ({ ok: true })),
+  deleteMock: vi.fn(async () => ({ ok: true })),
+  restoreMock: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/auth/admin', () => ({ isAdminUser: isAdminUserMock }));
+vi.mock('@/server/db/queries/admin-questions', () => ({
+  adminEditQuestion: editMock,
+  adminSoftDeleteQuestion: deleteMock,
+  adminRestoreQuestion: restoreMock,
+}));
+
+import { POST } from '@/app/api/admin/questions/route';
+
+function post(body: unknown): Promise<Response> {
+  const request = new Request('http://localhost/api/admin/questions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return POST(request as unknown as NextRequest);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  editMock.mockResolvedValue({ ok: true });
+  deleteMock.mockResolvedValue({ ok: true });
+  restoreMock.mockResolvedValue({ ok: true });
+});
+
+describe('admin questions mutation route — gating', () => {
+  it('404s for the unauthenticated and runs no mutation', async () => {
+    getSessionMock.mockResolvedValue(null);
+    isAdminUserMock.mockReturnValue(false);
+
+    const res = await post({ action: 'delete', id: 'q1' });
+    expect(res.status).toBe(404);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('404s for an authenticated non-admin and runs no mutation', async () => {
+    getSessionMock.mockResolvedValue({ userId: 'nope' });
+    isAdminUserMock.mockReturnValue(false);
+
+    const res = await post({ action: 'edit', id: 'q1', answerText: 'x' });
+    expect(res.status).toBe(404);
+    expect(editMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin questions mutation route — actions (admin)', () => {
+  beforeEach(() => {
+    getSessionMock.mockResolvedValue({ userId: 'admin-1' });
+    isAdminUserMock.mockReturnValue(true);
+  });
+
+  it('dispatches an edit with only the provided fields', async () => {
+    const res = await post({ action: 'edit', id: 'q1', questionText: 'New?', visibility: 'private' });
+    expect(res.status).toBe(200);
+    expect(editMock).toHaveBeenCalledWith('q1', expect.objectContaining({ questionText: 'New?', visibility: 'private' }));
+  });
+
+  it('rejects an edit with no editable fields', async () => {
+    const res = await post({ action: 'edit', id: 'q1' });
+    expect(res.status).toBe(400);
+    expect(editMock).not.toHaveBeenCalled();
+  });
+
+  it('soft-deletes', async () => {
+    const res = await post({ action: 'delete', id: 'q1' });
+    expect(res.status).toBe(200);
+    expect(deleteMock).toHaveBeenCalledWith('q1');
+  });
+
+  it('restores', async () => {
+    const res = await post({ action: 'restore', id: 'q1' });
+    expect(res.status).toBe(200);
+    expect(restoreMock).toHaveBeenCalledWith('q1');
+  });
+
+  it('404s when a mutation reports not_found', async () => {
+    deleteMock.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await post({ action: 'delete', id: 'missing' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects an invalid visibility value', async () => {
+    const res = await post({ action: 'edit', id: 'q1', visibility: 'blocked' });
+    expect(res.status).toBe(400);
+    expect(editMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/admin/questions/route.ts
+++ b/src/app/api/admin/questions/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { isAdminUser } from '@/server/auth/admin';
+import {
+  adminEditQuestion,
+  adminRestoreQuestion,
+  adminSoftDeleteQuestion,
+} from '@/server/db/queries/admin-questions';
+import { CATEGORIES } from '@/lib/questions-types';
+
+export const dynamic = 'force-dynamic';
+
+// B-ADMIN-QUESTIONS-OVERVIEW-01 Phase 4 — admin-gated mutations for the pool
+// audit table. edit reuses the canon "content changed ⇒ re-verify" stamp-clear;
+// delete is a SOFT delete (deletedAt) and restore is its inverse — never a hard
+// DELETE. Every mutation re-checks isAdminUser on the server (the client is never
+// trusted). Field set is the ratified minimal set (Decision B); no audit log
+// (Decision A1); no bulk actions (Decision C).
+
+// visibility is limited to the admin-settable values ('blocked' is a safety
+// terminal state set by the vet path, not hand-editable here).
+const editSchema = z.object({
+  action: z.literal('edit'),
+  id: z.string().trim().min(1),
+  questionText: z.string().trim().min(1).max(2000).optional(),
+  answerText: z.string().trim().min(1).max(1000).optional(),
+  acceptedAlternatives: z.array(z.string().trim().min(1).max(1000)).max(50).optional(),
+  factualExplanation: z.string().trim().max(4000).nullable().optional(),
+  category: z.enum(CATEGORIES).optional(),
+  visibility: z.enum(['public', 'friends', 'private']).optional(),
+});
+
+const bodySchema = z.discriminatedUnion('action', [
+  editSchema,
+  z.object({ action: z.literal('delete'), id: z.string().trim().min(1) }),
+  z.object({ action: z.literal('restore'), id: z.string().trim().min(1) }),
+]);
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  // Non-admins (and the unauthenticated) get 404 — never reveal the route exists.
+  if (!session || !isAdminUser(session.userId)) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation' }, { status: 400 });
+  }
+  const data = parsed.data;
+
+  if (data.action === 'delete') {
+    const result = await adminSoftDeleteQuestion(data.id);
+    if (!result.ok) return NextResponse.json({ error: result.reason }, { status: 404 });
+    return NextResponse.json(result);
+  }
+
+  if (data.action === 'restore') {
+    const result = await adminRestoreQuestion(data.id);
+    if (!result.ok) return NextResponse.json({ error: result.reason }, { status: 404 });
+    return NextResponse.json(result);
+  }
+
+  // edit — require at least one field to change.
+  const { id, ...fields } = data;
+  const patch = {
+    questionText: fields.questionText,
+    answerText: fields.answerText,
+    acceptedAlternatives: fields.acceptedAlternatives,
+    factualExplanation: fields.factualExplanation,
+    category: fields.category,
+    visibility: fields.visibility,
+  };
+  if (Object.values(patch).every((v) => v === undefined)) {
+    return NextResponse.json({ error: 'validation' }, { status: 400 });
+  }
+  const result = await adminEditQuestion(id, patch);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.reason }, { status: result.reason === 'not_found' ? 404 : 400 });
+  }
+  return NextResponse.json(result);
+}

--- a/src/server/db/queries/admin-questions.ts
+++ b/src/server/db/queries/admin-questions.ts
@@ -91,6 +91,167 @@ const HOUSE_LABEL = 'House';
 const DEFAULT_PAGE_SIZE = 50;
 const MAX_PAGE_SIZE = 200;
 
+function isoOrNull(value: Date | null): string | null {
+  return value ? value.toISOString() : null;
+}
+
+// The full read-only record for the Phase 3 detail view. Every non-embedding
+// Question column is inspectable here (the 1024-dim vector is deliberately
+// omitted — it is not human-inspectable and would bloat the payload). Same H-1
+// author guard as the list row.
+export type AdminQuestionDetail = {
+  id: string;
+  authorLabel: string;
+  authorIsPerson: boolean;
+  creatorId: string | null;
+  generatedQuestionId: string | null;
+  source: string;
+  sourceQuestionId: string | null;
+  sourceCreatorId: string | null;
+  suppressedBy: string | null;
+  subjectEntity: string | null;
+  categorizeProvider: string | null;
+  questionText: string;
+  answerText: string;
+  acceptedAlternatives: string[];
+  factualExplanation: string | null;
+  breadcrumbContext: string | null;
+  creatorNote: string | null;
+  insideJoke: string | null;
+  shortLabel: string | null;
+  llmSuggestedAnswer: string | null;
+  answerSource: string | null;
+  questionType: string;
+  minimumRequired: number | null;
+  category: string;
+  broadCategory: string | null;
+  subcategory: string | null;
+  canonicalSubcategory: string | null;
+  categoryOverridden: boolean;
+  difficultyEstimate: string | null;
+  llmDifficulty: string | null;
+  calibratedDifficulty: string | null;
+  explainerBrief: string | null;
+  explainerFull: string | null;
+  explainerBriefCorrect: string | null;
+  explainerFullCorrect: string | null;
+  explainerBriefWrong: string | null;
+  explainerFullWrong: string | null;
+  explainerBriefExpired: string | null;
+  explainerFullExpired: string | null;
+  status: string;
+  verified: boolean;
+  critiqueIterations: number;
+  visibility: string;
+  publicStatus: string;
+  publicEligibilityScore: number | null;
+  publicEligibilityReason: string | null;
+  sharedToFriendsFeed: boolean;
+  askedCount: number;
+  correctCount: number;
+  correctRate: number | null;
+  surfacePriorityScore: number;
+  trustTier: string;
+  perishable: boolean;
+  sourceRefs: string[];
+  nobodyCorrectFlag: boolean;
+  isDuplicate: boolean;
+  authorDeleted: boolean;
+  verificationVerdict: string | null;
+  verificationReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+  verifiedAt: string | null;
+};
+
+// Full-record fetch for the detail view. Unscoped by design (admin audit) and
+// does NOT filter deletedAt — a deleted row must still be inspectable from the
+// show-deleted list. The gate is the isAdminUser check on the calling route.
+export async function getAdminQuestionDetail(id: string): Promise<AdminQuestionDetail | null> {
+  const [row] = await db
+    .select({
+      q: questions,
+      authorDisplayName: users.displayName,
+    })
+    .from(questions)
+    .leftJoin(users, eq(users.id, questions.creatorId))
+    .where(eq(questions.id, id))
+    .limit(1);
+
+  if (!row) return null;
+  const q = row.q;
+
+  const resolved = resolveAuthorDisplay(q.creatorId, parseQuestionSource(q.source), row.authorDisplayName);
+  const isPerson = resolved.authorName !== null && !resolved.authorIsHouse && !q.authorDeleted;
+
+  return {
+    id: q.id,
+    authorLabel: isPerson ? (resolved.authorName as string) : HOUSE_LABEL,
+    authorIsPerson: isPerson,
+    creatorId: q.creatorId,
+    generatedQuestionId: q.generatedQuestionId,
+    source: q.source,
+    sourceQuestionId: q.sourceQuestionId,
+    sourceCreatorId: q.sourceCreatorId,
+    suppressedBy: q.suppressedBy,
+    subjectEntity: q.subjectEntity,
+    categorizeProvider: q.categorizeProvider,
+    questionText: q.questionText,
+    answerText: q.answerText,
+    acceptedAlternatives: q.acceptedAlternatives ?? [],
+    factualExplanation: q.factualExplanation,
+    breadcrumbContext: q.breadcrumbContext,
+    creatorNote: q.creatorNote,
+    insideJoke: q.insideJoke,
+    shortLabel: q.shortLabel,
+    llmSuggestedAnswer: q.llmSuggestedAnswer,
+    answerSource: q.answerSource,
+    questionType: q.questionType,
+    minimumRequired: q.minimumRequired,
+    category: q.category,
+    broadCategory: q.broadCategory,
+    subcategory: q.subcategory,
+    canonicalSubcategory: q.canonicalSubcategory,
+    categoryOverridden: q.categoryOverridden,
+    difficultyEstimate: q.difficultyEstimate,
+    llmDifficulty: q.llmDifficulty,
+    calibratedDifficulty: q.calibratedDifficulty,
+    explainerBrief: q.explainerBrief,
+    explainerFull: q.explainerFull,
+    explainerBriefCorrect: q.explainerBriefCorrect,
+    explainerFullCorrect: q.explainerFullCorrect,
+    explainerBriefWrong: q.explainerBriefWrong,
+    explainerFullWrong: q.explainerFullWrong,
+    explainerBriefExpired: q.explainerBriefExpired,
+    explainerFullExpired: q.explainerFullExpired,
+    status: q.status,
+    verified: q.verified,
+    critiqueIterations: q.critiqueIterations,
+    visibility: q.visibility,
+    publicStatus: q.publicStatus,
+    publicEligibilityScore: q.publicEligibilityScore,
+    publicEligibilityReason: q.publicEligibilityReason,
+    sharedToFriendsFeed: q.sharedToFriendsFeed,
+    askedCount: q.askedCount,
+    correctCount: q.correctCount,
+    correctRate: q.correctRate,
+    surfacePriorityScore: q.surfacePriorityScore,
+    trustTier: q.trustTier,
+    perishable: q.perishable,
+    sourceRefs: q.sourceRefs ?? [],
+    nobodyCorrectFlag: q.nobodyCorrectFlag,
+    isDuplicate: q.isDuplicate,
+    authorDeleted: q.authorDeleted,
+    verificationVerdict: q.verificationVerdict,
+    verificationReason: q.verificationReason,
+    createdAt: q.createdAt.toISOString(),
+    updatedAt: q.updatedAt.toISOString(),
+    deletedAt: isoOrNull(q.deletedAt),
+    verifiedAt: isoOrNull(q.verifiedAt),
+  };
+}
+
 function buildWhere(query: AdminQuestionsQuery): SQL | undefined {
   const clauses: SQL[] = [];
 

--- a/src/server/db/queries/admin-questions.ts
+++ b/src/server/db/queries/admin-questions.ts
@@ -1,0 +1,209 @@
+import { and, asc, desc, eq, ilike, isNull, or, sql, type SQL } from 'drizzle-orm';
+
+import { db, questions, users } from '@/server/db';
+import { resolveAuthorDisplay, parseQuestionSource } from '@/lib/questions-types';
+
+// B-ADMIN-QUESTIONS-OVERVIEW-01 — the admin-only "what's actually in the pool"
+// audit surface. UNLIKE every player-facing read path, this query is deliberately
+// unscoped: ALL creators, house + LLM rows, AND soft-deleted rows. The only gate
+// is the isAdminUser check on the calling route/action — never call this from a
+// player surface.
+
+// Sort keys the admin table exposes. Whitelisted so a client-supplied value can
+// never reach the ORDER BY as raw SQL (the map below is the trust boundary).
+export type AdminQuestionSortKey = 'createdAt' | 'askedCount' | 'correctRate' | 'category';
+export type AdminQuestionSortDir = 'asc' | 'desc';
+
+const SORT_COLUMNS = {
+  createdAt: questions.createdAt,
+  askedCount: questions.askedCount,
+  correctRate: questions.correctRate,
+  category: questions.category,
+} as const;
+
+export type AdminQuestionFilters = {
+  // Free text — matches question_text OR answer_text (case-insensitive contains).
+  search?: string;
+  category?: string;
+  trustTier?: string;
+  visibility?: string;
+  verificationVerdict?: string;
+  // Boolean flag filters — when set to true, narrow to rows where the flag holds.
+  // Omitted / false ⇒ no narrowing on that flag (they are includes, not toggles).
+  nobodyCorrectFlag?: boolean;
+  isDuplicate?: boolean;
+  authorDeleted?: boolean;
+  perishable?: boolean;
+};
+
+export type AdminQuestionsQuery = {
+  page?: number;
+  pageSize?: number;
+  // Whether to INCLUDE soft-deleted rows. Defaults false (deleted hidden) — the
+  // client's show-deleted toggle flips this. Canon: deleted rows are never
+  // silently dropped from the audit, only hidden behind the toggle.
+  showDeleted?: boolean;
+  sortKey?: AdminQuestionSortKey;
+  sortDir?: AdminQuestionSortDir;
+  filters?: AdminQuestionFilters;
+};
+
+// The row the admin table renders. `authorLabel`/`authorIsPerson` are resolved
+// server-side through resolveAuthorDisplay so the client never re-derives person
+// vs house from raw provenance (Invariant H-1: house/tombstone rows must NEVER
+// render as a person). A null creator, a house row, an LLM row, or an
+// author-deleted tombstone all resolve to the neutral "House" label.
+export type AdminQuestionRow = {
+  id: string;
+  questionText: string;
+  answerText: string;
+  category: string;
+  broadCategory: string | null;
+  authorLabel: string;
+  authorIsPerson: boolean;
+  creatorId: string | null;
+  source: string;
+  trustTier: string;
+  visibility: string;
+  publicStatus: string;
+  verificationVerdict: string | null;
+  askedCount: number;
+  correctCount: number;
+  correctRate: number | null;
+  nobodyCorrectFlag: boolean;
+  isDuplicate: boolean;
+  perishable: boolean;
+  authorDeleted: boolean;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+};
+
+export type AdminQuestionsPage = {
+  rows: AdminQuestionRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+  showDeleted: boolean;
+};
+
+const HOUSE_LABEL = 'House';
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 200;
+
+function buildWhere(query: AdminQuestionsQuery): SQL | undefined {
+  const clauses: SQL[] = [];
+
+  // Soft-deleted rows are hidden unless explicitly requested.
+  if (!query.showDeleted) clauses.push(isNull(questions.deletedAt));
+
+  const f = query.filters ?? {};
+  if (f.search) {
+    const needle = `%${f.search}%`;
+    const match = or(ilike(questions.questionText, needle), ilike(questions.answerText, needle));
+    if (match) clauses.push(match);
+  }
+  if (f.category) clauses.push(eq(questions.category, f.category as typeof questions.$inferSelect.category));
+  if (f.trustTier) clauses.push(eq(questions.trustTier, f.trustTier as typeof questions.$inferSelect.trustTier));
+  if (f.visibility) clauses.push(eq(questions.visibility, f.visibility as typeof questions.$inferSelect.visibility));
+  if (f.verificationVerdict) {
+    clauses.push(eq(questions.verificationVerdict, f.verificationVerdict as NonNullable<typeof questions.$inferSelect.verificationVerdict>));
+  }
+  if (f.nobodyCorrectFlag) clauses.push(eq(questions.nobodyCorrectFlag, true));
+  if (f.isDuplicate) clauses.push(eq(questions.isDuplicate, true));
+  if (f.authorDeleted) clauses.push(eq(questions.authorDeleted, true));
+  if (f.perishable) clauses.push(eq(questions.perishable, true));
+
+  if (clauses.length === 0) return undefined;
+  if (clauses.length === 1) return clauses[0];
+  return and(...clauses);
+}
+
+export async function getAllQuestionsForAdmin(query: AdminQuestionsQuery = {}): Promise<AdminQuestionsPage> {
+  const page = Math.max(1, Math.floor(query.page ?? 1));
+  const pageSize = Math.max(1, Math.min(Math.floor(query.pageSize ?? DEFAULT_PAGE_SIZE), MAX_PAGE_SIZE));
+  const showDeleted = query.showDeleted ?? false;
+
+  const where = buildWhere({ ...query, showDeleted });
+
+  const sortColumn = SORT_COLUMNS[query.sortKey ?? 'createdAt'];
+  const orderBy = (query.sortDir ?? 'desc') === 'asc' ? asc(sortColumn) : desc(sortColumn);
+
+  const [rows, [{ count } = { count: 0 }]] = await Promise.all([
+    db
+      .select({
+        id: questions.id,
+        questionText: questions.questionText,
+        answerText: questions.answerText,
+        category: questions.category,
+        broadCategory: questions.broadCategory,
+        creatorId: questions.creatorId,
+        source: questions.source,
+        authorDisplayName: users.displayName,
+        trustTier: questions.trustTier,
+        visibility: questions.visibility,
+        publicStatus: questions.publicStatus,
+        verificationVerdict: questions.verificationVerdict,
+        askedCount: questions.askedCount,
+        correctCount: questions.correctCount,
+        correctRate: questions.correctRate,
+        nobodyCorrectFlag: questions.nobodyCorrectFlag,
+        isDuplicate: questions.isDuplicate,
+        perishable: questions.perishable,
+        authorDeleted: questions.authorDeleted,
+        createdAt: questions.createdAt,
+        updatedAt: questions.updatedAt,
+        deletedAt: questions.deletedAt,
+      })
+      .from(questions)
+      .leftJoin(users, eq(users.id, questions.creatorId))
+      .where(where)
+      .orderBy(orderBy, desc(questions.id))
+      .limit(pageSize)
+      .offset((page - 1) * pageSize),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(questions)
+      .where(where),
+  ]);
+
+  return {
+    rows: rows.map((row) => {
+      // Tombstones re-source to the house identity (creator_id NULL), so
+      // resolveAuthorDisplay already routes them to house/non-person. The
+      // explicit authorDeleted guard is belt-and-suspenders: even a mis-recorded
+      // tombstone that still carries a creator_id must never render as a person.
+      const resolved = resolveAuthorDisplay(row.creatorId, parseQuestionSource(row.source), row.authorDisplayName);
+      const isPerson = resolved.authorName !== null && !resolved.authorIsHouse && !row.authorDeleted;
+      return {
+        id: row.id,
+        questionText: row.questionText,
+        answerText: row.answerText,
+        category: row.category,
+        broadCategory: row.broadCategory,
+        authorLabel: isPerson ? (resolved.authorName as string) : HOUSE_LABEL,
+        authorIsPerson: isPerson,
+        creatorId: row.creatorId,
+        source: row.source,
+        trustTier: row.trustTier,
+        visibility: row.visibility,
+        publicStatus: row.publicStatus,
+        verificationVerdict: row.verificationVerdict,
+        askedCount: row.askedCount,
+        correctCount: row.correctCount,
+        correctRate: row.correctRate,
+        nobodyCorrectFlag: row.nobodyCorrectFlag,
+        isDuplicate: row.isDuplicate,
+        perishable: row.perishable,
+        authorDeleted: row.authorDeleted,
+        createdAt: row.createdAt.toISOString(),
+        updatedAt: row.updatedAt.toISOString(),
+        deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
+      };
+    }),
+    total: Number(count ?? 0),
+    page,
+    pageSize,
+    showDeleted,
+  };
+}

--- a/src/server/db/queries/admin-questions.ts
+++ b/src/server/db/queries/admin-questions.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, ilike, isNull, or, sql, type SQL } from 'drizzle-orm';
+import { and, asc, desc, eq, ilike, isNotNull, isNull, or, sql, type SQL } from 'drizzle-orm';
 
 import { db, questions, users } from '@/server/db';
 import { resolveAuthorDisplay, parseQuestionSource } from '@/lib/questions-types';
@@ -93,6 +93,115 @@ const MAX_PAGE_SIZE = 200;
 
 function isoOrNull(value: Date | null): string | null {
   return value ? value.toISOString() : null;
+}
+
+// ── Phase 4 mutations (admin-gated; the caller re-checks isAdminUser) ─────────
+// WHY these live here rather than reusing questions.ts's updateQuestion/
+// deleteQuestion: those are USER-SCOPED — they resolve the row by
+// (id, creatorId=userId) and block edits on in-use rows, so they cannot serve an
+// admin editing another creator's (or a house) question. editQuestionContent
+// (machine-demotions.ts) is admin-safe but covers only 3 of the 6 minimal fields
+// AND unconditionally clears the verification stamp (wrong for a visibility-only
+// edit). So these helpers reuse the canonical MECHANICS — the soft-delete
+// primitive (deletedAt) and the "content changed ⇒ re-verify" stamp-clear that
+// editQuestionContent established — without reimplementing a divergent delete.
+
+export type AdminEditQuestionInput = {
+  questionText?: string;
+  answerText?: string;
+  acceptedAlternatives?: string[];
+  factualExplanation?: string | null;
+  category?: string;
+  visibility?: string;
+};
+
+export type AdminMutationResult = { ok: boolean; reason?: 'not_found' | 'no_fields' };
+
+// Edit a question as an admin. Grading-adjacent fields (question/answer/
+// alternatives/explanation) trigger the same canon editQuestionContent applies:
+// the verification stamp is cleared so the batch-verify sweep re-fact-checks the
+// edit, trustTier records a human shaped the row, and a demoted row returns to
+// circulation. category/visibility are metadata and do NOT touch the stamp.
+export async function adminEditQuestion(
+  id: string,
+  input: AdminEditQuestionInput,
+): Promise<AdminMutationResult> {
+  const values: Partial<typeof questions.$inferInsert> = {};
+  let contentChanged = false;
+
+  if (input.questionText !== undefined) {
+    values.questionText = input.questionText;
+    contentChanged = true;
+  }
+  if (input.answerText !== undefined) {
+    values.answerText = input.answerText;
+    contentChanged = true;
+  }
+  if (input.acceptedAlternatives !== undefined) {
+    values.acceptedAlternatives = input.acceptedAlternatives;
+    contentChanged = true;
+  }
+  if (input.factualExplanation !== undefined) {
+    values.factualExplanation = input.factualExplanation || null;
+    contentChanged = true;
+  }
+  if (input.category !== undefined) {
+    values.category = input.category as typeof questions.$inferInsert.category;
+    // Mirror updateQuestion: an explicit category edit clears the override flag.
+    values.categoryOverridden = false;
+  }
+  if (input.visibility !== undefined) {
+    values.visibility = input.visibility as typeof questions.$inferInsert.visibility;
+  }
+
+  if (Object.keys(values).length === 0) return { ok: false, reason: 'no_fields' };
+
+  // Only edit rows that still exist (deleted rows are restored first, not edited).
+  const [existing] = await db
+    .select({ publicStatus: questions.publicStatus })
+    .from(questions)
+    .where(and(eq(questions.id, id), isNull(questions.deletedAt)))
+    .limit(1);
+  if (!existing) return { ok: false, reason: 'not_found' };
+
+  if (contentChanged) {
+    // Canon (editQuestionContent): the facts changed, so the old stamp no longer
+    // vouches — clear it back into the sweep's dragnet and mark human-shaped.
+    values.verifiedAt = null;
+    values.verificationVerdict = null;
+    values.verificationReason = null;
+    values.trustTier = 'human_validated';
+    if (existing.publicStatus === 'needs_review') values.publicStatus = 'not_scored';
+  }
+  values.updatedAt = new Date();
+
+  await db.update(questions).set(values).where(eq(questions.id, id));
+  return { ok: true };
+}
+
+// Admin soft-delete — reuses the canonical soft-delete primitive (deletedAt),
+// never a hard DELETE. No in-use guard (an admin override is deliberate). A
+// no-op on an already-deleted row.
+export async function adminSoftDeleteQuestion(id: string): Promise<AdminMutationResult> {
+  const updated = await db
+    .update(questions)
+    .set({ deletedAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(questions.id, id), isNull(questions.deletedAt)))
+    .returning({ id: questions.id });
+  if (updated.length === 0) return { ok: false, reason: 'not_found' };
+  return { ok: true };
+}
+
+// Admin restore — the inverse of the soft-delete (deletedAt back to NULL). Since
+// delete is soft, restore must exist. A no-op on a row that isn't deleted.
+export async function adminRestoreQuestion(id: string): Promise<AdminMutationResult> {
+  const updated = await db
+    .update(questions)
+    .set({ deletedAt: null, updatedAt: new Date() })
+    .where(and(eq(questions.id, id), isNotNull(questions.deletedAt)))
+    .returning({ id: questions.id });
+  if (updated.length === 0) return { ok: false, reason: 'not_found' };
+  return { ok: true };
 }
 
 // The full read-only record for the Phase 3 detail view. Every non-embedding


### PR DESCRIPTION
## Summary
Implements the admin questions audit surface — a read-only pool inspection table with server-driven sort/filter, detail view, and minimal edit/delete/restore mutations. This is the fourth admin room, gated to admins only, and deliberately unscoped to show all creators, house/LLM rows, and soft-deleted questions.

## Key Changes

**Client UI (`AdminQuestionsClient.tsx`)**
- Read-only audit table with sortable columns (created, asked count, correct rate, category)
- Server-driven filtering: search (question/answer text), category, trust tier, visibility, verification verdict, and boolean flags (nobody-correct, duplicate, tombstone, perishable)
- Pagination with page size control (default 50, max 200)
- Text-only badges for flags (deleted, tombstone, nobody-correct, duplicate, perishable) — no color-only semantics
- Phase 3 detail sheet: full read-only record inspection (all non-embedding columns)
- Phase 4 edit form: minimal ratified field set (question, answer, alternatives, explanation, category, visibility)
- Soft-delete and restore actions with confirmation guards
- Grading-adjacent change guard: edits to answer/alternatives require explicit confirmation before persisting

**Server Query (`admin-questions.ts`)**
- `getAllQuestionsForAdmin()`: unscoped pool query with server-side sort/filter applied across the entire dataset (not just loaded page)
- `getAdminQuestionDetail()`: full-record fetch for detail view, includes all non-embedding columns
- `adminEditQuestion()`: reuses canonical "content changed ⇒ re-verify" stamp-clear (mirrors `editQuestionContent` mechanics)
- `adminSoftDeleteQuestion()` / `adminRestoreQuestion()`: soft-delete primitives (never hard DELETE)
- Author display resolution: house/tombstone/deleted rows always resolve to neutral "House" label (Invariant H-1)
- Whitelisted sort keys to prevent SQL injection

**API Route (`/api/admin/questions`)**
- POST endpoint for mutations (edit, delete, restore)
- Admin-gated: non-admins get 404 (route existence hidden)
- Zod validation on all inputs
- Visibility limited to editable values (public/friends/private; blocked is terminal)
- Field set matches Phase 4 ratified minimal set (Decision B)

**Page & Tests**
- Server page component with admin gate (404 for non-admins)
- Search params parsing for sort, filter, pagination, detail view
- Unit tests for gating and mutation dispatch
- Tests verify non-admins never trigger queries/mutations

## Implementation Details

- **Soft-delete canon:** deletedAt is the only delete mechanism; restore is its inverse. Deleted rows remain inspectable under "show deleted" toggle.
- **Author label resolution:** server-side via `resolveAuthorDisplay()` — client never re-derives person vs house from raw provenance.
- **Grading guard:** changes to answerText or acceptedAlternatives trigger a confirmation dialog and clear the verification stamp so the batch-verify sweep re-fact-checks.
- **Metadata-only edits:** category/visibility changes do NOT touch the verification stamp.
- **URL-driven state:** sort, filter, pagination, and detail view all live in search params for bookmarkability and back-button support.
- **Interface design:** deliberately plain (internal ops tool) — interface quiet, content loud. Every flag is a TEXT badge.

https://claude.ai/code/session_01TKLVoP1rEqbRW5JkCCsJqr