### PR TITLE
feat(supply): corpus-grounded domain size estimate + LLM resolver (D-SUPPLY-FINITENESS-01)

### DIFF
--- a/drizzle/0117_domain_size_estimate.sql
+++ b/drizzle/0117_domain_size_estimate.sql
@@ -1,0 +1,39 @@
+-- 0117: DomainDepthEstimate corpus-grounded size columns (D-SUPPLY-FINITENESS-01).
+--
+-- Extends the depth cache (0116) with a CORPUS-grounded size estimate. The
+-- resolver (src/server/daily/domain-size-estimate.ts) routes a domain to a real
+-- Wikipedia / Wikidata / Fandom anchor, counts it shape-aware, and
+-- normalizeToQuestionEstimate turns that into "estimated_questions" — the number
+-- getTargetQuestionCountForDomains now PREFERS over coefficient·depth² when
+-- present. The other columns record the resolution (shape, anchors, confidence,
+-- basis) for the coverage dashboard + the confidence-gated discrepancy alarm.
+--
+-- Purely additive: every column is nullable and idempotent (ADD COLUMN IF NOT
+-- EXISTS). A row with these NULL falls back to the depth-derived count exactly as
+-- before, so it is safe to record ahead of any backfill. Mirrored by a defensive
+-- guard in src/instrumentation.ts (same rationale as the 0116 guard).
+--
+-- Rollback:
+--   ALTER TABLE "DomainDepthEstimate"
+--     DROP COLUMN IF EXISTS "estimated_questions", DROP COLUMN IF EXISTS "corpus_count",
+--     DROP COLUMN IF EXISTS "shape", DROP COLUMN IF EXISTS "confidence",
+--     DROP COLUMN IF EXISTS "basis", DROP COLUMN IF EXISTS "wikipedia_title",
+--     DROP COLUMN IF EXISTS "wikidata_qid", DROP COLUMN IF EXISTS "fandom_host",
+--     DROP COLUMN IF EXISTS "resolved_at";
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "estimated_questions" integer;
+--> statement-breakpoint
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "corpus_count" integer;
+--> statement-breakpoint
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "shape" text;
+--> statement-breakpoint
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "confidence" text;
+--> statement-breakpoint
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "basis" text;
+--> statement-breakpoint
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "wikipedia_title" text;
+--> statement-breakpoint
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "wikidata_qid" text;
+--> statement-breakpoint
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "fandom_host" text;
+--> statement-breakpoint
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "resolved_at" timestamp with time zone;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -820,6 +820,13 @@
 			"when": 1786579200000,
 			"tag": "0116_domain_depth_estimate",
 			"breakpoints": true
+		},
+		{
+			"idx": 117,
+			"version": "7",
+			"when": 1786665600000,
+			"tag": "0117_domain_size_estimate",
+			"breakpoints": true
 		}
 	]
 }

