### PR TITLE
feat(knowledge): hide the create FAB on the knowledge page

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -121,6 +121,7 @@ export function Nav({
     pathname.startsWith('/daily') ||
     pathname.startsWith('/games/') ||
     pathname.startsWith('/admin') ||
+    pathname.startsWith('/knowledge') ||
     pathname === '/friends' ||
     isOtherUserProfilePath;
   const showNewGameShortcut = !hidesNewGameShortcut;


### PR DESCRIPTION
Add /knowledge to hidesNewGameShortcut so the global floating "+"
button no longer overlays the knowledge surface, matching how
/daily, /games, /admin, and /friends already suppress it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011Cku9kwsXAH5ESr87Q2m7z