### PR TITLE
Add pending friend questions nudge to daily summary

### DIFF
--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -166,6 +166,10 @@ export default function DailySummaryPage() {
   const coreCorrect = coreQuestions.filter((q) => q.isCorrect).length
   const coreTotal = coreQuestions.length
 
+  // Questions from friends still waiting across the "For You"/"To You" surfaces —
+  // powers the quiet nudge in the sticky footer. 0 hides the line entirely.
+  const pendingFriendQuestions = summary.pendingFriendQuestions
+
   return (
     <main className="min-h-dvh bg-[var(--brand-cream-page)] px-4 py-6 text-[var(--brand-ink)]">
       {/* B-CRAFTER-LIFECYCLE-01: an unseen author invitation takes over the
@@ -283,14 +287,27 @@ export default function DailySummaryPage() {
           </section>
         ) : null}
 
-        <section className="mt-8 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-6 text-center">
-          <p className="text-[1.05rem] leading-7 text-[var(--brand-ink-700)]">
+        {/* Sticky footer bar — narrow, centered, and pinned to the bottom of the
+            viewport so "Back home" is always reachable while the recap scrolls.
+            bottom-4 floats it off the edge; the shadow lifts it above the cards
+            that scroll behind its sides. */}
+        <section className="sticky bottom-4 z-20 mx-auto mt-8 max-w-xs rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-4 text-center shadow-[var(--shadow-overlay)] sm:max-w-sm">
+          <p className="text-sm leading-6 text-[var(--brand-ink-700)]">
             {tomorrowWeekday}’s five arrive at noon.
           </p>
-          <div className="mt-5 flex flex-col items-center gap-3">
-            <Link className="btn-primary w-full sm:w-auto sm:min-w-56" href="/">
+          <div className="mt-3 flex flex-col items-center gap-2">
+            <Link className="btn-primary w-full" href="/">
               Back home
             </Link>
+            {pendingFriendQuestions > 0 ? (
+              <Link
+                className="text-sm font-medium text-[var(--brand-link)] underline underline-offset-4 transition hover:opacity-70"
+                href="/for-you"
+              >
+                You have {pendingFriendQuestions} question
+                {pendingFriendQuestions === 1 ? '' : 's'} from friends
+              </Link>
+            ) : null}
             <Link
               className="text-muted-foreground text-sm font-medium underline underline-offset-4 transition hover:text-foreground"
               href="/knowledge"

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -53,6 +53,13 @@ export type DailySummaryView = {
   newTerritory: string[];
   tierCrossings: TierCrossing[];
   recentFriendBridge: RecentFriendBridge | null;
+  /**
+   * Count of question cards from friends still waiting for the player across the
+   * two direct surfaces — "Sent" (a friend sent it straight to you) plus
+   * "Broadcasts" (a friend created/shared it). Drives the recap's quiet "you have
+   * N questions from friends" nudge; 0 hides the line.
+   */
+  pendingFriendQuestions: number;
   isFirstCompletedRound: boolean;
   reminderPromptState: 'show' | 'hidden';
   /** Contextual "Refine Your Game" offers derived from this daily (empty → reassurance state). */
@@ -345,7 +352,8 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
   const pointsEarned = [...pointsByDomain.values()].reduce((sum, points) => sum + points, 0);
   const gainedDomains = [...touchedDomains].filter((domain) => (pointsByDomain.get(domain) ?? 0) > 0);
 
-  const recentFriendBridge = await getRecentFriendBridge(userId);
+  const { recentFriendBridge, pendingFriendQuestions } =
+    await getFriendSummarySignals(userId);
   const { isFirstCompletedRound, reminderPromptState } =
     await computeReminderPromptState(userId, dateString, totalAnswered);
   const refine: RefineSectionView = queue
@@ -390,6 +398,7 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
     newTerritory,
     tierCrossings,
     recentFriendBridge,
+    pendingFriendQuestions,
     isFirstCompletedRound,
     reminderPromptState,
     refine,
@@ -611,9 +620,21 @@ async function computeReminderPromptState(
   };
 }
 
-async function getRecentFriendBridge(userId: string): Promise<RecentFriendBridge | null> {
+// Both friend-facing recap signals come from a single feed read: the "Meanwhile"
+// bridge (the most recent in-window friend event) and the pending-questions count
+// that drives the sticky bar's nudge. The count sums the two direct surfaces —
+// Broadcasts (friend created/shared) + Sent (friend sent you directly) — which are
+// exactly the "For You"/"To You" pools the recap points the player back to.
+async function getFriendSummarySignals(userId: string): Promise<{
+  recentFriendBridge: RecentFriendBridge | null;
+  pendingFriendQuestions: number;
+}> {
   const mostRecentReset = new Date(getNextDailyResetBoundary().getTime() - ONE_DAY_MS);
   const page = await getFeedPagePayload(userId, { limit: 5, cursor: null, filter: 'all' });
+  const pendingFriendQuestions =
+    (page.meta.broadcasts_item_count ?? 0) + (page.meta.sent_item_count ?? 0);
+
+  let recentFriendBridge: RecentFriendBridge | null = null;
   for (const item of page.items) {
     if (item.card_type === 'answered_by_you') continue;
     const eventAtRaw = typeof item.source_event_at === 'string' ? item.source_event_at : null;
@@ -621,11 +642,13 @@ async function getRecentFriendBridge(userId: string): Promise<RecentFriendBridge
     const eventAt = new Date(eventAtRaw);
     if (Number.isNaN(eventAt.getTime())) continue;
     if (eventAt < mostRecentReset) continue;
-    return {
+    recentFriendBridge = {
       friendName: item.source_friend_display_name ?? 'A friend',
       cardType: item.card_type,
       domainDisplayName: item.domain_pill ?? null,
     };
+    break;
   }
-  return null;
+
+  return { recentFriendBridge, pendingFriendQuestions };
 }


### PR DESCRIPTION
## Summary
Adds a "you have N questions from friends" nudge to the daily summary recap's sticky footer, driven by a count of pending question cards from friends across the "Sent" and "Broadcasts" surfaces.

## Changes

**Backend (`src/server/db/queries/daily-summary.ts`)**
- Added `pendingFriendQuestions: number` field to `DailySummaryView` type with documentation explaining it drives the recap's quiet nudge and hides when 0
- Refactored `getRecentFriendBridge()` → `getFriendSummarySignals()` to return both the recent friend bridge event and the pending questions count in a single feed read
- Pending count sums `broadcasts_item_count` + `sent_item_count` from the feed page metadata, matching the "For You"/"To You" surfaces the recap points users back to
- Updated `getDailySummary()` to call the renamed function and include `pendingFriendQuestions` in the returned summary object

**Frontend (`src/app/daily/summary/page.tsx`)**
- Extracted `pendingFriendQuestions` from summary data
- Converted the footer section to a sticky, pinned-to-bottom bar (`sticky bottom-4 z-20`) with refined spacing and styling
- Added conditional link to `/for-you` that displays only when `pendingFriendQuestions > 0`, with proper pluralization ("question" vs "questions")
- Adjusted button and text sizing to fit the more compact sticky footer layout

## Implementation Details
- The pending count is computed from a single feed page read (limit 5), reusing the same query that finds the recent friend bridge event — no additional database round-trip
- The sticky footer uses `shadow-[var(--shadow-overlay)]` to lift it above scrolling content and `max-w-xs sm:max-w-sm` to keep it appropriately sized on mobile and desktop
- The nudge link is styled as a secondary action (underlined text) to avoid competing with the primary "Back home" button

https://claude.ai/code/session_01NVCbARdhLW6skwcDictaVS