### PR TITLE
feat(knowledge): daily mastery-v2 calibration report (shadow mode)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,3 +155,17 @@ DOTENV_CONFIG_QUIET=true
 # bubble map (B-KNOWLEDGE-TAXONOMY-01 P5 + D-KNOWLEDGE-MAP-USABILITY-01).
 # Default off; set in the production Vercel env where the map is live.
 # KNOWLEDGE_MAP_PAGE=true
+
+# ── Mastery-v2 calibration digest (daily cron) ───────────────
+# The mastery-calibration-report cron runs in SHADOW (computes what mastery-v2
+# WOULD show without enabling KNOWLEDGE_MASTERY_V2), stores a daily snapshot, and
+# emails a flip-readiness/recalibration digest. All optional — sensible defaults.
+# Recipient override (defaults to the ADMIN_USER_IDS account, like the cost report).
+# MASTERY_CALIBRATION_REPORT_EMAIL=""
+# Force a daily send during the observation window. Default: quiet-by-default —
+# only emails when actionable (a live player loses a badge on flip, a node is
+# unmasterable at its threshold, or reachability dropped week-over-week).
+# MASTERY_CALIBRATION_ALWAYS_EMAIL=true
+# Estimated points one bank question can award — the coarse proxy behind the
+# threshold-vs-supply ESTIMATE (real per-answer points vary). Default 50.
+# MASTERY_CALIBRATION_POINTS_PER_QUESTION=50

--- a/drizzle/0123_mastery_calibration_snapshot.sql
+++ b/drizzle/0123_mastery_calibration_snapshot.sql
@@ -1,0 +1,29 @@
+-- 0123: MasteryCalibrationSnapshot — one daily snapshot of the mastery-v2
+-- calibration picture (D-MASTERY-FINEST-NODE-01 observability).
+--
+-- Captured in SHADOW by the mastery-calibration-report cron: it computes what
+-- mastery-v2 WOULD show via the pure resolveV2Mastery, without enabling
+-- KNOWLEDGE_MASTERY_V2 or writing the leaf-freeze ledger. `metrics` (jsonb) holds
+-- the structured aggregate — reachability buckets, v1<->v2 badge divergence,
+-- per-node headroom, threshold-vs-supply classification, flip-readiness verdict —
+-- so trends chart without re-parsing markdown; `markdown` is the rendered digest
+-- (identical to the email body). One row per UTC day, replaced on a same-day
+-- re-run via the (day) unique key.
+--
+-- Purely additive; RLS enabled per B-SECURITY-RLS-01 (no policies — the app
+-- connects as the owner role, which bypasses RLS).
+--
+-- Rollback: DROP TABLE IF EXISTS "MasteryCalibrationSnapshot";
+CREATE TABLE IF NOT EXISTS "MasteryCalibrationSnapshot" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  "day" date NOT NULL,
+  "flag_enabled" boolean NOT NULL DEFAULT false,
+  "metrics" jsonb NOT NULL,
+  "markdown" text NOT NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "MasteryCalibrationSnapshot_day_unique" UNIQUE ("day")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "MasteryCalibrationSnapshot_day_idx" ON "MasteryCalibrationSnapshot" ("day");
+--> statement-breakpoint
+ALTER TABLE "MasteryCalibrationSnapshot" ENABLE ROW LEVEL SECURITY;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -862,6 +862,13 @@
 			"when": 1787097600000,
 			"tag": "0122_reviewed_domain_pair",
 			"breakpoints": true
+		},
+		{
+			"idx": 123,
+			"version": "7",
+			"when": 1787184000000,
+			"tag": "0123_mastery_calibration_snapshot",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/app/api/cron/mastery-calibration-report/route.ts
+++ b/src/app/api/cron/mastery-calibration-report/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { isCronAuthorized } from '@/server/auth/cron';
+import {
+  buildMasteryCalibration,
+  readCalibSnapshotAround,
+  renderMasteryCalibrationMarkdown,
+  writeMasteryCalibrationSnapshot,
+} from '@/server/knowledge/mastery-calibration';
+import { sendMasteryCalibrationEmail } from '@/server/email/send-mastery-calibration';
+
+export const dynamic = 'force-dynamic';
+
+// D-MASTERY-FINEST-NODE-01 observability — the DAILY mastery-v2 calibration
+// digest. Runs in SHADOW (computes what v2 would show without enabling the flag),
+// stores one snapshot row per UTC day, and — quiet-by-default — emails the digest
+// only when something is actionable: a live player would lose a badge on flip, a
+// node is unmasterable at its threshold, or mastery reachability dropped WoW. Set
+// MASTERY_CALIBRATION_ALWAYS_EMAIL=true to force a daily send during the initial
+// observation window. Owner can trigger manually (same cron auth) to refresh.
+const WOW_DAYS = 7;
+
+function boolEnv(name: string): boolean {
+  const raw = process.env[name]?.trim().toLowerCase();
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}
+
+export async function GET(request: NextRequest) {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const metrics = await buildMasteryCalibration();
+    // WoW baseline for deltas (nearest snapshot on/after ~7 days ago). Best-effort.
+    const previousSnap = await readCalibSnapshotAround(WOW_DAYS).catch(() => null);
+    const previous = previousSnap?.metrics ?? null;
+
+    const markdown = renderMasteryCalibrationMarkdown(metrics, previous);
+    await writeMasteryCalibrationSnapshot(metrics, markdown);
+
+    const wowMasteryDrop =
+      previous != null && metrics.reachability.bucket75plus < previous.reachability.bucket75plus;
+    const alwaysEmail = boolEnv('MASTERY_CALIBRATION_ALWAYS_EMAIL');
+    const shouldEmail = alwaysEmail || metrics.actionable || wowMasteryDrop;
+
+    let emailed = false;
+    let emailReason: string | undefined;
+    if (shouldEmail) {
+      const email = await sendMasteryCalibrationEmail(metrics, markdown);
+      emailed = email.ok;
+      if (!email.ok) {
+        emailReason = email.reason;
+        if (email.reason === 'send_failed') {
+          console.warn('[mastery-calibration-report] snapshot stored but email send failed', {
+            message: email.message,
+          });
+        }
+      }
+    } else {
+      emailReason = 'quiet';
+    }
+
+    return NextResponse.json({
+      stored: true,
+      shadow: metrics.shadow,
+      verdict: metrics.verdict,
+      players: metrics.players,
+      nodes: metrics.totalNodes,
+      badgesLostOnFlip: metrics.badges.lostByRealPlayers,
+      unmasterableThreshold: metrics.classificationCounts.UNREACHABLE_THRESHOLD,
+      masteredPairs: metrics.reachability.bucket75plus,
+      actionable: metrics.actionable,
+      wowMasteryDrop,
+      emailed,
+      emailReason,
+    });
+  } catch (error) {
+    console.error('[mastery-calibration-report] failed to build/store snapshot', error);
+    return NextResponse.json({ stored: false, error: 'report_failed' }, { status: 500 });
+  }
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1895,3 +1895,27 @@ export const gateDropStat = pgTable(
   },
   (table) => [unique('GateDropStat_day_gate_unique').on(table.day, table.gate)],
 );
