### PR TITLE
feat(admin): nest action, unfiled areas, knowledge+supply population unification

### DIFF
--- a/src/app/admin/domains/DomainMergeClient.tsx
+++ b/src/app/admin/domains/DomainMergeClient.tsx
@@ -278,9 +278,14 @@ export function DomainMergeClient({ pairs }: { pairs: FragmentationPair[] }) {
   );
 }
 
-// One candidate pair: the two labels with their question counts and a per-side
-// "see questions" peek, a recommended survivor (by count), and the Keep/Leave
-// decision. Peek state is per-row, so a component (not an inline map) is needed.
+// One candidate pair: the two labels with their question counts, an "in graph"
+// chip (merge candidates are RAW corpus labels — most have no KnowledgeNode,
+// which is why they don't appear on the knowledge-graph page), a per-side
+// "see questions" peek, a recommended survivor (by count), and the decision.
+// Three decisions, not two: same scope → Keep one (merge); CONTAINMENT (a work
+// inside its series/genre) → Nest, which authors both into the graph and draws
+// the edge — the pair then stops appearing here; unrelated → Leave.
+// Peek/nest state is per-row, so a component (not an inline map) is needed.
 function PairRow({
   pair,
   choice,
@@ -292,10 +297,43 @@ function PairRow({
   isConflict: boolean;
   onChoose: (choice: Choice) => void;
 }) {
+  const router = useRouter();
   const [peek, setPeek] = useState<'A' | 'B' | null>(null);
+  const [nesting, setNesting] = useState(false);
+  const [nestError, setNestError] = useState<string | null>(null);
   const recommended = recommendedSurvivor(pair);
 
-  const side = (which: 'A' | 'B', label: string, depth: number) => (
+  // Containment decision: child nests under parent. Nodes are created for
+  // labels not yet in the graph; on success the refresh drops the pair (the
+  // candidate query filters connected pairs).
+  async function nest(childLabel: string, parentLabel: string) {
+    if (nesting) return;
+    setNesting(true);
+    setNestError(null);
+    try {
+      const res = await fetch('/api/admin/domain-merges', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'nest', childLabel, parentLabel }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        setNestError(
+          body?.error === 'self_edge'
+            ? 'That nesting would loop — check the direction.'
+            : `Nest failed (${res.status}).`,
+        );
+        return;
+      }
+      router.refresh();
+    } catch {
+      setNestError('Nest failed — nothing was changed.');
+    } finally {
+      setNesting(false);
+    }
+  }
+
+  const side = (which: 'A' | 'B', label: string, depth: number, hasNode: boolean) => (
     <td className="py-2 pr-3 align-top">
       <div className="flex flex-col gap-0.5">
         <span>
@@ -309,6 +347,23 @@ function PairRow({
               ★ keep
             </span>
           ) : null}
+          {hasNode ? (
+            <span
+              className="ml-1.5 whitespace-nowrap rounded-sm border px-1 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
+              style={{ borderColor: 'var(--success)', color: 'var(--success)' }}
+              title="This label has an authored territory on the Knowledge graph page"
+            >
+              in graph
+            </span>
+          ) : (
+            <span
+              className="ml-1.5 whitespace-nowrap rounded-sm border px-1 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
+              style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+              title="A raw question label — not in the knowledge graph. Nest or merge adds it."
+            >
+              label only
+            </span>
+          )}
         </span>
         <button
           type="button"
@@ -329,8 +384,8 @@ function PairRow({
         className="border-b align-top"
         style={{ borderColor: 'var(--border)', background: isConflict ? 'rgba(220,50,50,0.06)' : undefined }}
       >
-        {side('A', pair.domainA, pair.depthA)}
-        {side('B', pair.domainB, pair.depthB)}
+        {side('A', pair.domainA, pair.depthA, pair.hasNodeA)}
+        {side('B', pair.domainB, pair.depthB, pair.hasNodeB)}
         <td className="py-2 pr-3 text-right align-top" style={{ color: 'var(--text-muted)' }}>
           {pct(pair.similarity)}
         </td>
@@ -346,6 +401,34 @@ function PairRow({
               Leave
             </ChoiceButton>
           </div>
+          {/* Containment path — immediate (not part of the merge batch). */}
+          <div className="mt-1.5 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void nest(pair.domainA, pair.domainB)}
+              disabled={nesting}
+              className="rounded-md border px-2.5 py-1 text-xs font-medium disabled:opacity-40"
+              style={{ borderColor: 'var(--success)', color: 'var(--success)' }}
+              title={`Parent/child, not duplicates: put “${pair.domainA}” INSIDE “${pair.domainB}” on the knowledge graph (both get territories; the pair leaves this list)`}
+            >
+              {nesting ? 'Nesting…' : 'A under B'}
+            </button>
+            <button
+              type="button"
+              onClick={() => void nest(pair.domainB, pair.domainA)}
+              disabled={nesting}
+              className="rounded-md border px-2.5 py-1 text-xs font-medium disabled:opacity-40"
+              style={{ borderColor: 'var(--success)', color: 'var(--success)' }}
+              title={`Parent/child, not duplicates: put “${pair.domainB}” INSIDE “${pair.domainA}” on the knowledge graph (both get territories; the pair leaves this list)`}
+            >
+              B under A
+            </button>
+          </div>
+          {nestError ? (
+            <p className="mt-1 text-xs" style={{ color: 'var(--danger)' }}>
+              {nestError}
+            </p>
+          ) : null}
         </td>
       </tr>
       {peek ? (

--- a/src/app/admin/domains/page.tsx
+++ b/src/app/admin/domains/page.tsx
@@ -33,16 +33,17 @@ export default async function AdminDomainsPage() {
             Domain merges
           </h1>
           <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
-            Near-duplicate domain labels the auto-reconcile left for a human call. If a pair is the{' '}
-            <strong>same scope</strong>, pick which spelling survives — the other folds into it
-            everywhere. If they are genuinely different (a specific work vs its genre, two
-            siblings), leave the pair. Each side shows its question count and a{' '}
-            <strong>see</strong> link to peek at the actual questions before you decide; the{' '}
-            <strong>★ keep</strong> tag marks the side that holds more (folding into it moves the
-            fewest rows). <strong>Preview</strong> shows the exact rows that would move before
-            anything changes. The knowledge graph follows automatically: if a folded label has a
-            graph node, its edges and structure move with it (same engine as the tree&apos;s
-            “Merge into…”).
+            Candidates here are <strong>raw labels from the question corpus</strong> — what the
+            categorizer filed questions under — paired by spelling similarity. Most are not on the
+            Knowledge graph page (that shows only territories you authored; the chips mark which
+            is which). Three calls per pair: <strong>same scope</strong> → pick which spelling
+            survives (the other folds into it everywhere, graph included);{' '}
+            <strong>parent/child</strong> (a work inside its series or genre) →{' '}
+            <strong>Nest</strong> it — both labels become graph territories with the edge drawn,
+            and the pair leaves this list; genuinely unrelated → leave it. Each side shows its
+            question count and a <strong>see</strong> peek; <strong>★ keep</strong> marks the side
+            holding more questions; <strong>Preview</strong> shows the exact rows a merge would
+            move before anything changes.
           </p>
         </div>
       </div>

--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -55,6 +55,52 @@ export type UnfiledArea = {
   exhausted: boolean;
 };
 
+// The supply lens for one area ("knowledge graph and domain supply should have
+// the same information") — the same classification the supply table shows,
+// rendered as a compact readout on every row here, linking to the full row.
+export type SupplyReadout = {
+  state: 'unsized' | 'filling' | 'raise_estimate' | 'soft_finite' | 'discrepancy';
+  realized: number;
+  estimatedQuestions: number | null;
+  ratio: number | null;
+  capped: boolean;
+};
+
+const SUPPLY_STATE_TEXT: Record<SupplyReadout['state'], string> = {
+  discrepancy: '⚠ discrepancy',
+  raise_estimate: 'raise estimate',
+  filling: 'filling',
+  soft_finite: 'resting',
+  unsized: 'unsized',
+};
+
+function SupplyChip({ domainKeyValue, supply }: { domainKeyValue: string; supply?: SupplyReadout }) {
+  if (!supply) return null;
+  const tone =
+    supply.capped || supply.state === 'discrepancy'
+      ? 'var(--danger)'
+      : supply.state === 'raise_estimate'
+        ? 'var(--brand-navy)'
+        : 'var(--text-muted)';
+  const text = supply.capped
+    ? `⛔ capped · ${supply.realized} made`
+    : supply.estimatedQuestions != null
+      ? `${SUPPLY_STATE_TEXT[supply.state]} · ${supply.realized}/${supply.estimatedQuestions}${
+          supply.ratio != null ? ` (${Math.round(supply.ratio * 100)}%)` : ''
+        }`
+      : `unsized · ${supply.realized} made`;
+  return (
+    <a
+      href={`/admin/supply#supply-${domainKeyValue}`}
+      className="underline-offset-2 hover:underline"
+      style={{ color: tone }}
+      title="Generation supply for this exact area (made / estimated) — tap for its full supply row: estimate basis, dry rounds, cap and re-size actions"
+    >
+      supply: {text} →
+    </a>
+  );
+}
+
 export function KnowledgeAdminClient({
   nodes,
   edges,
@@ -63,6 +109,7 @@ export function KnowledgeAdminClient({
   genStatsByKey,
   exhaustedByKey,
   unfiled,
+  supplyByKey,
 }: {
   nodes: KnowledgeNodeRow[];
   edges: KnowledgeEdgeRow[];
@@ -71,6 +118,7 @@ export function KnowledgeAdminClient({
   genStatsByKey: Record<string, { total: number; dupes: number }>;
   exhaustedByKey: Record<string, { self: boolean; descendants: number }>;
   unfiled: UnfiledArea[];
+  supplyByKey: Record<string, SupplyReadout>;
 }) {
   const router = useRouter();
 
@@ -104,10 +152,11 @@ export function KnowledgeAdminClient({
         pointsByKey={pointsByKey}
         genStatsByKey={genStatsByKey}
         exhaustedByKey={exhaustedByKey}
+        supplyByKey={supplyByKey}
         onDone={() => router.refresh()}
       />
 
-      <UnfiledAreas unfiled={unfiled} onDone={() => router.refresh()} />
+      <UnfiledAreas unfiled={unfiled} supplyByKey={supplyByKey} onDone={() => router.refresh()} />
 
       {/* Only the two tools with NO tree equivalent live here: the orphan
           check (structural gaps at a glance) and the edge composer (typed
@@ -186,6 +235,7 @@ function KnowledgeTreeEditor({
   pointsByKey,
   genStatsByKey,
   exhaustedByKey,
+  supplyByKey,
   onDone,
 }: {
   nodes: KnowledgeNodeRow[];
@@ -194,6 +244,7 @@ function KnowledgeTreeEditor({
   pointsByKey: Record<string, number>;
   genStatsByKey: Record<string, { total: number; dupes: number }>;
   exhaustedByKey: Record<string, { self: boolean; descendants: number }>;
+  supplyByKey: Record<string, SupplyReadout>;
   onDone: () => void;
 }) {
   const nodeByKey = useMemo(() => new Map(nodes.map((n) => [n.domainKey, n])), [nodes]);
@@ -771,6 +822,7 @@ function KnowledgeTreeEditor({
                 pointsByKey={pointsByKey}
                 genStatsByKey={genStatsByKey}
                 exhaustedByKey={exhaustedByKey}
+                supplyByKey={supplyByKey}
                 childrenByParent={childrenByParent}
                 parentCountByChild={parentCountByChild}
                 parentsByChild={parentsByChild}
@@ -817,7 +869,15 @@ function KnowledgeTreeEditor({
 // place from there); everything else about the area is read-only until then.
 const UNFILED_PREVIEW_COUNT = 40;
 
-function UnfiledAreas({ unfiled, onDone }: { unfiled: UnfiledArea[]; onDone: () => void }) {
+function UnfiledAreas({
+  unfiled,
+  supplyByKey,
+  onDone,
+}: {
+  unfiled: UnfiledArea[];
+  supplyByKey: Record<string, SupplyReadout>;
+  onDone: () => void;
+}) {
   const [showAll, setShowAll] = useState(false);
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -891,6 +951,7 @@ function UnfiledAreas({ unfiled, onDone }: { unfiled: UnfiledArea[]; onDone: () 
                       ⟳ {Math.round(dupRate * 100)}% duplicates
                     </span>
                   ) : null}
+                  <SupplyChip domainKeyValue={area.domainKey} supply={supplyByKey[area.domainKey]} />
                 </span>
               </span>
               <button
@@ -952,6 +1013,7 @@ function TreeRow({
   pointsByKey,
   genStatsByKey,
   exhaustedByKey,
+  supplyByKey,
   childrenByParent,
   parentCountByChild,
   parentsByChild,
@@ -978,6 +1040,7 @@ function TreeRow({
   pointsByKey: Record<string, number>;
   genStatsByKey: Record<string, { total: number; dupes: number }>;
   exhaustedByKey: Record<string, { self: boolean; descendants: number }>;
+  supplyByKey: Record<string, SupplyReadout>;
   childrenByParent: Map<string, string[]>;
   parentCountByChild: Map<string, number>;
   parentsByChild: Map<string, string[]>;
@@ -1301,6 +1364,7 @@ function TreeRow({
                   </span>
                 );
               })()}
+              <SupplyChip domainKeyValue={nodeKey} supply={supplyByKey[nodeKey]} />
             </span>
           </span>
         )}
@@ -1536,6 +1600,7 @@ function TreeRow({
               pointsByKey={pointsByKey}
               genStatsByKey={genStatsByKey}
               exhaustedByKey={exhaustedByKey}
+              supplyByKey={supplyByKey}
               childrenByParent={childrenByParent}
               parentCountByChild={parentCountByChild}
               parentsByChild={parentsByChild}

--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -43,6 +43,18 @@ async function post(body: Record<string, unknown>): Promise<{
 }
 
 
+// A corpus area with questions but no authored node — real territory that
+// exists only as a raw label until it's added to the tree.
+export type UnfiledArea = {
+  domainKey: string;
+  label: string;
+  questions: number;
+  points: number;
+  genTotal: number;
+  genDupes: number;
+  exhausted: boolean;
+};
+
 export function KnowledgeAdminClient({
   nodes,
   edges,
@@ -50,6 +62,7 @@ export function KnowledgeAdminClient({
   pointsByKey,
   genStatsByKey,
   exhaustedByKey,
+  unfiled,
 }: {
   nodes: KnowledgeNodeRow[];
   edges: KnowledgeEdgeRow[];
@@ -57,6 +70,7 @@ export function KnowledgeAdminClient({
   pointsByKey: Record<string, number>;
   genStatsByKey: Record<string, { total: number; dupes: number }>;
   exhaustedByKey: Record<string, { self: boolean; descendants: number }>;
+  unfiled: UnfiledArea[];
 }) {
   const router = useRouter();
 
@@ -70,13 +84,13 @@ export function KnowledgeAdminClient({
           Knowledge graph
         </h1>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          The territory structure — <strong>only what you&apos;ve authored appears here</strong>{' '}
-          (raw question labels live on Domain merges until you nest or merge them in). Under every
-          name: the points to master it (color-coded by size — green small, gold moderate, red
-          large; edit via ⋯), how many questions live there, and the points currently available —
-          both rolled up through the subtree for parents. <em>⟳ duplicates</em> marks where new
-          questions are hard to find; <em>⛔ exhausted</em> marks a tapped-out area at the
-          expansion gate (author more to refill it). Nothing here touches questions or any
+          The whole map: <strong>the tree is what you&apos;ve authored</strong>; every other area
+          with questions waits in <strong>Unfiled areas</strong> below until you add it. Under
+          every name: the points to master it (color-coded by size — green small, gold moderate,
+          red large; edit via ⋯), how many questions live there, and the points currently
+          available — both rolled up through the subtree for parents. <em>⟳ duplicates</em> marks
+          where new questions are hard to find; <em>⛔ exhausted</em> marks a tapped-out area at
+          the expansion gate (author more to refill it). Nothing here touches questions or any
           player&apos;s mastery.
         </p>
       </header>
@@ -92,6 +106,8 @@ export function KnowledgeAdminClient({
         exhaustedByKey={exhaustedByKey}
         onDone={() => router.refresh()}
       />
+
+      <UnfiledAreas unfiled={unfiled} onDone={() => router.refresh()} />
 
       {/* Only the two tools with NO tree equivalent live here: the orphan
           check (structural gaps at a glance) and the edge composer (typed
@@ -789,6 +805,119 @@ function KnowledgeTreeEditor({
           ) : null}
         </DragOverlay>
       </DndContext>
+    </section>
+  );
+}
+
+// ─── unfiled areas ──────────────────────────────────────────────────────────
+// Every corpus area that has questions but NO authored territory ("show all
+// areas, not just the ones I did"). The tree above is the curated structure;
+// this is the complete rest-of-the-map, biggest first. "Add to tree" creates
+// the node (it appears as a top-level territory on refresh — drag it into
+// place from there); everything else about the area is read-only until then.
+const UNFILED_PREVIEW_COUNT = 40;
+
+function UnfiledAreas({ unfiled, onDone }: { unfiled: UnfiledArea[]; onDone: () => void }) {
+  const [showAll, setShowAll] = useState(false);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (unfiled.length === 0) return null;
+  const visible = showAll ? unfiled : unfiled.slice(0, UNFILED_PREVIEW_COUNT);
+
+  async function addToTree(area: UnfiledArea) {
+    if (busyKey) return;
+    setBusyKey(area.domainKey);
+    setError(null);
+    const res = await post({ action: 'create_node', label: area.label, nodeKind: 'leaf' });
+    setBusyKey(null);
+    // 409 = a node raced into existence for this key — that IS the goal.
+    if (!res.ok && res.status !== 409) {
+      setError(`Couldn't add "${area.label}" (${res.status}).`);
+      return;
+    }
+    onDone();
+  }
+
+  return (
+    <section className="mt-8">
+      <h2 className="mb-1 font-serif text-lg font-semibold text-[var(--brand-ink)]">
+        Unfiled areas ({unfiled.length})
+      </h2>
+      <p className="text-muted-foreground mb-2 text-xs">
+        Areas with questions that aren&apos;t in your tree yet — the categorizer filed content
+        here, but no territory exists. <strong>Add to tree</strong> makes one (it lands at the top
+        level; drag it into place). Biggest first.
+      </p>
+      {error ? (
+        <p className="mb-2 text-[13px]" style={{ color: 'var(--danger)' }}>
+          {error}
+        </p>
+      ) : null}
+      <div className="rounded-md border py-1" style={{ borderColor: 'var(--border)' }}>
+        {visible.map((area) => {
+          const dupRate = area.genTotal > 0 ? area.genDupes / area.genTotal : 0;
+          const showDup =
+            area.genTotal >= HARD_TO_SOURCE_MIN_SAMPLE && dupRate >= HARD_TO_SOURCE_MIN_RATE;
+          return (
+            <div
+              key={area.domainKey}
+              className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b px-3 py-1.5 text-sm last:border-b-0"
+              style={{ borderColor: 'var(--border)' }}
+            >
+              <span className="flex min-w-0 flex-1 flex-col gap-y-0.5 py-0.5">
+                <span className="min-w-0 break-words text-[var(--brand-ink)]">{area.label}</span>
+                <span className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs">
+                  <span className="text-muted-foreground" title="Questions filed under this label">
+                    {area.questions} question{area.questions === 1 ? '' : 's'}
+                  </span>
+                  <span className="text-muted-foreground" title="Points currently earnable here (difficulty-weighted)">
+                    {area.points.toLocaleString()} pts available
+                  </span>
+                  {area.exhausted ? (
+                    <span
+                      className="font-semibold"
+                      style={{ color: 'var(--danger)' }}
+                      title="Exhausted — few servable facts remain despite generation"
+                    >
+                      ⛔ exhausted
+                    </span>
+                  ) : showDup ? (
+                    <span
+                      className="font-medium"
+                      style={{ color: dupRateColor(dupRate) }}
+                      title={`${Math.round(dupRate * 100)}% of generated questions here came back as duplicates (${area.genDupes}/${area.genTotal})`}
+                    >
+                      ⟳ {Math.round(dupRate * 100)}% duplicates
+                    </span>
+                  ) : null}
+                </span>
+              </span>
+              <button
+                type="button"
+                onClick={() => void addToTree(area)}
+                disabled={busyKey !== null}
+                className="inline-flex min-h-9 shrink-0 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-40"
+                style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+                title="Create a territory for this area — it appears at the top level of the tree; drag it into place from there"
+              >
+                {busyKey === area.domainKey ? 'Adding…' : '+ Add to tree'}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {unfiled.length > UNFILED_PREVIEW_COUNT ? (
+        <button
+          type="button"
+          onClick={() => setShowAll((v) => !v)}
+          className="text-muted-foreground mt-2 text-xs underline-offset-2 hover:underline"
+        >
+          {showAll
+            ? 'show fewer'
+            : `show all ${unfiled.length} (${unfiled.length - UNFILED_PREVIEW_COUNT} more)`}
+        </button>
+      ) : null}
     </section>
   );
 }

--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -70,14 +70,14 @@ export function KnowledgeAdminClient({
           Knowledge graph
         </h1>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          The territory structure — human-authored, always. Nodes are leaves/parents. Each row
-          shows its <strong>mastery threshold</strong> (<em>pts</em> — the points to master the
-          topic, color-coded by size; edit it via ⋯), its question count (<em>Qs</em>), and the
-          points currently <em>avail</em>able there (difficulty-weighted) — the latter two rolled
-          up through the subtree for parents. A <em>⟳ dup</em> flag marks where new questions are
-          hard to find (a high share of generations come back duplicates); <em>⛔ exhausted</em>
-          marks a tapped-out area at the expansion gate (author more to refill it). Nothing here
-          touches questions or any player&apos;s mastery.
+          The territory structure — <strong>only what you&apos;ve authored appears here</strong>{' '}
+          (raw question labels live on Domain merges until you nest or merge them in). Under every
+          name: the points to master it (color-coded by size — green small, gold moderate, red
+          large; edit via ⋯), how many questions live there, and the points currently available —
+          both rolled up through the subtree for parents. <em>⟳ duplicates</em> marks where new
+          questions are hard to find; <em>⛔ exhausted</em> marks a tapped-out area at the
+          expansion gate (author more to refill it). Nothing here touches questions or any
+          player&apos;s mastery.
         </p>
       </header>
 
@@ -986,8 +986,8 @@ function TreeRow({
           borderRadius: isFlashed || isOver || dropEligible ? 6 : undefined,
         }}
       >
-        {/* Left group is ONE non-wrapping line (min-w-0 + truncate) so a long
-            label can never shove the ⋯ button onto its own row. */}
+        {/* Left group: handle + expander + a two-line content column (name
+            wraps; stats beneath). min-w-0 keeps the ⋯ button on the row. */}
         <span className="flex min-w-0 flex-1 items-center gap-x-2">
         {/* Drag handle — a real 44px control, not a bare glyph. Drag it to
             re-file; a plain TAP falls back to pick-up mode (big "Place here"
@@ -1063,38 +1063,73 @@ function TreeRow({
             </button>
           </span>
         ) : (
-          <>
-            <span
-              className={
-                (isParentish ? 'font-medium text-[var(--brand-ink)]' : 'text-[var(--brand-ink)]') +
-                ' min-w-0 truncate'
-              }
-            >
-              {node.label}
+          /* Two lines, always (2026-07-08: "sometimes can't read the category"):
+             the NAME gets the full row width and WRAPS — never truncates — and
+             the stats live on their own line beneath in plain words, so a long
+             territory name and its numbers can both be read on a phone. */
+          <span className="flex min-w-0 flex-1 flex-col gap-y-0.5 py-0.5">
+            <span className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
+              <span
+                className={
+                  (isParentish ? 'font-medium text-[var(--brand-ink)]' : 'text-[var(--brand-ink)]') +
+                  ' min-w-0 break-words'
+                }
+              >
+                {node.label}
+              </span>
+              {/* Multi-parent chip: tap to see every place this territory lives
+                  and jump to any of them. */}
+              {parentCount > 1 ? (
+                <button
+                  type="button"
+                  onClick={() => setPlacesOpen((v) => !v)}
+                  aria-expanded={placesOpen}
+                  aria-label={`${node.label} is in ${parentCount} places — show them`}
+                  title="This territory lives in more than one place — tap to see and jump"
+                  className="inline-flex min-h-7 shrink-0 items-center gap-1 rounded-md border px-1.5 text-xs font-medium"
+                  style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+                >
+                  ⧉ {parentCount}
+                </button>
+              ) : null}
+              {/* "This is too small" — a thin leaf that isn't already nested is a
+                  condense-me candidate (Move it under a parent). */}
+              {!isParentish && (depthByKey[nodeKey] ?? 0) < THIN_LEAF_THRESHOLD && parentCount === 0 ? (
+                <span
+                  className="shrink-0 rounded-sm px-1.5 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
+                  style={{ color: 'var(--warning)', background: 'var(--warning-surface)' }}
+                  title="Too few questions to stand alone — Move it under a broader parent"
+                >
+                  thin
+                </span>
+              ) : null}
             </span>
-            {/* Two facts under every name (leaves included): the node's mastery
-                THRESHOLD in points (color-coded by size; master at 75% of it) and
-                the question count (rolled up through the subtree for parents). */}
-            <span className="flex shrink-0 items-center gap-2 whitespace-nowrap text-xs">
+            {/* The stats line — spelled out, not abbreviated ("stats hard to
+                decipher"): mastery target (color = size), question count and
+                points available (both rolled up through the subtree for
+                parents), then the escalating supply flag. */}
+            <span className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs">
               <span
                 className="font-medium"
                 style={{ color: node.masteryThreshold ? thresholdColor(node.masteryThreshold) : 'var(--warning)' }}
                 title={
                   node.masteryThreshold
-                    ? `Mastery threshold: ${node.masteryThreshold.toLocaleString()} pts (master at 75%)`
-                    : 'No threshold set — tap ⋯ to set one'
+                    ? `Mastery threshold: ${node.masteryThreshold.toLocaleString()} pts (a player masters this at 75% of it)`
+                    : 'No mastery target set — tap ⋯ → Edit to set one'
                 }
               >
-                {node.masteryThreshold ? `${node.masteryThreshold.toLocaleString()} pts` : '— pts'}
+                {node.masteryThreshold
+                  ? `${node.masteryThreshold.toLocaleString()} pts to master`
+                  : 'no mastery target'}
               </span>
-              <span className="text-muted-foreground" title="Questions in this area">
-                {depthByKey[nodeKey] ?? 0} Qs
+              <span className="text-muted-foreground" title="Questions filed in this area (rolled up through the subtree for parents)">
+                {depthByKey[nodeKey] ?? 0} questions
               </span>
               <span
                 className="text-muted-foreground"
-                title="Points currently available here (difficulty-weighted, rolled up) — eyeball against the threshold"
+                title="Points currently earnable here (difficulty-weighted, rolled up) — eyeball against the mastery target"
               >
-                {(pointsByKey[nodeKey] ?? 0).toLocaleString()} avail
+                {(pointsByKey[nodeKey] ?? 0).toLocaleString()} pts available
               </span>
               {(() => {
                 // Escalating supply signal: EXHAUSTED (at the expansion gate) beats
@@ -1105,7 +1140,7 @@ function TreeRow({
                     <span
                       className="font-semibold"
                       style={{ color: 'var(--danger)' }}
-                      title="Exhausted — at the narrow-KB expansion gate: few servable facts remain despite generation, so the system stops serving fresh Qs here and offers area-expansion instead. Author more by hand to refill it."
+                      title="Exhausted — at the narrow-KB expansion gate: few servable facts remain despite generation, so the system stops serving fresh questions here and offers area-expansion instead. Author more by hand to refill it."
                     >
                       ⛔ exhausted
                     </span>
@@ -1131,40 +1166,14 @@ function TreeRow({
                   <span
                     className="font-medium"
                     style={{ color: dupRateColor(rate) }}
-                    title={`${pct}% of generated questions here are duplicates — new ones are hard to find (${g.dupes}/${g.total} generated)`}
+                    title={`${pct}% of generated questions here came back as duplicates — new ones are hard to find (${g.dupes}/${g.total} generated)`}
                   >
-                    ⟳ {pct}% dup
+                    ⟳ {pct}% duplicates
                   </span>
                 );
               })()}
             </span>
-            {/* Multi-parent chip: tap to see every place this territory lives
-                and jump to any of them. */}
-            {parentCount > 1 ? (
-              <button
-                type="button"
-                onClick={() => setPlacesOpen((v) => !v)}
-                aria-expanded={placesOpen}
-                aria-label={`${node.label} is in ${parentCount} places — show them`}
-                title="This territory lives in more than one place — tap to see and jump"
-                className="inline-flex min-h-7 shrink-0 items-center gap-1 rounded-md border px-1.5 text-xs font-medium"
-                style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
-              >
-                ⧉ {parentCount}
-              </button>
-            ) : null}
-            {/* "This is too small" — a thin leaf that isn't already nested is a
-                condense-me candidate (Move it under a parent). */}
-            {!isParentish && (depthByKey[nodeKey] ?? 0) < THIN_LEAF_THRESHOLD && parentCount === 0 ? (
-              <span
-                className="shrink-0 rounded-sm px-1.5 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
-                style={{ color: 'var(--warning)', background: 'var(--warning-surface)' }}
-                title="Too few questions to stand alone — Move it under a broader parent"
-              >
-                thin
-              </span>
-            ) : null}
-          </>
+          </span>
         )}
         </span>
 

--- a/src/app/admin/knowledge/page.tsx
+++ b/src/app/admin/knowledge/page.tsx
@@ -9,9 +9,10 @@ import {
 } from '@/server/db/queries/crafter-demand';
 import { listKnowledgeGraph } from '@/server/db/queries/knowledge-graph';
 import { getRetrievalConfig } from '@/server/daily/retrieval-config';
+import { buildSupplyCoverageSummary } from '@/server/daily/supply-coverage';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
-import { KnowledgeAdminClient } from './KnowledgeAdminClient';
+import { KnowledgeAdminClient, type SupplyReadout } from './KnowledgeAdminClient';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,7 +24,7 @@ export default async function AdminKnowledgePage() {
   const session = await getSession();
   if (!session || !isAdminUser(session.userId)) notFound();
 
-  const [{ nodes, edges }, corpusDepths, corpusPoints, corpusGenStats] = await Promise.all([
+  const [{ nodes, edges }, corpusDepths, corpusPoints, corpusGenStats, supply] = await Promise.all([
     listKnowledgeGraph(),
     // Per-label question depth (machine + human), so the tree can flag
     // territories too thin to stand alone ("this is too small — condense it").
@@ -34,6 +35,10 @@ export default async function AdminKnowledgePage() {
     // Per-label generation exhaustion (total produced + duplicates), so the tree
     // can flag where NEW questions are hard to find (high duplicate share).
     getCorpusLabelGenStats(),
+    // The supply lens over the SAME areas ("knowledge graph and domain supply
+    // should have the same information") — per-row readout + a link to the
+    // supply table. Fail-open internally: null just means no chips this load.
+    buildSupplyCoverageSummary(),
   ]);
   const ownDepthByKey: Record<string, number> = {};
   const ownMachineDepthByKey: Record<string, number> = {};
@@ -148,6 +153,18 @@ export default async function AdminKnowledgePage() {
     .filter((area) => area.questions > 0)
     .sort((a, b) => b.questions - a.questions || a.label.localeCompare(b.label));
 
+  // Per-key supply readout for the row chips. Serializable subset only.
+  const supplyByKey: Record<string, SupplyReadout> = {};
+  for (const entry of supply?.entries ?? []) {
+    supplyByKey[entry.domainKey] = {
+      state: entry.state,
+      realized: entry.realized,
+      estimatedQuestions: entry.estimatedQuestions,
+      ratio: entry.ratio,
+      capped: entry.generationCapped,
+    };
+  }
+
   return (
     <KnowledgeAdminClient
       nodes={nodes}
@@ -157,6 +174,7 @@ export default async function AdminKnowledgePage() {
       genStatsByKey={genStatsByKey}
       exhaustedByKey={exhaustedByKey}
       unfiled={unfiled}
+      supplyByKey={supplyByKey}
     />
   );
 }

--- a/src/app/admin/knowledge/page.tsx
+++ b/src/app/admin/knowledge/page.tsx
@@ -119,6 +119,35 @@ export default async function AdminKnowledgePage() {
     exhaustedByKey[key] = { self: isExhaustedLeaf(key), descendants: exhaustedDescendants };
   }
 
+  // UNFILED areas ("show all areas, not just the ones I did", 2026-07-08):
+  // every corpus label whose folded key has NO authored node — questions exist
+  // there, but the territory isn't in the tree yet. Shown below the tree with
+  // an add-to-tree action, so the graph page is the complete picture instead of
+  // only the authored subset. Display label = the deepest spelling per key
+  // (spelling variants fold to one row); sorted most-questions-first so the
+  // biggest missing territories surface at the top.
+  const nodeKeySet = new Set(nodes.map((n) => n.domainKey));
+  const bestLabelByKey = new Map<string, { label: string; depth: number }>();
+  for (const entry of corpusDepths) {
+    const key = domainKey(entry.label);
+    if (nodeKeySet.has(key)) continue;
+    const depth = entry.machineDepth + entry.humanAuthored;
+    const best = bestLabelByKey.get(key);
+    if (!best || depth > best.depth) bestLabelByKey.set(key, { label: entry.label, depth });
+  }
+  const unfiled = [...bestLabelByKey.entries()]
+    .map(([key, { label }]) => ({
+      domainKey: key,
+      label,
+      questions: ownDepthByKey[key] ?? 0,
+      points: ownPointsByKey[key] ?? 0,
+      genTotal: ownGenByKey[key]?.total ?? 0,
+      genDupes: ownGenByKey[key]?.dupes ?? 0,
+      exhausted: isExhaustedLeaf(key),
+    }))
+    .filter((area) => area.questions > 0)
+    .sort((a, b) => b.questions - a.questions || a.label.localeCompare(b.label));
+
   return (
     <KnowledgeAdminClient
       nodes={nodes}
@@ -127,6 +156,7 @@ export default async function AdminKnowledgePage() {
       pointsByKey={pointsByKey}
       genStatsByKey={genStatsByKey}
       exhaustedByKey={exhaustedByKey}
+      unfiled={unfiled}
     />
   );
 }

--- a/src/app/admin/supply/page.tsx
+++ b/src/app/admin/supply/page.tsx
@@ -71,10 +71,12 @@ export default async function AdminSupplyPage() {
             Domain supply
           </h1>
           <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
-            Corpus-grounded size estimate vs realized generation, per domain. A{' '}
-            <strong>discrepancy</strong> is a domain that went dry far short of a trusted
-            estimate — a supply problem, not completion. Resting domains are believed complete
-            and stay re-probeable. <strong>Cap</strong> a domain to stop generating new
+            Corpus-grounded size estimate vs realized generation, per domain.{' '}
+            <strong>Rows appear here once the sizing machinery has touched a domain</strong> — a
+            different population from the authored Knowledge graph and the raw labels on Domain
+            merges. A <strong>discrepancy</strong> is a domain that went dry far short of a
+            trusted estimate — a supply problem, not completion. Resting domains are believed
+            complete and stay re-probeable. <strong>Cap</strong> a domain to stop generating new
             questions for it entirely — existing questions still serve, and it stops alarming.
           </p>
         </div>

--- a/src/app/admin/supply/page.tsx
+++ b/src/app/admin/supply/page.tsx
@@ -57,6 +57,9 @@ export default async function AdminSupplyPage() {
     ? [...summary.entries].sort((a, b) => {
         const stateDelta = STATE_ORDER.indexOf(a.state) - STATE_ORDER.indexOf(b.state);
         if (stateDelta !== 0) return stateDelta;
+        // Unsized rows have no ratio — biggest areas first so the ones most
+        // worth sizing surface at the top of that band.
+        if (a.ratio == null && b.ratio == null) return b.realized - a.realized;
         return (a.ratio ?? 1) - (b.ratio ?? 1);
       })
     : [];
@@ -71,12 +74,13 @@ export default async function AdminSupplyPage() {
             Domain supply
           </h1>
           <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
-            Corpus-grounded size estimate vs realized generation, per domain.{' '}
-            <strong>Rows appear here once the sizing machinery has touched a domain</strong> — a
-            different population from the authored Knowledge graph and the raw labels on Domain
-            merges. A <strong>discrepancy</strong> is a domain that went dry far short of a
-            trusted estimate — a supply problem, not completion. Resting domains are believed
-            complete and stay re-probeable. <strong>Cap</strong> a domain to stop generating new
+            Corpus-grounded size estimate vs realized generation.{' '}
+            <strong>Every knowledge area appears here</strong> — the same population as the
+            Knowledge graph page, seen through the supply lens. Un-sized areas read{' '}
+            <strong>Unsized</strong> (biggest first) until you Re-size or set an estimate. A{' '}
+            <strong>discrepancy</strong> is a domain that went dry far short of a trusted
+            estimate — a supply problem, not completion. Resting domains are believed complete
+            and stay re-probeable. <strong>Cap</strong> a domain to stop generating new
             questions for it entirely — existing questions still serve, and it stops alarming.
           </p>
         </div>
@@ -135,7 +139,9 @@ export default async function AdminSupplyPage() {
                 {ordered.map((entry) => (
                   <tr
                     key={entry.domainKey}
-                    className="border-b"
+                    // Anchor target for the knowledge page's per-row supply link.
+                    id={`supply-${entry.domainKey}`}
+                    className="border-b scroll-mt-24"
                     style={{ borderColor: 'var(--border-light)' }}
                   >
                     <td className="py-2 pr-3">{entry.label}</td>

--- a/src/app/api/admin/domain-merges/route.ts
+++ b/src/app/api/admin/domain-merges/route.ts
@@ -5,6 +5,8 @@ import { getSession } from '@/server/auth/session';
 import { isAdminUser } from '@/server/auth/admin';
 import { runDomainMergeApply, runDomainMergePreview } from '@/server/db/queries/domain-merges';
 import { getLabelQuestionPeek } from '@/server/db/queries/domain-fragmentation';
+import { attachChild, createKnowledgeNode } from '@/server/db/queries/knowledge-graph';
+import { domainKey } from '@/lib/knowledge/domain-key';
 
 export const dynamic = 'force-dynamic';
 // Apply is one transaction over the low-hundreds of rows a label spans; preview is
@@ -20,7 +22,13 @@ const mergeSpec = z.object({
   sources: z.array(z.string().trim().min(1).max(200)).min(1).max(10),
 });
 // preview/apply act on a batch of merge specs; peek is a read-only sample of one
-// label's questions (the "see the questions before you decide" sanity check).
+// label's questions (the "see the questions before you decide" sanity check);
+// nest records a CONTAINMENT decision — the pair is parent/child, not
+// duplicates — by authoring it into the knowledge graph (nodes created for
+// labels that have none, then the edge). A nested pair stops appearing in the
+// candidate list (the query filters connected pairs), so "these are related but
+// not the same" is a decision you make ONCE, here, instead of leaving the pair
+// to nag forever.
 const bodySchema = z.discriminatedUnion('action', [
   z.object({
     action: z.literal('preview'),
@@ -34,7 +42,26 @@ const bodySchema = z.discriminatedUnion('action', [
     action: z.literal('peek'),
     label: z.string().trim().min(1).max(200),
   }),
+  z.object({
+    action: z.literal('nest'),
+    childLabel: z.string().trim().min(1).max(200),
+    parentLabel: z.string().trim().min(1).max(200),
+  }),
 ]);
+
+// Node-or-existing: the collision result IS success for nesting — the label
+// already lives in the graph, which is exactly what we need.
+async function ensureNode(
+  label: string,
+  nodeKind: 'leaf' | 'parent',
+  actorUserId: string,
+): Promise<boolean> {
+  const result = await createKnowledgeNode(
+    { label, nodeKind, masteryThreshold: null, broadCategory: null, fieldHue: null },
+    actorUserId,
+  );
+  return result.ok || result.reason === 'domain_key_collision';
+}
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
@@ -54,6 +81,32 @@ export async function POST(request: NextRequest) {
     if (data.action === 'peek') {
       const questions = await getLabelQuestionPeek(data.label);
       return NextResponse.json({ questions });
+    }
+    if (data.action === 'nest') {
+      const childKey = domainKey(data.childLabel);
+      const parentKey = domainKey(data.parentLabel);
+      if (childKey === parentKey) {
+        return NextResponse.json({ error: 'self_edge' }, { status: 400 });
+      }
+      // Both labels enter the graph (no-op for sides that already have a node),
+      // then the containment edge. attachChild handles cycle rejection and
+      // promotes a leaf parent to 'both'.
+      const childOk = await ensureNode(data.childLabel, 'leaf', session.userId);
+      const parentOk = await ensureNode(data.parentLabel, 'parent', session.userId);
+      if (!childOk || !parentOk) {
+        return NextResponse.json({ error: 'node_create_failed' }, { status: 500 });
+      }
+      const edge = await attachChild(
+        { childDomainKey: childKey, toParentDomainKey: parentKey },
+        session.userId,
+      );
+      if (!edge.ok && edge.reason !== 'duplicate') {
+        return NextResponse.json(
+          { error: edge.reason },
+          { status: edge.reason === 'self_edge' ? 400 : 422 },
+        );
+      }
+      return NextResponse.json({ ok: true });
     }
     const { merges } = data;
     if (data.action === 'preview') {

--- a/src/app/api/admin/supply/route.ts
+++ b/src/app/api/admin/supply/route.ts
@@ -6,6 +6,7 @@ import { isAdminUser } from '@/server/auth/admin';
 import { estimateDomainSize, SIZE_CEIL } from '@/server/daily/domain-size-estimate';
 import {
   getDepthEstimates,
+  resolveSampleLabelForKey,
   setGenerationCap,
   setManualEstimate,
   upsertCorpusSizeEstimate,
@@ -58,23 +59,28 @@ export async function POST(request: NextRequest) {
   }
   const data = parsed.data;
 
+  // The dashboard now lists every knowledge area, sized or not — a key may have
+  // no DomainDepthEstimate row yet. The label is ALWAYS resolved server-side
+  // (stored sample_label, else the corpus spelling for the key — never client
+  // input); actions on a row-less key seed the row through the upsert paths.
+  const row = (await getDepthEstimates([data.domainKey])).get(data.domainKey);
+  const label = row?.sampleLabel ?? (await resolveSampleLabelForKey(data.domainKey));
+  if (!label) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
   if (data.action === 'set_estimate') {
-    const updated = await setManualEstimate(data.domainKey, data.estimate);
+    const updated = await setManualEstimate(data.domainKey, data.estimate, label);
     if (!updated) return NextResponse.json({ error: 'not_found' }, { status: 404 });
     return NextResponse.json({ ok: true });
   }
 
   if (data.action === 'set_cap') {
-    const updated = await setGenerationCap(data.domainKey, data.capped);
+    const updated = await setGenerationCap(data.domainKey, data.capped, label);
     if (!updated) return NextResponse.json({ error: 'not_found' }, { status: 404 });
     return NextResponse.json({ ok: true });
   }
 
-  // resize — resolve the row's stored label against the live corpus.
-  const row = (await getDepthEstimates([data.domainKey])).get(data.domainKey);
-  if (!row) return NextResponse.json({ error: 'not_found' }, { status: 404 });
-
-  const label = row.sampleLabel ?? data.domainKey;
+  // resize — run the corpus resolver against the resolved label; the upsert
+  // below creates the estimate row when the key never had one.
   const estimate = await estimateDomainSize(label).catch(() => null);
   if (!estimate || estimate.estimatedQuestions == null) {
     // Resolver miss or bespoke shape — nothing trustworthy to write. The row

--- a/src/server/db/queries/domain-depth-estimate.ts
+++ b/src/server/db/queries/domain-depth-estimate.ts
@@ -1,9 +1,10 @@
 // D-DIFFICULTY-SIZE-COMPLETION-01 — read/write for the cached topic depth score
 // (DomainDepthEstimate, migration 0116). Keyed on the folded domain_key so it
 // covers every played canonical_subcategory, not just authored KnowledgeNodes.
-import { eq, inArray, isNotNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
 
-import { db, domainDepthEstimates, generatedQuestions } from '@/server/db';
+import { db, domainDepthEstimates, generatedQuestions, questions } from '@/server/db';
+import { domainKey } from '@/lib/knowledge/domain-key';
 
 export type DepthEstimateRow = {
   domainKey: string;
@@ -173,40 +174,97 @@ export async function coCalibrateRaisedEstimates(
 }
 
 /**
+ * The display label for a folded domain key, resolved SERVER-SIDE (the resolver
+ * and estimate rows must never be seeded from client input): the most common
+ * generated spelling, else a human-authored label that folds to the key. Null =
+ * the key has no corpus presence at all.
+ */
+export async function resolveSampleLabelForKey(key: string): Promise<string | null> {
+  const [gen] = await db
+    .select({ label: sql<string | null>`min(${generatedQuestions.canonicalSubcategory})` })
+    .from(generatedQuestions)
+    .where(eq(generatedQuestions.domainKey, key));
+  if (gen?.label) return gen.label;
+  // Human-authored-only area: Question has no domain_key column — fold in TS.
+  const humanLabels = await db
+    .selectDistinct({ label: questions.canonicalSubcategory })
+    .from(questions)
+    .where(
+      and(
+        isNotNull(questions.canonicalSubcategory),
+        isNotNull(questions.creatorId),
+        isNull(questions.deletedAt),
+        ne(questions.visibility, 'blocked'),
+      ),
+    );
+  for (const row of humanLabels) {
+    const label = row.label?.trim();
+    if (label && domainKey(label) === key) return label;
+  }
+  return null;
+}
+
+/**
  * Admin manual estimate override (0119). value=null clears the override so the
- * domain returns to its corpus/depth path. UPDATE-only: the /admin/supply rows
- * all exist in the table by construction; returns false when the key has no
- * row so the API can 404 instead of silently no-oping.
+ * domain returns to its corpus/depth path. Upserts (2026-07-09): the supply
+ * dashboard now lists EVERY knowledge area, not just sized ones, so an admin
+ * may set an estimate on a key with no row yet — `sampleLabel` (resolved
+ * server-side) seeds the insert. Clearing a nonexistent row is an idempotent
+ * success; setting one without a resolvable label fails so the API can 404.
  */
 export async function setManualEstimate(
   domainKeyValue: string,
   value: number | null,
+  sampleLabel?: string | null,
 ): Promise<boolean> {
   const rows = await db
     .update(domainDepthEstimates)
     .set({ manualEstimatedQuestions: value })
     .where(eq(domainDepthEstimates.domainKey, domainKeyValue))
     .returning({ domainKey: domainDepthEstimates.domainKey });
-  return rows.length > 0;
+  if (rows.length > 0) return true;
+  if (value === null) return true; // nothing to clear
+  if (!sampleLabel) return false;
+  await db
+    .insert(domainDepthEstimates)
+    .values({ domainKey: domainKeyValue, sampleLabel, source: 'default', manualEstimatedQuestions: value })
+    .onConflictDoUpdate({
+      target: domainDepthEstimates.domainKey,
+      set: { manualEstimatedQuestions: value },
+    });
+  return true;
 }
 
 /**
  * Admin generation cap (0121). value=true stamps generation_capped_at (now);
  * value=false clears it. A capped domain is excluded from fresh generation
  * everywhere generateDailyQuestionsFromKnowledgeBase builds its palette; serving
- * is untouched. UPDATE-only like setManualEstimate: the /admin/supply rows all
- * exist by construction; returns false when the key has no row so the API 404s.
+ * is untouched. Upserts like setManualEstimate (2026-07-09): capping an unsized
+ * area seeds its row from the server-resolved `sampleLabel`; un-capping a
+ * nonexistent row is an idempotent success.
  */
 export async function setGenerationCap(
   domainKeyValue: string,
   capped: boolean,
+  sampleLabel?: string | null,
 ): Promise<boolean> {
+  const stamp = capped ? new Date() : null;
   const rows = await db
     .update(domainDepthEstimates)
-    .set({ generationCappedAt: capped ? new Date() : null })
+    .set({ generationCappedAt: stamp })
     .where(eq(domainDepthEstimates.domainKey, domainKeyValue))
     .returning({ domainKey: domainDepthEstimates.domainKey });
-  return rows.length > 0;
+  if (rows.length > 0) return true;
+  if (!capped) return true; // nothing to un-cap
+  if (!sampleLabel) return false;
+  await db
+    .insert(domainDepthEstimates)
+    .values({ domainKey: domainKeyValue, sampleLabel, source: 'default', generationCappedAt: stamp })
+    .onConflictDoUpdate({
+      target: domainDepthEstimates.domainKey,
+      set: { generationCappedAt: stamp },
+    });
+  return true;
 }
 
 /**
@@ -242,9 +300,13 @@ export type DomainSupplyCoverageRow = {
 
 /**
  * Coverage read for the supply-state machine's two surfaces (weekly digest +
- * admin dashboard, D-SUPPLY-FINITENESS-01 #5): every sized domain joined with
- * its REALIZED distinct-fact count from the shared bank. State classification
- * happens in TS (classifySupplyState) so the query stays pure observation.
+ * admin dashboard, D-SUPPLY-FINITENESS-01 #5). Covers EVERY knowledge area
+ * (2026-07-09, "knowledge graph and domain supply should have the same
+ * information of all knowledge areas"), not just sized ones: a FULL JOIN of
+ * estimate rows against every generated domain_key, plus human-authored-only
+ * labels folded in TS (Question has no domain_key column). Areas with no
+ * estimate row classify `unsized` downstream. State classification happens in
+ * TS (classifySupplyState) so the query stays pure observation.
  */
 export async function getDomainSupplyCoverage(): Promise<DomainSupplyCoverageRow[]> {
   const realized = db.$with('realized').as(
@@ -252,28 +314,67 @@ export async function getDomainSupplyCoverage(): Promise<DomainSupplyCoverageRow
       .select({
         domainKey: generatedQuestions.domainKey,
         realized: sql<number>`count(distinct ${generatedQuestions.factKey})::int`.as('realized'),
+        genLabel: sql<string>`min(${generatedQuestions.canonicalSubcategory})`.as('gen_label'),
       })
       .from(generatedQuestions)
       .where(isNotNull(generatedQuestions.factKey))
       .groupBy(generatedQuestions.domainKey),
   );
-  const rows = await db
+  const joined = await db
     .with(realized)
     .select({
-      domainKey: domainDepthEstimates.domainKey,
-      sampleLabel: domainDepthEstimates.sampleLabel,
+      domainKey: sql<string>`coalesce(${domainDepthEstimates.domainKey}, ${realized.domainKey})`,
+      sampleLabel: sql<string | null>`coalesce(${domainDepthEstimates.sampleLabel}, ${realized.genLabel})`,
       estimatedQuestions: domainDepthEstimates.estimatedQuestions,
       manualEstimatedQuestions: domainDepthEstimates.manualEstimatedQuestions,
       confidence: domainDepthEstimates.confidence,
       shape: domainDepthEstimates.shape,
       basis: domainDepthEstimates.basis,
-      source: domainDepthEstimates.source,
-      consecutiveDryRounds: domainDepthEstimates.consecutiveDryRounds,
+      source: sql<string>`coalesce(${domainDepthEstimates.source}, 'none')`,
+      consecutiveDryRounds: sql<number>`coalesce(${domainDepthEstimates.consecutiveDryRounds}, 0)::int`,
       lastYieldAt: domainDepthEstimates.lastYieldAt,
       generationCappedAt: domainDepthEstimates.generationCappedAt,
       realized: sql<number>`coalesce(${realized.realized}, 0)::int`,
     })
     .from(domainDepthEstimates)
-    .leftJoin(realized, eq(realized.domainKey, domainDepthEstimates.domainKey));
-  return rows;
+    .fullJoin(realized, eq(realized.domainKey, domainDepthEstimates.domainKey));
+
+  // Human-authored-only areas: live, non-blocked authored questions whose
+  // folded key has neither an estimate row nor any generated rows.
+  const humanLabels = await db
+    .selectDistinct({ label: questions.canonicalSubcategory })
+    .from(questions)
+    .where(
+      and(
+        isNotNull(questions.canonicalSubcategory),
+        isNotNull(questions.creatorId),
+        isNull(questions.deletedAt),
+        ne(questions.visibility, 'blocked'),
+      ),
+    );
+  const present = new Set(joined.map((row) => row.domainKey));
+  const humanOnly = new Map<string, string>();
+  for (const row of humanLabels) {
+    const label = row.label?.trim();
+    if (!label) continue;
+    const key = domainKey(label);
+    if (!present.has(key) && !humanOnly.has(key)) humanOnly.set(key, label);
+  }
+  for (const [key, label] of humanOnly) {
+    joined.push({
+      domainKey: key,
+      sampleLabel: label,
+      estimatedQuestions: null,
+      manualEstimatedQuestions: null,
+      confidence: null,
+      shape: null,
+      basis: null,
+      source: 'none',
+      consecutiveDryRounds: 0,
+      lastYieldAt: null,
+      generationCappedAt: null,
+      realized: 0,
+    });
+  }
+  return joined;
 }

--- a/src/server/db/queries/domain-fragmentation.ts
+++ b/src/server/db/queries/domain-fragmentation.ts
@@ -1,6 +1,6 @@
-import { and, desc, eq, isNull, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 
-import { db, generatedQuestions, questions } from '@/server/db';
+import { db, generatedQuestions, knowledgeEdges, knowledgeNodes, questions } from '@/server/db';
 import { domainKey } from '@/lib/knowledge/domain-key';
 import type { DomainQuestionPeek } from '@/server/db/queries/knowledge-graph';
 
@@ -22,6 +22,11 @@ export type FragmentationPair = {
   depthB: number;
   /** pg_trgm trigram similarity, 0..1. */
   similarity: number;
+  /** Whether each side's folded key has an authored KnowledgeNode — merge
+      candidates are RAW corpus labels, most of which never got a node, which is
+      why they don't appear on the knowledge-graph page until nested/merged. */
+  hasNodeA: boolean;
+  hasNodeB: boolean;
 };
 
 type FragmentationRow = {
@@ -86,18 +91,53 @@ export async function getDomainFragmentationCandidates(
     (result as unknown as { rows?: FragmentationRow[] }).rows ??
     (result as unknown as FragmentationRow[]);
 
+  // Drop pairs the strengthened domainKey() already auto-folds at write time —
+  // those converge on their own and need no human. Surface only distinct-key
+  // near-duplicates, the genuine judgment calls.
+  const candidates = rows
+    .map((row) => ({ row, keyA: domainKey(row.domain_a), keyB: domainKey(row.domain_b) }))
+    .filter((c) => c.keyA !== c.keyB);
+
+  // Graph context for the survivors: which sides already have an authored node
+  // (the "in graph" chip), and which pairs are already CONNECTED by an edge —
+  // a nested pair is a decided pair (parent/child, not duplicates), so it stops
+  // appearing here. Without this filter, a Nest decision would nag forever.
+  const keys = [...new Set(candidates.flatMap((c) => [c.keyA, c.keyB]))];
+  const [nodeRows, edgeRows] =
+    keys.length > 0
+      ? await Promise.all([
+          db
+            .select({ domainKey: knowledgeNodes.domainKey })
+            .from(knowledgeNodes)
+            .where(inArray(knowledgeNodes.domainKey, keys)),
+          db
+            .select({
+              childDomainKey: knowledgeEdges.childDomainKey,
+              parentDomainKey: knowledgeEdges.parentDomainKey,
+            })
+            .from(knowledgeEdges)
+            .where(
+              or(
+                inArray(knowledgeEdges.childDomainKey, keys),
+                inArray(knowledgeEdges.parentDomainKey, keys),
+              ),
+            ),
+        ])
+      : [[], []];
+  const nodeKeys = new Set(nodeRows.map((n) => n.domainKey));
+  const connected = new Set(edgeRows.map((e) => `${e.childDomainKey}→${e.parentDomainKey}`));
+
   const pairs: FragmentationPair[] = [];
-  for (const row of rows) {
-    // Drop pairs the strengthened domainKey() already auto-folds at write time —
-    // those converge on their own and need no human. Surface only distinct-key
-    // near-duplicates, the genuine judgment calls.
-    if (domainKey(row.domain_a) === domainKey(row.domain_b)) continue;
+  for (const { row, keyA, keyB } of candidates) {
+    if (connected.has(`${keyA}→${keyB}`) || connected.has(`${keyB}→${keyA}`)) continue;
     pairs.push({
       domainA: row.domain_a,
       depthA: Number(row.depth_a),
       domainB: row.domain_b,
       depthB: Number(row.depth_b),
       similarity: Number(row.sim),
+      hasNodeA: nodeKeys.has(keyA),
+      hasNodeB: nodeKeys.has(keyB),
     });
     if (pairs.length >= limit) break;
   }

--- a/src/server/email/templates/__tests__/domain-fragmentation.test.ts
+++ b/src/server/email/templates/__tests__/domain-fragmentation.test.ts
@@ -9,6 +9,8 @@ const pair = (over: Partial<FragmentationPair> = {}): FragmentationPair => ({
   domainB: 'Evil Spy School',
   depthB: 4,
   similarity: 0.62,
+  hasNodeA: false,
+  hasNodeB: false,
   ...over,
 });
 


### PR DESCRIPTION
## Why this PR exists

PR #1452 was merged at 2026-07-09T00:26Z — **before the last three commits were pushed to its branch**, so they never landed on main. This PR delivers them; they merge cleanly onto current main.

## What's in it

### 1. Nest action + merge-pair context (`/admin/domains`)
Many merge candidates are **containment** (a work inside its series/genre), not duplicates — but the page only offered Keep/Leave, and "Leave" silently discarded the parent/child call. Now: **"A under B" / "B under A"** creates graph territories for both labels and draws the edge (cycle-rejected); nested pairs stop reappearing in the candidates list. Plus **"in graph" / "label only" chips** per side and population-explainer intros.

**Tree legibility** (same commit): knowledge tree rows become two lines — the name wraps at full width (never truncates), stats beneath in plain words (`1,500 pts to master · 42 questions · 3,200 pts available`).

### 2. Unfiled areas on the knowledge page
"Show all areas, not just the ones that I did": an **Unfiled areas** section below the tree lists every corpus area with questions but no authored territory, biggest first, each with **+ Add to tree**. No new queries — derived from reads the page already made.

### 3. Knowledge + supply share one population
- **Supply lists every area** (full join over generated keys + human-only labels folded in); unsized areas sort biggest-first.
- **Actions work on unsized areas** — the row is seeded on first action, label resolved server-side.
- **Knowledge rows carry the supply lens**: `supply: filling · 42/60 (70%) →` chips linking to the area's anchor row on the supply table, from the same `buildSupplyCoverageSummary`, so the surfaces cannot disagree.

## Verification
Typecheck/lint/ratchets/tests green at authoring; branch CI green; `git merge-tree` vs current main: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XT3vCvhVfApr31VDFrD1F