### PR TITLE
Admin-only link from the Questions tab to /admin/questions

### DIFF
--- a/src/app/api/nav/__tests__/route.test.ts
+++ b/src/app/api/nav/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Locks the /api/nav contract the Questions-tab admin link depends on: isAdmin is
+// resolved server-side from the ADMIN_USER_IDS allowlist and returned as a plain
+// boolean (the allowlist itself never crosses to the client).
+
+const {
+  getSessionMock,
+  isAdminUserMock,
+  profileMock,
+  bellMock,
+  friendReqMock,
+  discoveryMock,
+} = vi.hoisted(() => ({
+  getSessionMock: vi.fn<() => Promise<{ userId: string } | null>>(),
+  isAdminUserMock: vi.fn<(userId: string | null | undefined) => boolean>(),
+  profileMock: vi.fn(async () => ({ displayName: 'Josh' })),
+  bellMock: vi.fn(async () => 0),
+  friendReqMock: vi.fn(async () => 0),
+  discoveryMock: vi.fn(async () => ({ hasNew: false, count: 0 })),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/auth/admin', () => ({ isAdminUser: isAdminUserMock }));
+vi.mock('@/server/db/queries/users', () => ({ getUserOnboardingProfile: profileMock }));
+vi.mock('@/server/db/queries/activity', () => ({ getBellBadgeCount: bellMock }));
+vi.mock('@/server/db/queries/friends', () => ({ getIncomingFollowRequestCount: friendReqMock }));
+vi.mock('@/server/db/queries/contact-hashes', () => ({ getNewDiscoveryStatus: discoveryMock }));
+
+import { GET } from '@/app/api/nav/route';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('/api/nav isAdmin', () => {
+  it('401s when unauthenticated', async () => {
+    getSessionMock.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns isAdmin: true for an admin', async () => {
+    getSessionMock.mockResolvedValue({ userId: 'admin-1' });
+    isAdminUserMock.mockReturnValue(true);
+    const body = await (await GET()).json();
+    expect(body.isAdmin).toBe(true);
+    expect(isAdminUserMock).toHaveBeenCalledWith('admin-1');
+  });
+
+  it('returns isAdmin: false for a non-admin', async () => {
+    getSessionMock.mockResolvedValue({ userId: 'user-2' });
+    isAdminUserMock.mockReturnValue(false);
+    const body = await (await GET()).json();
+    expect(body.isAdmin).toBe(false);
+  });
+});

--- a/src/app/api/nav/route.ts
+++ b/src/app/api/nav/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
+import { isAdminUser } from '@/server/auth/admin';
 import { getUserOnboardingProfile } from '@/server/db/queries/users';
 import { getBellBadgeCount } from '@/server/db/queries/activity';
 import { getIncomingFollowRequestCount } from '@/server/db/queries/friends';
@@ -31,6 +32,11 @@ export async function GET() {
   return NextResponse.json({
     userId: session.userId,
     displayName: profile?.displayName ?? null,
+    // Admin membership resolved server-side from the ADMIN_USER_IDS allowlist —
+    // the client receives only this boolean, never the allowlist itself. Purely
+    // to reveal admin-only affordances (e.g. the /admin/questions link on the
+    // Questions tab); every admin route still re-checks the gate and 404s.
+    isAdmin: isAdminUser(session.userId),
     bellBadgeCount,
     friendRequestCount,
     friendsDotVisible: discoveryStatus.hasNew,

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -184,6 +184,23 @@ function QuestionsPageContent() {
   const [cardError, setCardError] = useState<Record<string, string>>({});
   const [removingId, setRemovingId] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  // Admin-only affordance: reveal a jump to the /admin/questions pool audit.
+  // isAdmin is resolved server-side (ADMIN_USER_IDS) and delivered by /api/nav —
+  // the client only receives the boolean, and the admin route re-checks the gate.
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch('/api/nav', { cache: 'no-store', credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body) => {
+        if (!cancelled && body?.isAdmin === true) setIsAdmin(true);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const loadQuestions = useCallback(async () => {
     // Cold load shows the skeleton; a warm cache revalidates silently underneath
@@ -435,6 +452,14 @@ function QuestionsPageContent() {
         >
           Answered
         </button>
+        {isAdmin ? (
+          <a
+            href="/admin/questions"
+            className="ml-auto self-center px-4 py-2.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+          >
+            Admin overview →
+          </a>
+        ) : null}
       </div>
 
       {tab === 'authored' ? (


### PR DESCRIPTION
- /api/nav returns isAdmin, resolved server-side from the ADMIN_USER_IDS allowlist. The client receives only the boolean — the allowlist never crosses the boundary, and /admin/questions still re-checks the gate and 404s, so the link is a reveal, not a gate.
- The Questions page fetches /api/nav on mount and renders a discreet "Admin overview →" link at the end of the tab bar only when isAdmin is true; non-admins see nothing.
- Locks the /api/nav isAdmin contract with a focused test.


Claude-Session: https://claude.ai/code/session_01TKLVoP1rEqbRW5JkCCsJqr