+
+// D-MASTERY-FINEST-NODE-01 observability — one daily snapshot of the mastery-v2
+// calibration picture, captured in SHADOW (computed via the pure resolveV2Mastery
+// without enabling KNOWLEDGE_MASTERY_V2 or writing the freeze ledger). `metrics`
+// holds the structured aggregate (reachability buckets, v1↔v2 badge divergence,
+// per-node headroom, threshold-vs-supply classification, flip-readiness verdict)
+// so trends chart without re-parsing markdown; `markdown` is the rendered digest
+// (identical to the email body). One row per UTC day, replaced on a same-day re-run.
+export const masteryCalibrationSnapshot = pgTable(
+  'MasteryCalibrationSnapshot',
+  {
+    id: id(),
+    day: date('day').notNull(),
+    // Was KNOWLEDGE_MASTERY_V2 actually live when captured? false = pure shadow.
+    flagEnabled: boolean('flag_enabled').notNull().default(false),
+    metrics: jsonb('metrics').notNull(),
+    markdown: text('markdown').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    unique('MasteryCalibrationSnapshot_day_unique').on(table.day),
+    index('MasteryCalibrationSnapshot_day_idx').on(table.day),
+  ],
+);

--- a/src/server/email/send-mastery-calibration.ts
+++ b/src/server/email/send-mastery-calibration.ts
@@ -1,0 +1,39 @@
+/**
+ * Best-effort delivery of the daily mastery-v2 calibration digest. Never throws —
+ * mirrors send-cost-report.ts. The cron decides WHETHER to send (quiet-by-default);
+ * this module handles recipient resolution + template + Resend.
+ *
+ * Recipient: MASTERY_CALIBRATION_REPORT_EMAIL overrides; otherwise it falls back
+ * to the same admin address the cost report uses (resolveCostReportRecipient).
+ */
+
+import { sendEmail } from '@/server/email/client';
+import { buildMasteryCalibrationEmailTemplate } from '@/server/email/templates/mastery-calibration';
+import { resolveCostReportRecipient } from '@/server/db/queries/llm-cost-report';
+import type { MasteryCalibrationMetrics } from '@/server/knowledge/mastery-calibration';
+
+export type RecipientSource = 'env' | 'admin_verified' | 'admin_unverified';
+
+export type SendCalibResult =
+  | { ok: true; id: string | null; source: RecipientSource }
+  | { ok: false; reason: 'no_recipient' | 'send_failed'; message?: string };
+
+async function resolveRecipient(): Promise<{ to: string; source: RecipientSource } | null> {
+  const override = process.env.MASTERY_CALIBRATION_REPORT_EMAIL?.trim();
+  if (override) return { to: override, source: 'env' };
+  const fallback = await resolveCostReportRecipient();
+  return fallback ? { to: fallback.to, source: fallback.source } : null;
+}
+
+export async function sendMasteryCalibrationEmail(
+  metrics: MasteryCalibrationMetrics,
+  markdown: string,
+): Promise<SendCalibResult> {
+  const recipient = await resolveRecipient();
+  if (!recipient) return { ok: false, reason: 'no_recipient' };
+
+  const { subject, html, text } = buildMasteryCalibrationEmailTemplate({ metrics, markdown });
+  const result = await sendEmail({ to: recipient.to, subject, html, text });
+  if (!result.ok) return { ok: false, reason: 'send_failed', message: result.message };
+  return { ok: true, id: result.id, source: recipient.source };
+}

--- a/src/server/email/templates/mastery-calibration.ts
+++ b/src/server/email/templates/mastery-calibration.ts
@@ -1,0 +1,58 @@
+/**
+ * Email template for the daily mastery-v2 calibration digest.
+ *
+ * Internal admin digest — a branded header + the rendered markdown body (kept as
+ * the email `text` so the stored snapshot and the email stay byte-identical). The
+ * HTML is a lightweight card, not a per-metric table, so there's nothing to drift
+ * out of sync with the markdown renderer.
+ */
+
+import type { MasteryCalibrationMetrics } from '@/server/knowledge/mastery-calibration';
+
+const CREAM = '#fcf8f2';
+const CARD = '#fdfcfb';
+const INK = '#0a1f3d';
+const MUTED = '#5b6472';
+const DANGER = '#a3341f';
+const OK = '#1f6d3a';
+const SANS =
+  "'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif";
+const MONO = "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
+
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function buildMasteryCalibrationEmailTemplate(params: {
+  metrics: MasteryCalibrationMetrics;
+  markdown: string;
+}): { subject: string; html: string; text: string } {
+  const { metrics, markdown } = params;
+  const notReady = metrics.verdict === 'NOT_READY';
+
+  const subject = notReady
+    ? `Mastery-v2 calibration — NOT READY (${metrics.badges.lostByRealPlayers} badge${metrics.badges.lostByRealPlayers === 1 ? '' : 's'} at risk)`
+    : `Mastery-v2 calibration — READY (${metrics.reachability.bucket75plus} mastered pairs)`;
+
+  const verdictColor = notReady ? DANGER : OK;
+  const shadowNote = metrics.shadow
+    ? 'Shadow mode — computed without enabling the v2 flag.'
+    : 'v2 flag is LIVE.';
+
+  const html = `<!doctype html><html><body style="margin:0;padding:24px;background:${CREAM};font-family:${SANS};color:${INK}">
+  <div style="max-width:680px;margin:0 auto;background:${CARD};border-radius:12px;padding:28px 32px;border:1px solid #eadfce">
+    <div style="font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:${MUTED}">Mastery v2 · daily calibration</div>
+    <div style="font-size:22px;font-weight:700;margin:6px 0 2px">Flip-readiness: <span style="color:${verdictColor}">${esc(metrics.verdict)}</span></div>
+    <div style="font-size:12px;color:${MUTED};margin-bottom:16px">${esc(shadowNote)}</div>
+    <div style="display:flex;gap:16px;flex-wrap:wrap;margin-bottom:16px">
+      <div><div style="font-size:11px;color:${MUTED}">BADGES LOST ON FLIP</div><div style="font-size:20px;font-weight:700;color:${metrics.badges.lostByRealPlayers > 0 ? DANGER : INK}">${metrics.badges.lostByRealPlayers}</div></div>
+      <div><div style="font-size:11px;color:${MUTED}">UNMASTERABLE (THRESHOLD)</div><div style="font-size:20px;font-weight:700">${metrics.classificationCounts.UNREACHABLE_THRESHOLD}</div></div>
+      <div><div style="font-size:11px;color:${MUTED}">MASTERED PAIRS</div><div style="font-size:20px;font-weight:700">${metrics.reachability.bucket75plus}</div></div>
+      <div><div style="font-size:11px;color:${MUTED}">v1 → v2 BADGES</div><div style="font-size:20px;font-weight:700">${metrics.badges.v1Total} → ${metrics.badges.v2Total}</div></div>
+    </div>
+    <pre style="white-space:pre-wrap;font-family:${MONO};font-size:12px;line-height:1.5;background:${CREAM};padding:16px;border-radius:8px;overflow-x:auto">${esc(markdown)}</pre>
+  </div>
+</body></html>`;
+
+  return { subject, html, text: markdown };
+}

