### PR TITLE
Merge dev2 into main

### DIFF
--- a/drizzle/0117_reviewed_domain_pair.sql
+++ b/drizzle/0117_reviewed_domain_pair.sql
@@ -1,0 +1,31 @@
+-- 0117: ReviewedDomainPair (D-DOMAIN-MERGE-REVIEW-REDESIGN-01, Part 1).
+--
+-- Permanent "Dismiss" record for the domain-merge review surface. When a
+-- curator decides a near-duplicate pair is genuinely two different territories
+-- ("a work vs its genre"), Dismiss writes one row here so the pair never
+-- resurfaces on the next similarity recompute.
+--
+-- The primary key is ORDER-INDEPENDENT and ID-based: it is the two domains'
+-- folded domain_key values sorted ascending and joined with '::' (see
+-- reviewedPairKey in src/server/db/queries/domain-fragmentation.ts). Keying on
+-- the folded key — not the raw label — means (A,B) and (B,A) collapse to one
+-- key AND a cosmetic domain rename that folds to the same key does not
+-- resurrect a dismissed pair. domain_a/domain_b keep a human-readable spelling
+-- of each side at dismiss time, for debugging only — never for matching.
+--
+-- Purely additive: no existing table is altered. RLS enabled with no policies
+-- (the app connects as the owner role, which bypasses RLS) per B-SECURITY-RLS-01
+-- / migration 0081 — without it the table is reachable over Supabase's public
+-- Data API. Every statement is idempotent and mirrored by a defensive guard in
+-- src/instrumentation.ts (precedent: 0116's DomainDepthEstimate guard).
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "ReviewedDomainPair";
+CREATE TABLE IF NOT EXISTS "ReviewedDomainPair" (
+  "pair_key" text PRIMARY KEY NOT NULL,
+  "domain_a" text NOT NULL,
+  "domain_b" text NOT NULL,
+  "reviewed_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "ReviewedDomainPair" ENABLE ROW LEVEL SECURITY;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -820,6 +820,13 @@
 			"when": 1786579200000,
 			"tag": "0116_domain_depth_estimate",
 			"breakpoints": true
+		},
+		{
+			"idx": 117,
+			"version": "7",
+			"when": 1786665600000,
+			"tag": "0117_reviewed_domain_pair",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
   DndContext,
@@ -78,6 +79,14 @@ export function KnowledgeAdminClient({
           touches questions or any player&apos;s mastery.
         </p>
       </header>
+
+      <Link
+        href="/admin/knowledge/merge-review"
+        className="mb-4 inline-flex min-h-9 items-center rounded-md border px-3 text-sm font-medium"
+        style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+      >
+        Merge review — near-duplicate pairs →
+      </Link>
 
       <StructureSuggester graphIsEmpty={nodes.length === 0} onDone={() => router.refresh()} />
 

--- a/src/app/admin/knowledge/merge-review/MergeReviewClient.tsx
+++ b/src/app/admin/knowledge/merge-review/MergeReviewClient.tsx
@@ -1,0 +1,589 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { AdminTabs } from '@/app/admin/AdminTabs';
+
+// D-DOMAIN-MERGE-REVIEW-REDESIGN-01 — the redesigned near-duplicate review list.
+// The old design (never shipped past the weekly email) would have been five flat
+// pills per row: Keep A, Keep B, Leave, A under B, B under A. This replaces that
+// with PROGRESSIVE DISCLOSURE — the real decision is two-level (is this pair
+// related? → if so, how?), so a collapsed row shows just Merge/Nest + Dismiss,
+// and expanding reveals the four specific choices grouped by scope.
+//
+// Styling matches the sibling /admin/knowledge tree editor (rounded-md, brand
+// tokens, --brand-navy primary, --success/--danger reserved) so the two rooms of
+// the knowledge tool read as one surface, per AdminTabs' whole reason to exist.
+
+export type MergeReviewPair = {
+  domainA: string;
+  domainB: string;
+  depthA: number;
+  depthB: number;
+  /** pg_trgm similarity, 0..1. */
+  similarity: number;
+  keyA: string;
+  keyB: string;
+  /** Whether each side exists as a KnowledgeNode — merge/nest need both. */
+  inGraphA: boolean;
+  inGraphB: boolean;
+};
+
+type ActionKind = 'keepA' | 'keepB' | 'aUnderB' | 'bUnderA';
+
+// How long the optimistic toast stays before the action actually commits. Undo
+// within the window means we never call the API at all — the cleanest possible
+// "commit nothing", and the only honest undo for a merge (which is irreversible
+// once the server runs it). Nest could be un-done by deleting the edge, but the
+// same deferred-commit path gives one uniform, atomic restore for all four.
+const UNDO_MS = 6000;
+
+const pairId = (p: MergeReviewPair) => `${p.keyA}__${p.keyB}`;
+// A pair only counts as "big" (worth a confirm tap on the destructive Dismiss)
+// when its combined question depth is substantial — a mis-tap there costs real
+// re-surfacing work. Small pairs dismiss immediately.
+const BIG_PAIR_DEPTH = 20;
+
+type QuestionPeek = { text: string; answer: string; suppressed: boolean };
+
+async function post(body: Record<string, unknown>): Promise<{
+  ok: boolean;
+  status: number;
+  body: unknown;
+}> {
+  try {
+    const res = await fetch('/api/admin/knowledge', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+    return { ok: res.ok, status: res.status, body: await res.json().catch(() => null) };
+  } catch {
+    return { ok: false, status: 0, body: null };
+  }
+}
+
+// The four concrete choices, resolved against a pair. Keep-X folds the OTHER
+// side into X (merge_node source=other, target=kept). X-under-Y draws a
+// containment edge (attach_child child=X, parent=Y). The human-readable label
+// is what the undo toast announces.
+function actionSpec(
+  pair: MergeReviewPair,
+  action: ActionKind,
+): { label: string; body: Record<string, unknown> } {
+  switch (action) {
+    case 'keepA':
+      return {
+        label: `Merged into “${pair.domainA}”`,
+        body: { action: 'merge_node', sourceDomainKey: pair.keyB, targetDomainKey: pair.keyA },
+      };
+    case 'keepB':
+      return {
+        label: `Merged into “${pair.domainB}”`,
+        body: { action: 'merge_node', sourceDomainKey: pair.keyA, targetDomainKey: pair.keyB },
+      };
+    case 'aUnderB':
+      return {
+        label: `Nested “${pair.domainA}” under “${pair.domainB}”`,
+        body: { action: 'attach_child', childDomainKey: pair.keyA, toParentDomainKey: pair.keyB },
+      };
+    case 'bUnderA':
+      return {
+        label: `Nested “${pair.domainB}” under “${pair.domainA}”`,
+        body: { action: 'attach_child', childDomainKey: pair.keyB, toParentDomainKey: pair.keyA },
+      };
+  }
+}
+
+type Pending = { id: string; label: string; pair: MergeReviewPair; body: Record<string, unknown> };
+
+export function MergeReviewClient({ pairs }: { pairs: MergeReviewPair[] }) {
+  // Server truth stays in props; the client only tracks what to HIDE (rows a
+  // dismiss/apply optimistically removed) so a router refresh or reload — which
+  // re-excludes committed/dismissed pairs server-side — reconciles cleanly.
+  const [removed, setRemoved] = useState<Set<string>>(new Set());
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<Pending | null>(null);
+  const pendingRef = useRef<Pending | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const hide = useCallback((id: string) => setRemoved((prev) => new Set(prev).add(id)), []);
+  const unhide = useCallback(
+    (id: string) =>
+      setRemoved((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      }),
+    [],
+  );
+
+  // Commit the pending action for real: run the merge/nest, then record the pair
+  // as reviewed so it never resurfaces (a nest leaves both labels intact, so
+  // without this the near-duplicate would recompute right back onto the list).
+  const commitPending = useCallback(async () => {
+    const pend = pendingRef.current;
+    if (!pend) return;
+    pendingRef.current = null;
+    setPending(null);
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const res = await post(pend.body);
+    if (!res.ok) {
+      unhide(pend.id); // put the row back and surface the failure
+      setError(`Couldn’t apply — ${pend.label} failed (${res.status}). The pair is back in the list.`);
+      return;
+    }
+    await post({ action: 'dismiss_pair', domainA: pend.pair.domainA, domainB: pend.pair.domainB });
+  }, [unhide]);
+
+  // A new action auto-commits whatever was still pending (one toast at a time).
+  const flushPending = useCallback(() => {
+    if (pendingRef.current) void commitPending();
+  }, [commitPending]);
+
+  useEffect(() => {
+    // Leaving the page mid-window commits the in-flight action rather than
+    // silently dropping it (the curator already made the call).
+    return () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      void commitPending();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function apply(pair: MergeReviewPair, action: ActionKind) {
+    flushPending();
+    const spec = actionSpec(pair, action);
+    const id = pairId(pair);
+    setError(null);
+    setExpandedId(null);
+    hide(id);
+    const pend: Pending = { id, label: spec.label, pair, body: spec.body };
+    pendingRef.current = pend;
+    setPending(pend);
+    timerRef.current = window.setTimeout(() => void commitPending(), UNDO_MS);
+  }
+
+  function undo() {
+    const pend = pendingRef.current;
+    if (!pend) return;
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    pendingRef.current = null;
+    setPending(null);
+    unhide(pend.id); // restores row position AND edge/label state — nothing committed
+  }
+
+  async function dismiss(pair: MergeReviewPair) {
+    flushPending();
+    const id = pairId(pair);
+    setError(null);
+    setExpandedId(null);
+    hide(id);
+    const res = await post({ action: 'dismiss_pair', domainA: pair.domainA, domainB: pair.domainB });
+    if (!res.ok) {
+      unhide(id);
+      setError(`Couldn’t dismiss that pair (${res.status}).`);
+    }
+  }
+
+  const visible = pairs.filter((p) => !removed.has(pairId(p)));
+
+  return (
+    <main className="mx-auto min-h-dvh max-w-3xl px-4 pt-6 pb-24">
+      <header className="mb-5">
+        <h1 className="mb-3 font-serif text-2xl font-semibold text-[var(--brand-ink)]">
+          Merge review
+        </h1>
+        <AdminTabs active="knowledge" />
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Near-duplicate territory pairs the automated reconcile deliberately left for a human call.
+          For each, decide: <strong>same scope</strong> (merge them into one) or{' '}
+          <strong>different scope</strong> (nest one under the other) — or{' '}
+          <strong>Dismiss</strong> if they’re genuinely two things (a work vs its genre). Dismiss is
+          permanent; merge/nest give you a few seconds to undo.{' '}
+          <Link href="/admin/knowledge" className="underline">
+            Back to the tree
+          </Link>
+          .
+        </p>
+      </header>
+
+      {error ? (
+        <p className="mb-3 text-[13px]" style={{ color: 'var(--danger)' }}>
+          {error}
+        </p>
+      ) : null}
+
+      {visible.length === 0 ? (
+        <p className="text-muted-foreground rounded-md border px-3 py-6 text-center text-sm" style={{ borderColor: 'var(--border)' }}>
+          Nothing to review — no near-duplicate pairs above the similarity threshold.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {visible.map((pair) => (
+            <MergeReviewRow
+              key={pairId(pair)}
+              pair={pair}
+              expanded={expandedId === pairId(pair)}
+              onToggle={() =>
+                setExpandedId((cur) => (cur === pairId(pair) ? null : pairId(pair)))
+              }
+              onApply={(action) => apply(pair, action)}
+              onDismiss={() => void dismiss(pair)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Persist-with-undo toast (Part 2) — one at a time, fixed in reach. */}
+      {pending ? (
+        <div className="fixed inset-x-0 bottom-0 z-[60] flex justify-center p-3">
+          <div
+            className="flex w-full max-w-lg items-center gap-3 rounded-xl border px-4 py-3 text-sm shadow-[var(--shadow-overlay)]"
+            style={{ background: 'var(--brand-card)', borderColor: 'var(--brand-navy)', color: 'var(--brand-ink-700)' }}
+            aria-live="polite"
+          >
+            <span className="min-w-0 flex-1 truncate">
+              <span aria-hidden className="mr-1">
+                ✓
+              </span>
+              {pending.label}
+            </span>
+            <button
+              type="button"
+              onClick={undo}
+              className="inline-flex min-h-11 shrink-0 items-center rounded-md border px-4 text-sm font-semibold"
+              style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+            >
+              Undo
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}
+
+function badge(inGraph: boolean) {
+  return inGraph ? (
+    <span
+      className="ml-1 shrink-0 rounded-sm px-1 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
+      style={{ color: 'var(--brand-navy)', background: 'color-mix(in srgb, var(--brand-navy) 10%, transparent)' }}
+      title="This territory exists as a node in the knowledge graph"
+    >
+      in graph
+    </span>
+  ) : (
+    <span
+      className="ml-1 shrink-0 rounded-sm px-1 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
+      style={{ color: 'var(--warning)', background: 'var(--warning-surface)' }}
+      title="Not yet a node in the graph — add it in the tree before you can merge or nest it"
+    >
+      not in graph
+    </span>
+  );
+}
+
+function MergeReviewRow({
+  pair,
+  expanded,
+  onToggle,
+  onApply,
+  onDismiss,
+}: {
+  pair: MergeReviewPair;
+  expanded: boolean;
+  onToggle: () => void;
+  onApply: (action: ActionKind) => void;
+  onDismiss: () => void;
+}) {
+  const [choice, setChoice] = useState<ActionKind | null>(null);
+  const [preview, setPreview] = useState<{ a: QuestionPeek[]; b: QuestionPeek[] } | null>(null);
+  const [previewBusy, setPreviewBusy] = useState(false);
+  const [confirmingDismiss, setConfirmingDismiss] = useState(false);
+
+  const bothInGraph = pair.inGraphA && pair.inGraphB;
+  // The ★ keep marker annotates the side holding MORE questions (existing logic).
+  const starSide: 'A' | 'B' | null =
+    pair.depthA === pair.depthB ? null : pair.depthA > pair.depthB ? 'A' : 'B';
+  const pct = Math.round(pair.similarity * 100);
+  const bigPair = pair.depthA + pair.depthB >= BIG_PAIR_DEPTH;
+
+  async function loadPreview() {
+    if (previewBusy) return;
+    if (preview) {
+      setPreview(null); // toggle closed
+      return;
+    }
+    setPreviewBusy(true);
+    const [a, b] = await Promise.all([
+      post({ action: 'list_questions', domainKey: pair.keyA }),
+      post({ action: 'list_questions', domainKey: pair.keyB }),
+    ]);
+    const rows = (r: { ok: boolean; body: unknown }): QuestionPeek[] =>
+      r.ok && r.body && typeof r.body === 'object' && 'questions' in r.body
+        ? ((r.body as { questions: QuestionPeek[] }).questions ?? [])
+        : [];
+    setPreview({ a: rows(a), b: rows(b) });
+    setPreviewBusy(false);
+  }
+
+  const menuBtn =
+    'inline-flex min-h-11 items-center justify-center rounded-md border px-4 text-sm font-semibold disabled:opacity-40';
+
+  return (
+    <div
+      className="rounded-md border transition-colors"
+      style={{ borderColor: expanded ? 'var(--brand-navy)' : 'var(--border)' }}
+    >
+      {/* ── Collapsed row header ── */}
+      <div className="flex flex-wrap items-start gap-x-3 gap-y-2 px-3 py-3">
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+            <span className="flex min-w-0 items-center text-sm font-medium text-[var(--brand-ink)]">
+              <span className="truncate">{pair.domainA}</span>
+              {badge(pair.inGraphA)}
+            </span>
+            <span className="text-muted-foreground text-xs" aria-hidden>
+              ≈
+            </span>
+            <span className="flex min-w-0 items-center text-sm font-medium text-[var(--brand-ink)]">
+              <span className="truncate">{pair.domainB}</span>
+              {badge(pair.inGraphB)}
+            </span>
+            <span
+              className="ml-auto shrink-0 text-xs font-semibold"
+              style={{ color: 'var(--brand-ink-700)' }}
+              title="Trigram similarity"
+            >
+              {pct}%
+            </span>
+          </div>
+          <div className="text-muted-foreground flex flex-wrap gap-x-4 text-xs">
+            <span>
+              {pair.depthA} question{pair.depthA === 1 ? '' : 's'}
+              {starSide === 'A' ? ' · ★ more' : ''}
+            </span>
+            <span>
+              {pair.depthB} question{pair.depthB === 1 ? '' : 's'}
+              {starSide === 'B' ? ' · ★ more' : ''}
+            </span>
+          </div>
+        </div>
+
+        {/* Exactly two controls when collapsed — primary Merge/Nest + quiet Dismiss. */}
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            className={menuBtn}
+            style={
+              expanded
+                ? { borderColor: 'var(--brand-navy)', background: 'var(--brand-navy)', color: 'var(--brand-cream-page)' }
+                : { borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }
+            }
+          >
+            Merge / Nest
+          </button>
+          {confirmingDismiss ? (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="inline-flex min-h-11 items-center rounded-md px-3 text-sm font-semibold"
+              style={{ color: 'var(--danger)' }}
+            >
+              Dismiss — sure?
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => (bigPair ? setConfirmingDismiss(true) : onDismiss())}
+              className="text-muted-foreground inline-flex min-h-11 items-center px-2 text-sm font-medium underline underline-offset-4 hover:text-[var(--brand-ink)]"
+              title="These are genuinely two different territories — never show this pair again"
+            >
+              Dismiss
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Expanded drawer ── */}
+      {expanded ? (
+        <div className="border-t px-3 py-3" style={{ borderColor: 'var(--border)' }}>
+          {!bothInGraph ? (
+            <p className="text-muted-foreground text-sm leading-relaxed">
+              Merge and nest both act on graph nodes, but{' '}
+              {!pair.inGraphA && !pair.inGraphB
+                ? 'neither territory is'
+                : `“${pair.inGraphA ? pair.domainB : pair.domainA}” is not`}{' '}
+              in the graph yet. Add it in the{' '}
+              <Link href="/admin/knowledge" className="underline">
+                tree
+              </Link>{' '}
+              first, then come back — or Dismiss if they’re different scopes.
+            </p>
+          ) : (
+            <fieldset className="space-y-4">
+              <legend className="sr-only">Choose how to resolve this pair</legend>
+
+              <div>
+                <p className="mb-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-[var(--brand-ink-700)]">
+                  Same scope — merge into one domain
+                </p>
+                <div className="space-y-1">
+                  <ChoiceRadio
+                    name={`${pairId(pair)}-choice`}
+                    checked={choice === 'keepA'}
+                    onSelect={() => setChoice('keepA')}
+                    label={`Keep “${pair.domainA}”`}
+                    hint={`${pair.depthA} q${starSide === 'A' ? '  ★ more questions' : ''}`}
+                  />
+                  <ChoiceRadio
+                    name={`${pairId(pair)}-choice`}
+                    checked={choice === 'keepB'}
+                    onSelect={() => setChoice('keepB')}
+                    label={`Keep “${pair.domainB}”`}
+                    hint={`${pair.depthB} q${starSide === 'B' ? '  ★ more questions' : ''}`}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <p className="mb-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-[var(--brand-ink-700)]">
+                  Different scope — nest one under the other
+                </p>
+                <div className="space-y-1">
+                  <ChoiceRadio
+                    name={`${pairId(pair)}-choice`}
+                    checked={choice === 'aUnderB'}
+                    onSelect={() => setChoice('aUnderB')}
+                    label={`“${pair.domainA}” under “${pair.domainB}”`}
+                  />
+                  <ChoiceRadio
+                    name={`${pairId(pair)}-choice`}
+                    checked={choice === 'bUnderA'}
+                    onSelect={() => setChoice('bUnderA')}
+                    label={`“${pair.domainB}” under “${pair.domainA}”`}
+                  />
+                </div>
+              </div>
+
+              {preview ? (
+                <div className="grid gap-3 rounded-md border p-2 sm:grid-cols-2" style={{ borderColor: 'var(--border)', background: 'var(--surface-2)' }}>
+                  <PreviewColumn title={pair.domainA} rows={preview.a} />
+                  <PreviewColumn title={pair.domainB} rows={preview.b} />
+                </div>
+              ) : null}
+
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => void loadPreview()}
+                  disabled={previewBusy}
+                  className={menuBtn}
+                  style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+                >
+                  {previewBusy ? 'Loading…' : preview ? 'Hide preview' : 'Preview'}
+                </button>
+                <span className="ml-auto flex gap-2">
+                  <button
+                    type="button"
+                    onClick={onToggle}
+                    className={menuBtn}
+                    style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    disabled={!choice}
+                    onClick={() => choice && onApply(choice)}
+                    className={menuBtn}
+                    style={
+                      choice
+                        ? { borderColor: 'var(--success)', color: 'var(--success)' }
+                        : { borderColor: 'var(--border)', color: 'var(--text-muted)' }
+                    }
+                  >
+                    Apply
+                  </button>
+                </span>
+              </div>
+            </fieldset>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ChoiceRadio({
+  name,
+  checked,
+  onSelect,
+  label,
+  hint,
+}: {
+  name: string;
+  checked: boolean;
+  onSelect: () => void;
+  label: string;
+  hint?: string;
+}) {
+  return (
+    <label
+      className="flex min-h-11 cursor-pointer items-center gap-2.5 rounded-md border px-3 text-sm transition-colors"
+      style={
+        checked
+          ? { borderColor: 'var(--brand-navy)', background: 'color-mix(in srgb, var(--brand-navy) 6%, transparent)' }
+          : { borderColor: 'var(--border)' }
+      }
+    >
+      <input
+        type="radio"
+        name={name}
+        checked={checked}
+        onChange={onSelect}
+        className="size-4 accent-[var(--brand-navy)]"
+      />
+      <span className="text-[var(--brand-ink)]">{label}</span>
+      {hint ? <span className="text-muted-foreground ml-auto text-xs">{hint}</span> : null}
+    </label>
+  );
+}
+
+function PreviewColumn({ title, rows }: { title: string; rows: QuestionPeek[] }) {
+  return (
+    <div className="min-w-0">
+      <p className="mb-1 truncate text-xs font-semibold text-[var(--brand-ink-700)]" title={title}>
+        {title} · {rows.length} shown
+      </p>
+      {rows.length === 0 ? (
+        <p className="text-muted-foreground text-xs">No questions found.</p>
+      ) : (
+        <ul className="space-y-1">
+          {rows.map((q, i) => (
+            <li
+              key={i}
+              className="text-muted-foreground truncate text-xs"
+              style={q.suppressed ? { opacity: 0.5 } : undefined}
+              title={`${q.text} — ${q.answer}`}
+            >
+              {q.text}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/knowledge/merge-review/page.tsx
+++ b/src/app/admin/knowledge/merge-review/page.tsx
@@ -1,0 +1,49 @@
+import { notFound } from 'next/navigation';
+
+import { getSession } from '@/server/auth/session';
+import { isAdminUser } from '@/server/auth/admin';
+import { getDomainFragmentationCandidates } from '@/server/db/queries/domain-fragmentation';
+import { listKnowledgeGraph } from '@/server/db/queries/knowledge-graph';
+import { domainKey } from '@/lib/knowledge/domain-key';
+
+import { MergeReviewClient, type MergeReviewPair } from './MergeReviewClient';
+
+export const dynamic = 'force-dynamic';
+
+// D-DOMAIN-MERGE-REVIEW-REDESIGN-01 — the interactive review surface for the
+// near-duplicate domain pairs the weekly fragmentation cron used to only email.
+// Progressive disclosure: each collapsed row offers Merge/Nest + Dismiss;
+// expanding reveals the four specific choices grouped by Same-scope / Different-
+// scope. Same admin gate as every /admin page (ADMIN_USER_IDS or Next's 404).
+export default async function DomainMergeReviewPage() {
+  const session = await getSession();
+  if (!session || !isAdminUser(session.userId)) notFound();
+
+  const [candidates, { nodes }] = await Promise.all([
+    getDomainFragmentationCandidates({ limit: 50 }),
+    listKnowledgeGraph(),
+  ]);
+
+  // Merge and Nest both operate on KnowledgeNodes — a corpus label with no node
+  // can't be merged/nested through the graph API. Surface that per side so the
+  // row can show the [IN GRAPH] badge and gate the four actions honestly.
+  const nodeKeys = new Set(nodes.map((n) => n.domainKey));
+
+  const pairs: MergeReviewPair[] = candidates.map((c) => {
+    const keyA = domainKey(c.domainA);
+    const keyB = domainKey(c.domainB);
+    return {
+      domainA: c.domainA,
+      domainB: c.domainB,
+      depthA: c.depthA,
+      depthB: c.depthB,
+      similarity: c.similarity,
+      keyA,
+      keyB,
+      inGraphA: nodeKeys.has(keyA),
+      inGraphB: nodeKeys.has(keyB),
+    };
+  });
+
+  return <MergeReviewClient pairs={pairs} />;
+}

--- a/src/app/api/admin/knowledge/route.ts
+++ b/src/app/api/admin/knowledge/route.ts
@@ -16,6 +16,10 @@ import {
 } from '@/server/db/queries/knowledge-graph';
 import { proposeKnowledgeStructure } from '@/server/knowledge/propose-structure';
 import { mergeDomainIntoTarget } from '@/server/knowledge/merge-domain';
+import {
+  recordReviewedDomainPair,
+  reviewedPairKey,
+} from '@/server/db/queries/domain-fragmentation';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
 export const dynamic = 'force-dynamic';
@@ -99,6 +103,14 @@ const bodySchema = z.discriminatedUnion('action', [
     action: z.literal('merge_node'),
     sourceDomainKey: keySchema,
     targetDomainKey: keySchema,
+  }),
+  // Domain-merge review (D-DOMAIN-MERGE-REVIEW-REDESIGN-01 Part 1): permanently
+  // dismiss a near-duplicate pair so it never resurfaces. Non-destructive —
+  // nothing moves; the pair is just excluded from future review lists.
+  z.object({
+    action: z.literal('dismiss_pair'),
+    domainA: z.string().trim().min(1).max(160),
+    domainB: z.string().trim().min(1).max(160),
   }),
   // The structure suggester: one LLM pass drafts a full grouping of the real
   // corpus; NOTHING persists (suggestions live only in the response).
@@ -302,6 +314,15 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: result.reason, detail: result.detail }, { status });
       }
       return NextResponse.json(result);
+    }
+
+    case 'dismiss_pair': {
+      await recordReviewedDomainPair(data.domainA, data.domainB);
+      console.info('[knowledge-admin] merge pair dismissed', {
+        actorUserId: session.userId,
+        pairKey: reviewedPairKey(data.domainA, data.domainB),
+      });
+      return NextResponse.json({ ok: true });
     }
 
     case 'propose_structure': {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2115,6 +2115,19 @@ export async function register() {
       `);
       await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ENABLE ROW LEVEL SECURITY`);
       await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "DomainDepthEstimate_domain_key" ON "DomainDepthEstimate" ("domain_key")`);
+      // Migration 0117 (D-DOMAIN-MERGE-REVIEW-REDESIGN-01): permanent Dismiss
+      // records for the domain-merge review surface. getDomainFragmentationCandidates
+      // reads it on every review load and would 42P01 if the migration recorded
+      // without the table. Self-contained; same rationale as the 0116 guard.
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "ReviewedDomainPair" (
+          "pair_key" text PRIMARY KEY NOT NULL,
+          "domain_a" text NOT NULL,
+          "domain_b" text NOT NULL,
+          "reviewed_at" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "ReviewedDomainPair" ENABLE ROW LEVEL SECURITY`);
     } catch {
       // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
     }

--- a/src/server/db/queries/__tests__/reviewed-pair-key.test.ts
+++ b/src/server/db/queries/__tests__/reviewed-pair-key.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { reviewedPairKey } from '@/server/db/queries/domain-fragmentation';
+
+// D-DOMAIN-MERGE-REVIEW-REDESIGN-01 Part 1 — the Dismiss key must be
+// order-independent and ID-based (folded domainKey), so (A,B) and (B,A) collapse
+// to one row AND a cosmetic rename that folds to the same key can't resurrect a
+// dismissed pair.
+describe('reviewedPairKey', () => {
+  it('is order-independent: (A,B) and (B,A) produce the same key', () => {
+    expect(reviewedPairKey('Spy School', 'Evil Spy School')).toBe(
+      reviewedPairKey('Evil Spy School', 'Spy School'),
+    );
+  });
+
+  it('folds typographic/connector spelling variants to one key (survives rename)', () => {
+    // Curly vs straight apostrophe, and colon-connector vs space — both fold in
+    // domainKey, so a rename between these spellings keeps the pair dismissed.
+    expect(reviewedPairKey('90’s Hip Hop', 'Rap')).toBe(reviewedPairKey("90's Hip Hop", 'Rap'));
+    expect(reviewedPairKey('Star Trek: TNG', 'Star Wars')).toBe(
+      reviewedPairKey('Star Trek - TNG', 'Star Wars'),
+    );
+  });
+
+  it('keeps genuinely different domains on distinct keys', () => {
+    expect(reviewedPairKey('Alien', 'Predator')).not.toBe(
+      reviewedPairKey('Alien: Covenant', 'Predator'),
+    );
+  });
+
+  it('joins the two folded keys sorted ascending with "::"', () => {
+    expect(reviewedPairKey('Beta', 'Alpha')).toBe('alpha::beta');
+  });
+});

--- a/src/server/db/queries/domain-fragmentation.ts
+++ b/src/server/db/queries/domain-fragmentation.ts
@@ -1,7 +1,40 @@
 import { sql } from 'drizzle-orm';
 
-import { db } from '@/server/db';
+import { db, reviewedDomainPairs } from '@/server/db';
 import { domainKey } from '@/lib/knowledge/domain-key';
+
+/**
+ * The canonical, order-independent key for a reviewed pair (Part 1 of
+ * D-DOMAIN-MERGE-REVIEW-REDESIGN-01). The two domains' FOLDED keys sorted
+ * ascending and '::'-joined, so (A,B) and (B,A) collapse to one key and a
+ * cosmetic rename that folds to the same key does not resurrect a dismissed
+ * pair. Deliberately keyed on domainKey(), never the raw label.
+ */
+export function reviewedPairKey(a: string, b: string): string {
+  return [domainKey(a), domainKey(b)].sort().join('::');
+}
+
+/** The set of pair keys a curator has permanently dismissed (Part 1). */
+export async function getReviewedPairKeys(): Promise<Set<string>> {
+  const rows = await db.select({ pairKey: reviewedDomainPairs.pairKey }).from(reviewedDomainPairs);
+  return new Set(rows.map((r) => r.pairKey));
+}
+
+/**
+ * Record a permanent Dismiss for a near-duplicate pair. Idempotent on the
+ * order-independent key — a re-dismiss (or a (B,A) re-order) is a no-op that
+ * refreshes the display spellings. Never surfaces again after this.
+ */
+export async function recordReviewedDomainPair(domainA: string, domainB: string): Promise<void> {
+  const pairKey = reviewedPairKey(domainA, domainB);
+  await db
+    .insert(reviewedDomainPairs)
+    .values({ pairKey, domainA, domainB })
+    .onConflictDoUpdate({
+      target: reviewedDomainPairs.pairKey,
+      set: { domainA, domainB, reviewedAt: sql`now()` },
+    });
+}
 
 /**
  * Tier-2 fragmentation surfacing (D-NARROW-KB-FABRICATION-01 follow-up). Tier-1
@@ -85,12 +118,18 @@ export async function getDomainFragmentationCandidates(
     (result as unknown as { rows?: FragmentationRow[] }).rows ??
     (result as unknown as FragmentationRow[]);
 
+  // Permanently dismissed pairs never resurface, including after a similarity
+  // recompute (Part 1). Loaded once and filtered in JS because the pair key is
+  // the folded domainKey() (a TS function), not a raw column comparison.
+  const dismissed = await getReviewedPairKeys();
+
   const pairs: FragmentationPair[] = [];
   for (const row of rows) {
     // Drop pairs the strengthened domainKey() already auto-folds at write time —
     // those converge on their own and need no human. Surface only distinct-key
     // near-duplicates, the genuine judgment calls.
     if (domainKey(row.domain_a) === domainKey(row.domain_b)) continue;
+    if (dismissed.has(reviewedPairKey(row.domain_a, row.domain_b))) continue;
     pairs.push({
       domainA: row.domain_a,
       depthA: Number(row.depth_a),

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1765,6 +1765,19 @@ export const domainDepthEstimates = pgTable(
   ],
 );
 
+// ReviewedDomainPair (0117, D-DOMAIN-MERGE-REVIEW-REDESIGN-01): permanent
+// "Dismiss" record for the domain-merge review surface. pair_key is the two
+// domains' folded domain_key values sorted + '::'-joined (order-independent,
+// rename-surviving — see reviewedPairKey). getDomainFragmentationCandidates
+// excludes any pair whose key sits here, so a dismissed pair never resurfaces
+// after a similarity recompute. domain_a/domain_b are display spellings only.
+export const reviewedDomainPairs = pgTable('ReviewedDomainPair', {
+  pairKey: text('pair_key').primaryKey(),
+  domainA: text('domain_a').notNull(),
+  domainB: text('domain_b').notNull(),
+  reviewedAt: timestamp('reviewed_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
 // Batch-verify async mode (0106): one row per Anthropic Message Batch of
 // verification requests submitted by /api/cron/batch-verify-questions when
 // BATCH_VERIFY_ASYNC_ENABLED is on. The daily cron harvests 'submitted' runs


### PR DESCRIPTION
Merges `dev2` into `main`. At merge time `main` was 50 commits ahead of the merge base while `dev2` carried the 2-commit **domain-merge review redesign** (`D-DOMAIN-MERGE-REVIEW-REDESIGN-01`). This is a real merge commit with both branch tips as parents.

## Conflicts resolved (3)

1. **Migration numbering collision** — dev2's `0117_reviewed_domain_pair` collided with main's `0117`–`0121` supply-finiteness migrations. Renumbered dev2's migration to **`0122_reviewed_domain_pair`**: renamed the SQL file, appended a `_journal.json` entry (idx 122, `when` later than the prior entry per repo convention), and updated the `0117`→`0122` references in `instrumentation.ts` and `schema.ts`. Verified 123 contiguous journal indices matching 123 SQL files, no duplicates.

2. **`src/instrumentation.ts`** — both sides added additive boot guards. Kept **both** blocks: main's `DomainDepthEstimate`/`GateDropStat` guards and dev2's `ReviewedDomainPair` guard (relabeled 0122).

3. **`src/server/db/queries/domain-fragmentation.ts`** — both branches rewrote `getDomainFragmentationCandidates`. Combined **both** filters: main's graph-context logic (`hasNodeA`/`hasNodeB` chips + skip pairs already connected by an edge) and dev2's permanent dismissed-pair filtering. Merged the imports accordingly.

`schema.ts`, the admin knowledge route, and `KnowledgeAdminClient.tsx` auto-merged cleanly.

## Verification

- No conflict markers remain; `_journal.json` parses as valid JSON.
- All consumers (`recordReviewedDomainPair`, `reviewedPairKey`, the merge-review client and its test) resolve against the merged exports.
- Confirmed no stray `src/middleware.ts` (a recurring regression in this repo — this codebase uses `src/proxy.ts`).

## Caveat

`node_modules` is not installed in the merge environment, so `tsc`, the test suite, and `scripts/reconcile-drizzle.mjs` could not be run locally. The journal was hand-reconciled per the documented convention and the merged code was reviewed by hand — CI is the first place a full typecheck/test run executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFiMRMeMyqHJ2iXrfjQiKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFiMRMeMyqHJ2iXrfjQiKK)_