### PR TITLE
feat(supply): finiteness state machine + discrepancy alarm (email + dashboard) (D-SUPPLY-FINITENESS-01 #4/#5)

### DIFF
--- a/drizzle/0118_supply_dry_tracking.sql
+++ b/drizzle/0118_supply_dry_tracking.sql
@@ -1,0 +1,19 @@
+-- 0118: dry-round observation counters on DomainDepthEstimate
+-- (D-SUPPLY-FINITENESS-01 #4, the soft/provisional finiteness state machine).
+--
+-- Persists ONLY the raw observations; the supply STATE (filling / soft_finite /
+-- discrepancy / raise_estimate) is derived at read time by classifySupplyState
+-- (src/server/daily/supply-state.ts) so there is no stored state to go stale.
+--  - consecutive_dry_rounds: offered-to-fresh-generation rounds in a row that
+--    yielded zero surviving rows for the domain; reset on any yield.
+--  - last_yield_at: when the domain last produced a surviving row.
+--
+-- Purely additive + idempotent; mirrored by an instrumentation guard.
+--
+-- Rollback:
+--   ALTER TABLE "DomainDepthEstimate"
+--     DROP COLUMN IF EXISTS "consecutive_dry_rounds",
+--     DROP COLUMN IF EXISTS "last_yield_at";
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "consecutive_dry_rounds" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "last_yield_at" timestamp with time zone;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -827,6 +827,13 @@
 			"when": 1786665600000,
 			"tag": "0117_domain_size_estimate",
 			"breakpoints": true
+		},
+		{
+			"idx": 118,
+			"version": "7",
+			"when": 1786752000000,
+			"tag": "0118_supply_dry_tracking",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/app/admin/AdminTabs.tsx
+++ b/src/app/admin/AdminTabs.tsx
@@ -10,7 +10,7 @@ export function AdminTabs({
   active,
   needingReviewCount,
 }: {
-  active: 'crafter' | 'reports' | 'knowledge' | 'questions';
+  active: 'crafter' | 'reports' | 'knowledge' | 'questions' | 'supply';
   needingReviewCount?: number;
 }) {
   const tabClass = 'rounded-md border px-3 py-1.5 text-sm font-medium';
@@ -53,6 +53,14 @@ export function AdminTabs({
         aria-current={active === 'questions' ? 'page' : undefined}
       >
         Questions
+      </Link>
+      <Link
+        href="/admin/supply"
+        className={tabClass}
+        style={active === 'supply' ? activeStyle : idleStyle}
+        aria-current={active === 'supply' ? 'page' : undefined}
+      >
+        Domain supply
       </Link>
     </nav>
   );

--- a/src/app/admin/supply/page.tsx
+++ b/src/app/admin/supply/page.tsx
@@ -1,0 +1,149 @@
+import { notFound } from 'next/navigation';
+
+import { getSession } from '@/server/auth/session';
+import { isAdminUser } from '@/server/auth/admin';
+import { buildSupplyCoverageSummary } from '@/server/daily/supply-coverage';
+import type { SupplyState } from '@/server/daily/supply-state';
+import { AdminTabs } from '../AdminTabs';
+
+export const dynamic = 'force-dynamic';
+
+// D-SUPPLY-FINITENESS-01 #5 — the domain-supply coverage dashboard: per domain,
+// the corpus-grounded size estimate vs realized generation, the dry-round
+// counter, and the derived supply state. Read-only observation surface (the
+// weekly digest email carries the same alarm); classification happens in
+// classifySupplyState so the two surfaces always agree. Same admin gate as
+// every /admin page: ADMIN_USER_IDS or a 404 that doesn't reveal the route.
+
+const STATE_LABEL: Record<SupplyState, string> = {
+  discrepancy: 'Discrepancy',
+  raise_estimate: 'Raise estimate',
+  filling: 'Filling',
+  soft_finite: 'Resting (believed complete)',
+  unsized: 'Unsized',
+};
+
+const STATE_COLOR: Record<SupplyState, string> = {
+  discrepancy: 'var(--danger)',
+  raise_estimate: 'var(--brand-navy)',
+  filling: 'var(--text-muted)',
+  soft_finite: 'var(--text-muted)',
+  unsized: 'var(--text-muted)',
+};
+
+// Alarm-first ordering for the table.
+const STATE_ORDER: SupplyState[] = [
+  'discrepancy',
+  'raise_estimate',
+  'filling',
+  'soft_finite',
+  'unsized',
+];
+
+function pctLabel(ratio: number | null): string {
+  return ratio == null ? '—' : `${Math.round(ratio * 100)}%`;
+}
+
+export default async function AdminSupplyPage() {
+  const session = await getSession();
+  if (!session || !isAdminUser(session.userId)) notFound();
+
+  const summary = await buildSupplyCoverageSummary();
+
+  const ordered = summary
+    ? [...summary.entries].sort((a, b) => {
+        const stateDelta = STATE_ORDER.indexOf(a.state) - STATE_ORDER.indexOf(b.state);
+        if (stateDelta !== 0) return stateDelta;
+        return (a.ratio ?? 1) - (b.ratio ?? 1);
+      })
+    : [];
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <div className="mb-6 flex flex-col gap-4">
+        <AdminTabs active="supply" />
+        <div>
+          <h1 className="text-2xl font-semibold" style={{ color: 'var(--brand-navy)' }}>
+            Domain supply
+          </h1>
+          <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
+            Corpus-grounded size estimate vs realized generation, per domain. A{' '}
+            <strong>discrepancy</strong> is a domain that went dry far short of a trusted
+            estimate — a supply problem, not completion. Resting domains are believed complete
+            and stay re-probeable.
+          </p>
+        </div>
+      </div>
+
+      {!summary ? (
+        <p className="text-sm" style={{ color: 'var(--danger)' }}>
+          Coverage read failed — see server logs ([supply-coverage]).
+        </p>
+      ) : (
+        <>
+          <div className="mb-4 flex flex-wrap gap-3 text-sm" style={{ color: 'var(--text-muted)' }}>
+            <span>
+              <strong style={{ color: 'var(--danger)' }}>{summary.counts.discrepancy}</strong>{' '}
+              discrepancy
+            </span>
+            <span>
+              <strong style={{ color: 'var(--brand-navy)' }}>{summary.counts.raise_estimate}</strong>{' '}
+              raise estimate
+            </span>
+            <span>
+              <strong>{summary.counts.filling}</strong> filling
+            </span>
+            <span>
+              <strong>{summary.counts.soft_finite}</strong> resting
+            </span>
+            <span>
+              <strong>{summary.counts.unsized}</strong> unsized
+            </span>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr
+                  className="border-b text-left"
+                  style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+                >
+                  <th className="py-2 pr-3 font-medium">Domain</th>
+                  <th className="py-2 pr-3 font-medium">State</th>
+                  <th className="py-2 pr-3 text-right font-medium">Have</th>
+                  <th className="py-2 pr-3 text-right font-medium">Est.</th>
+                  <th className="py-2 pr-3 text-right font-medium">Coverage</th>
+                  <th className="py-2 pr-3 text-right font-medium">Dry rounds</th>
+                  <th className="py-2 pr-3 font-medium">Confidence</th>
+                  <th className="py-2 font-medium">Basis</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ordered.map((entry) => (
+                  <tr
+                    key={entry.domainKey}
+                    className="border-b"
+                    style={{ borderColor: 'var(--border-light)' }}
+                  >
+                    <td className="py-2 pr-3">{entry.label}</td>
+                    <td className="py-2 pr-3" style={{ color: STATE_COLOR[entry.state] }}>
+                      {STATE_LABEL[entry.state]}
+                    </td>
+                    <td className="py-2 pr-3 text-right">{entry.realized}</td>
+                    <td className="py-2 pr-3 text-right">{entry.estimatedQuestions ?? '—'}</td>
+                    <td className="py-2 pr-3 text-right">{pctLabel(entry.ratio)}</td>
+                    <td className="py-2 pr-3 text-right">{entry.consecutiveDryRounds}</td>
+                    <td className="py-2 pr-3">{entry.confidence ?? '—'}</td>
+                    <td className="py-2" style={{ color: 'var(--text-muted)' }}>
+                      {entry.basis ?? '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/app/api/cron/llm-cost-report/route.ts
+++ b/src/app/api/cron/llm-cost-report/route.ts
@@ -7,6 +7,7 @@ import {
   writeCostReport,
 } from '@/server/db/queries/llm-cost-report';
 import { sendCostReportEmail } from '@/server/email/send-cost-report';
+import { buildSupplyCoverageSummary } from '@/server/daily/supply-coverage';
 
 export const dynamic = 'force-dynamic';
 
@@ -28,9 +29,15 @@ export async function GET(request: NextRequest) {
     const markdown = renderCostLatencyReportMarkdown(report);
     await writeCostReport(report, markdown);
 
+    // Domain-supply coverage section (D-SUPPLY-FINITENESS-01 #5): discrepancy
+    // domains (dry far short of a trusted corpus estimate) surface here weekly.
+    // buildSupplyCoverageSummary fails open (null → section simply absent), so
+    // it can never block the cost digest.
+    const supply = await buildSupplyCoverageSummary();
+
     // Best-effort email (Decision B3) — a send failure must not fail the stored
     // digest, which is the durable artifact. sendCostReportEmail never throws.
-    const email = await sendCostReportEmail(report, markdown);
+    const email = await sendCostReportEmail(report, markdown, supply);
     if (!email.ok && email.reason === 'send_failed') {
       console.warn('[llm-cost-report] digest stored but email send failed', { message: email.message });
     }
@@ -41,6 +48,8 @@ export async function GET(request: NextRequest) {
       totalUsd: Number(report.totalUsd.toFixed(4)),
       surfaces: report.surfaces.length,
       anyUnpriced: report.anyUnpriced,
+      supplyDiscrepancies: supply ? supply.discrepancies.length : null,
+      supplyDomains: supply ? supply.entries.length : null,
       emailed: email.ok,
       emailSource: email.ok ? email.source : undefined,
       emailReason: email.ok ? undefined : email.reason,

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2128,6 +2128,10 @@ export async function register() {
       await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "wikidata_qid" text`);
       await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "fandom_host" text`);
       await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "resolved_at" timestamp with time zone`);
+      // Migration 0118 (D-SUPPLY-FINITENESS-01 #4): dry-round observation
+      // counters for the supply-state machine. Additive + nullable/defaulted.
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "consecutive_dry_rounds" integer NOT NULL DEFAULT 0`);
+      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "last_yield_at" timestamp with time zone`);
     } catch {
       // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
     }

--- a/src/server/daily/__tests__/supply-coverage.test.ts
+++ b/src/server/daily/__tests__/supply-coverage.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { summarizeSupplyCoverage } from '@/server/daily/supply-coverage';
+import type { DomainSupplyCoverageRow } from '@/server/db/queries/domain-depth-estimate';
+
+function row(overrides: Partial<DomainSupplyCoverageRow>): DomainSupplyCoverageRow {
+  return {
+    domainKey: 'x',
+    sampleLabel: 'X',
+    estimatedQuestions: 100,
+    confidence: 'high',
+    shape: 'abstract_topic',
+    basis: 'wp:sections',
+    source: 'corpus',
+    consecutiveDryRounds: 0,
+    lastYieldAt: null,
+    realized: 10,
+    ...overrides,
+  };
+}
+
+describe('summarizeSupplyCoverage (the shared #5 surface summary)', () => {
+  it('classifies, counts, and sorts discrepancies worst-coverage-first', () => {
+    const summary = summarizeSupplyCoverage([
+      row({ domainKey: 'a', sampleLabel: 'Hamlet', realized: 30, consecutiveDryRounds: 5 }),
+      row({ domainKey: 'b', sampleLabel: 'Wallace Stevens', realized: 3, consecutiveDryRounds: 5 }),
+      row({ domainKey: 'c', sampleLabel: 'Filling', realized: 10, consecutiveDryRounds: 0 }),
+      row({
+        domainKey: 'd',
+        sampleLabel: 'Shakespearean Tragedy',
+        realized: 45,
+        estimatedQuestions: 27,
+      }),
+      row({ domainKey: 'e', sampleLabel: 'Bespoke', estimatedQuestions: null }),
+      row({
+        domainKey: 'f',
+        sampleLabel: 'Wagner',
+        realized: 80,
+        consecutiveDryRounds: 5,
+      }),
+    ]);
+
+    expect(summary.counts).toEqual({
+      discrepancy: 2,
+      raise_estimate: 1,
+      filling: 1,
+      soft_finite: 1,
+      unsized: 1,
+    });
+    // Worst coverage first: Wallace Stevens (3%) before Hamlet (30%).
+    expect(summary.discrepancies.map((entry) => entry.label)).toEqual([
+      'Wallace Stevens',
+      'Hamlet',
+    ]);
+    expect(summary.raiseEstimates.map((entry) => entry.label)).toEqual([
+      'Shakespearean Tragedy',
+    ]);
+    // Ratio is computed for sized rows, null for unsized.
+    expect(summary.discrepancies[0].ratio).toBeCloseTo(0.03);
+    expect(summary.entries.find((entry) => entry.label === 'Bespoke')?.ratio).toBeNull();
+  });
+
+  it('a dry shortfall at low confidence never lands in the alarm list', () => {
+    const summary = summarizeSupplyCoverage([
+      row({ domainKey: 'a', realized: 3, consecutiveDryRounds: 5, confidence: 'low' }),
+    ]);
+    expect(summary.discrepancies).toHaveLength(0);
+    expect(summary.counts.soft_finite).toBe(1);
+  });
+
+  it('empty coverage produces an empty, well-formed summary', () => {
+    const summary = summarizeSupplyCoverage([]);
+    expect(summary.entries).toHaveLength(0);
+    expect(summary.discrepancies).toHaveLength(0);
+    expect(summary.counts.discrepancy).toBe(0);
+  });
+});

--- a/src/server/daily/__tests__/supply-state.test.ts
+++ b/src/server/daily/__tests__/supply-state.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifySupplyState } from '@/server/daily/supply-state';
+
+const base = { realized: 10, estimatedQuestions: 100, confidence: 'high', consecutiveDryRounds: 0 };
+const OPTS = { dryK: 3, nearRatio: 0.7 };
+
+describe('classifySupplyState (the four arrows + gates)', () => {
+  it('unsized: no estimate → never classified, never alarms', () => {
+    expect(classifySupplyState({ ...base, estimatedQuestions: null }, OPTS)).toBe('unsized');
+    expect(classifySupplyState({ ...base, estimatedQuestions: 0 }, OPTS)).toBe('unsized');
+  });
+
+  it('filling: yielding and below the estimate (the normal state)', () => {
+    expect(classifySupplyState({ ...base, consecutiveDryRounds: 2 }, OPTS)).toBe('filling');
+  });
+
+  it('raise_estimate: still yielding PAST the estimate → co-calibration corrects upward', () => {
+    // The measured Shakespearean Tragedy case: realized 45 > seed 27, not dry.
+    expect(
+      classifySupplyState(
+        { realized: 45, estimatedQuestions: 27, confidence: 'high', consecutiveDryRounds: 0 },
+        OPTS,
+      ),
+    ).toBe('raise_estimate');
+  });
+
+  it('soft_finite: dry at ~the estimate → believed complete, resting, re-probeable', () => {
+    expect(
+      classifySupplyState(
+        { realized: 75, estimatedQuestions: 100, confidence: 'high', consecutiveDryRounds: 3 },
+        OPTS,
+      ),
+    ).toBe('soft_finite');
+    // dry AND past the estimate is completion, not a raise signal
+    expect(
+      classifySupplyState(
+        { realized: 110, estimatedQuestions: 100, confidence: 'high', consecutiveDryRounds: 5 },
+        OPTS,
+      ),
+    ).toBe('soft_finite');
+  });
+
+  it('discrepancy: dry FAR short of a high-confidence estimate → alarm, never finalize', () => {
+    expect(
+      classifySupplyState(
+        { realized: 10, estimatedQuestions: 100, confidence: 'high', consecutiveDryRounds: 3 },
+        OPTS,
+      ),
+    ).toBe('discrepancy');
+  });
+
+  it('confidence gate: the same dry shortfall at medium/low confidence rests instead of alarming', () => {
+    for (const confidence of ['medium', 'low', null]) {
+      expect(
+        classifySupplyState(
+          { realized: 10, estimatedQuestions: 100, confidence, consecutiveDryRounds: 3 },
+          OPTS,
+        ),
+      ).toBe('soft_finite');
+    }
+  });
+
+  it('dry threshold K is the boundary', () => {
+    const shortfall = { realized: 10, estimatedQuestions: 100, confidence: 'high' };
+    expect(classifySupplyState({ ...shortfall, consecutiveDryRounds: 2 }, OPTS)).toBe('filling');
+    expect(classifySupplyState({ ...shortfall, consecutiveDryRounds: 3 }, OPTS)).toBe('discrepancy');
+  });
+});

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -47,6 +47,7 @@ import {
   type RecentFactKeyEntry,
 } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
+import { recordSupplyYieldObservation } from '@/server/db/queries/domain-depth-estimate';
 import { getCulturalAnchor, type CulturalAnchor } from '@/server/db/queries/account';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
 import { adminUserIds } from '@/server/auth/admin';
@@ -2444,6 +2445,23 @@ export async function generateDailyQuestionsFromKnowledgeBase(
         domainReferences,
       },
     );
+
+    // Dry-round observation (D-SUPPLY-FINITENESS-01 #4): of the domains OFFERED
+    // to fresh generation this round, which yielded a surviving row and which
+    // came back empty? Feeds the consecutive_dry_rounds counter the supply-state
+    // machine reads (K in a row → provisionally dry). Matched on the folded
+    // domain_key because the persist path reconciles labels. Fire-and-forget
+    // telemetry: never blocks or fails the build.
+    try {
+      const yieldedKeys = new Set(llmGenerated.map((row) => domainKey(row.canonicalSubcategory)));
+      const offeredKeys = [...new Set(domainsForLlm.map((domain) => domainKey(domain)))];
+      void recordSupplyYieldObservation({
+        yieldedDomainKeys: [...yieldedKeys],
+        dryDomainKeys: offeredKeys.filter((key) => !yieldedKeys.has(key)),
+      }).catch(() => {});
+    } catch {
+      // observation-only
+    }
   }
 
   return [...bankPicks, ...llmGenerated];

--- a/src/server/daily/supply-coverage.ts
+++ b/src/server/daily/supply-coverage.ts
@@ -1,0 +1,97 @@
+import {
+  getDomainSupplyCoverage,
+  type DomainSupplyCoverageRow,
+} from '@/server/db/queries/domain-depth-estimate';
+import { classifySupplyState, type SupplyState } from '@/server/daily/supply-state';
+
+/**
+ * Shared coverage summary for the supply-state machine's two surfaces
+ * (D-SUPPLY-FINITENESS-01 #5): the weekly cost digest email and the
+ * /admin/supply dashboard. One classification pass so both surfaces always
+ * agree on what is alarming.
+ */
+
+export interface SupplyCoverageEntry {
+  domainKey: string;
+  label: string;
+  state: SupplyState;
+  realized: number;
+  estimatedQuestions: number | null;
+  /** realized / estimate; null when unsized. */
+  ratio: number | null;
+  confidence: string | null;
+  shape: string | null;
+  basis: string | null;
+  consecutiveDryRounds: number;
+  lastYieldAt: Date | null;
+}
+
+export interface SupplyCoverageSummary {
+  entries: SupplyCoverageEntry[];
+  /** Dry far short of a HIGH-confidence estimate — the alarm list, worst first. */
+  discrepancies: SupplyCoverageEntry[];
+  /** Still yielding past the estimate — co-calibration should raise these. */
+  raiseEstimates: SupplyCoverageEntry[];
+  counts: Record<SupplyState, number>;
+}
+
+export function summarizeSupplyCoverage(
+  rows: DomainSupplyCoverageRow[],
+): SupplyCoverageSummary {
+  const entries: SupplyCoverageEntry[] = rows.map((row) => {
+    const state = classifySupplyState({
+      realized: row.realized,
+      estimatedQuestions: row.estimatedQuestions,
+      confidence: row.confidence,
+      consecutiveDryRounds: row.consecutiveDryRounds,
+    });
+    return {
+      domainKey: row.domainKey,
+      label: row.sampleLabel ?? row.domainKey,
+      state,
+      realized: row.realized,
+      estimatedQuestions: row.estimatedQuestions,
+      ratio:
+        row.estimatedQuestions && row.estimatedQuestions > 0
+          ? row.realized / row.estimatedQuestions
+          : null,
+      confidence: row.confidence,
+      shape: row.shape,
+      basis: row.basis,
+      consecutiveDryRounds: row.consecutiveDryRounds,
+      lastYieldAt: row.lastYieldAt,
+    };
+  });
+
+  const counts: Record<SupplyState, number> = {
+    unsized: 0,
+    filling: 0,
+    raise_estimate: 0,
+    soft_finite: 0,
+    discrepancy: 0,
+  };
+  for (const entry of entries) counts[entry.state] += 1;
+
+  const bySeverity = (a: SupplyCoverageEntry, b: SupplyCoverageEntry) =>
+    (a.ratio ?? 1) - (b.ratio ?? 1);
+  return {
+    entries,
+    discrepancies: entries.filter((entry) => entry.state === 'discrepancy').sort(bySeverity),
+    raiseEstimates: entries
+      .filter((entry) => entry.state === 'raise_estimate')
+      .sort((a, b) => (b.ratio ?? 0) - (a.ratio ?? 0)),
+    counts,
+  };
+}
+
+/** Fetch + classify. Fail-open: callers treat null as "no section this week". */
+export async function buildSupplyCoverageSummary(): Promise<SupplyCoverageSummary | null> {
+  try {
+    return summarizeSupplyCoverage(await getDomainSupplyCoverage());
+  } catch (error) {
+    console.warn('[supply-coverage] failed to build summary (fail-open)', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}

--- a/src/server/daily/supply-state.ts
+++ b/src/server/daily/supply-state.ts
@@ -1,0 +1,77 @@
+/**
+ * Soft/provisional finiteness state machine (D-SUPPLY-FINITENESS-01 #4).
+ *
+ * Classifies each domain's SUPPLY STATE by reconciling observed generation
+ * yield (the dry-round counter) against the corpus-grounded size estimate
+ * (DomainDepthEstimate.estimated_questions, #3). Pure and derived AT READ TIME —
+ * no stored state to go stale; the DB persists only the raw observations
+ * (consecutive_dry_rounds, last_yield_at).
+ *
+ * The four arrows (agreed with Josh, 2026-07-07):
+ *  - not dry, realized <  estimate → `filling`        (normal; keep generating)
+ *  - not dry, realized >= estimate → `raise_estimate` (still yielding past the
+ *      seed — the estimate was too low; co-calibration corrects it UPWARD)
+ *  - dry,     realized ≈  estimate → `soft_finite`    (believed complete;
+ *      resting + re-probeable — NEVER a tombstone)
+ *  - dry,     realized ≪  estimate → `discrepancy`    (the generator quit far
+ *      short of a trusted corpus size — a supply problem, NOT completion;
+ *      surfaces in the weekly email + admin dashboard, never auto-finalizes)
+ *
+ * Confidence gate: `discrepancy` requires a HIGH-confidence resolution — a
+ * low/medium-confidence estimate can rest a domain (soft_finite) but can never
+ * fire the alarm off a possibly-wrong anchor. Unsized domains (bespoke/depth
+ * fallback) are `unsized` and never alarm.
+ *
+ * "Dry" = K consecutive generation rounds where the domain was OFFERED to fresh
+ * generation and zero rows survived the gates. Deliberately provisional: the
+ * palette sampler and the model's own domain choice make single observations
+ * noisy, so K absorbs noise and soft_finite stays re-probeable by design.
+ */
+
+export type SupplyState =
+  | 'unsized'
+  | 'filling'
+  | 'raise_estimate'
+  | 'soft_finite'
+  | 'discrepancy';
+
+function numEnv(name: string, fallback: number): number {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+}
+
+/** Consecutive zero-yield offered rounds before a domain reads as dry. */
+export const dryRoundsThreshold = (): number => Math.round(numEnv('SUPPLY_DRY_ROUNDS_K', 3));
+
+/** realized/estimate ratio at or above which a dry domain reads as complete. */
+export const nearCompleteRatio = (): number => numEnv('SUPPLY_NEAR_COMPLETE_RATIO', 0.7);
+
+export interface SupplyObservation {
+  /** Distinct facts actually generated for the domain (bank-wide). */
+  realized: number;
+  /** Corpus-grounded size estimate; null = unsized (bespoke/depth fallback). */
+  estimatedQuestions: number | null;
+  /** Resolution confidence from the size estimator ('high' | 'medium' | 'low' | null). */
+  confidence: string | null;
+  /** Consecutive offered-but-zero-yield generation rounds. */
+  consecutiveDryRounds: number;
+}
+
+export function classifySupplyState(
+  observation: SupplyObservation,
+  opts?: { dryK?: number; nearRatio?: number },
+): SupplyState {
+  const { realized, estimatedQuestions, confidence, consecutiveDryRounds } = observation;
+  if (estimatedQuestions == null || estimatedQuestions <= 0) return 'unsized';
+
+  const dry = consecutiveDryRounds >= (opts?.dryK ?? dryRoundsThreshold());
+  if (!dry) {
+    return realized >= estimatedQuestions ? 'raise_estimate' : 'filling';
+  }
+
+  if (realized >= (opts?.nearRatio ?? nearCompleteRatio()) * estimatedQuestions) {
+    return 'soft_finite';
+  }
+  // Dry far short of the estimate. Only a trusted anchor may alarm.
+  return confidence === 'high' ? 'discrepancy' : 'soft_finite';
+}

--- a/src/server/db/queries/domain-depth-estimate.ts
+++ b/src/server/db/queries/domain-depth-estimate.ts
@@ -1,9 +1,9 @@
 // D-DIFFICULTY-SIZE-COMPLETION-01 — read/write for the cached topic depth score
 // (DomainDepthEstimate, migration 0116). Keyed on the folded domain_key so it
 // covers every played canonical_subcategory, not just authored KnowledgeNodes.
-import { inArray } from 'drizzle-orm';
+import { eq, inArray, isNotNull, sql } from 'drizzle-orm';
 
-import { db, domainDepthEstimates } from '@/server/db';
+import { db, domainDepthEstimates, generatedQuestions } from '@/server/db';
 
 export type DepthEstimateRow = {
   domainKey: string;
@@ -98,4 +98,83 @@ export async function upsertCorpusSizeEstimate(input: {
     .insert(domainDepthEstimates)
     .values({ domainKey: input.domainKey, ...set })
     .onConflictDoUpdate({ target: domainDepthEstimates.domainKey, set });
+}
+
+/**
+ * Dry-round observation write (0118, D-SUPPLY-FINITENESS-01 #4). After a fresh
+ * generation round, reset the counter (+ stamp last_yield_at) for domains that
+ * yielded a surviving row, and increment it for domains that were OFFERED to
+ * the model but yielded nothing. UPDATE-only: a domain with no estimate row yet
+ * simply isn't observed (it gets a row lazily via the sizing paths). Fire-and-
+ * forget telemetry — callers void+catch; a miss never touches generation.
+ */
+export async function recordSupplyYieldObservation(input: {
+  yieldedDomainKeys: string[];
+  dryDomainKeys: string[];
+}): Promise<void> {
+  const yielded = [...new Set(input.yieldedDomainKeys)].filter(Boolean);
+  const dry = [...new Set(input.dryDomainKeys)].filter(Boolean)
+    .filter((key) => !yielded.includes(key));
+  if (yielded.length > 0) {
+    await db
+      .update(domainDepthEstimates)
+      .set({ consecutiveDryRounds: 0, lastYieldAt: new Date() })
+      .where(inArray(domainDepthEstimates.domainKey, yielded));
+  }
+  if (dry.length > 0) {
+    await db
+      .update(domainDepthEstimates)
+      .set({ consecutiveDryRounds: sql`${domainDepthEstimates.consecutiveDryRounds} + 1` })
+      .where(inArray(domainDepthEstimates.domainKey, dry));
+  }
+}
+
+export type DomainSupplyCoverageRow = {
+  domainKey: string;
+  sampleLabel: string | null;
+  estimatedQuestions: number | null;
+  confidence: string | null;
+  shape: string | null;
+  basis: string | null;
+  source: string;
+  consecutiveDryRounds: number;
+  lastYieldAt: Date | null;
+  /** Distinct facts generated for the domain, bank-wide (all users). */
+  realized: number;
+};
+
+/**
+ * Coverage read for the supply-state machine's two surfaces (weekly digest +
+ * admin dashboard, D-SUPPLY-FINITENESS-01 #5): every sized domain joined with
+ * its REALIZED distinct-fact count from the shared bank. State classification
+ * happens in TS (classifySupplyState) so the query stays pure observation.
+ */
+export async function getDomainSupplyCoverage(): Promise<DomainSupplyCoverageRow[]> {
+  const realized = db.$with('realized').as(
+    db
+      .select({
+        domainKey: generatedQuestions.domainKey,
+        realized: sql<number>`count(distinct ${generatedQuestions.factKey})::int`.as('realized'),
+      })
+      .from(generatedQuestions)
+      .where(isNotNull(generatedQuestions.factKey))
+      .groupBy(generatedQuestions.domainKey),
+  );
+  const rows = await db
+    .with(realized)
+    .select({
+      domainKey: domainDepthEstimates.domainKey,
+      sampleLabel: domainDepthEstimates.sampleLabel,
+      estimatedQuestions: domainDepthEstimates.estimatedQuestions,
+      confidence: domainDepthEstimates.confidence,
+      shape: domainDepthEstimates.shape,
+      basis: domainDepthEstimates.basis,
+      source: domainDepthEstimates.source,
+      consecutiveDryRounds: domainDepthEstimates.consecutiveDryRounds,
+      lastYieldAt: domainDepthEstimates.lastYieldAt,
+      realized: sql<number>`coalesce(${realized.realized}, 0)::int`,
+    })
+    .from(domainDepthEstimates)
+    .leftJoin(realized, eq(realized.domainKey, domainDepthEstimates.domainKey));
+  return rows;
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1771,6 +1771,11 @@ export const domainDepthEstimates = pgTable(
     wikidataQid: text('wikidata_qid'),
     fandomHost: text('fandom_host'),
     resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+    // Dry-round observations (0118, D-SUPPLY-FINITENESS-01 #4). Raw counters
+    // only — the supply STATE is derived at read time by classifySupplyState
+    // (src/server/daily/supply-state.ts), so nothing stored can go stale.
+    consecutiveDryRounds: integer('consecutive_dry_rounds').notNull().default(0),
+    lastYieldAt: timestamp('last_yield_at', { withTimezone: true }),
     computedAt: timestamp('computed_at', { withTimezone: true }).notNull().defaultNow(),
     createdAt: createdAt(),
   },

--- a/src/server/email/send-cost-report.ts
+++ b/src/server/email/send-cost-report.ts
@@ -4,6 +4,8 @@ import {
   type CostReportRecipient,
 } from '@/server/db/queries/llm-cost-report';
 
+import type { SupplyCoverageSummary } from '@/server/daily/supply-coverage';
+
 import { sendEmail } from './client';
 import { buildCostReportEmailTemplate } from './templates/llm-cost-report';
 
@@ -25,6 +27,9 @@ export type SendCostReportEmailResult =
 export async function sendCostReportEmail(
   report: CostLatencyReport,
   markdown: string,
+  // Domain-supply coverage (D-SUPPLY-FINITENESS-01 #5); optional + null-safe so
+  // a coverage failure never blocks the cost digest.
+  supply?: SupplyCoverageSummary | null,
 ): Promise<SendCostReportEmailResult> {
   const recipient = await resolveCostReportRecipient();
   if (!recipient) {
@@ -35,7 +40,7 @@ export async function sendCostReportEmail(
     };
   }
 
-  const template = buildCostReportEmailTemplate({ report, markdown });
+  const template = buildCostReportEmailTemplate({ report, markdown, supply });
   const sendResult = await sendEmail({
     to: recipient.to,
     subject: template.subject,

--- a/src/server/email/templates/llm-cost-report.ts
+++ b/src/server/email/templates/llm-cost-report.ts
@@ -1,4 +1,5 @@
 import type { CostLatencyReport } from '@/server/db/queries/llm-cost-report';
+import type { SupplyCoverageSummary } from '@/server/daily/supply-coverage';
 
 /**
  * Email template for the weekly LLM cost & latency digest
@@ -77,9 +78,88 @@ function td(value: string, align: 'left' | 'right'): string {
   return `<td align="${align}" style="font-family:${SERIF};font-size:15px;color:${INK};padding:6px 0;border-bottom:1px solid ${RULE};">${value}</td>`;
 }
 
+// Domain-supply section (D-SUPPLY-FINITENESS-01 #5). Alarm-first: discrepancy
+// domains (generation went dry FAR short of a trusted corpus estimate — a
+// supply problem, not completion) lead; raise-estimate (still yielding past the
+// seed) follows; the healthy states are one summary line. Renders nothing when
+// the summary is absent (coverage read failed — fail-open) or empty.
+function supplySectionHtml(supply: SupplyCoverageSummary | null | undefined): string {
+  if (!supply || supply.entries.length === 0) return '';
+  const { counts, discrepancies, raiseEstimates } = supply;
+
+  const discRows = discrepancies
+    .slice(0, 8)
+    .map((entry) => {
+      const est = entry.estimatedQuestions == null ? '—' : num(entry.estimatedQuestions);
+      const ratio = entry.ratio == null ? '—' : pct(entry.ratio);
+      return `<tr>${td(escapeHtml(entry.label), 'left')}${td(num(entry.realized), 'right')}${td(est, 'right')}${td(ratio, 'right')}</tr>`;
+    })
+    .join('');
+
+  const raiseLine =
+    raiseEstimates.length > 0
+      ? `<tr><td style="font-family:${SERIF};font-size:14px;color:${INK_SOFT};padding:8px 0 0;">Estimate too low (still yielding past it): ${raiseEstimates
+          .slice(0, 5)
+          .map((entry) => escapeHtml(entry.label))
+          .join(', ')}${raiseEstimates.length > 5 ? ` +${raiseEstimates.length - 5} more` : ''}.</td></tr>`
+      : '';
+
+  const healthyLine = `<tr><td style="font-family:${SANS};font-size:12px;color:${INK_FAINT};padding-top:10px;">${num(
+    counts.filling,
+  )} filling · ${num(counts.soft_finite)} resting (believed complete) · ${num(
+    counts.unsized,
+  )} unsized</td></tr>`;
+
+  const discBlock =
+    discrepancies.length > 0
+      ? `<tr><td style="font-family:${SERIF};font-size:15px;line-height:1.5;color:${INK};padding-bottom:8px;"><strong>${num(
+          discrepancies.length,
+        )} domain${discrepancies.length === 1 ? '' : 's'} went dry far short of a trusted size estimate</strong> — a supply problem, not completion. Worst first:</td></tr>
+      <tr><td>
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+          <tr>${th('Domain', 'left')}${th('Have', 'right')}${th('Est.', 'right')}${th('Coverage', 'right')}</tr>
+          ${discRows}
+        </table>
+      </td></tr>`
+      : `<tr><td style="font-family:${SERIF};font-size:15px;color:${INK_SOFT};">No supply discrepancies — no domain is dry while far short of a trusted estimate.</td></tr>`;
+
+  return `${eyebrow('Domain supply')}${discBlock}${raiseLine}${healthyLine}`;
+}
+
+// Plain-text twin of the section, appended to the markdown body so the text
+// part carries the same alarm (the STORED cost-report artifact is unchanged).
+function supplySectionText(supply: SupplyCoverageSummary | null | undefined): string {
+  if (!supply || supply.entries.length === 0) return '';
+  const lines: string[] = ['', '## Domain supply', ''];
+  if (supply.discrepancies.length > 0) {
+    lines.push(
+      `${supply.discrepancies.length} domain(s) went dry far short of a trusted size estimate (supply problem, not completion):`,
+    );
+    for (const entry of supply.discrepancies.slice(0, 8)) {
+      lines.push(
+        `- ${entry.label}: ${entry.realized}/${entry.estimatedQuestions ?? '—'} (${
+          entry.ratio == null ? '—' : `${Math.round(entry.ratio * 100)}%`
+        }), dry ${entry.consecutiveDryRounds} rounds`,
+      );
+    }
+  } else {
+    lines.push('No supply discrepancies.');
+  }
+  if (supply.raiseEstimates.length > 0) {
+    lines.push(
+      `Estimate too low (raise): ${supply.raiseEstimates.map((entry) => entry.label).join(', ')}`,
+    );
+  }
+  lines.push(
+    `${supply.counts.filling} filling · ${supply.counts.soft_finite} resting · ${supply.counts.unsized} unsized`,
+  );
+  return lines.join('\n');
+}
+
 export function buildCostReportEmailTemplate(params: {
   report: CostLatencyReport;
   markdown: string;
+  supply?: SupplyCoverageSummary | null;
 }): { subject: string; html: string; text: string } {
   const { report: r, markdown } = params;
   const range = `${fmtDate(r.periodStart)}–${fmtDate(r.periodEnd)}`;
@@ -166,6 +246,8 @@ export function buildCostReportEmailTemplate(params: {
                   : ''
               }
 
+              ${supplySectionHtml(params.supply)}
+
               ${unpricedNote}
             </table>
           </td></tr>
@@ -175,5 +257,5 @@ export function buildCostReportEmailTemplate(params: {
   </body>
 </html>`;
 
-  return { subject, html, text: markdown };
+  return { subject, html, text: markdown + supplySectionText(params.supply) };
 }


### PR DESCRIPTION
## What

The last two components of the supply redesign: the **soft/provisional finiteness state machine** (#4) and the **discrepancy alarm on both agreed surfaces** (#5). Stacked on #1446 (replenish + never-repeat) and includes #1445 (corpus size estimate) via merge — **review just the top commit**; the PR base is the #1446 branch so the diff stays scoped.

## #4 — finiteness, derived at read time

No stored state to go stale: the DB persists only raw observations. Migration `0118` adds `consecutive_dry_rounds` + `last_yield_at` to `DomainDepthEstimate`, maintained by a fire-and-forget hook at the generation tail (domains **offered** to fresh generation vs rows that **survived**, matched on the folded `domain_key`).

`classifySupplyState` (pure, unit-tested) reconciles dryness against the corpus estimate — the four agreed arrows:

| Observation | State |
|---|---|
| not dry, realized < est | `filling` (normal) |
| not dry, realized ≥ est | `raise_estimate` (co-calibration corrects **upward**) |
| dry, realized ≈ est | `soft_finite` (resting, re-probeable — never a tombstone) |
| dry, realized ≪ est | **`discrepancy`** (supply problem, NOT completion) |

**Confidence gate:** `discrepancy` requires a high-confidence resolution — a low/medium estimate can rest a domain but can never fire the alarm. Env-tunable: `SUPPLY_DRY_ROUNDS_K=3`, `SUPPLY_NEAR_COMPLETE_RATIO=0.7`. **Observation-only — generation behavior unchanged.**

## #5 — the alarm, on both surfaces

One shared summary (`buildSupplyCoverageSummary`, fail-open) so the surfaces always agree:
- **Weekly digest email** (`llm-cost-report`): new "Domain supply" section — discrepancy domains worst-coverage-first, raise-estimate list, healthy counts. The *stored* markdown artifact is unchanged.
- **`/admin/supply`**: read-only coverage dashboard (state / have / est / coverage / dry rounds / confidence / basis), alarm-first ordering; new AdminTabs entry.

## Test
13 new tests (state-machine arrows + confidence/K gates; summary classification + severity sorting). Daily + queries + email suites: **538 pass**. Typecheck, lint, and all four ratchets clean.

## Deploy
Migration `0118` is additive + idempotent (guard mirrored in instrumentation.ts). No flags: the counters are telemetry; the alarm only surfaces where an estimate exists (104 domains populated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)