--- a/src/server/knowledge/__tests__/mastery-calibration.test.ts
+++ b/src/server/knowledge/__tests__/mastery-calibration.test.ts
@@ -1,0 +1,158 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// The module imports @/server/db (the DB wrapper), which throws at load without a
+// connection string. computeMasteryCalibration is pure; dummy URL + dynamic import
+// keeps the unit pure (repo convention, see mastery-v2-resolve.test.ts).
+let mod: typeof import('@/server/knowledge/mastery-calibration');
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  mod = await import('@/server/knowledge/mastery-calibration');
+});
+
+type NodeInput = import('@/server/knowledge/mastery-calibration').CalibNodeInput;
+type UserInput = import('@/server/knowledge/mastery-calibration').CalibUserInput;
+type Edge = import('@/server/knowledge/graph').GraphEdge;
+
+const leaf = (key: string, threshold: number | null): NodeInput => ({
+  domainKey: key,
+  label: key,
+  nodeKind: 'leaf',
+  masteryThreshold: threshold,
+  broadCategory: null,
+});
+const parent = (key: string, threshold: number): NodeInput => ({
+  domainKey: key,
+  label: key,
+  nodeKind: 'parent',
+  masteryThreshold: threshold,
+  broadCategory: null,
+});
+const edge = (child: string, p: string): Edge => ({ childDomainKey: child, parentDomainKey: p });
+const user = (userId: string, points: Record<string, number>, masteryKeys: string[] = []): UserInput => ({
+  userId,
+  pointsByKey: new Map(Object.entries(points)),
+  masteryTierKeys: new Set(masteryKeys),
+});
+
+// High supply so nodes aren't flagged unmasterable unless we intend it.
+const richSupply = (keys: string[], perKey = 1000) => new Map(keys.map((k) => [k, perKey]));
+
+describe('computeMasteryCalibration — reachability buckets', () => {
+  it('buckets each (player, node) pair with points by v2 progress', () => {
+    const nodes = [leaf('king lear', 1000)];
+    const m = mod.computeMasteryCalibration({
+      nodes,
+      edges: [],
+      users: [
+        user('a', { 'king lear': 100 }), // 10% → 0-25
+        user('b', { 'king lear': 400 }), // 40% → 25-50
+        user('c', { 'king lear': 600 }), // 60% → 50-75
+        user('d', { 'king lear': 800 }), // 80% → 75+
+      ],
+      supplyByKey: richSupply(['king lear']),
+      shadow: true,
+    });
+    expect(m.reachability.pairs).toBe(4);
+    expect(m.reachability.bucket0_25).toBe(1);
+    expect(m.reachability.bucket25_50).toBe(1);
+    expect(m.reachability.bucket50_75).toBe(1);
+    expect(m.reachability.bucket75plus).toBe(1);
+  });
+});
+
+describe('computeMasteryCalibration — badge divergence + flip-readiness', () => {
+  it('flags NOT_READY when a v1 leaf-mastery badge is not reproduced under v2', () => {
+    // Player has tier-'mastery' on king lear (v1 badge) but only 100 of 1000 pts,
+    // so v2 does NOT master it → badge lost on flip.
+    const m = mod.computeMasteryCalibration({
+      nodes: [leaf('king lear', 1000)],
+      edges: [],
+      users: [user('a', { 'king lear': 100 }, ['king lear'])],
+      supplyByKey: richSupply(['king lear']),
+      shadow: true,
+    });
+    expect(m.badges.v1Total).toBe(1);
+    expect(m.badges.v2Total).toBe(0);
+    expect(m.badges.lostByRealPlayers).toBe(1);
+    expect(m.badges.playersLosing).toBe(1);
+    expect(m.verdict).toBe('NOT_READY');
+  });
+
+  it('is READY when no live player loses a badge', () => {
+    const m = mod.computeMasteryCalibration({
+      nodes: [leaf('king lear', 1000)],
+      edges: [],
+      users: [user('a', { 'king lear': 800 }, ['king lear'])], // 80% → v2 masters it too
+      supplyByKey: richSupply(['king lear']),
+      shadow: true,
+    });
+    expect(m.badges.lostByRealPlayers).toBe(0);
+    expect(m.verdict).toBe('READY');
+  });
+});
+
+describe('computeMasteryCalibration — node classification', () => {
+  it('UNREACHABLE_THRESHOLD when the 75% bar exceeds reachable supply but questions exist', () => {
+    // threshold 100000 → bar 75000 pts; supply 10 questions × 50 = 500 pts. Way short.
+    const m = mod.computeMasteryCalibration({
+      nodes: [leaf('huge topic', 100000)],
+      edges: [],
+      users: [user('a', { 'huge topic': 400 })],
+      supplyByKey: new Map([['huge topic', 10]]),
+      shadow: true,
+    });
+    const n = m.worstNodes.find((x) => x.domainKey === 'huge topic');
+    expect(n?.classification).toBe('UNREACHABLE_THRESHOLD');
+    expect(n?.suggestedThreshold).toBeGreaterThan(0);
+    expect(m.classificationCounts.UNREACHABLE_THRESHOLD).toBe(1);
+  });
+
+  it('UNREACHABLE_SUPPLY (not threshold) when supply is too thin to suggest a bar', () => {
+    // Only 1 question → below minSupplyQuestionsForThresholdSuggestion (3): a
+    // supply problem, no threshold suggestion.
+    const m = mod.computeMasteryCalibration({
+      nodes: [leaf('thin niche', 5000)],
+      edges: [],
+      users: [user('a', { 'thin niche': 20 })],
+      supplyByKey: new Map([['thin niche', 1]]),
+      shadow: true,
+    });
+    const n = m.worstNodes.find((x) => x.domainKey === 'thin niche');
+    expect(n?.classification).toBe('UNREACHABLE_SUPPLY');
+    expect(n?.suggestedThreshold).toBeNull();
+  });
+
+  it('TOO_EASY when a majority of active players already sit at mastery', () => {
+    const m = mod.computeMasteryCalibration({
+      nodes: [leaf('easy topic', 100)],
+      edges: [],
+      users: [
+        user('a', { 'easy topic': 90 }), // 90% mastered
+        user('b', { 'easy topic': 95 }), // mastered
+      ],
+      supplyByKey: richSupply(['easy topic']),
+      shadow: true,
+      config: { tooEasyPlayerShare: 0.5 },
+    });
+    const n = m.worstNodes.find((x) => x.domainKey === 'easy topic');
+    expect(n?.classification).toBe('TOO_EASY');
+    expect(n?.suggestedThreshold).toBeGreaterThan(100);
+  });
+
+  it('rolls a parent up from its leaves and classifies it', () => {
+    const nodes = [parent('tragedy', 15000), leaf('king lear', 1500), leaf('hamlet', 1500)];
+    const edges = [edge('king lear', 'tragedy'), edge('hamlet', 'tragedy')];
+    const m = mod.computeMasteryCalibration({
+      nodes,
+      edges,
+      users: [user('a', { 'king lear': 1500, hamlet: 1500 })], // 3000 rolled into tragedy = 20% → not mastered
+      supplyByKey: richSupply(['king lear', 'hamlet']),
+      shadow: true,
+    });
+    // Parent supply rolls up from its two leaves.
+    const tragedy = [...m.worstNodes, ...[]].find((x) => x.domainKey === 'tragedy');
+    // 20% of threshold, reachable in principle (supply high) → TOO_HARD.
+    expect(tragedy?.classification).toBe('TOO_HARD');
+  });
+});

