### PR TITLE
knowledge: make the "previous" flat portrait the default view

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -11,16 +11,17 @@ export const dynamic = 'force-dynamic';
 
 // The knowledge page now offers three interchangeable views, chosen live via
 // ?view= (replacing the old build-time KNOWLEDGE_MAP_PAGE env gate):
-//   - peaks    (default) → the leaf-first "what you're smart at" gallery
+//   - previous (default) → the flat portrait page (per-circle frequency + the
+//                          tapped-circle detail pop-up)
+//   - peaks              → the leaf-first "what you're smart at" gallery
 //   - current            → the nested circle-pack bubble map
-//   - previous           → the flat portrait page that predates the map
 // Each view owns its own header + switcher chrome; only the selected one's
 // server component runs, so we never double-fetch the tree. The friend page
 // keeps its own flag for now — this switch is the owner surface only.
 function parseView(raw: string | string[] | undefined): KnowledgeView {
   const value = Array.isArray(raw) ? raw[0] : raw;
-  if (value === 'current' || value === 'previous') return value;
-  return 'peaks';
+  if (value === 'current' || value === 'peaks') return value;
+  return 'previous';
 }
 
 export default async function KnowledgePage({
@@ -35,34 +36,35 @@ export default async function KnowledgePage({
     return <KnowledgeBubblePage />;
   }
 
-  if (view === 'previous') {
-    const session = await getSession();
-    if (!session) redirect('/login');
-
-    // The flat portrait still self-loads /api/knowledge, but the per-circle
-    // frequency word and the tapped-circle detail pop-up need the knowledge tree
-    // + rotation preferences (same reads the "peaks" view makes). Fetch them here
-    // and thread them in — an additive read, no change to the portrait's own load.
-    const [{ tree }, preferences, fullyExplored] = await Promise.all([
-      getKnowledgeMapData(session.userId),
-      getDailyPreferences(session.userId),
-      getFullyExploredDomains(session.userId),
-    ]);
-
-    return (
-      <>
-        <div className="mx-auto flex w-[min(672px,94vw)] items-center justify-center pt-5">
-          <KnowledgeViewSwitcher current="previous" />
-        </div>
-        <KnowledgeFlatClient
-          tree={tree}
-          frequencyByDomain={preferences.domainPreferenceFrequency}
-          fullyExploredDomains={fullyExplored}
-        />
-      </>
-    );
+  if (view === 'peaks') {
+    const { KnowledgePeaksPage } = await import('./KnowledgePeaksPage');
+    return <KnowledgePeaksPage />;
   }
 
-  const { KnowledgePeaksPage } = await import('./KnowledgePeaksPage');
-  return <KnowledgePeaksPage />;
+  // Default view: the flat portrait. It still self-loads /api/knowledge, but the
+  // per-circle frequency word and the tapped-circle detail pop-up need the
+  // knowledge tree + rotation preferences (same reads the "peaks" view makes).
+  // Fetch them here and thread them in — an additive read, no change to the
+  // portrait's own load.
+  const session = await getSession();
+  if (!session) redirect('/login');
+
+  const [{ tree }, preferences, fullyExplored] = await Promise.all([
+    getKnowledgeMapData(session.userId),
+    getDailyPreferences(session.userId),
+    getFullyExploredDomains(session.userId),
+  ]);
+
+  return (
+    <>
+      <div className="mx-auto flex w-[min(672px,94vw)] items-center justify-center pt-5">
+        <KnowledgeViewSwitcher current="previous" />
+      </div>
+      <KnowledgeFlatClient
+        tree={tree}
+        frequencyByDomain={preferences.domainPreferenceFrequency}
+        fullyExploredDomains={fullyExplored}
+      />
+    </>
+  );
 }


### PR DESCRIPTION
/knowledge with no ?view= now lands on the flat portrait (per-circle frequency + tapped-circle detail pop-up). peaks becomes an explicit ?view=peaks branch; previous is the fallthrough. The switcher is unchanged — every option already links with an explicit ?view=, so nothing else depended on the old default.


Claude-Session: https://claude.ai/code/session_01P6yNBE2cLGH2TNoArbmdbM