### PR TITLE
From Friends cards default to OPEN on home feed

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -108,8 +108,14 @@ export function ActivityStreamItem({
   // served window on return; surfaces that don't care simply omit it.
   onQuestionResolved?: () => void;
 }) {
-  const [open, setOpen] = useState(false);
   const expandable = questionBacked(item.expand);
+  // From Friends milestone cards on the home/elevated surface default to OPEN so
+  // the friend's questions are visible without a tap (request 2026-07-09). The
+  // flat /activities one-liners and texture reveals still default closed — this
+  // is scoped to the elevated, playable milestone bundle (the From Friends card).
+  const [open, setOpen] = useState(
+    () => expandable && elevated && !nested && item.expand?.kind === 'milestone',
+  );
 
   // CORRECTION 3 (revised): the answered-of-total state is conveyed by the
   // bundle triangle mark (solid → hollow as questions are answered), so the

--- a/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
+++ b/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
@@ -205,8 +205,8 @@ describe('ActivityStreamItem — playable milestone card on the home feed', () =
   });
 });
 
-describe('ActivityStreamItem — collapsed bundle summary expands in place (not a page link)', () => {
-  it('renders the triangle summary with a Play affordance and no link to a streak page', () => {
+describe('ActivityStreamItem — bundle summary defaults OPEN and expands in place (not a page link)', () => {
+  it('opens by default: the streak questions show inline and the affordance reads Close', () => {
     const html = renderToStaticMarkup(
       <ActivityStreamItem
         item={MILESTONE_ITEM}
@@ -215,9 +215,12 @@ describe('ActivityStreamItem — collapsed bundle summary expands in place (not 
         showTimestamp={false}
       />,
     );
-    // Collapsed summary: the remaining count + a Play affordance, tapped to expand.
+    // The From Friends card defaults to OPEN (request 2026-07-09), so the still-
+    // answerable question is already revealed inline and the disclosure reads
+    // "Close" rather than "Play".
     expect(html).toContain('1 of 3 questions');
-    expect(html).toContain('Play');
+    expect(html).toContain('Close');
+    expect(html).toContain('Name the Enterprise-D android.');
     // It is NOT a navigation to a separate streak page — it expands in place.
     expect(html).not.toContain('href="/from-friends/');
   });


### PR DESCRIPTION
## Summary
Changes the default state of From Friends milestone bundle cards on the home feed to display OPEN (showing inline questions) rather than collapsed. This surfaces friend questions without requiring a tap, improving discoverability on the elevated/playable milestone surface.

## Changes
- **ActivityStreamItem.tsx**: Modified the `open` state initialization to default to `true` for expandable milestone bundles on elevated surfaces (home feed), while keeping flat `/activities` one-liners and nested reveals closed by default
  - Added conditional logic: `useState(() => expandable && elevated && !nested && item.expand?.kind === 'milestone')`
  - Scoped to the specific card type and surface to avoid affecting other disclosure patterns
  
- **MilestoneStreamItem.test.tsx**: Updated test expectations to reflect the new default-open behavior
  - Changed test description from "collapsed bundle summary" to "bundle summary defaults OPEN"
  - Updated affordance expectation from "Play" to "Close"
  - Added assertion that the question content is visible inline by default

## Implementation Details
The change is narrowly scoped to the elevated, playable milestone bundle (From Friends card) via a multi-condition check. Other surfaces (flat activity one-liners, nested reveals) retain their closed-by-default behavior, preserving existing UX patterns where appropriate.

https://claude.ai/code/session_01TGnDuKtSk7HE85wmj9HG7P