--- a/src/server/knowledge/mastery-calibration.ts
+++ b/src/server/knowledge/mastery-calibration.ts
@@ -1,0 +1,573 @@
+/**
+ * Mastery-v2 calibration observability (D-MASTERY-FINEST-NODE-01).
+ *
+ * A daily, SHADOW-mode picture of what mastery-v2 WOULD show against live data —
+ * computed via the pure `resolveV2Mastery`/`rollUpCredit` primitives WITHOUT
+ * enabling `KNOWLEDGE_MASTERY_V2` or writing the leaf-freeze ledger. It answers
+ * three questions before (and after) you flip the flag:
+ *
+ *   1. Is mastery even reachable at the current thresholds + supply?
+ *   2. If we flip v2 on today, does any live player LOSE a badge they have under
+ *      v1? (the user-visible harm — the flip-readiness gate)
+ *   3. Which nodes are mis-calibrated, and what threshold would fix them?
+ *
+ * `computeMasteryCalibration` is pure (unit-tested, no I/O); `buildMasteryCalibration`
+ * is the DB wrapper. Nothing here mutates player state — it only reads.
+ */
+
+import { desc, eq, gte, sql } from 'drizzle-orm';
+
+import { db, generatedQuestions, masteryCalibrationSnapshot, playerMastery } from '@/server/db';
+import { listKnowledgeGraph } from '@/server/db/queries/knowledge-graph';
+import { domainKey } from '@/lib/knowledge/domain-key';
+import { rollUpCredit, type GraphEdge } from '@/server/knowledge/graph';
+import {
+  DEFAULT_MASTERY_THRESHOLD,
+  MASTERY_FRACTION,
+  isMastered,
+  masteryProgress,
+} from '@/server/knowledge/mastery-v2';
+import { isKnowledgeMasteryV2Enabled } from '@/server/knowledge/mastery-v2-resolve';
+import { resolveParentMastery, type ParentNodeInput } from '@/server/knowledge/parent-mastery';
+
+// ─── Config (env-tunable) ────────────────────────────────────────────────────
+
+export type CalibConfig = {
+  /**
+   * Estimated points a single bank question can award a player. Used only for the
+   * threshold-vs-supply ESTIMATE (labelled as such in the digest) — real
+   * per-answer points vary by state/creator-share, so this is a deliberately
+   * coarse proxy, tunable via MASTERY_CALIBRATION_POINTS_PER_QUESTION.
+   */
+  pointsPerQuestion: number;
+  /**
+   * A node with fewer than this many bank questions that can't be mastered is a
+   * SUPPLY problem (questions not generated yet — by design under the finite-set
+   * model), NOT a threshold problem. We don't suggest lowering its threshold.
+   */
+  minSupplyQuestionsForThresholdSuggestion: number;
+  /** Fraction of a node's active players already ≥75% that marks it TOO_EASY. */
+  tooEasyPlayerShare: number;
+  /** How many worst-calibrated nodes to surface in the digest. */
+  worstNodeLimit: number;
+};
+
+export const DEFAULT_CALIB_CONFIG: CalibConfig = {
+  pointsPerQuestion: 50,
+  minSupplyQuestionsForThresholdSuggestion: 3,
+  tooEasyPlayerShare: 0.5,
+  worstNodeLimit: 15,
+};
+
+function calibConfigFromEnv(): CalibConfig {
+  const ppq = Number(process.env.MASTERY_CALIBRATION_POINTS_PER_QUESTION);
+  return {
+    ...DEFAULT_CALIB_CONFIG,
+    pointsPerQuestion: Number.isFinite(ppq) && ppq > 0 ? ppq : DEFAULT_CALIB_CONFIG.pointsPerQuestion,
+  };
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type CalibNodeInput = {
+  domainKey: string;
+  label: string;
+  nodeKind: 'leaf' | 'parent' | 'both';
+  masteryThreshold: number | null;
+  broadCategory: string | null;
+};
+
+export type CalibUserInput = {
+  userId: string;
+  /** domainKey → total points (already folded to node keys). */
+  pointsByKey: Map<string, number>;
+  /** Leaf domainKeys the player holds at tier 'mastery' today (the v1 leaf badge). */
+  masteryTierKeys: Set<string>;
+};
+
+export type NodeClassification =
+  | 'WELL_CALIBRATED'
+  | 'TOO_HARD'
+  | 'TOO_EASY'
+  | 'UNREACHABLE_THRESHOLD'
+  | 'UNREACHABLE_SUPPLY';
+
+export type NodeCalib = {
+  domainKey: string;
+  label: string;
+  nodeKind: 'leaf' | 'parent' | 'both';
+  broadCategory: string | null;
+  threshold: number;
+  /** Rolled-up (own + descendant) reachable supply, in ESTIMATED points. */
+  estSupplyPoints: number;
+  /** Rolled-up (own + descendant) bank-question count. */
+  supplyQuestions: number;
+  activePlayers: number;
+  /** Best player's v2 progress on this node, 0..1. */
+  topProgress: number;
+  playersAtMastery: number;
+  classification: NodeClassification;
+  /** A data-anchored threshold suggestion for the misfits; null otherwise. */
+  suggestedThreshold: number | null;
+};
+
+export type MasteryCalibrationMetrics = {
+  /** True when captured WITHOUT the v2 flag live (pure shadow). */
+  shadow: boolean;
+  totalNodes: number;
+  seededNodes: number;
+  defaultThresholdNodes: number;
+  players: number;
+  reachability: {
+    pairs: number;
+    bucket0_25: number;
+    bucket25_50: number;
+    bucket50_75: number;
+    bucket75plus: number;
+  };
+  badges: {
+    v1Total: number;
+    v2Total: number;
+    lostByRealPlayers: number;
+    gainedByRealPlayers: number;
+    playersLosing: number;
+    playersGaining: number;
+  };
+  classificationCounts: Record<NodeClassification, number>;
+  worstNodes: NodeCalib[];
+  verdict: 'READY' | 'NOT_READY';
+  verdictReasons: string[];
+  /** Whether the digest is worth emailing (quiet-by-default). */
+  actionable: boolean;
+  config: CalibConfig;
+};
+
+// ─── Pure compute ────────────────────────────────────────────────────────────
+
+function thresholdOf(node: CalibNodeInput): number {
+  return node.masteryThreshold != null && node.masteryThreshold > 0
+    ? node.masteryThreshold
+    : DEFAULT_MASTERY_THRESHOLD;
+}
+
+/** Severity for ranking misfits worst-first in the digest. */
+function severity(n: NodeCalib): number {
+  switch (n.classification) {
+    // A wrong bar the player base is actively hitting a wall on is the worst.
+    case 'UNREACHABLE_THRESHOLD':
+      return 400 + (1 - n.topProgress) * 100;
+    case 'TOO_HARD':
+      return 300 + (1 - n.topProgress) * 100;
+    case 'TOO_EASY':
+      return 200 + n.playersAtMastery;
+    case 'UNREACHABLE_SUPPLY':
+      return 100 + (1 - n.topProgress) * 100;
+    case 'WELL_CALIBRATED':
+      return 0;
+  }
+}
+
+export function computeMasteryCalibration(params: {
+  nodes: readonly CalibNodeInput[];
+  edges: readonly GraphEdge[];
+  users: readonly CalibUserInput[];
+  /** domainKey → OWN bank-question count (rolled up internally). */
+  supplyByKey: ReadonlyMap<string, number>;
+  shadow: boolean;
+  config?: Partial<CalibConfig>;
+}): MasteryCalibrationMetrics {
+  const config: CalibConfig = { ...DEFAULT_CALIB_CONFIG, ...params.config };
+  const { nodes, edges, users, supplyByKey } = params;
+
+  // Descendant rollups of supply (questions and estimated points).
+  const supplyCountsByKey = rollUpCredit(supplyByKey, edges);
+  const supplyPointsOwn = new Map<string, number>();
+  for (const [key, count] of supplyByKey) supplyPointsOwn.set(key, count * config.pointsPerQuestion);
+  const reachablePointsByKey = rollUpCredit(supplyPointsOwn, edges);
+
+  const parents: ParentNodeInput[] = nodes
+    .filter((n) => n.nodeKind !== 'leaf')
+    .map((n) => ({ domainKey: n.domainKey, masteryThreshold: n.masteryThreshold }));
+  const leafKeys = new Set(nodes.filter((n) => n.nodeKind !== 'parent').map((n) => n.domainKey));
+
+  // Per-node accumulators.
+  const topProgress = new Map<string, number>();
+  const activePlayers = new Map<string, number>();
+  const playersAtMastery = new Map<string, number>();
+
+  const reachability = { pairs: 0, bucket0_25: 0, bucket25_50: 0, bucket50_75: 0, bucket75plus: 0 };
+  let v1Total = 0;
+  let v2Total = 0;
+  let lostByRealPlayers = 0;
+  let gainedByRealPlayers = 0;
+  let playersLosing = 0;
+  let playersGaining = 0;
+
+  for (const user of users) {
+    const rolled = rollUpCredit(user.pointsByKey, edges);
+
+    // v2 badge set (shadow — no freeze ledger).
+    const v2Set = new Set<string>();
+    for (const node of nodes) {
+      const threshold = thresholdOf(node);
+      const points = rolled.get(node.domainKey) ?? 0;
+      const prog = masteryProgress(points, threshold);
+
+      if (points > 0) {
+        reachability.pairs += 1;
+        if (prog >= 0.75) reachability.bucket75plus += 1;
+        else if (prog >= 0.5) reachability.bucket50_75 += 1;
+        else if (prog >= 0.25) reachability.bucket25_50 += 1;
+        else reachability.bucket0_25 += 1;
+        activePlayers.set(node.domainKey, (activePlayers.get(node.domainKey) ?? 0) + 1);
+        if (prog > (topProgress.get(node.domainKey) ?? 0)) topProgress.set(node.domainKey, prog);
+      }
+      if (isMastered(points, threshold)) {
+        v2Set.add(node.domainKey);
+        playersAtMastery.set(node.domainKey, (playersAtMastery.get(node.domainKey) ?? 0) + 1);
+      }
+    }
+
+    // v1 badge set = frozen/mastered PARENTS (shadow) ∪ LEAF tier-'mastery'.
+    const v1Parents = resolveParentMastery(parents, rolled, edges, new Set());
+    const v1Set = new Set<string>();
+    for (const [key, entry] of v1Parents) if (entry.isMaster) v1Set.add(key);
+    for (const key of user.masteryTierKeys) if (leafKeys.has(key)) v1Set.add(key);
+
+    v1Total += v1Set.size;
+    v2Total += v2Set.size;
+    let lost = 0;
+    let gained = 0;
+    for (const key of v1Set) if (!v2Set.has(key)) lost += 1;
+    for (const key of v2Set) if (!v1Set.has(key)) gained += 1;
+    lostByRealPlayers += lost;
+    gainedByRealPlayers += gained;
+    if (lost > 0) playersLosing += 1;
+    if (gained > 0) playersGaining += 1;
+  }
+
+  // Per-node classification + suggestions.
+  const classificationCounts: Record<NodeClassification, number> = {
+    WELL_CALIBRATED: 0,
+    TOO_HARD: 0,
+    TOO_EASY: 0,
+    UNREACHABLE_THRESHOLD: 0,
+    UNREACHABLE_SUPPLY: 0,
+  };
+  let seededNodes = 0;
+  const nodeCalibs: NodeCalib[] = [];
+
+  for (const node of nodes) {
+    const threshold = thresholdOf(node);
+    if (node.masteryThreshold != null && node.masteryThreshold > 0) seededNodes += 1;
+    const estSupplyPoints = reachablePointsByKey.get(node.domainKey) ?? 0;
+    const supplyQuestions = supplyCountsByKey.get(node.domainKey) ?? 0;
+    const active = activePlayers.get(node.domainKey) ?? 0;
+    const top = topProgress.get(node.domainKey) ?? 0;
+    const atMastery = playersAtMastery.get(node.domainKey) ?? 0;
+    // The 75%-of-threshold bar in points, and whether ANY reachable supply clears it.
+    const bar = MASTERY_FRACTION * threshold;
+
+    let classification: NodeClassification;
+    let suggestedThreshold: number | null = null;
+
+    if (top >= 0.75 && active >= 2 && atMastery / active >= config.tooEasyPlayerShare) {
+      classification = 'TOO_EASY';
+      // Raise the bar so mastery reflects the seeded topic size; cautious (flag).
+      suggestedThreshold = Math.max(threshold + 1, Math.round((top * threshold) * 1.3));
+    } else if (bar > estSupplyPoints) {
+      // Nobody can EVER cross the bar with the supply that exists.
+      if (supplyQuestions < config.minSupplyQuestionsForThresholdSuggestion) {
+        classification = 'UNREACHABLE_SUPPLY'; // needs generation, not a lower bar
+      } else {
+        classification = 'UNREACHABLE_THRESHOLD';
+        // Put the 75% bar at ~90% of existing reachable supply → masterable by a
+        // strong player without cheapening it. Anchored to SUPPLY, not the (tiny)
+        // current player base, to avoid over-fitting to few users.
+        suggestedThreshold = Math.max(1, Math.round((estSupplyPoints / MASTERY_FRACTION) * 0.9));
+      }
+    } else if (top < 0.75) {
+      classification = 'TOO_HARD'; // reachable in principle, nobody close
+    } else {
+      classification = 'WELL_CALIBRATED';
+    }
+    classificationCounts[classification] += 1;
+
+    nodeCalibs.push({
+      domainKey: node.domainKey,
+      label: node.label,
+      nodeKind: node.nodeKind,
+      broadCategory: node.broadCategory,
+      threshold,
+      estSupplyPoints,
+      supplyQuestions,
+      activePlayers: active,
+      topProgress: top,
+      playersAtMastery: atMastery,
+      classification,
+      suggestedThreshold,
+    });
+  }
+
+  const worstNodes = nodeCalibs
+    .filter((n) => n.classification !== 'WELL_CALIBRATED')
+    .sort((a, b) => severity(b) - severity(a))
+    .slice(0, config.worstNodeLimit);
+
+  // Flip-readiness: the user-visible harm is a live player LOSING a badge.
+  const verdictReasons: string[] = [];
+  if (lostByRealPlayers > 0) {
+    verdictReasons.push(
+      `${lostByRealPlayers} badge(s) across ${playersLosing} player(s) would disappear on flip (had under v1, not under v2).`,
+    );
+  }
+  const unreachableThreshold = classificationCounts.UNREACHABLE_THRESHOLD;
+  if (unreachableThreshold > 0) {
+    verdictReasons.push(
+      `${unreachableThreshold} node(s) are mathematically unmasterable at their current threshold (bar exceeds all reachable supply).`,
+    );
+  }
+  const verdict: 'READY' | 'NOT_READY' = lostByRealPlayers > 0 ? 'NOT_READY' : 'READY';
+  if (verdict === 'READY' && verdictReasons.length === 0) {
+    verdictReasons.push('No live player loses a badge on flip; no unmasterable-threshold nodes.');
+  }
+
+  const actionable = lostByRealPlayers > 0 || unreachableThreshold > 0;
+
+  return {
+    shadow: params.shadow,
+    totalNodes: nodes.length,
+    seededNodes,
+    defaultThresholdNodes: nodes.length - seededNodes,
+    players: users.length,
+    reachability,
+    badges: {
+      v1Total,
+      v2Total,
+      lostByRealPlayers,
+      gainedByRealPlayers,
+      playersLosing,
+      playersGaining,
+    },
+    classificationCounts,
+    worstNodes,
+    verdict,
+    verdictReasons,
+    actionable,
+    config,
+  };
+}
+
+// ─── Markdown digest ─────────────────────────────────────────────────────────
+
+function pct(n: number, d: number): string {
+  return d > 0 ? `${Math.round((n / d) * 100)}%` : '—';
+}
+
+function delta(now: number, prev: number | undefined): string {
+  if (prev === undefined) return '';
+  const d = now - prev;
+  if (d === 0) return ' (±0)';
+  return d > 0 ? ` (+${d})` : ` (${d})`;
+}
+
+const CLASS_LABEL: Record<NodeClassification, string> = {
+  WELL_CALIBRATED: 'well-calibrated',
+  TOO_HARD: 'too hard (reachable, nobody close)',
+  TOO_EASY: 'too easy (cheap badge)',
+  UNREACHABLE_THRESHOLD: 'UNMASTERABLE — threshold too high',
+  UNREACHABLE_SUPPLY: 'unmasterable — supply too thin (needs generation)',
+};
+
+export function renderMasteryCalibrationMarkdown(
+  m: MasteryCalibrationMetrics,
+  previous?: MasteryCalibrationMetrics | null,
+): string {
+  const p = previous ?? null;
+  const lines: string[] = [];
+
+  lines.push(`# Mastery-v2 calibration — flip-readiness: ${m.verdict}`);
+  lines.push('');
+  lines.push(m.shadow ? '_Captured in SHADOW (v2 flag off — this is what v2 WOULD show)._' : '_v2 flag is LIVE._');
+  lines.push('');
+  for (const reason of m.verdictReasons) lines.push(`- ${reason}`);
+  lines.push('');
+
+  lines.push('## Badge divergence (v1 → v2)');
+  lines.push(`- Badges shown today (v1): **${m.badges.v1Total}**${delta(m.badges.v1Total, p?.badges.v1Total)}`);
+  lines.push(`- Badges under v2: **${m.badges.v2Total}**${delta(m.badges.v2Total, p?.badges.v2Total)}`);
+  lines.push(
+    `- **Lost on flip: ${m.badges.lostByRealPlayers}** across ${m.badges.playersLosing} player(s) — the user-visible harm.`,
+  );
+  lines.push(`- Gained on flip: ${m.badges.gainedByRealPlayers} across ${m.badges.playersGaining} player(s).`);
+  lines.push('');
+
+  lines.push('## Reachability (player × node pairs with any points)');
+  const r = m.reachability;
+  lines.push(`- 0–25%: ${r.bucket0_25} (${pct(r.bucket0_25, r.pairs)})`);
+  lines.push(`- 25–50%: ${r.bucket25_50} (${pct(r.bucket25_50, r.pairs)})`);
+  lines.push(`- 50–75%: ${r.bucket50_75} (${pct(r.bucket50_75, r.pairs)})`);
+  lines.push(`- **75%+ (mastered): ${r.bucket75plus} (${pct(r.bucket75plus, r.pairs)})**${delta(r.bucket75plus, p?.reachability.bucket75plus)}`);
+  lines.push('');
+
+  lines.push('## Node calibration');
+  const c = m.classificationCounts;
+  lines.push(`- Well-calibrated: ${c.WELL_CALIBRATED} / ${m.totalNodes}`);
+  lines.push(`- Too hard: ${c.TOO_HARD}${delta(c.TOO_HARD, p?.classificationCounts.TOO_HARD)}`);
+  lines.push(`- Too easy: ${c.TOO_EASY}${delta(c.TOO_EASY, p?.classificationCounts.TOO_EASY)}`);
+  lines.push(
+    `- **Unmasterable (threshold): ${c.UNREACHABLE_THRESHOLD}**${delta(c.UNREACHABLE_THRESHOLD, p?.classificationCounts.UNREACHABLE_THRESHOLD)} — lower the bar`,
+  );
+  lines.push(
+    `- Unmasterable (supply): ${c.UNREACHABLE_SUPPLY}${delta(c.UNREACHABLE_SUPPLY, p?.classificationCounts.UNREACHABLE_SUPPLY)} — needs more questions, not a lower bar`,
+  );
+  lines.push(`- Thresholds: ${m.seededNodes} seeded, ${m.defaultThresholdNodes} on the ${DEFAULT_MASTERY_THRESHOLD}-pt default.`);
+  lines.push('');
+
+  if (m.worstNodes.length > 0) {
+    lines.push('## Worst-calibrated nodes (suggested recalibration)');
+    lines.push('');
+    lines.push('| node | kind | issue | threshold | top player | est. supply | suggested |');
+    lines.push('|---|---|---|---:|---:|---:|---:|');
+    for (const n of m.worstNodes) {
+      const suggested = n.suggestedThreshold != null ? `${n.suggestedThreshold}` : '—';
+      lines.push(
+        `| ${n.label} | ${n.nodeKind} | ${CLASS_LABEL[n.classification]} | ${n.threshold} | ${Math.round(n.topProgress * 100)}% | ~${Math.round(n.estSupplyPoints)}pt (${n.supplyQuestions}q) | ${suggested} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push(
+    `_Supply is an ESTIMATE: ${m.config.pointsPerQuestion} pts × non-duplicate bank questions (rolled up the tree). Threshold suggestions are anchored to that supply, not the current player base. Players: ${m.players}, nodes: ${m.totalNodes}._`,
+  );
+
+  return lines.join('\n');
+}
+
+// ─── DB wrapper ──────────────────────────────────────────────────────────────
+
+export async function buildMasteryCalibration(): Promise<MasteryCalibrationMetrics> {
+  const config = calibConfigFromEnv();
+  const [graph, masteryRows, supplyRows] = await Promise.all([
+    listKnowledgeGraph(),
+    db
+      .select({
+        userId: playerMastery.userId,
+        canonicalSubcategory: playerMastery.canonicalSubcategory,
+        totalPoints: playerMastery.totalPoints,
+        tier: playerMastery.tier,
+      })
+      .from(playerMastery),
+    db
+      .select({
+        domainKey: generatedQuestions.domainKey,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(generatedQuestions)
+      // Non-duplicate bank rows are the reachable pool; null-domain rows group
+      // into a null bucket we skip below.
+      .where(eq(generatedQuestions.isDuplicate, false))
+      .groupBy(generatedQuestions.domainKey),
+  ]);
+
+  const nodes: CalibNodeInput[] = graph.nodes.map((n) => ({
+    domainKey: n.domainKey,
+    label: n.label,
+    nodeKind: n.nodeKind,
+    masteryThreshold: n.masteryThreshold,
+    broadCategory: n.broadCategory,
+  }));
+  const edges: GraphEdge[] = graph.edges.map((e) => ({
+    childDomainKey: e.childDomainKey,
+    parentDomainKey: e.parentDomainKey,
+  }));
+
+  // Fold player rows into per-user point maps + v1 leaf-mastery sets.
+  const userMap = new Map<string, CalibUserInput>();
+  for (const row of masteryRows) {
+    const key = domainKey(row.canonicalSubcategory);
+    let u = userMap.get(row.userId);
+    if (!u) {
+      u = { userId: row.userId, pointsByKey: new Map(), masteryTierKeys: new Set() };
+      userMap.set(row.userId, u);
+    }
+    u.pointsByKey.set(key, (u.pointsByKey.get(key) ?? 0) + (row.totalPoints ?? 0));
+    if (row.tier === 'mastery') u.masteryTierKeys.add(key);
+  }
+
+  const supplyByKey = new Map<string, number>();
+  for (const row of supplyRows) {
+    if (!row.domainKey) continue;
+    supplyByKey.set(row.domainKey, (supplyByKey.get(row.domainKey) ?? 0) + (row.count ?? 0));
+  }
+
+  return computeMasteryCalibration({
+    nodes,
+    edges,
+    users: [...userMap.values()],
+    supplyByKey,
+    shadow: !isKnowledgeMasteryV2Enabled(),
+    config,
+  });
+}
+
+// ─── Persistence ─────────────────────────────────────────────────────────────
+
+function utcDay(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function writeMasteryCalibrationSnapshot(
+  metrics: MasteryCalibrationMetrics,
+  markdown: string,
+): Promise<void> {
+  await db
+    .insert(masteryCalibrationSnapshot)
+    .values({
+      day: utcDay(),
+      flagEnabled: !metrics.shadow,
+      metrics,
+      markdown,
+    })
+    .onConflictDoUpdate({
+      target: masteryCalibrationSnapshot.day,
+      set: {
+        flagEnabled: !metrics.shadow,
+        metrics,
+        markdown,
+        createdAt: sql`now()`,
+      },
+    });
+}
+
+export type StoredCalibSnapshot = {
+  day: string;
+  metrics: MasteryCalibrationMetrics;
+  markdown: string;
+  createdAt: Date;
+};
+
+/** The snapshot from ~`daysAgo` days back (nearest on/before), for WoW deltas. */
+export async function readCalibSnapshotAround(daysAgo: number): Promise<StoredCalibSnapshot | null> {
+  const cutoff = new Date(Date.now() - daysAgo * 86_400_000).toISOString().slice(0, 10);
+  const [row] = await db
+    .select({
+      day: masteryCalibrationSnapshot.day,
+      metrics: masteryCalibrationSnapshot.metrics,
+      markdown: masteryCalibrationSnapshot.markdown,
+      createdAt: masteryCalibrationSnapshot.createdAt,
+    })
+    .from(masteryCalibrationSnapshot)
+    .where(gte(masteryCalibrationSnapshot.day, cutoff))
+    .orderBy(desc(masteryCalibrationSnapshot.day))
+    .limit(1);
+  if (!row) return null;
+  return {
+    day: row.day,
+    metrics: row.metrics as MasteryCalibrationMetrics,
+    markdown: row.markdown,
+    createdAt: row.createdAt,
+  };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -44,6 +44,10 @@
     {
       "path": "/api/cron/quality-aggregation",
       "schedule": "0 14 * * 1"
+    },
+    {
+      "path": "/api/cron/mastery-calibration-report",
+      "schedule": "0 11 * * *"
     }
   ]
 }


### PR DESCRIPTION
## What

A daily, **shadow-mode** observability system for the mastery-v2 model (`D-MASTERY-FINEST-NODE-01`). It computes what mastery-v2 *would* show against live data — via the pure `resolveV2Mastery`/`rollUpCredit` primitives, **without enabling `KNOWLEDGE_MASTERY_V2` or writing the leaf-freeze ledger** — so the flip can be judged, and thresholds recalibrated, before and after shipping v2.

## Why

Flipping v2 on with the current seeded thresholds would show **zero mastery for every user**, because the thresholds ("true topic size", 1000–28000 pts) dwarf the actual question supply. This report makes that measurable and tracks it over time. A read-only shadow run against prod today:

- **Flip-readiness: READY** — v1 badges `0` → v2 badges `0`; **no live player loses a badge** on flip.
- **But mastery is unreachable:** 0 mastered pairs, 98% of 278 player×node pairs at 0–25%, **89/126 nodes mathematically unmasterable** at their current threshold, 34 more from thin supply, **0 well-calibrated**.
- The report separates the two fixes: **89 = lower the threshold** (supply-anchored suggestions provided, e.g. Human Anatomy 28000 → 540), **34 = generate more questions** (the finite-set signal, not a threshold problem).

## What's in it

- **`MasteryCalibrationSnapshot`** table (migration `0123`, journaled) — one shadow snapshot per UTC day (structured metrics + rendered digest).
- **`mastery-calibration.ts`** — pure `computeMasteryCalibration` (reachability buckets, v1↔v2 badge divergence, per-node headroom, threshold-vs-supply classification, supply-anchored suggested thresholds, flip-readiness verdict) + DB wrapper + markdown renderer + persistence. **7 unit tests.**
- **`mastery-calibration-report` cron** (daily 11:00 UTC) — quiet-by-default Resend digest with WoW deltas.
- Env knobs (all optional): `MASTERY_CALIBRATION_ALWAYS_EMAIL` (force daily during the observation window), `MASTERY_CALIBRATION_REPORT_EMAIL`, `MASTERY_CALIBRATION_POINTS_PER_QUESTION`.

## Safety / scope

- **Read-only** — never mutates player state; suggest-only recalibration.
- Migration `0123` is additive (RLS-enabled, journaled) and **not yet applied** — it applies on the next deploy / `db:migrate`. Do **not** `reconcile --apply` (that would mark it applied without running the DDL).
- The threshold-vs-supply line is a labelled **estimate** (`POINTS_PER_QUESTION × non-duplicate bank questions`, rolled up the tree); badge-divergence and reachability are exact.

## Verification

- `vitest run mastery-calibration.test.ts` — 7/7 pass.
- `eslint` on all new files — clean.
- `tsc` — no new errors (pre-existing `.next/` `replay`-route type errors are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrEnXchnUG6EVzVsUEB63V
