### PR TITLE
B-FREQUENCY-MARK-01: frequency signal-mark iconography

### DIFF
--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -12,6 +12,7 @@ import {
 import Link from 'next/link';
 import { Plus, Trash2, X } from 'lucide-react';
 
+import { FrequencyMark } from '@/components/knowledge/FrequencyMark';
 import { KnowledgeBubble } from '@/components/knowledge/KnowledgeBubble';
 import { AddTopicField } from '@/components/interests/AddTopicField';
 import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
@@ -785,7 +786,10 @@ function TerritoryZone({
   return (
     <section ref={setRef} className="transition">
       <div className="mb-4 border-b border-[var(--border-light)] pb-3">
-        <h2 className="font-serif text-2xl font-semibold text-[var(--ink)]">{zone.title}</h2>
+        <h2 className="flex items-center gap-2 font-serif text-2xl font-semibold text-[var(--ink)]">
+          <FrequencyMark frequency={zone.value} color="var(--brand-ink-400)" size={18} decorative />
+          {zone.title}
+        </h2>
         <p className="mt-1 text-sm leading-6 text-[var(--text-muted-warm)]">{zone.copy}</p>
       </div>
       <div

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -162,6 +162,7 @@
     --cat-pop-culture-text: #5c0e2a;
     --cat-language:         #2e6e7e;  /* teal — moved off the CORRECT green       */
     --cat-language-text:    #173f4a;
+    --freq-blue-moon:       #65a8bb;  /* Blue Moon crescent — the rotation exception */
     /* Shared width for every left-aligned card in the play thread (question,
        bonus, result, reflection, session-close) so the column reads as one
        coherent conversation with a consistent left + right edge. A percentage of

--- a/src/components/feed/NewTerritoryUndo.tsx
+++ b/src/components/feed/NewTerritoryUndo.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Sparkles } from 'lucide-react';
 
 import { ThreadCard } from '@/components/play/ThreadCard';
+import { FrequencyMark } from '@/components/knowledge/FrequencyMark';
 import {
   TERRITORY_FREQUENCIES,
   TERRITORY_FREQUENCY_LABEL,
@@ -134,7 +135,7 @@ export function NewTerritoryUndo({
               onClick={() => void handleSelect(frequency)}
               disabled={busy}
               aria-pressed={isSelected}
-              className="inline-flex min-h-9 items-center rounded-full border px-3.5 text-[13px] transition-colors disabled:opacity-60"
+              className="inline-flex min-h-9 items-center gap-1.5 rounded-full border px-3.5 text-[13px] transition-colors disabled:opacity-60"
               style={{
                 fontWeight: isSelected ? 700 : 500,
                 color: isSelected ? GOLD_INK : 'var(--text-muted)',
@@ -146,6 +147,7 @@ export function NewTerritoryUndo({
                   : 'var(--brand-rule)',
               }}
             >
+              <FrequencyMark frequency={frequency} color="var(--brand-ink-400)" decorative />
               {TERRITORY_FREQUENCY_LABEL[frequency]}
             </button>
           );

--- a/src/components/knowledge/FrequencyMark.tsx
+++ b/src/components/knowledge/FrequencyMark.tsx
@@ -1,0 +1,122 @@
+// The rotation-frequency signal mark (B-FREQUENCY-MARK-01). One reusable SVG
+// glyph for the four rotation-frequency states, rendered alongside the existing
+// text label wherever the four `TERRITORY_FREQUENCY_LABEL` strings appear.
+//
+// Vocabulary (ratified):
+//   often     → three ascending signal bars rising from a baseline rule.
+//   sometimes → the baseline rule + the first two (shortest) bars.
+//   blue_moon → a small blue crescent (a distinct glyph, NOT "one bar"). Its
+//               blue is a fixed cross-category token, never category-tinted.
+//   resting   → no mark at all. Absence is the signal ("Never" = null).
+//
+// The bars inherit the domain's category color via the `color` prop (a CSS var
+// like `var(--cat-literature)`), falling back to `--brand-ink-400`. The label
+// always carries the meaning — the mark is decorative next to its own text, and
+// only self-labels (role="img" + <title>) when a caller renders it label-less.
+// Pure presentational: it reads no preferences and writes nothing.
+
+import type { ReactElement } from 'react';
+
+import {
+  TERRITORY_FREQUENCY_LABEL,
+  type TerritoryFrequency,
+} from '@/lib/daily/territory-model';
+
+export function FrequencyMark({
+  frequency,
+  color = 'var(--brand-ink-400)',
+  size = 14,
+  className,
+  decorative = false,
+}: {
+  frequency: TerritoryFrequency;
+  /** Resolved category color for the bars, e.g. 'var(--cat-literature)'.
+   *  Ignored for blue_moon (fixed blue) and resting (renders nothing).
+   *  Defaults to 'var(--brand-ink-400)' when omitted. */
+  color?: string;
+  size?: number;
+  className?: string;
+  /** When true, the mark sits next to its own text label → aria-hidden, no
+   *  <title>. When false (default), it self-labels for SR users. */
+  decorative?: boolean;
+}): ReactElement | null {
+  // `resting` ("Never") renders nothing — absence is the signal. No wrapper, no
+  // spacer, so a resting row degrades cleanly to label-only.
+  if (frequency === 'resting') return null;
+
+  // Never render below ~11px effective; the bars/crescent lose legibility.
+  const px = Math.max(12, size);
+
+  // Decorative marks (the common case, beside their own label) are aria-hidden;
+  // label-less marks self-describe via role="img" + <title>.
+  const a11y = decorative
+    ? ({ 'aria-hidden': true } as const)
+    : ({ role: 'img' } as const);
+  const title = decorative ? null : <title>{TERRITORY_FREQUENCY_LABEL[frequency]}</title>;
+
+  if (frequency === 'blue_moon') {
+    // Self-contained crescent — fixed blue, never category-tinted.
+    return (
+      <svg
+        width={px}
+        height={px}
+        viewBox="0 0 14 14"
+        fill="none"
+        className={className}
+        style={{ display: 'block', flexShrink: 0 }}
+        {...a11y}
+      >
+        {title}
+        <path d="M9.5 2.2a5 5 0 1 0 2.3 6.8A5.6 5.6 0 0 1 9.5 2.2Z" fill="var(--freq-blue-moon)" />
+      </svg>
+    );
+  }
+
+  // Signal bars (often / sometimes) — strokes only, flat, no fills or gradients.
+  // Uniform stroke width scales with size (≈1px at size 14).
+  const strokeWidth = px / 14;
+  // Bar x-slots and tops from the ratified prototype (viewBox 0 0 14 10). Bar 1
+  // is shortest, bar 3 tallest — the signal-strength slant. `sometimes` drops
+  // the tallest bar, keeping the baseline + first two shortest bars.
+  const bars = [
+    { x: 4.3, top: 6 },
+    { x: 7.1, top: 3.5 },
+    { x: 9.9, top: 1 },
+  ];
+  const shown = frequency === 'often' ? bars : bars.slice(0, 2);
+
+  return (
+    <svg
+      width={px}
+      height={(px * 10) / 14}
+      viewBox="0 0 14 10"
+      fill="none"
+      className={className}
+      style={{ display: 'block', flexShrink: 0 }}
+      {...a11y}
+    >
+      {title}
+      <line
+        x1={1.5}
+        y1={9}
+        x2={12.5}
+        y2={9}
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+      />
+      {shown.map((bar) => (
+        <line
+          key={bar.x}
+          x1={bar.x}
+          y1={9}
+          x2={bar.x}
+          y2={bar.top}
+          stroke={color}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+        />
+      ))}
+    </svg>
+  );
+}

--- a/src/components/knowledge/KnowledgePeaksView.tsx
+++ b/src/components/knowledge/KnowledgePeaksView.tsx
@@ -13,6 +13,7 @@ import {
   getCircleSize,
   getCircleOpacity,
 } from '@/components/knowledge/CategoryCircles';
+import { FrequencyMark } from '@/components/knowledge/FrequencyMark';
 import {
   TERRITORY_FREQUENCIES,
   TERRITORY_FREQUENCY_COPY,
@@ -524,9 +525,10 @@ function ControlsBar({
               type="button"
               onClick={() => onToggleFreq(freq)}
               aria-pressed={freqFilter.has(freq)}
-              className={pill}
+              className={`${pill} gap-1`}
               style={pillStyle(freqFilter.has(freq))}
             >
+              <FrequencyMark frequency={freq} color="var(--brand-ink-400)" decorative />
               {TERRITORY_FREQUENCY_LABEL[freq]}
             </button>
           ))}
@@ -661,7 +663,8 @@ function KnowledgeCircleCell({
           ✦ Fully explored
         </span>
       ) : showFrequency ? (
-        <span className="text-[10px] tracking-[0.02em] text-[var(--brand-ink-400)]">
+        <span className="inline-flex items-center gap-1 text-[10px] tracking-[0.02em] text-[var(--brand-ink-400)]">
+          <FrequencyMark frequency={frequency} color={fieldColor(node.field)} decorative />
           {TERRITORY_FREQUENCY_LABEL[frequency]}
         </span>
       ) : null}


### PR DESCRIPTION
## Summary

Adds a single reusable SVG mark for the four rotation-frequency states (`often` / `sometimes` / `blue_moon` / `resting`) and renders it beside the existing text label on every surface where those labels appear. Presentational only — no schema, query, API, or rotation-logic change. Labels are untouched and remain the source of meaning (the mark is additive, decorative).

## Changes

- **`globals.css`**: add `--freq-blue-moon: #65a8bb` token — the cross-category crescent blue (the only new token; bars inherit `--cat-*`, resting renders nothing).
- **`FrequencyMark.tsx`** (new): `often` = three ascending category-colored bars on a baseline rule; `sometimes` = baseline + first two bars; `blue_moon` = fixed-blue crescent (never category-tinted); `resting` = `null` (absence is the signal). Bars stroke the passed category color, falling back to `--brand-ink-400`. Decorative beside its own label (`aria-hidden`); self-labels via `role="img"` + `<title>` when used label-less. `size` clamped to a min of 12. Pure presentational.
- **Consumers** (all pass `decorative`, labels unchanged): KnowledgePeaksView detail line (category color) + rotation filter chips (muted ink); TerritorySetup zone headers (muted ink); NewTerritoryUndo segmented control (muted ink).

## Verification

- `tsc -p tsconfig.typecheck.json` clean; `npm test -- territory-model domain-selection` passes; ESLint 0 errors; color ratchet within ceiling.
- Rendered the four marks to confirm geometry: category-colored ascending bars (3 / 2), blue crescent, and label-only for "Never" with no layout shift.

## Note on scope vs. `main`

Authored against the `dev2` line and rebased cleanly onto `main` (only these 5 files, no unrelated commits). `main`'s knowledge portrait page (`KnowledgeFlatClient` / `PortraitCircles`) carries its own frequency **meter** visual that `dev2` did not have; this PR does not touch it, so that face keeps its meter. Reconciling the mark with that meter is a separate design decision, flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEzBqm4hYCxLtFK2nDve6e