### PR TITLE
Refine portrait frequency indicators: placement, opacity, sliver moon

### DIFF
--- a/src/components/knowledge/FrequencyMark.tsx
+++ b/src/components/knowledge/FrequencyMark.tsx
@@ -67,7 +67,9 @@ export function FrequencyMark({
         {...a11y}
       >
         {title}
-        <path d="M9.5 2.2a5 5 0 1 0 2.3 6.8A5.6 5.6 0 0 1 9.5 2.2Z" fill="var(--freq-blue-moon)" />
+        {/* Thin sliver crescent: outer edge (r=5) and a slightly flatter inner
+            cut (r=6) both bow the same way, leaving a narrow lune. */}
+        <path d="M8 2.5A5 5 0 0 0 8 11.5A6 6 0 0 1 8 2.5Z" fill="var(--freq-blue-moon)" />
       </svg>
     );
   }

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -145,7 +145,9 @@ function FrequencyTag({ label, color, dim }: { label: string; color: string; dim
       style={{
         display: 'inline-flex',
         alignItems: 'center',
-        opacity: dim ? 0.5 : 1,
+        // Indicators sit above the title now; hold them back to 80% so they
+        // read as a quiet signal rather than competing with the name.
+        opacity: dim ? 0.4 : 0.8,
       }}
     >
       <FrequencyMark frequency={freq} color={color} size={11} />
@@ -241,9 +243,6 @@ export function PortraitDomainCircle({
   const isHidden = Boolean(entry.isHidden)
   const dimForHidden = editMode && isHidden
   const opacity = dimForHidden ? baseOpacity * 0.35 : baseOpacity
-  const labelOpacity =
-    (0.5 + (entry.totalMasteryPoints / Math.max(maxPointsForTier, 1)) * 0.5) *
-    (dimForHidden ? 0.5 : 1)
   const showMasteryCount =
     showCount &&
     entry.tier !== 'establishing' &&
@@ -376,6 +375,9 @@ export function PortraitDomainCircle({
           )}
         </div>
       </div>
+      {frequencyLabel ? (
+        <FrequencyTag label={frequencyLabel} color={dc.primary} dim={dimForHidden} />
+      ) : null}
       <span
         style={{
           fontSize: 10.5,
@@ -385,15 +387,12 @@ export function PortraitDomainCircle({
           lineHeight: 1.3,
           maxWidth: Math.max(90, resolvedCircleSlotSize),
           wordWrap: 'break-word',
-          opacity: labelOpacity,
+          opacity: dimForHidden ? 0.5 : undefined,
           textDecoration: dimForHidden ? 'line-through' : undefined,
         }}
       >
         {entry.canonicalSubcategory}
       </span>
-      {frequencyLabel ? (
-        <FrequencyTag label={frequencyLabel} color={dc.primary} dim={dimForHidden} />
-      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
- Move the frequency indicator above the domain title (was below).
- Hold the indicator back to 80% opacity so it reads as a quiet signal.
- Remove the mastery-linked opacity from titles; they were fading in step with their circles, which hurt readability. Titles now render at full opacity (edit-mode hidden still dims + strikes through).
- Slim the blue-moon crescent to a thin sliver (outer r=5 with a flatter r=6 inner cut, both bowing the same way).


Claude-Session: https://claude.ai/code/session_01Fo88AAcNU1MJMRz41z8TYx