--- a/scripts/backfill-domain-size.ts
+++ b/scripts/backfill-domain-size.ts
@@ -1,0 +1,112 @@
+/**
+ * Populate CORPUS-grounded domain size estimates (D-SUPPLY-FINITENESS-01).
+ *
+ * For each played domain, resolves it to a real Wikipedia / Wikidata / Fandom
+ * anchor (Haiku, candidate-grounded), counts it shape-aware, normalizes to an
+ * estimated sustainable question count, and caches it on DomainDepthEstimate
+ * (source='corpus'). getTargetQuestionCountForDomains then PREFERS that number
+ * over coefficient·depth². The estimate is a SEED — the finiteness loop
+ * co-calibrates it from observed yield.
+ *
+ * Fail-open per domain: a resolver miss or a low/bespoke resolution leaves the
+ * row on its depth-derived fallback (never written), so a partial run is safe.
+ *
+ * Read-only by default. Run from repo root (Node 24):
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-domain-size.ts               # dry-run, all played domains
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-domain-size.ts --apply        # write
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-domain-size.ts "Hamlet" "Star Trek"  # specific domains (dry-run)
+ *
+ * Idempotent: an upsert keyed on domain_key, so re-running refreshes in place.
+ */
+import { sql } from 'drizzle-orm';
+
+import { db } from '../src/server/db';
+import { domainKey } from '../src/lib/knowledge/domain-key';
+import { estimateDomainSize } from '../src/server/daily/domain-size-estimate';
+import { upsertCorpusSizeEstimate } from '../src/server/db/queries/domain-depth-estimate';
+
+const APPLY = process.argv.includes('--apply');
+const explicit = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function domainsToSize(): Promise<string[]> {
+  if (explicit.length > 0) return explicit;
+  const result = await db.execute(sql`
+    SELECT DISTINCT canonical_subcategory AS d
+    FROM "PLAYER_MASTERY"
+    WHERE canonical_subcategory IS NOT NULL AND canonical_subcategory <> ''
+  `);
+  const rows = (result as { rows?: Record<string, unknown>[] }).rows ?? [];
+  return rows.map((r) => String(r.d ?? '')).filter(Boolean);
+}
+
+async function main(): Promise<void> {
+  const domains = await domainsToSize();
+  // One estimate per folded domain_key; label = a representative canonical string.
+  const labelByKey = new Map<string, string>();
+  for (const d of domains) {
+    const k = domainKey(d);
+    if (!labelByKey.has(k)) labelByKey.set(k, d);
+  }
+  console.log(
+    `${labelByKey.size} unique domain keys (${domains.length} canonical labels). ${
+      APPLY ? 'APPLY — writing' : 'DRY-RUN'
+    }\n`,
+  );
+
+  let sized = 0;
+  let bespoke = 0;
+  let failed = 0;
+  for (const [key, label] of labelByKey) {
+    let est = null;
+    try {
+      est = await estimateDomainSize(label);
+    } catch {
+      est = null;
+    }
+    if (!est) {
+      failed += 1;
+      console.log(`  · FAIL      ${label} (resolver returned null)`);
+      await sleep(400);
+      continue;
+    }
+    if (est.estimatedQuestions == null) {
+      bespoke += 1;
+      console.log(`  · bespoke   ${est.shape.padEnd(18)} ${label} (Haiku depth fallback)`);
+    } else {
+      sized += 1;
+      console.log(
+        `  · ${String(est.estimatedQuestions).padStart(5)}q  ${est.confidence.padEnd(6)} ${est.shape.padEnd(
+          18,
+        )} ${est.basis.padEnd(28)} ${label}`,
+      );
+      if (APPLY) {
+        await upsertCorpusSizeEstimate({
+          domainKey: key,
+          sampleLabel: label,
+          estimatedQuestions: est.estimatedQuestions,
+          corpusCount: est.corpusCount,
+          shape: est.shape,
+          confidence: est.confidence,
+          basis: est.basis,
+          wikipediaTitle: est.wikipediaTitle,
+          wikidataQid: est.wikidataQid,
+          fandomHost: est.fandomHost,
+        });
+      }
+    }
+    await sleep(500);
+  }
+
+  console.log(
+    `\nDone. sized=${sized} bespoke-fallback=${bespoke} failed=${failed}. ${
+      APPLY ? 'Written.' : 'Dry-run — re-run with --apply to write.'
+    }`,
+  );
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2115,6 +2115,19 @@ export async function register() {
       `);
       await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ENABLE ROW LEVEL SECURITY`);
       await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "DomainDepthEstimate_domain_key" ON "DomainDepthEstimate" ("domain_key")`);
+      // Migration 0117 (D-SUPPLY-FINITENESS-01): corpus-grounded size columns on
+      // DomainDepthEstimate. Additive + nullable; getTargetQuestionCountForDomains
+      // reads estimated_questions and would 42703 on an un-migrated DB. Same guard
+      // rationale as the 0116 block above.
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "estimated_questions" integer`);
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "corpus_count" integer`);
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "shape" text`);
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "confidence" text`);
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "basis" text`);
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "wikipedia_title" text`);
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "wikidata_qid" text`);
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "fandom_host" text`);
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "resolved_at" timestamp with time zone`);
     } catch {
       // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
     }

