### PR TITLE
Admin: re-attribute a question's author to House

### DIFF
--- a/src/app/admin/questions/AdminQuestionsClient.tsx
+++ b/src/app/admin/questions/AdminQuestionsClient.tsx
@@ -192,6 +192,10 @@ function EditForm({
   const [factualExplanation, setFactualExplanation] = useState(detail.factualExplanation ?? '');
   const [category, setCategory] = useState(detail.category);
   const [visibility, setVisibility] = useState(detail.visibility);
+  // Author: 'person' keeps the current human creator; 'house' re-sources to the
+  // house author. Only a person-authored row can switch (a house/LLM row has no
+  // person to switch back to without a picker), so the control is read-only then.
+  const [authorChoice, setAuthorChoice] = useState<'person' | 'house'>(detail.authorIsPerson ? 'person' : 'house');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -213,6 +217,9 @@ function EditForm({
     }
     if (category !== detail.category) patch.category = category;
     if (visibility !== detail.visibility) patch.visibility = visibility;
+    // Re-attribution: only person → house is a real transition.
+    const toHouse = detail.authorIsPerson && authorChoice === 'house';
+    if (toHouse) patch.attribution = 'house';
 
     if (Object.keys(patch).length === 0) {
       setError('No changes to save.');
@@ -224,6 +231,15 @@ function EditForm({
     if (gradingChanged) {
       const ok = window.confirm(
         'This changes the answer key or accepted alternatives, which changes how past and future answers grade. Save?',
+      );
+      if (!ok) return;
+    }
+
+    // Re-attribution guard: dropping the person link renders the question as house
+    // content and is not reversible from this tool.
+    if (toHouse) {
+      const ok = window.confirm(
+        `Change author from "${detail.authorLabel}" to House? This drops the person's authorship (it leaves their authored list and renders as house content) and can't be reversed here.`,
       );
       if (!ok) return;
     }
@@ -278,6 +294,26 @@ function EditForm({
           Factual explanation
         </label>
         <textarea rows={3} className={inputClass} style={inputStyle} value={factualExplanation} onChange={(e) => setFactualExplanation(e.target.value)} />
+      </div>
+      <div className="mb-3">
+        <label className={labelClass} style={labelStyle}>
+          Author
+        </label>
+        <select
+          className={inputClass}
+          style={inputStyle}
+          value={authorChoice}
+          disabled={!detail.authorIsPerson}
+          onChange={(e) => setAuthorChoice(e.target.value as 'person' | 'house')}
+        >
+          {detail.authorIsPerson ? <option value="person">{detail.authorLabel}</option> : null}
+          <option value="house">House (Joshing)</option>
+        </select>
+        {!detail.authorIsPerson ? (
+          <p className="mt-1 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+            Already house/non-person — reassigning to a specific person isn&apos;t supported here.
+          </p>
+        ) : null}
       </div>
       <div className="mb-3 flex gap-3">
         <div className="flex-1">

--- a/src/app/api/admin/questions/__tests__/route.test.ts
+++ b/src/app/api/admin/questions/__tests__/route.test.ts
@@ -78,6 +78,18 @@ describe('admin questions mutation route — actions (admin)', () => {
     expect(editMock).not.toHaveBeenCalled();
   });
 
+  it('dispatches a re-attribution to house', async () => {
+    const res = await post({ action: 'edit', id: 'q1', attribution: 'house' });
+    expect(res.status).toBe(200);
+    expect(editMock).toHaveBeenCalledWith('q1', expect.objectContaining({ attribution: 'house' }));
+  });
+
+  it('rejects an unsupported attribution target', async () => {
+    const res = await post({ action: 'edit', id: 'q1', attribution: 'person' });
+    expect(res.status).toBe(400);
+    expect(editMock).not.toHaveBeenCalled();
+  });
+
   it('soft-deletes', async () => {
     const res = await post({ action: 'delete', id: 'q1' });
     expect(res.status).toBe(200);

--- a/src/app/api/admin/questions/route.ts
+++ b/src/app/api/admin/questions/route.ts
@@ -30,6 +30,10 @@ const editSchema = z.object({
   factualExplanation: z.string().trim().max(4000).nullable().optional(),
   category: z.enum(CATEGORIES).optional(),
   visibility: z.enum(['public', 'friends', 'private']).optional(),
+  // Re-attribution to the house author (creator_id NULL + source house_authored).
+  // Only 'house' is settable here — reassigning to a specific person would need a
+  // person picker this tool doesn't have.
+  attribution: z.enum(['house']).optional(),
 });
 
 const bodySchema = z.discriminatedUnion('action', [
@@ -72,6 +76,7 @@ export async function POST(request: NextRequest) {
     factualExplanation: fields.factualExplanation,
     category: fields.category,
     visibility: fields.visibility,
+    attribution: fields.attribution,
   };
   if (Object.values(patch).every((v) => v === undefined)) {
     return NextResponse.json({ error: 'validation' }, { status: 400 });

--- a/src/server/db/queries/admin-questions.ts
+++ b/src/server/db/queries/admin-questions.ts
@@ -113,6 +113,13 @@ export type AdminEditQuestionInput = {
   factualExplanation?: string | null;
   category?: string;
   visibility?: string;
+  // Re-attribution. 'house' re-sources the question to the labeled non-human
+  // house author (creator_id NULL + source 'house_authored') — the same override
+  // the crafter "keep" flow applies. NOT a tombstone: authorDeleted stays false
+  // (a deliberate re-attribution, not an account-deletion retention). One-way in
+  // this tool: the original creator link is dropped, so there is no house→person
+  // reverse without a person picker.
+  attribution?: 'house';
 };
 
 export type AdminMutationResult = { ok: boolean; reason?: 'not_found' | 'no_fields' };
@@ -152,6 +159,12 @@ export async function adminEditQuestion(
   }
   if (input.visibility !== undefined) {
     values.visibility = input.visibility as typeof questions.$inferInsert.visibility;
+  }
+  if (input.attribution === 'house') {
+    // House marker: creator_id NULL + source 'house_authored' (crafter-keep
+    // precedent). Not a content change — the verification stamp is untouched.
+    values.creatorId = null;
+    values.source = 'house_authored';
   }
 
   if (Object.keys(values).length === 0) return { ok: false, reason: 'no_fields' };


### PR DESCRIPTION
Adds an Author dropdown to the admin edit form so a person-authored question can be re-sourced to the house author.

- adminEditQuestion accepts attribution: 'house' → creator_id NULL + source 'house_authored', matching the crafter-keep override. Not a tombstone (authorDeleted stays false) and not a content change (verification stamp untouched). One-way: the person link is dropped, so there is no house→person reverse without a person picker.
- Route validates attribution: z.enum(['house']).
- Edit form: Author <select> offering the current person or "House (Joshing)". A house/non-person row shows the control read-only (nothing to switch to). Switching to House requires an explicit confirm (drops authorship, renders as house content, not reversible here).
- Route tests cover the attribution dispatch and reject unsupported targets.


Claude-Session: https://claude.ai/code/session_01TKLVoP1rEqbRW5JkCCsJqr