### PR TITLE
D-FREQUENCY-MARK-01: washed Never line, right-side placement, previous-tab coverage

### DIFF
--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -787,8 +787,8 @@ function TerritoryZone({
     <section ref={setRef} className="transition">
       <div className="mb-4 border-b border-[var(--border-light)] pb-3">
         <h2 className="flex items-center gap-2 font-serif text-2xl font-semibold text-[var(--ink)]">
-          <FrequencyMark frequency={zone.value} color="var(--brand-ink-400)" size={18} decorative />
           {zone.title}
+          <FrequencyMark frequency={zone.value} color="var(--brand-ink-400)" size={18} decorative />
         </h2>
         <p className="mt-1 text-sm leading-6 text-[var(--text-muted-warm)]">{zone.copy}</p>
       </div>

--- a/src/components/feed/NewTerritoryUndo.tsx
+++ b/src/components/feed/NewTerritoryUndo.tsx
@@ -147,8 +147,8 @@ export function NewTerritoryUndo({
                   : 'var(--brand-rule)',
               }}
             >
-              <FrequencyMark frequency={frequency} color="var(--brand-ink-400)" decorative />
               {TERRITORY_FREQUENCY_LABEL[frequency]}
+              <FrequencyMark frequency={frequency} color="var(--brand-ink-400)" size={13} decorative />
             </button>
           );
         })}

--- a/src/components/knowledge/FrequencyMark.tsx
+++ b/src/components/knowledge/FrequencyMark.tsx
@@ -1,19 +1,23 @@
-// The rotation-frequency signal mark (B-FREQUENCY-MARK-01). One reusable SVG
-// glyph for the four rotation-frequency states, rendered alongside the existing
-// text label wherever the four `TERRITORY_FREQUENCY_LABEL` strings appear.
+// The rotation-frequency signal mark (B-FREQUENCY-MARK-01 / D-FREQUENCY-MARK-01).
+// One reusable SVG glyph for the four rotation-frequency states, rendered to the
+// RIGHT of the existing text label wherever the four `TERRITORY_FREQUENCY_LABEL`
+// strings appear.
 //
 // Vocabulary (ratified):
-//   often     → three ascending signal bars rising from a baseline rule.
-//   sometimes → the baseline rule + the first two (shortest) bars.
-//   blue_moon → a small blue crescent (a distinct glyph, NOT "one bar"). Its
-//               blue is a fixed cross-category token, never category-tinted.
-//   resting   → no mark at all. Absence is the signal ("Never" = null).
+//   often     → baseline rule + three ascending signal bars (short→tall).
+//   sometimes → baseline rule + the first two (shortest) bars.
+//   resting   → the baseline rule ALONE (no bars), washed to 0.28 stroke-opacity
+//               — "no signal" in the same visual family, mirroring the washed
+//               Never *circle* (coreOpacity = 0.28). Never is not absent and not
+//               neutral-gray; it is the faint floor of the category-tinted set.
+//   blue_moon → a small blue crescent (a distinct glyph, NOT "one bar"). Its blue
+//               is a fixed cross-category token, never category-tinted.
 //
-// The bars inherit the domain's category color via the `color` prop (a CSS var
-// like `var(--cat-literature)`), falling back to `--brand-ink-400`. The label
-// always carries the meaning — the mark is decorative next to its own text, and
-// only self-labels (role="img" + <title>) when a caller renders it label-less.
-// Pure presentational: it reads no preferences and writes nothing.
+// The bars AND the Never line inherit the domain's category color via the `color`
+// prop (a CSS var like `var(--cat-literature)`), falling back to `--brand-ink-400`
+// on category-less surfaces. The label always carries the meaning — the mark is
+// decorative next to its own text, and only self-labels (role="img" + <title>)
+// when a caller renders it label-less. Pure presentational: no preference reads.
 
 import type { ReactElement } from 'react';
 