--- a/src/server/daily/__tests__/domain-size-estimate.test.ts
+++ b/src/server/daily/__tests__/domain-size-estimate.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SIZE_CEIL,
+  SIZE_FLOOR,
+  normalizeToQuestionEstimate,
+} from '@/server/daily/domain-size-estimate';
+
+describe('normalizeToQuestionEstimate (locked size model)', () => {
+  it('scales counted entities by the per-shape constant', () => {
+    // single_work K=3: Hamlet (39 sections) → 117, Wagner (25) → 75
+    expect(normalizeToQuestionEstimate('single_work', 39)).toBe(117);
+    expect(normalizeToQuestionEstimate('single_work', 25)).toBe(75);
+    // person_creator K=5: Wallace Stevens (86 works) → 430
+    expect(normalizeToQuestionEstimate('person_creator', 86)).toBe(430);
+    // abstract K=3: Tudor (34 sections) → 102
+    expect(normalizeToQuestionEstimate('abstract_topic', 34)).toBe(102);
+  });
+
+  it('clamps a huge franchise signal to the ceiling (never reads as unbounded)', () => {
+    // franchise whole-wiki article counts (Star Trek 65k, Star Wars 226k) → CEIL
+    expect(normalizeToQuestionEstimate('series_or_franchise', 65_674)).toBe(SIZE_CEIL);
+    expect(normalizeToQuestionEstimate('series_or_franchise', 226_923)).toBe(SIZE_CEIL);
+  });
+
+  it('applies the floor so a genuinely tiny signal never reads as near-complete-at-zero', () => {
+    // 3 sections × 3 = 9, floored to 20
+    expect(normalizeToQuestionEstimate('abstract_topic', 3)).toBe(SIZE_FLOOR);
+    // just above the floor is preserved
+    expect(normalizeToQuestionEstimate('abstract_topic', 13)).toBe(39);
+  });
+
+  it('returns null for bespoke and degenerate inputs (caller uses the Haiku depth fallback)', () => {
+    expect(normalizeToQuestionEstimate('bespoke', 100)).toBeNull();
+    expect(normalizeToQuestionEstimate('abstract_topic', null)).toBeNull();
+    expect(normalizeToQuestionEstimate('single_work', 0)).toBeNull();
+    expect(normalizeToQuestionEstimate('single_work', -5)).toBeNull();
+    expect(normalizeToQuestionEstimate('person_creator', Number.NaN)).toBeNull();
+  });
+
+  it('keeps the co-calibration boundary meaningful (seed can be below realized)', () => {
+    // Shakespearean Tragedy: 9 sections → seed 27; realized 45 exceeds it, which
+    // is what the finiteness state machine reads as "raise the estimate".
+    const seed = normalizeToQuestionEstimate('abstract_topic', 9);
+    expect(seed).toBe(27);
+    expect(45).toBeGreaterThan(seed as number);
+  });
+});

