### PR TITLE
knowledge (previous view): per-circle frequency + peaks detail pop-up

### DIFF
--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -13,10 +13,14 @@ import { SharePortraitModal } from '@/components/knowledge/SharePortraitModal';
 import { useSharePortraitCapture } from '@/components/knowledge/useSharePortraitCapture';
 import { RecentlyExpanding, type ExpandingDomain } from '@/components/knowledge/RecentlyExpanding';
 import { AskFriendForDomain } from '@/components/knowledge/AskFriendForDomain';
+import { PeakDetailCard, type LeafInfo } from '@/components/knowledge/KnowledgePeaksView';
+import { usePeakDetail, freqKey } from '@/components/knowledge/usePeakDetail';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
 import { domainKey } from '@/lib/knowledge/domain-key';
+import { TERRITORY_FREQUENCY_LABEL, type DomainPreferenceFrequency } from '@/lib/daily/territory-model';
+import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
 import type { MasteryTier } from '@/types/db';
 
 type DomainMastery = {
@@ -133,6 +137,69 @@ function emptyDomain(domain: string): DomainMastery {
   };
 }
 
+// Detail-pop-up inputs threaded from the server (page.tsx). The flat portrait
+// itself still loads from /api/knowledge client-side; these ride alongside so a
+// tapped circle can open the same PeakDetailCard the "peaks" view uses.
+type PeaksDetailData = {
+  tree: KnowledgeTreeNode;
+  frequencyByDomain: DomainPreferenceFrequency;
+  fullyExploredDomains: ReadonlySet<string>;
+};
+
+type TreeIndex = { byId: Map<string, LeafInfo>; byFreqKey: Map<string, LeafInfo> };
+
+function isOwnedTreeLeaf(node: KnowledgeTreeNode): boolean {
+  return !node.ghost && (node.value ?? 0) > 0 && (!node.children || node.children.length === 0);
+}
+
+// One walk of the tree → every non-root node as a LeafInfo (with its lineage),
+// indexed by id (for sibling/child jumps) and by normalized name (for resolving
+// a tapped portrait circle). Top-level nodes get parent/topParent = null, exactly
+// like KnowledgePeaksView's `areas`, so the detail card's "More in…" reads right.
+// When a name collides, an owned terminal leaf wins over a container/ghost.
+function indexTree(tree: KnowledgeTreeNode): TreeIndex {
+  const byId = new Map<string, LeafInfo>();
+  const byFreqKey = new Map<string, LeafInfo>();
+  const walk = (node: KnowledgeTreeNode, ancestors: KnowledgeTreeNode[]) => {
+    if (ancestors.length > 0) {
+      const topLevel = ancestors.length === 1; // only the synthetic root above it
+      const path = topLevel ? [] : ancestors.slice(1);
+      const info: LeafInfo = {
+        node,
+        path,
+        parent: topLevel ? null : ancestors.at(-1) ?? null,
+        topParent: path[0] ?? null,
+      };
+      byId.set(node.id, info);
+      const key = freqKey(node.name);
+      const existing = byFreqKey.get(key);
+      if (!existing || (isOwnedTreeLeaf(node) && !isOwnedTreeLeaf(existing.node))) {
+        byFreqKey.set(key, info);
+      }
+    }
+    for (const child of node.children ?? []) walk(child, [...ancestors, node]);
+  };
+  walk(tree, []);
+  return { byId, byFreqKey };
+}
+
+// A portrait domain with no matching tree node still gets a pop-up: a bare leaf
+// (no lineage, no siblings) so the identity header and frequency editor work.
+function synthesizeLeaf(domain: DomainMastery): LeafInfo {
+  return {
+    node: {
+      id: `flat:${domain.domain}`,
+      name: domain.displayName,
+      field: null,
+      value: domain.points,
+      mastered: domain.tier === 'mastery',
+    },
+    path: [],
+    parent: null,
+    topParent: null,
+  };
+}
+
 function LoadingSkeleton() {
   return (
     <main className="w-[min(672px,94vw)] mx-auto pt-5 pb-10 grid gap-3.5">
@@ -150,15 +217,15 @@ function LoadingSkeleton() {
   );
 }
 
-export function KnowledgeFlatClient() {
+export function KnowledgeFlatClient(props: PeaksDetailData) {
   return (
     <Suspense fallback={<LoadingSkeleton />}>
-      <KnowledgePageContent />
+      <KnowledgePageContent {...props} />
     </Suspense>
   );
 }
 
-function KnowledgePageContent() {
+function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }: PeaksDetailData) {
   const searchParams = useSearchParams();
   const highlightedDomainSlug = searchParams.get('domain');
   const tierCrossed = searchParams.get('tier_crossed');
@@ -189,6 +256,21 @@ function KnowledgePageContent() {
   const [hiddenOverrides, setHiddenOverrides] = useState<Record<string, boolean>>({});
   const [hidePending, setHidePending] = useState<string | null>(null);
   const [hideError, setHideError] = useState<string | null>(null);
+
+  // Detail pop-up controller (shared with the peaks view): owns the optimistic
+  // tree + rotation map and the frequency/adopt writes. `selectedLeaf` is the
+  // tapped circle resolved to a tree leaf (or a synthesized bare leaf).
+  const { tree: detailTree, resolveFrequency, setFrequency, adoptNode } = usePeakDetail(
+    tree,
+    frequencyByDomain,
+  );
+  const [selectedLeaf, setSelectedLeaf] = useState<LeafInfo | null>(null);
+  const treeIndex = useMemo(() => indexTree(detailTree), [detailTree]);
+  const fullyExploredKeys = useMemo(() => {
+    const set = new Set<string>();
+    for (const domain of fullyExploredDomains) set.add(freqKey(domain));
+    return set;
+  }, [fullyExploredDomains]);
 
   const loadKnowledge = async () => {
     const response = await fetch('/api/knowledge', { cache: 'no-store', credentials: 'include' });
@@ -276,6 +358,25 @@ function KnowledgePageContent() {
     [annotatedDomains],
   );
   const hiddenCount = annotatedDomains.length - visibleDomains.length;
+
+  // Rotation word shown under every circle's name — resolves through the same
+  // frequency map that seeds the detail pop-up, so face and sheet always agree.
+  const frequencyLabelFor = (canonicalSubcategory: string): string =>
+    TERRITORY_FREQUENCY_LABEL[resolveFrequency(canonicalSubcategory)];
+
+  // A tapped circle (outside edit mode) opens the peaks detail pop-up. Prefer the
+  // real tree leaf; fall back to a synthesized bare leaf for a domain the tree
+  // doesn't carry, so the frequency editor still works everywhere.
+  const openDomainDetail = (canonicalSubcategory: string) => {
+    const key = freqKey(canonicalSubcategory);
+    const fromTree = treeIndex.byFreqKey.get(key);
+    if (fromTree) {
+      setSelectedLeaf(fromTree);
+      return;
+    }
+    const domain = annotatedDomains.find((entry) => freqKey(entry.displayName) === key);
+    setSelectedLeaf(domain ? synthesizeLeaf(domain) : null);
+  };
 
   const portraitEntries = useMemo(
     () => (editMode ? annotatedDomains : visibleDomains).map(toPortraitEntry),
@@ -674,6 +775,8 @@ function KnowledgePageContent() {
               editMode={editMode}
               onToggleHidden={(canonical, nextHidden) => void toggleDomainHidden(canonical, nextHidden)}
               pendingDomain={hidePending}
+              frequencyLabelFor={frequencyLabelFor}
+              onSelectDomain={openDomainDetail}
             />
             {hideError ? (
               <p className="mt-3 text-[0.78rem] text-[var(--cat-literature-text)] border border-[var(--cat-literature)]/40 p-2">{hideError}</p>
@@ -945,6 +1048,33 @@ function KnowledgePageContent() {
                 onCancel={() => setActiveModal(null)}
               />
             </div>
+          </div>
+        </div>
+      ) : null}
+
+      {/* Domain detail pop-up — the same PeakDetailCard the "peaks" view uses,
+          opened by tapping a circle. Backdrop tap closes; the card owns its X. */}
+      {selectedLeaf ? (
+        <div
+          className="fixed inset-0 z-[55] flex items-end justify-center bg-black/30 p-4 sm:items-center"
+          onClick={() => setSelectedLeaf(null)}
+        >
+          <div className="w-[min(480px,100%)]" onClick={(event) => event.stopPropagation()}>
+            <PeakDetailCard
+              key={selectedLeaf.node.id}
+              leaf={selectedLeaf}
+              variant="own"
+              frequency={resolveFrequency(selectedLeaf.node.name)}
+              fullyExplored={fullyExploredKeys.has(freqKey(selectedLeaf.node.name))}
+              adopted={false}
+              onClose={() => setSelectedLeaf(null)}
+              onSelectSibling={(id) => {
+                const info = treeIndex.byId.get(id);
+                if (info) setSelectedLeaf(info);
+              }}
+              onAdd={adoptNode}
+              onSetFrequency={setFrequency}
+            />
           </div>
         </div>
       ) : null}

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -11,16 +11,17 @@ export const dynamic = 'force-dynamic';
 
 // The knowledge page now offers three interchangeable views, chosen live via
 // ?view= (replacing the old build-time KNOWLEDGE_MAP_PAGE env gate):
-//   - peaks    (default) → the leaf-first "what you're smart at" gallery
+//   - previous (default) → the flat portrait page (per-circle frequency + the
+//                          tapped-circle detail pop-up)
+//   - peaks              → the leaf-first "what you're smart at" gallery
 //   - current            → the nested circle-pack bubble map
-//   - previous           → the flat portrait page that predates the map
 // Each view owns its own header + switcher chrome; only the selected one's
 // server component runs, so we never double-fetch the tree. The friend page
 // keeps its own flag for now — this switch is the owner surface only.
 function parseView(raw: string | string[] | undefined): KnowledgeView {
   const value = Array.isArray(raw) ? raw[0] : raw;
-  if (value === 'current' || value === 'previous') return value;
-  return 'peaks';
+  if (value === 'current' || value === 'peaks') return value;
+  return 'previous';
 }
 
 export default async function KnowledgePage({
@@ -35,34 +36,35 @@ export default async function KnowledgePage({
     return <KnowledgeBubblePage />;
   }
 
-  if (view === 'previous') {
-    const session = await getSession();
-    if (!session) redirect('/login');
-
-    // The flat portrait still self-loads /api/knowledge, but the per-circle
-    // frequency word and the tapped-circle detail pop-up need the knowledge tree
-    // + rotation preferences (same reads the "peaks" view makes). Fetch them here
-    // and thread them in — an additive read, no change to the portrait's own load.
-    const [{ tree }, preferences, fullyExplored] = await Promise.all([
-      getKnowledgeMapData(session.userId),
-      getDailyPreferences(session.userId),
-      getFullyExploredDomains(session.userId),
-    ]);
-
-    return (
-      <>
-        <div className="mx-auto flex w-[min(672px,94vw)] items-center justify-center pt-5">
-          <KnowledgeViewSwitcher current="previous" />
-        </div>
-        <KnowledgeFlatClient
-          tree={tree}
-          frequencyByDomain={preferences.domainPreferenceFrequency}
-          fullyExploredDomains={fullyExplored}
-        />
-      </>
-    );
+  if (view === 'peaks') {
+    const { KnowledgePeaksPage } = await import('./KnowledgePeaksPage');
+    return <KnowledgePeaksPage />;
   }
 
-  const { KnowledgePeaksPage } = await import('./KnowledgePeaksPage');
-  return <KnowledgePeaksPage />;
+  // Default view: the flat portrait. It still self-loads /api/knowledge, but the
+  // per-circle frequency word and the tapped-circle detail pop-up need the
+  // knowledge tree + rotation preferences (same reads the "peaks" view makes).
+  // Fetch them here and thread them in — an additive read, no change to the
+  // portrait's own load.
+  const session = await getSession();
+  if (!session) redirect('/login');
+
+  const [{ tree }, preferences, fullyExplored] = await Promise.all([
+    getKnowledgeMapData(session.userId),
+    getDailyPreferences(session.userId),
+    getFullyExploredDomains(session.userId),
+  ]);
+
+  return (
+    <>
+      <div className="mx-auto flex w-[min(672px,94vw)] items-center justify-center pt-5">
+        <KnowledgeViewSwitcher current="previous" />
+      </div>
+      <KnowledgeFlatClient
+        tree={tree}
+        frequencyByDomain={preferences.domainPreferenceFrequency}
+        fullyExploredDomains={fullyExplored}
+      />
+    </>
+  );
 }

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -1,5 +1,11 @@
+import { redirect } from 'next/navigation';
+
 import { KnowledgeFlatClient } from './KnowledgeFlatClient';
 import { KnowledgeViewSwitcher, type KnowledgeView } from '@/components/knowledge/KnowledgeViewSwitcher';
+import { getSession } from '@/server/auth/session';
+import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
+import { getFullyExploredDomains } from '@/server/knowledge/fully-explored';
+import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,12 +36,29 @@ export default async function KnowledgePage({
   }
 
   if (view === 'previous') {
+    const session = await getSession();
+    if (!session) redirect('/login');
+
+    // The flat portrait still self-loads /api/knowledge, but the per-circle
+    // frequency word and the tapped-circle detail pop-up need the knowledge tree
+    // + rotation preferences (same reads the "peaks" view makes). Fetch them here
+    // and thread them in — an additive read, no change to the portrait's own load.
+    const [{ tree }, preferences, fullyExplored] = await Promise.all([
+      getKnowledgeMapData(session.userId),
+      getDailyPreferences(session.userId),
+      getFullyExploredDomains(session.userId),
+    ]);
+
     return (
       <>
         <div className="mx-auto flex w-[min(672px,94vw)] items-center justify-center pt-5">
           <KnowledgeViewSwitcher current="previous" />
         </div>
-        <KnowledgeFlatClient />
+        <KnowledgeFlatClient
+          tree={tree}
+          frequencyByDomain={preferences.domainPreferenceFrequency}
+          fullyExploredDomains={fullyExplored}
+        />
       </>
     );
   }

--- a/src/components/knowledge/KnowledgePeaksView.tsx
+++ b/src/components/knowledge/KnowledgePeaksView.tsx
@@ -6,6 +6,7 @@ import { ArrowUpRight, Check, ChevronRight, Plus, X } from 'lucide-react';
 
 import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
 import { adoptDomain } from '@/components/knowledge/adopt';
+import { freqKey, usePeakDetail } from '@/components/knowledge/usePeakDetail';
 import {
   MIN_SIZE,
   MAX_SIZE,
@@ -78,17 +79,8 @@ function quizHref(name: string): string {
   return `/daily/setup?domainMode=custom&domain=${encodeURIComponent(name)}`;
 }
 
-// A peaks leaf's `node.name` === its `canonicalSubcategory`, which is exactly the
-// key `domainPreferenceFrequency` stores — matched case-insensitively, just like
-// the domain-frequency route. Normalize both sides the same way to resolve it.
-function freqKey(name: string): string {
-  return name.trim().toLowerCase();
-}
-
-// Decision A: a leaf with no explicit preference shows its actual effective
-// default. For an owned peak that's `'sometimes'` ("Sometimes") — the rotation
-// it's already in — so the face is truthful, not blank.
-const DEFAULT_FREQUENCY: TerritoryFrequency = 'sometimes';
+// `freqKey` + `DEFAULT_FREQUENCY` (and the frequency/adopt writes below) live in
+// usePeakDetail so the flat portrait page drives the same PeakDetailCard.
 
 const EMPTY_DOMAIN_SET: ReadonlySet<string> = new Set();
 
@@ -114,7 +106,7 @@ function isOwnedLeaf(node: KnowledgeTreeNode): boolean {
   );
 }
 
-type LeafInfo = {
+export type LeafInfo = {
   node: KnowledgeTreeNode;
   /** Non-root ancestors, top area → leaf's immediate parent (excludes the leaf). */
   path: KnowledgeTreeNode[];
@@ -125,7 +117,7 @@ type LeafInfo = {
 // One walk of the tree: every owned terminal leaf with its lineage. Parents
 // carry their child roster inline, so siblings (owned + addable ghosts) come
 // straight off `parent.children` at render time.
-function indexLeaves(tree: KnowledgeTreeNode): LeafInfo[] {
+export function indexLeaves(tree: KnowledgeTreeNode): LeafInfo[] {
   const out: LeafInfo[] = [];
   const walk = (node: KnowledgeTreeNode, ancestors: KnowledgeTreeNode[]) => {
     if (isOwnedLeaf(node)) {
@@ -164,54 +156,12 @@ export function KnowledgePeaksView({
    */
   fullyExploredDomains?: ReadonlySet<string>;
 }) {
-  const [tree, setTree] = useState<KnowledgeTreeNode>(data);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);
 
-  // Optimistic frequency map, keyed by normalized domain. Seeded from the
-  // server preference and updated in place on write (like `adoptNode`), so the
-  // face pill and detail sheet reflect the change before the round rebuilds.
-  const [freqMap, setFreqMap] = useState<Record<string, TerritoryFrequency>>(() => {
-    const seeded: Record<string, TerritoryFrequency> = {};
-    for (const [domain, frequency] of Object.entries(frequencyByDomain)) {
-      seeded[freqKey(domain)] = frequency;
-    }
-    return seeded;
-  });
-
-  const resolveFrequency = useCallback(
-    (name: string): TerritoryFrequency => freqMap[freqKey(name)] ?? DEFAULT_FREQUENCY,
-    [freqMap],
-  );
-
-  // Optimistic write: flip local state, POST the single-domain change, revert on
-  // failure. The route merges server-side and drops untouched Daily Five queues.
-  const setFrequency = useCallback(
-    async (name: string, frequency: TerritoryFrequency): Promise<boolean> => {
-      const key = freqKey(name);
-      const previous = freqMap[key];
-      setFreqMap((prev) => ({ ...prev, [key]: frequency }));
-      try {
-        const res = await fetch('/api/daily/preferences/domain-frequency', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({ domain: name, frequency }),
-        });
-        if (!res.ok) throw new Error('frequency update failed');
-        return true;
-      } catch {
-        setFreqMap((prev) => {
-          const next = { ...prev };
-          if (previous === undefined) delete next[key];
-          else next[key] = previous;
-          return next;
-        });
-        return false;
-      }
-    },
-    [freqMap],
-  );
+  // The optimistic tree, per-leaf rotation map, and the frequency/adopt writes
+  // are shared with the flat portrait page via this controller.
+  const { tree, resolveFrequency, setFrequency, adoptNode } = usePeakDetail(data, frequencyByDomain);
 
   // "Fully explored" honor (P4) — resolve per node by normalized domain key,
   // same match as frequency. Currently the source set is gated/empty.
@@ -357,19 +307,6 @@ export function KnowledgePeaksView({
     if (standalone.length > 0) list.push({ title: 'More', field: null, leaves: standalone });
     return list;
   }, [sorted]);
-
-  // Optimistic confirmed add: flip the ghost sibling into a real leaf so it
-  // jumps from "add next" to owned; revert on failure. Mirrors the bubble map.
-  const adoptNode = useCallback(async (id: string, name: string): Promise<boolean> => {
-    const flip = (node: KnowledgeTreeNode, ghost: boolean, value: number): KnowledgeTreeNode =>
-      node.id === id
-        ? { ...node, ghost: ghost || undefined, value }
-        : { ...node, children: node.children?.map((c) => flip(c, ghost, value)) };
-    setTree((prev) => flip(prev, false, 1));
-    const ok = await adoptDomain(name);
-    if (!ok) setTree((prev) => flip(prev, true, 40));
-    return ok;
-  }, []);
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
@@ -765,7 +702,7 @@ type AddPhase =
 
 // The leaf-first detail: identity, the rollup PATH, and the sibling roster —
 // owned siblings you can jump to, plus addable ghosts (the "grow it next" move).
-function PeakDetailCard({
+export function PeakDetailCard({
   leaf,
   variant,
   frequency,

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -27,6 +27,16 @@ type PortraitCirclesProps = {
   editMode?: boolean
   onToggleHidden?: (canonicalSubcategory: string, nextHidden: boolean) => void
   pendingDomain?: string | null
+  /**
+   * Rotation word ("Often" / "Sometimes" / "Blue Moon" / "Never") shown under
+   * each circle's name. Returns null to omit the line for a given domain.
+   */
+  frequencyLabelFor?: (canonicalSubcategory: string) => string | null
+  /**
+   * Tap handler for a circle when NOT in edit mode — opens the domain's detail
+   * pop-up. Edit mode keeps its own hide/show tap (onToggleHidden).
+   */
+  onSelectDomain?: (canonicalSubcategory: string) => void
 }
 
 const TIER_ORDER: PortraitTier[] = [
@@ -159,6 +169,8 @@ export function PortraitDomainCircle({
   editMode = false,
   onToggleHidden,
   pending = false,
+  frequencyLabel = null,
+  onSelectDomain,
 }: {
   entry: PortraitEntry
   maxPointsForTier: number
@@ -170,6 +182,8 @@ export function PortraitDomainCircle({
   editMode?: boolean
   onToggleHidden?: (canonicalSubcategory: string, nextHidden: boolean) => void
   pending?: boolean
+  frequencyLabel?: string | null
+  onSelectDomain?: (canonicalSubcategory: string) => void
 }) {
   const broadCategory = normalizeBroadCategory(entry.broadCategory) ?? 'General Knowledge'
   const dc = getPortraitDomainColor(broadCategory)
@@ -197,21 +211,28 @@ export function PortraitDomainCircle({
   const countFontSize = Math.min(48, Math.max(10, Math.round(size * 0.13)))
 
   const handleClick = () => {
-    if (!editMode || !onToggleHidden || pending) return
-    onToggleHidden(entry.canonicalSubcategory, !isHidden)
+    if (pending) return
+    if (editMode) {
+      onToggleHidden?.(entry.canonicalSubcategory, !isHidden)
+      return
+    }
+    onSelectDomain?.(entry.canonicalSubcategory)
   }
 
-  const interactive = editMode && Boolean(onToggleHidden)
+  const interactive =
+    (editMode && Boolean(onToggleHidden)) || (!editMode && Boolean(onSelectDomain))
 
   return (
     <div
       role={interactive ? 'button' : undefined}
       tabIndex={interactive ? 0 : undefined}
-      aria-pressed={interactive ? isHidden : undefined}
+      aria-pressed={editMode && interactive ? isHidden : undefined}
       aria-label={
-        interactive
-          ? `${isHidden ? 'Show' : 'Hide'} ${entry.canonicalSubcategory} ${isHidden ? 'on your portrait' : 'from friends'}`
-          : undefined
+        !interactive
+          ? undefined
+          : editMode
+            ? `${isHidden ? 'Show' : 'Hide'} ${entry.canonicalSubcategory} ${isHidden ? 'on your portrait' : 'from friends'}`
+            : `View ${entry.canonicalSubcategory} details`
       }
       onClick={interactive ? handleClick : undefined}
       onKeyDown={
@@ -329,6 +350,21 @@ export function PortraitDomainCircle({
       >
         {entry.canonicalSubcategory}
       </span>
+      {frequencyLabel ? (
+        <span
+          style={{
+            fontSize: 9,
+            color: 'var(--warm-ink-400)',
+            fontFamily: 'var(--font-serif)',
+            textAlign: 'center',
+            lineHeight: 1.2,
+            letterSpacing: '0.02em',
+            opacity: dimForHidden ? 0.5 : 1,
+          }}
+        >
+          {frequencyLabel}
+        </span>
+      ) : null}
     </div>
   )
 }
@@ -346,7 +382,14 @@ function getPortraitEntryCircleSize(
   )
 }
 
-export function PortraitCircles({ entries, editMode = false, onToggleHidden, pendingDomain = null }: PortraitCirclesProps) {
+export function PortraitCircles({
+  entries,
+  editMode = false,
+  onToggleHidden,
+  pendingDomain = null,
+  frequencyLabelFor,
+  onSelectDomain,
+}: PortraitCirclesProps) {
   const [sortMode, setSortMode] = useState<SortMode>('domain')
 
   const validEntries = useMemo(
@@ -493,6 +536,8 @@ export function PortraitCircles({ entries, editMode = false, onToggleHidden, pen
                     editMode={editMode}
                     onToggleHidden={onToggleHidden}
                     pending={pendingDomain === entry.canonicalSubcategory}
+                    frequencyLabel={frequencyLabelFor?.(entry.canonicalSubcategory) ?? null}
+                    onSelectDomain={onSelectDomain}
                   />
                 ))}
               </div>

--- a/src/components/knowledge/usePeakDetail.ts
+++ b/src/components/knowledge/usePeakDetail.ts
@@ -1,0 +1,99 @@
+'use client';
+
+import { useCallback, useState, type Dispatch, type SetStateAction } from 'react';
+
+import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
+import { adoptDomain } from '@/components/knowledge/adopt';
+import type { DomainPreferenceFrequency, TerritoryFrequency } from '@/lib/daily/territory-model';
+
+// A peaks leaf's `node.name` === its `canonicalSubcategory`, which is exactly the
+// key `domainPreferenceFrequency` stores — matched case-insensitively, just like
+// the domain-frequency route. Normalize both sides the same way to resolve it.
+export function freqKey(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+// Decision A: a leaf with no explicit preference shows its actual effective
+// default. For an owned peak that's `'sometimes'` ("Sometimes") — the rotation
+// it's already in — so the face is truthful, not blank.
+export const DEFAULT_FREQUENCY: TerritoryFrequency = 'sometimes';
+
+export type PeakDetailController = {
+  tree: KnowledgeTreeNode;
+  setTree: Dispatch<SetStateAction<KnowledgeTreeNode>>;
+  resolveFrequency: (name: string) => TerritoryFrequency;
+  setFrequency: (name: string, frequency: TerritoryFrequency) => Promise<boolean>;
+  adoptNode: (id: string, name: string) => Promise<boolean>;
+};
+
+// Shared state controller for the knowledge peaks detail sheet: it owns the
+// optimistic tree, the per-leaf rotation map (seeded from the server preference),
+// and the two writes the sheet performs — set-frequency and adopt. Extracted so
+// both the peaks circle grid (KnowledgePeaksView) and the flat portrait page
+// (KnowledgeFlatClient) can mount the same PeakDetailCard against one behavior.
+export function usePeakDetail(
+  initialTree: KnowledgeTreeNode,
+  frequencyByDomain: DomainPreferenceFrequency = {},
+): PeakDetailController {
+  const [tree, setTree] = useState<KnowledgeTreeNode>(initialTree);
+
+  // Optimistic frequency map, keyed by normalized domain. Seeded from the server
+  // preference and updated in place on write, so the face pill and detail sheet
+  // reflect the change before the next round rebuilds.
+  const [freqMap, setFreqMap] = useState<Record<string, TerritoryFrequency>>(() => {
+    const seeded: Record<string, TerritoryFrequency> = {};
+    for (const [domain, frequency] of Object.entries(frequencyByDomain)) {
+      seeded[freqKey(domain)] = frequency;
+    }
+    return seeded;
+  });
+
+  const resolveFrequency = useCallback(
+    (name: string): TerritoryFrequency => freqMap[freqKey(name)] ?? DEFAULT_FREQUENCY,
+    [freqMap],
+  );
+
+  // Optimistic write: flip local state, POST the single-domain change, revert on
+  // failure. The route merges server-side and drops untouched Daily Five queues.
+  const setFrequency = useCallback(
+    async (name: string, frequency: TerritoryFrequency): Promise<boolean> => {
+      const key = freqKey(name);
+      const previous = freqMap[key];
+      setFreqMap((prev) => ({ ...prev, [key]: frequency }));
+      try {
+        const res = await fetch('/api/daily/preferences/domain-frequency', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ domain: name, frequency }),
+        });
+        if (!res.ok) throw new Error('frequency update failed');
+        return true;
+      } catch {
+        setFreqMap((prev) => {
+          const next = { ...prev };
+          if (previous === undefined) delete next[key];
+          else next[key] = previous;
+          return next;
+        });
+        return false;
+      }
+    },
+    [freqMap],
+  );
+
+  // Optimistic confirmed add: flip the ghost sibling into a real leaf so it jumps
+  // from "add next" to owned; revert on failure. Mirrors the bubble map.
+  const adoptNode = useCallback(async (id: string, name: string): Promise<boolean> => {
+    const flip = (node: KnowledgeTreeNode, ghost: boolean, value: number): KnowledgeTreeNode =>
+      node.id === id
+        ? { ...node, ghost: ghost || undefined, value }
+        : { ...node, children: node.children?.map((c) => flip(c, ghost, value)) };
+    setTree((prev) => flip(prev, false, 1));
+    const ok = await adoptDomain(name);
+    if (!ok) setTree((prev) => flip(prev, true, 40));
+    return ok;
+  }, []);
+
+  return { tree, setTree, resolveFrequency, setFrequency, adoptNode };
+}


### PR DESCRIPTION
Keeps the flat **"previous"** knowledge view as the base and adds two things from the **"new" (peaks)** view.

## What changed
- **Frequency word under each circle.** Every domain circle in the "Your Knowledge" section now shows its Daily Five rotation word — **Often / Sometimes / Blue Moon / Never** — beneath its name, matching the peaks captions. A domain with no explicit setting shows its true effective default ("Sometimes").
- **Tap-to-open detail pop-up.** Tapping a circle (outside edit mode) opens the same `PeakDetailCard` the peaks view uses — full frequency editor (all four options, optimistic write with revert-on-failure), the "Part of" rollup path, neighboring areas, and "add adjacent" moves. Edit mode keeps its existing hide/show tap.

## How it's wired
- Extracted the peaks detail controller (optimistic tree, per-leaf rotation map, set-frequency + adopt writes) into a shared `usePeakDetail` hook. `KnowledgePeaksView` is refactored onto it with **no behavior change**, so both views share one source of truth.
- Exported `PeakDetailCard` / `indexLeaves` / `LeafInfo` for reuse.
- `PortraitCircles` gains `frequencyLabelFor` + `onSelectDomain` props; threaded down to each circle.
- `KnowledgeFlatClient` resolves a tapped circle to its tree leaf, or a synthesized bare leaf when the tree doesn't carry that domain (so the frequency editor works everywhere), and renders the pop-up in a backdrop modal.
- `page.tsx` fetches the knowledge tree + rotation preferences + fully-explored set for the `previous` branch (the same reads the peaks view makes) and threads them in — an additive read, no change to the portrait's own client-side load.

## Known limitation
Because the flat portrait loads its circles from `/api/knowledge` (not the tree), adopting a *new* adjacent area from the pop-up won't appear in the portrait grid until reload — the modal's own "added" confirmation still fires.

## Verification
- `npx tsc -p tsconfig.typecheck.json` — clean (touched files)
- `eslint` on all changed files — clean
- `check:colors` / `check:spacing` / `check:radius` / `check:fonts` — all pass
- `vitest run src/components/knowledge` — 5 passed
- `next build` — compiles + passes TypeScript (page-data collection needs a DB, unavailable in the build sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6yNBE2cLGH2TNoArbmdbM

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6yNBE2cLGH2TNoArbmdbM)_