### PR TITLE
Add inside-joke field to admin question editor

### DIFF
--- a/src/app/admin/questions/AdminQuestionsClient.tsx
+++ b/src/app/admin/questions/AdminQuestionsClient.tsx
@@ -190,6 +190,7 @@ function EditForm({
   const [answerText, setAnswerText] = useState(detail.answerText);
   const [acceptedAlternatives, setAcceptedAlternatives] = useState(detail.acceptedAlternatives.join('\n'));
   const [factualExplanation, setFactualExplanation] = useState(detail.factualExplanation ?? '');
+  const [insideJoke, setInsideJoke] = useState(detail.insideJoke ?? '');
   const [category, setCategory] = useState(detail.category);
   const [visibility, setVisibility] = useState(detail.visibility);
   // Author: 'person' keeps the current human creator; 'house' re-sources to the
@@ -214,6 +215,9 @@ function EditForm({
     }
     if ((factualExplanation.trim() || null) !== (detail.factualExplanation ?? null)) {
       patch.factualExplanation = factualExplanation.trim() || null;
+    }
+    if ((insideJoke.trim() || null) !== (detail.insideJoke ?? null)) {
+      patch.insideJoke = insideJoke.trim() || null;
     }
     if (category !== detail.category) patch.category = category;
     if (visibility !== detail.visibility) patch.visibility = visibility;
@@ -294,6 +298,15 @@ function EditForm({
           Factual explanation
         </label>
         <textarea rows={3} className={inputClass} style={inputStyle} value={factualExplanation} onChange={(e) => setFactualExplanation(e.target.value)} />
+      </div>
+      <div className="mb-3">
+        <label className={labelClass} style={labelStyle}>
+          Inside joke
+        </label>
+        <textarea rows={2} className={inputClass} style={inputStyle} value={insideJoke} onChange={(e) => setInsideJoke(e.target.value)} />
+        <p className="mt-1 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          The &ldquo;between us&rdquo; aside. Leave blank to clear it.
+        </p>
       </div>
       <div className="mb-3">
         <label className={labelClass} style={labelStyle}>

--- a/src/app/api/admin/questions/__tests__/route.test.ts
+++ b/src/app/api/admin/questions/__tests__/route.test.ts
@@ -72,6 +72,17 @@ describe('admin questions mutation route — actions (admin)', () => {
     expect(editMock).toHaveBeenCalledWith('q1', expect.objectContaining({ questionText: 'New?', visibility: 'private' }));
   });
 
+  it('dispatches an inside-joke edit (including clearing it to empty)', async () => {
+    const set = await post({ action: 'edit', id: 'q1', insideJoke: 'between us' });
+    expect(set.status).toBe(200);
+    expect(editMock).toHaveBeenCalledWith('q1', expect.objectContaining({ insideJoke: 'between us' }));
+
+    editMock.mockClear();
+    const clear = await post({ action: 'edit', id: 'q1', insideJoke: '' });
+    expect(clear.status).toBe(200);
+    expect(editMock).toHaveBeenCalledWith('q1', expect.objectContaining({ insideJoke: '' }));
+  });
+
   it('rejects an edit with no editable fields', async () => {
     const res = await post({ action: 'edit', id: 'q1' });
     expect(res.status).toBe(400);

--- a/src/app/api/admin/questions/route.ts
+++ b/src/app/api/admin/questions/route.ts
@@ -28,6 +28,8 @@ const editSchema = z.object({
   answerText: z.string().trim().min(1).max(1000).optional(),
   acceptedAlternatives: z.array(z.string().trim().min(1).max(1000)).max(50).optional(),
   factualExplanation: z.string().trim().max(4000).nullable().optional(),
+  // The "between us" aside — flavor text, not grading-adjacent.
+  insideJoke: z.string().trim().max(2000).nullable().optional(),
   category: z.enum(CATEGORIES).optional(),
   visibility: z.enum(['public', 'friends', 'private']).optional(),
   // Re-attribution to the house author (creator_id NULL + source house_authored).
@@ -74,6 +76,7 @@ export async function POST(request: NextRequest) {
     answerText: fields.answerText,
     acceptedAlternatives: fields.acceptedAlternatives,
     factualExplanation: fields.factualExplanation,
+    insideJoke: fields.insideJoke,
     category: fields.category,
     visibility: fields.visibility,
     attribution: fields.attribution,

--- a/src/server/db/queries/admin-questions.ts
+++ b/src/server/db/queries/admin-questions.ts
@@ -111,6 +111,10 @@ export type AdminEditQuestionInput = {
   answerText?: string;
   acceptedAlternatives?: string[];
   factualExplanation?: string | null;
+  // The "between us" aside. Flavor text, not grading-adjacent — editing it does
+  // NOT clear the verification stamp (verification fact-checks the answer, not
+  // the aside). Empty string normalizes to null.
+  insideJoke?: string | null;
   category?: string;
   visibility?: string;
   // Re-attribution. 'house' re-sources the question to the labeled non-human
@@ -151,6 +155,11 @@ export async function adminEditQuestion(
   if (input.factualExplanation !== undefined) {
     values.factualExplanation = input.factualExplanation || null;
     contentChanged = true;
+  }
+  if (input.insideJoke !== undefined) {
+    // Metadata, not content: the aside is flavor and isn't fact-checked, so it
+    // does NOT flip contentChanged (the verification stamp stays put).
+    values.insideJoke = input.insideJoke || null;
   }
   if (input.category !== undefined) {
     values.category = input.category as typeof questions.$inferInsert.category;


### PR DESCRIPTION
## Summary
Adds support for editing an "inside joke" field on questions — a flavor-text aside that is not fact-checked and does not affect the verification stamp.

## Changes
- **Client UI:** Added textarea input in `AdminQuestionsClient.tsx` for the `insideJoke` field with a helper label ("The 'between us' aside. Leave blank to clear it.")
- **API validation:** Extended the edit schema in `route.ts` to accept `insideJoke` as a trimmed string up to 2000 characters, nullable
- **Database query:** Updated `adminEditQuestion()` in `admin-questions.ts` to handle the `insideJoke` field; marked as metadata (not content), so editing it does not flip the `contentChanged` flag and preserves the verification stamp
- **Tests:** Added test case covering both setting and clearing the inside-joke field

## Implementation details
- The field is treated as metadata flavor text, not grading-adjacent content — editing it does not trigger a verification stamp reset (unlike `factualExplanation` or answer changes)
- Empty string normalizes to `null` in the database, consistent with the `factualExplanation` pattern
- Max length is 2000 characters (half the `factualExplanation` limit, appropriate for a brief aside)

https://claude.ai/code/session_01J7YBotv28kWBKRdxHEbzTy