--- a/src/server/daily/domain-size-estimate.ts
+++ b/src/server/daily/domain-size-estimate.ts
@@ -1,0 +1,343 @@
+import {
+  HAIKU_MODEL,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+  wrapUserInput,
+} from '@/lib/llm';
+
+/**
+ * Corpus-grounded domain SIZE estimate (D-SUPPLY-FINITENESS-01).
+ *
+ * Answers "how many distinct good daily-five questions can this domain sustain?"
+ * — the referee the finiteness state machine and the discrepancy alarm compare
+ * REALIZED generation against. This replaces the bare Haiku 1-10 guess in
+ * `scoreDomainDepth` (domain-depth.ts) with a resolve → count → normalize pass:
+ *
+ *   1. RESOLVE  — Haiku disambiguates the domain label against real Wikipedia /
+ *      Wikidata candidates and routes it to a SHAPE (+ a fandom host if one
+ *      exists). Feeding it candidates (not guessing blind) is what stops
+ *      "Classical Symphonic Music" resolving to "Symphonic metal".
+ *   2. COUNT    — a SHAPE-AWARE corpus count: author works (Wikidata P50),
+ *      article sections, or fandom category/article counts.
+ *   3. NORMALIZE— entities × a per-shape questions-per-entity constant, clamped.
+ *
+ * Everything FAILS OPEN: any outage / malformed response / low-confidence
+ * resolution returns null so callers fall back to the existing depth estimate.
+ * The estimate is a SEED — the finiteness loop co-calibrates it from observed
+ * yield (a domain that keeps yielding past the estimate raises it).
+ */
+
+export type DomainShape =
+  | 'person_creator'
+  | 'single_work'
+  | 'series_or_franchise'
+  | 'event'
+  | 'abstract_topic'
+  | 'bespoke';
+
+export type ResolutionConfidence = 'high' | 'medium' | 'low';
+
+export interface DomainSizeEstimate {
+  shape: DomainShape;
+  /** The raw corpus signal that was counted (works / sections / articles / members). */
+  corpusCount: number | null;
+  /** Normalized "distinct good questions" the domain can sustain. null → use the Haiku depth fallback. */
+  estimatedQuestions: number | null;
+  confidence: ResolutionConfidence;
+  /** Which signal produced corpusCount — for the dashboard + debugging. */
+  basis: string;
+  /** Resolved anchors (for auditability / the coverage dashboard). */
+  wikipediaTitle: string | null;
+  wikidataQid: string | null;
+  fandomHost: string | null;
+}
+
+// Questions a single counted entity is worth. A work → several askable facts;
+// a fandom character/item or an article section → fewer. Tunable; the alarm and
+// finiteness gate only need order-of-magnitude accuracy, and co-calibration
+// corrects per-domain drift over time.
+const K_PER_SHAPE: Record<Exclude<DomainShape, 'bespoke'>, number> = {
+  person_creator: 5,
+  single_work: 3,
+  series_or_franchise: 2.5,
+  event: 3,
+  abstract_topic: 3,
+};
+
+export const SIZE_FLOOR = 20;
+export const SIZE_CEIL = 1200;
+
+/**
+ * PURE core (unit-tested): counted entities → estimated sustainable questions.
+ * Returns null for `bespoke` or an absent/degenerate count so the caller uses
+ * the Haiku depth fallback instead of a floored guess.
+ */
+export function normalizeToQuestionEstimate(
+  shape: DomainShape,
+  entities: number | null | undefined,
+): number | null {
+  if (shape === 'bespoke') return null;
+  if (entities == null || !Number.isFinite(entities) || entities <= 0) return null;
+  const raw = Math.round(entities * K_PER_SHAPE[shape]);
+  return Math.max(SIZE_FLOOR, Math.min(SIZE_CEIL, raw));
+}
+
+// --- Corpus fetchers (fail-open; plain MediaWiki / Wikidata / Fandom APIs) ---
+
+const UA = 'Joshing/1.0 (domain-size-estimate; +https://joshing.app)';
+
+async function fetchJson<T>(url: string, timeoutMs = 15_000): Promise<T | null> {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), timeoutMs);
+  try {
+    const r = await fetch(url, {
+      headers: { 'User-Agent': UA, Accept: 'application/json' },
+      signal: ctl.signal,
+    });
+    if (!r.ok) return null;
+    return (await r.json()) as T;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+// SPARQL COUNT(...) responses share this shape.
+type SparqlCount = { results?: { bindings?: { c?: { value?: string } }[] } };
+function sparqlCountValue(data: SparqlCount | null): number | null {
+  const raw = data?.results?.bindings?.[0]?.c?.value;
+  const n = raw == null ? NaN : Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function wikipediaSections(title: string): Promise<number | null> {
+  const url =
+    'https://en.wikipedia.org/w/api.php?format=json&formatversion=2&action=parse' +
+    `&page=${encodeURIComponent(title)}&prop=sections`;
+  const data = await fetchJson<{ parse?: { sections?: unknown[] } }>(url);
+  const n = data?.parse?.sections?.length;
+  return typeof n === 'number' ? n : null;
+}
+
+async function wikipediaCandidates(label: string): Promise<{ title: string; snippet: string }[]> {
+  const url =
+    'https://en.wikipedia.org/w/api.php?format=json&formatversion=2&action=query&list=search' +
+    `&srsearch=${encodeURIComponent(label)}&srlimit=5`;
+  const data = await fetchJson<{ query?: { search?: { title?: string; snippet?: string }[] } }>(url);
+  return (data?.query?.search ?? []).map((x) => ({
+    title: String(x.title ?? ''),
+    snippet: String(x.snippet ?? '').replace(/<[^>]+>/g, '').slice(0, 90),
+  }));
+}
+
+async function wikidataCandidates(label: string): Promise<{ qid: string; label: string; desc: string }[]> {
+  const url =
+    'https://www.wikidata.org/w/api.php?action=wbsearchentities&format=json&language=en&limit=5' +
+    `&search=${encodeURIComponent(label)}`;
+  const data = await fetchJson<{ search?: { id?: string; label?: string; description?: string }[] }>(url);
+  return (data?.search ?? []).map((x) => ({
+    qid: String(x.id ?? ''),
+    label: String(x.label ?? ''),
+    desc: String(x.description ?? ''),
+  }));
+}
+
+async function resolveQidByTitle(title: string): Promise<string | null> {
+  const url =
+    'https://www.wikidata.org/w/api.php?action=wbsearchentities&format=json&language=en&limit=1' +
+    `&search=${encodeURIComponent(title)}`;
+  const data = await fetchJson<{ search?: { id?: string }[] }>(url);
+  return data?.search?.[0]?.id ?? null;
+}
+
+async function worksAuthored(qid: string): Promise<number | null> {
+  const sparql = `SELECT (COUNT(DISTINCT ?w) AS ?c) WHERE { ?w wdt:P50 wd:${qid}. }`;
+  const url = `https://query.wikidata.org/sparql?query=${encodeURIComponent(sparql)}&format=json`;
+  return sparqlCountValue(await fetchJson<SparqlCount>(url, 25_000));
+}
+
+/** Whole-wiki article count — the reliable franchise size signal (bounded by the CEIL downstream). */
+async function fandomArticles(host: string): Promise<number | null> {
+  const url = `https://${host}/api.php?action=query&meta=siteinfo&siprop=statistics&format=json`;
+  const data = await fetchJson<{ query?: { statistics?: { articles?: number } } }>(url);
+  const n = data?.query?.statistics?.articles;
+  return typeof n === 'number' ? n : null;
+}
+
+/**
+ * Sub-topic entity count: sum members of CONTENT categories on `host` whose
+ * titles match `phrase` (e.g. "… in Tears of the Kingdom"). Scopes a rich work
+ * inside a broader fandom without pulling the whole wiki. Members capped at 500
+ * per category — the estimate only needs magnitude.
+ */
+async function fandomScopedEntities(host: string, phrase: string): Promise<number | null> {
+  const search = await fetchJson<{ query?: { search?: { title?: string }[] } }>(
+    `https://${host}/api.php?action=query&list=search&srnamespace=14&srlimit=8&format=json` +
+      `&srsearch=${encodeURIComponent(phrase)}`,
+  );
+  const cats: string[] = (search?.query?.search ?? [])
+    .map((x) => String(x.title ?? ''))
+    .filter((c) =>
+      /character|item|location|episode|film|song|quest|boss|weapon|creature|species|planet|ship/i.test(c),
+    );
+  if (cats.length === 0) return null;
+  let sum = 0;
+  for (const c of cats.slice(0, 8)) {
+    const info = await fetchJson<{ query?: { categorymembers?: unknown[] } }>(
+      `https://${host}/api.php?action=query&list=categorymembers&cmlimit=500&format=json` +
+        `&cmtitle=${encodeURIComponent(c)}`,
+    );
+    sum += info?.query?.categorymembers?.length ?? 0;
+  }
+  return sum > 0 ? sum : null;
+}
+
+// --- Haiku resolution (candidate-grounded disambiguation + routing) ---
+
+interface Route {
+  wikipediaTitle: string | null;
+  wikidataQid: string | null;
+  shape: DomainShape;
+  fandomHost: string | null;
+  confidence: ResolutionConfidence;
+  /** A distinctive phrase for scoped fandom category lookup (defaults to the label). */
+  phrase: string | null;
+}
+
+const RESOLVE_SYSTEM = `You route a trivia DOMAIN to its best knowledge-base anchor for estimating how many distinct quiz questions it can support. You are given the domain label plus candidate matches from Wikipedia and Wikidata. Choose the anchor that represents the FULL domain as a trivia player means it — NOT a coincidental name match (e.g. "Classical Symphonic Music" is NOT "Symphonic metal"; "Hamlet" the play is NOT the settlement type). Prefer null over a wrong match. Classify the shape. If a large dedicated Fandom wiki plausibly exists, give its host (e.g. starwars.fandom.com). Output STRICT JSON only, no prose.
+Schema: {"wikipedia_title": string|null, "wikidata_qid": string|null, "shape": "person_creator"|"single_work"|"series_or_franchise"|"event"|"abstract_topic"|"bespoke", "fandom_host": string|null, "phrase": string|null, "confidence": "high"|"medium"|"low"}`;
+
+const VALID_SHAPES: ReadonlySet<string> = new Set<DomainShape>([
+  'person_creator',
+  'single_work',
+  'series_or_franchise',
+  'event',
+  'abstract_topic',
+  'bespoke',
+]);
+
+async function resolveRoute(label: string): Promise<Route | null> {
+  const client = getAnthropicClient();
+  if (!client) return null;
+  const [wp, wd] = await Promise.all([wikipediaCandidates(label), wikidataCandidates(label)]);
+  const user = `DOMAIN: ${label}\n\nWIKIPEDIA_CANDIDATES: ${JSON.stringify(wp)}\n\nWIKIDATA_CANDIDATES: ${JSON.stringify(wd)}`;
+  try {
+    const response = await loggedMessagesCreate(client, 'domain-size-resolve', {
+      model: HAIKU_MODEL,
+      max_tokens: 300,
+      temperature: 0,
+      system: RESOLVE_SYSTEM,
+      messages: [{ role: 'user', content: wrapUserInput('domain', user) }],
+    });
+    const parsed = parseJsonObject(extractTextContent(response.content));
+    if (!parsed) return null;
+    const shape = String(parsed.shape ?? '');
+    if (!VALID_SHAPES.has(shape)) return null;
+    const conf = String(parsed.confidence ?? 'low');
+    return {
+      wikipediaTitle: parsed.wikipedia_title ? String(parsed.wikipedia_title) : null,
+      wikidataQid: parsed.wikidata_qid ? String(parsed.wikidata_qid) : null,
+      shape: shape as DomainShape,
+      fandomHost: parsed.fandom_host ? String(parsed.fandom_host) : null,
+      confidence: (conf === 'high' || conf === 'medium' ? conf : 'low') as ResolutionConfidence,
+      phrase: parsed.phrase ? String(parsed.phrase) : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// --- Shape-aware counting: route → corpusCount + basis ---
+
+async function countForRoute(
+  label: string,
+  route: Route,
+): Promise<{ corpusCount: number | null; basis: string; fandomHost: string | null }> {
+  const { shape } = route;
+
+  if (shape === 'bespoke') return { corpusCount: null, basis: 'bespoke', fandomHost: null };
+
+  if (shape === 'person_creator') {
+    const qid = route.wikidataQid ?? (route.wikipediaTitle ? await resolveQidByTitle(route.wikipediaTitle) : null);
+    const works = qid ? await worksAuthored(qid) : null;
+    if (works && works > 0) return { corpusCount: works, basis: `wikidata:works(P50,${qid})`, fandomHost: null };
+    const sections = route.wikipediaTitle ? await wikipediaSections(route.wikipediaTitle) : null;
+    return { corpusCount: sections, basis: 'wp:sections(no-works)', fandomHost: null };
+  }
+
+  if (shape === 'series_or_franchise') {
+    // Verify any proposed host (catches hallucinated hosts) and use the RELIABLE
+    // whole-wiki article count — it clamps to the CEIL, so a franchise never
+    // falsely reads as small/complete the way a flaky category search can.
+    if (route.fandomHost) {
+      const articles = await fandomArticles(route.fandomHost);
+      if (articles && articles > 0) {
+        return { corpusCount: articles, basis: 'fandom:articles', fandomHost: route.fandomHost };
+      }
+    }
+    const qid = route.wikidataQid;
+    if (qid) {
+      const sparql = `SELECT (COUNT(DISTINCT ?x) AS ?c) WHERE { ?x ?p wd:${qid}. VALUES ?p { wdt:P1441 wdt:P179 wdt:P361 } }`;
+      const n = sparqlCountValue(
+        await fetchJson<SparqlCount>(
+          `https://query.wikidata.org/sparql?query=${encodeURIComponent(sparql)}&format=json`,
+          25_000,
+        ),
+      );
+      if (n != null && n > 0) return { corpusCount: n, basis: 'wikidata:appearances', fandomHost: null };
+    }
+    const sections = route.wikipediaTitle ? await wikipediaSections(route.wikipediaTitle) : null;
+    return { corpusCount: sections, basis: 'wp:sections(franchise-fallback)', fandomHost: null };
+  }
+
+  if (shape === 'single_work') {
+    // Rich works (a big game inside a fandom) → scoped category sum; text works
+    // (a play/book) → sections. Take the larger so a content-rich work isn't
+    // undercounted by its short encyclopedia article.
+    let host: string | null = null;
+    let scoped: number | null = null;
+    if (route.fandomHost && (await fandomArticles(route.fandomHost))) {
+      host = route.fandomHost;
+      scoped = await fandomScopedEntities(route.fandomHost, route.phrase ?? label);
+    }
+    const sections = route.wikipediaTitle ? await wikipediaSections(route.wikipediaTitle) : null;
+    const best = Math.max(scoped ?? 0, sections ?? 0) || null;
+    const basis = (scoped ?? 0) >= (sections ?? 0) && scoped ? 'fandom:scoped-categories' : 'wp:sections';
+    return { corpusCount: best, basis, fandomHost: host };
+  }
+
+  // event | abstract_topic
+  const sections = route.wikipediaTitle ? await wikipediaSections(route.wikipediaTitle) : null;
+  return { corpusCount: sections, basis: 'wp:sections', fandomHost: null };
+}
+
+/**
+ * Orchestrator: resolve → count → normalize. Returns null on any failure so the
+ * caller falls back to the Haiku depth estimate. A `low`-confidence resolution
+ * still returns an estimate, but callers should NOT fire the discrepancy alarm
+ * off it (confidence-gate the alarm, not the estimate).
+ */
+export async function estimateDomainSize(label: string): Promise<DomainSizeEstimate | null> {
+  const clean = label.trim().replace(/\s+/g, ' ');
+  if (!clean) return null;
+
+  const route = await resolveRoute(clean);
+  if (!route) return null;
+
+  const { corpusCount, basis, fandomHost } = await countForRoute(clean, route);
+  const estimatedQuestions = normalizeToQuestionEstimate(route.shape, corpusCount);
+
+  return {
+    shape: route.shape,
+    corpusCount,
+    estimatedQuestions,
+    confidence: route.confidence,
+    basis,
+    wikipediaTitle: route.wikipediaTitle,
+    wikidataQid: route.wikidataQid,
+    fandomHost: fandomHost ?? route.fandomHost,
+  };
+}

--- a/src/server/daily/domain-size.ts
+++ b/src/server/daily/domain-size.ts
@@ -76,10 +76,15 @@ export async function getTargetQuestionCountForDomains(
 
   const cached = await getDepthEstimates(keys).catch(() => new Map());
 
+  // Corpus-grounded target counts win outright when present (D-SUPPLY-FINITENESS-01):
+  // a resolved Wikipedia/Wikidata/Fandom count is a truer set size than
+  // coefficient·depth². Depth remains the fallback for keys with no corpus row.
+  const estimateByKey = new Map<string, number>();
   const depthByKey = new Map<string, number>();
   for (const key of keys) {
     const row = cached.get(key);
     if (row) {
+      if (row.estimatedQuestions != null) estimateByKey.set(key, row.estimatedQuestions);
       depthByKey.set(key, row.depthScore ?? defaultDepth());
       continue;
     }
@@ -104,7 +109,11 @@ export async function getTargetQuestionCountForDomains(
 
   for (const canonical of unique) {
     const key = keyByCanonical.get(canonical)!;
-    out.set(canonical, depthToTargetCount(depthByKey.get(key) ?? defaultDepth()));
+    const corpus = estimateByKey.get(key);
+    out.set(
+      canonical,
+      corpus != null ? corpus : depthToTargetCount(depthByKey.get(key) ?? defaultDepth()),
+    );
   }
   return out;
 }

--- a/src/server/db/queries/domain-depth-estimate.ts
+++ b/src/server/db/queries/domain-depth-estimate.ts
@@ -9,6 +9,8 @@ export type DepthEstimateRow = {
   domainKey: string;
   depthScore: number | null;
   source: string;
+  // Corpus-grounded size (0117). When present, the PREFERRED target count.
+  estimatedQuestions: number | null;
 };
 
 /** Cached depth estimates for the given folded domain keys. */
@@ -21,6 +23,7 @@ export async function getDepthEstimates(
       domainKey: domainDepthEstimates.domainKey,
       depthScore: domainDepthEstimates.depthScore,
       source: domainDepthEstimates.source,
+      estimatedQuestions: domainDepthEstimates.estimatedQuestions,
     })
     .from(domainDepthEstimates)
     .where(inArray(domainDepthEstimates.domainKey, domainKeys));
@@ -56,4 +59,43 @@ export async function upsertDepthEstimate(input: {
         computedAt: new Date(),
       },
     });
+}
+
+/**
+ * Cache a CORPUS-grounded size estimate (0117, D-SUPPLY-FINITENESS-01). Writes
+ * estimated_questions (the number getTargetQuestionCountForDomains prefers) plus
+ * the resolution provenance for the coverage dashboard + confidence-gated alarm.
+ * Leaves depth_score untouched (keyed on the same domain_key, so it coexists with
+ * any depth row). Upsert so a re-run / concurrent org-wide sizing converges.
+ */
+export async function upsertCorpusSizeEstimate(input: {
+  domainKey: string;
+  sampleLabel: string;
+  estimatedQuestions: number | null;
+  corpusCount: number | null;
+  shape: string;
+  confidence: string;
+  basis: string;
+  wikipediaTitle: string | null;
+  wikidataQid: string | null;
+  fandomHost: string | null;
+}): Promise<void> {
+  const set = {
+    sampleLabel: input.sampleLabel,
+    source: 'corpus' as const,
+    estimatedQuestions: input.estimatedQuestions,
+    corpusCount: input.corpusCount,
+    shape: input.shape,
+    confidence: input.confidence,
+    basis: input.basis,
+    wikipediaTitle: input.wikipediaTitle,
+    wikidataQid: input.wikidataQid,
+    fandomHost: input.fandomHost,
+    resolvedAt: new Date(),
+    computedAt: new Date(),
+  };
+  await db
+    .insert(domainDepthEstimates)
+    .values({ domainKey: input.domainKey, ...set })
+    .onConflictDoUpdate({ target: domainDepthEstimates.domainKey, set });
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1755,8 +1755,22 @@ export const domainDepthEstimates = pgTable(
     depthScore: integer('depth_score'),
     // A canonical_subcategory that folded to this key — for debugging only.
     sampleLabel: text('sample_label'),
-    // 'llm' (scored) | 'default' (LLM unavailable/null; using the code default).
+    // 'llm' (depth scored) | 'default' (LLM unavailable) | 'corpus' (0117: resolved
+    // + counted against a real Wikipedia/Wikidata/Fandom anchor).
     source: text('source').notNull().default('llm'),
+    // Corpus-grounded size (0117, D-SUPPLY-FINITENESS-01). estimatedQuestions is
+    // the number getTargetQuestionCountForDomains PREFERS over coefficient·depth²
+    // when present; the rest record the resolution for the coverage dashboard +
+    // the confidence-gated discrepancy alarm. All nullable — absent → depth fallback.
+    estimatedQuestions: integer('estimated_questions'),
+    corpusCount: integer('corpus_count'),
+    shape: text('shape'),
+    confidence: text('confidence'),
+    basis: text('basis'),
+    wikipediaTitle: text('wikipedia_title'),
+    wikidataQid: text('wikidata_qid'),
+    fandomHost: text('fandom_host'),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true }),
     computedAt: timestamp('computed_at', { withTimezone: true }).notNull().defaultNow(),
     createdAt: createdAt(),
   },


### PR DESCRIPTION
## What

Replaces the bare Haiku 1–10 depth guess as the source of a domain's **target question count** with a **resolve → count → normalize** pass. This is component #3 of the supply-finiteness redesign (the *referee* the finiteness state machine + discrepancy alarm will compare realized generation against).

### Why
Diagnosing Josh's short/slow daily fives showed the "exhaustion" was **supply throughput**, not domain completion — and the only size signal we had (`DomainDepthEstimate`, 6 rows, all a Haiku 1–10 guess) couldn't tell "clearly under-served" from "genuinely near-complete." This gives that signal a real corpus grounding.

## How
- **`src/server/daily/domain-size-estimate.ts`** — candidate-grounded Haiku resolution (Wikipedia + Wikidata candidates → shape + anchors + fandom host + confidence; refuses coincidental name matches like *Classical Symphonic Music → Symphonic metal*), **shape-aware corpus count** (Wikidata `P50` works / article sections / fandom whole-wiki articles / scoped fandom categories), and the pure **`normalizeToQuestionEstimate`** (`entities × K_shape`, clamped 20..1200). Fail-open throughout; bespoke/low-confidence → existing Haiku depth fallback.
- **Migration `0117`** — additive nullable columns on `DomainDepthEstimate` (`estimated_questions` + corpus provenance). Idempotent; mirrored by an `instrumentation.ts` guard. A NULL row falls back to `coefficient·depth²` **exactly as before**, so this is safe to ship ahead of any backfill.
- **`getTargetQuestionCountForDomains`** now **prefers** `estimated_questions` when present — slots into the existing set-completion machinery, no fork.
- **`upsertCorpusSizeEstimate`** query helper + **`scripts/backfill-domain-size.ts`** (dry-run default) to populate.

### Measured resolver lift (32 real domains)
High-confidence coverage **20/32 (with ~6 confidently-wrong) → 26/32 with zero wrong**; recovered 6 verified fandom hosts (Star Wars 226k, Star Trek 65k, …) and caught a hallucinated host via `siteinfo` verification. The estimate is a **seed** — co-calibration raises it when realized exceeds it (validated: Shakespearean Tragedy 45 > seed 27).

## Test
Typecheck + lint clean; **23 daily tests pass** (existing depth/completion path unchanged); live dry-run resolves real domains correctly.

## Deploy steps (manual)
1. `npm run db:migrate` (or apply `0117` — additive/idempotent).
2. `node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-domain-size.ts --apply` (dry-run first).

Until applied, the reader behaves exactly as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)