@@ -26,26 +30,22 @@ export function FrequencyMark({
   frequency,
   color = 'var(--brand-ink-400)',
   size = 14,
-  className,
   decorative = false,
+  className,
 }: {
   frequency: TerritoryFrequency;
-  /** Resolved category color for the bars, e.g. 'var(--cat-literature)'.
-   *  Ignored for blue_moon (fixed blue) and resting (renders nothing).
-   *  Defaults to 'var(--brand-ink-400)' when omitted. */
+  /** Resolved category color for the bars + the Never line, e.g.
+   *  'var(--cat-literature)'. Ignored for blue_moon (fixed blue).
+   *  Defaults to 'var(--brand-ink-400)' for category-less surfaces. */
   color?: string;
   size?: number;
-  className?: string;
-  /** When true, the mark sits next to its own text label → aria-hidden, no
-   *  <title>. When false (default), it self-labels for SR users. */
+  /** When true, an adjacent text label already carries the meaning (the common
+   *  case) → aria-hidden, no <title>. When false, self-labels for SR users. */
   decorative?: boolean;
-}): ReactElement | null {
-  // `resting` ("Never") renders nothing — absence is the signal. No wrapper, no
-  // spacer, so a resting row degrades cleanly to label-only.
-  if (frequency === 'resting') return null;
-
+  className?: string;
+}): ReactElement {
   // Never render below ~11px effective; the bars/crescent lose legibility.
-  const px = Math.max(12, size);
+  const px = Math.max(11, size);
 
   // Decorative marks (the common case, beside their own label) are aria-hidden;
   // label-less marks self-describe via role="img" + <title>.
@@ -72,23 +72,28 @@ export function FrequencyMark({
     );
   }
 
-  // Signal bars (often / sometimes) — strokes only, flat, no fills or gradients.
-  // Uniform stroke width scales with size (≈1px at size 14).
+  // The signal mark (often / sometimes / resting) shares one viewBox so all three
+  // align in a row. viewBox is 14 wide × 10 tall; height maps to `size`, so the
+  // rendered mark is `size` tall and `round(size * 14/10)` wide. Strokes only —
+  // flat, no fills or gradients.
   const strokeWidth = px / 14;
-  // Bar x-slots and tops from the ratified prototype (viewBox 0 0 14 10). Bar 1
-  // is shortest, bar 3 tallest — the signal-strength slant. `sometimes` drops
-  // the tallest bar, keeping the baseline + first two shortest bars.
+  const width = Math.round((px * 14) / 10);
+  // Bar x-slots and tops from the ratified prototype. Bar 1 is shortest, bar 3
+  // tallest — the signal-strength slant. `sometimes` keeps the two shortest;
+  // `resting` shows the baseline rule alone (washed), no bars.
   const bars = [
     { x: 4.3, top: 6 },
     { x: 7.1, top: 3.5 },
     { x: 9.9, top: 1 },
   ];
-  const shown = frequency === 'often' ? bars : bars.slice(0, 2);
+  const shown =
+    frequency === 'often' ? bars : frequency === 'sometimes' ? bars.slice(0, 2) : [];
+  const resting = frequency === 'resting';
 
   return (
     <svg
-      width={px}
-      height={(px * 10) / 14}
+      width={width}
+      height={px}
       viewBox="0 0 14 10"
       fill="none"
       className={className}
@@ -96,6 +101,8 @@ export function FrequencyMark({
       {...a11y}
     >
       {title}
+      {/* Baseline rule. For `resting` it is the whole mark, washed to 0.28 —
+          the faint floor of the same category-tinted family as the raised bars. */}
       <line
         x1={1.5}
         y1={9}
@@ -104,6 +111,7 @@ export function FrequencyMark({
         stroke={color}
         strokeWidth={strokeWidth}
         strokeLinecap="round"
+        strokeOpacity={resting ? 0.28 : undefined}
       />
       {shown.map((bar) => (
         <line

--- a/src/components/knowledge/KnowledgePeaksView.tsx
+++ b/src/components/knowledge/KnowledgePeaksView.tsx
@@ -528,8 +528,8 @@ function ControlsBar({
               className={`${pill} gap-1`}
               style={pillStyle(freqFilter.has(freq))}
             >
-              <FrequencyMark frequency={freq} color="var(--brand-ink-400)" decorative />
               {TERRITORY_FREQUENCY_LABEL[freq]}
+              <FrequencyMark frequency={freq} color="var(--brand-ink-400)" size={12} decorative />
             </button>
           ))}
         </div>
@@ -664,8 +664,8 @@ function KnowledgeCircleCell({
         </span>
       ) : showFrequency ? (
         <span className="inline-flex items-center gap-1 text-[10px] tracking-[0.02em] text-[var(--brand-ink-400)]">
-          <FrequencyMark frequency={frequency} color={fieldColor(node.field)} decorative />
           {TERRITORY_FREQUENCY_LABEL[frequency]}
+          <FrequencyMark frequency={frequency} color={fieldColor(node.field)} size={11} decorative />
         </span>
       ) : null}
     </>

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/lib/knowledge/circle-sizing'
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category'
 import { KnowledgeBubble } from '@/components/knowledge/KnowledgeBubble'
+import { FrequencyMark } from '@/components/knowledge/FrequencyMark'
 import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy'
 import {
   TERRITORY_FREQUENCY_LABEL,
@@ -121,49 +122,23 @@ export function expandingTerritoryAccent(domain: string): { border: string; fill
 // grey line — you couldn't tell one circle's rotation from another at a glance.
 // A tiny 3-dot meter fixes that: filled-dot count encodes rotation depth so the
 // whole grid scans without reading a word (Often ●●●, Sometimes ●●○, Never ○○○).
-// The meter is monochrome on purpose — color is reserved for category
-// (STYLE-GUIDE-COLOR §3) and rotation is category-independent — with ONE playful
-// literal exception: "Blue Moon" swaps the dots for an actual small blue crescent
-// moon (the rarest rotation, so the whimsy earns its keep).
-const FREQUENCY_TOTAL_DOTS = 3
-
-const FREQUENCY_FILLED_DOTS: Record<TerritoryFrequency, number> = {
-  often: 3,
-  sometimes: 2,
-  blue_moon: 1,
-  resting: 0,
-}
-
 // Invert the single-source label map so the string coming through
-// `frequencyLabelFor` resolves back to its enum (and thus its meter level)
-// without the caller having to pass both.
+// `frequencyLabelFor` resolves back to its enum (so the shared FrequencyMark can
+// draw the right glyph) without the caller having to pass both.
 const FREQUENCY_BY_LABEL: Record<string, TerritoryFrequency> = Object.fromEntries(
   (Object.entries(TERRITORY_FREQUENCY_LABEL) as [TerritoryFrequency, string][]).map(
     ([freq, label]) => [label, freq]
   )
 )
 
-// Filled crescent (lucide "moon" path), rendered blue for the Blue Moon rotation.
-function BlueMoonGlyph() {
-  return (
-    <svg
-      width={11}
-      height={11}
-      viewBox="0 0 24 24"
-      aria-hidden
-      fill="var(--exploring-accent-blue)"
-      style={{ display: 'block' }}
-    >
-      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
-    </svg>
-  )
-}
-
-function FrequencyTag({ label, dim }: { label: string; dim: boolean }) {
+// The rotation word with the shared signal mark to its RIGHT (D-FREQUENCY-MARK-01,
+// decision E). The mark inherits the domain's category color on this single-domain
+// face (decision D) — `often`/`sometimes` ascending bars, `resting` the washed
+// baseline line, `blue_moon` the blue crescent — replacing the old monochrome
+// dots meter so every frequency surface reads as one object.
+function FrequencyTag({ label, color, dim }: { label: string; color: string; dim: boolean }) {
   const freq = FREQUENCY_BY_LABEL[label] ?? null
-  const filled = freq ? FREQUENCY_FILLED_DOTS[freq] : 0
   const resting = freq === 'resting'
-  const blueMoon = freq === 'blue_moon'
   return (
     <span
       style={{
@@ -174,25 +149,6 @@ function FrequencyTag({ label, dim }: { label: string; dim: boolean }) {
         opacity: dim ? 0.5 : 1,
       }}
     >
-      {blueMoon ? (
-        <BlueMoonGlyph />
-      ) : (
-        <span aria-hidden style={{ display: 'inline-flex', gap: 2 }}>
-          {Array.from({ length: FREQUENCY_TOTAL_DOTS }).map((_, i) => (
-            <span
-              key={i}
-              style={{
-                width: 4,
-                height: 4,
-                borderRadius: '50%',
-                boxSizing: 'border-box',
-                background: i < filled ? 'var(--warm-ink-700)' : 'transparent',
-                border: `1px solid ${i < filled ? 'var(--warm-ink-700)' : 'var(--warm-ink-400)'}`,
-              }}
-            />
-          ))}
-        </span>
-      )}
       <span
         style={{
           fontFamily: 'var(--font-mono)',
@@ -204,6 +160,7 @@ function FrequencyTag({ label, dim }: { label: string; dim: boolean }) {
       >
         {label}
       </span>
+      {freq ? <FrequencyMark frequency={freq} color={color} size={11} decorative /> : null}
     </span>
   )
 }
@@ -447,7 +404,7 @@ export function PortraitDomainCircle({
         {entry.canonicalSubcategory}
       </span>
       {frequencyLabel ? (
-        <FrequencyTag label={frequencyLabel} dim={dimForHidden} />
+        <FrequencyTag label={frequencyLabel} color={dc.primary} dim={dimForHidden} />
       ) : null}
     </div>
   )


### PR DESCRIPTION
## Summary

Revises the frequency signal-mark per the ratified **D-FREQUENCY-MARK-01**, and extends coverage to the knowledge **"previous" tab**. Presentational only — no schema, query, API, or rotation-logic change. Labels remain the source of meaning; the mark is additive, to the right of each label.

## Changes

- **`FrequencyMark.tsx`** reworked:
  - **`resting` reversed** — no longer returns `null`. It now draws the baseline rule alone, **washed to 0.28 stroke-opacity in the category color** — the faint floor of the same signal family, mirroring the washed Never *circle* (`coreOpacity = 0.28`). Every row now carries a mark.
  - **Geometry** — signal viewBox height maps to `size` (mark is `size` tall, `round(size·14/10)` wide), stroke `size/14`, min size clamped to **11**. Crescent + `--freq-blue-moon` token unchanged.
  - Returns a real element for every state (no null branch).
- **Placement flipped to the RIGHT of the label** (decision E) on every surface, cap-height-matched.
- **Previous tab** (`KnowledgeFlatClient` → `PortraitCircles`): replaced the old monochrome **dots-meter + lucide crescent** in `FrequencyTag` with the shared `FrequencyMark`, category-tinted from the portrait's own domain color; removed the now-dead dots constants and `BlueMoonGlyph`. Unifies the previous tab with the other surfaces instead of leaving two competing frequency visuals.

## Surfaces covered (5)

KnowledgePeaksView detail line (category-tinted) + rotation filter chips (neutral); Territory Setup zone headers (neutral); NewTerritoryUndo control (neutral); and the previous-tab portrait face (category-tinted).

## Verification

- Done-when greps: token present, `strokeOpacity` 0.28 branch exists, no `return null`, label render count unchanged.
- `tsc -p tsconfig.typecheck.json` clean; `npm test -- territory-model domain-selection` 17/17; ESLint 0 errors.
- Rendered all five states to confirm: three category bars / two / blue crescent / faint washed 0.28 line, all right of the label.

## Note on scope

The original B-FREQUENCY-MARK-01 done-when expected **4** consumer sites; adding the "previous" tab (decision F — "every surface where the labels appear") makes it **5**. Intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEzBqm4hYCxLtFK2nDve6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEzBqm4hYCxLtFK2nDve6e)_