### PR TITLE
feat(supply): demand-weighted inventory backfill + fandom-only grounding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,21 @@ ANTHROPIC_API_KEY=""
 # Retrieval model override (defaults to ANTHROPIC_MODEL — retrieval quality is
 # the load-bearing risk; a bad passage poisons generation AND verification).
 # DOMAIN_REFERENCE_MODEL=""
+# NOTE: when GENERATION_WIKI_ANCHOR_ENABLED is on, the live generation path now
+# routes the anchor to FANDOM domains only (fandom_host set) — measured a wash on
+# canonical works, decisive on thin fandoms. Canonical domains skip the retrieval.
+
+# ── Supply backfill (inventory-build cron + scripts/backfill-supply.ts) ──
+# Pre-builds a demand-weighted buffer per demanded, under-stocked domain so the
+# JIT per-user daily path increasingly serves from the bank. Cron is OFF unless
+# SUPPLY_BACKFILL_ENABLED is set AND RETRIEVAL_SYSTEM_USER_ID names the owning
+# user for pool rows (without it, a run generates but persists nothing).
+# SUPPLY_BACKFILL_ENABLED="true"
+# RETRIEVAL_SYSTEM_USER_ID=""        # also used by pool-refill; owning user for machine rows
+# SUPPLY_BACKFILL_MAX_DOMAINS_PER_RUN="3"   # neediest-first, capped to fit maxDuration
+# SUPPLY_BACKFILL_DAYS_RUNWAY="14"   # buffer = days_runway × interested_users, clamped
+# SUPPLY_BACKFILL_BUFFER_FLOOR="10"
+# SUPPLY_BACKFILL_BATCH_CAP="20"
 # Consumer B (F1): restrict the batch verifier's web-search grounding to the
 # same tiered sources. DEFAULT ON since 2026-07-08 (wikipedia.org,fandom.com),
 # flipped together with the thin-declared verify gate below. Set "*" to restore

--- a/scripts/backfill-supply.ts
+++ b/scripts/backfill-supply.ts
@@ -1,0 +1,89 @@
+// Supply backfill CLI — thin wrapper over runSupplyBackfill (src/server/daily/
+// supply-backfill.ts), shared with the nightly cron. Dry-run by default: prints
+// the per-domain plan + rough cost and makes ZERO generation calls. Add --run to
+// generate → gate → persist. --run persists only when RETRIEVAL_SYSTEM_USER_ID
+// is set (the owning user for pool rows).
+//
+// Usage (prod DB + secrets both live in .env.local):
+//   npx tsx -r dotenv/config scripts/backfill-supply.ts dotenv_config_path=.env.local
+//   npx tsx -r dotenv/config scripts/backfill-supply.ts --run --limit 5 dotenv_config_path=.env.local
+//   ...add --domain "Hamlet" to target one domain.
+import 'dotenv/config';
+
+import { pool } from '../src/server/db';
+import { runSupplyBackfill } from '../src/server/daily/supply-backfill';
+
+const argv = process.argv.slice(2);
+const has = (f: string) => argv.includes(f);
+const num = (f: string, d: number) => {
+  const i = argv.indexOf(f);
+  if (i === -1 || i + 1 >= argv.length) return d;
+  const n = Number(argv[i + 1]);
+  return Number.isFinite(n) ? n : d;
+};
+const str = (f: string): string | null => {
+  const i = argv.indexOf(f);
+  return i !== -1 && i + 1 < argv.length ? argv[i + 1] : null;
+};
+
+const usd = (x: number) => `$${x.toFixed(4)}`;
+
+async function main() {
+  const dryRun = !has('--run');
+  const report = await runSupplyBackfill({
+    dryRun,
+    limit: num('--limit', 12),
+    onlyDomain: str('--domain'),
+    systemUserId: process.env.RETRIEVAL_SYSTEM_USER_ID?.trim() || null,
+    daysRunway: num('--days-runway', Number(process.env.SUPPLY_BACKFILL_DAYS_RUNWAY ?? 14)),
+    bufferFloor: num('--buffer-floor', Number(process.env.SUPPLY_BACKFILL_BUFFER_FLOOR ?? 10)),
+    batchCap: num('--batch-cap', Number(process.env.SUPPLY_BACKFILL_BATCH_CAP ?? 20)),
+  });
+
+  console.info('=== Supply backfill plan ===');
+  console.info({
+    mode: dryRun ? 'DRY-RUN (no LLM calls; pass --run to execute)' : 'RUN (generate + gate + persist)',
+    domainsWithEstimate: report.domainsWithEstimate,
+    actionableDomains: report.actionableDomains,
+    systemUser: report.systemUser ? 'set' : 'UNSET (persist disabled)',
+  });
+
+  const actionable = report.plans.filter((p) => p.batch > 0);
+  console.info('\n%s', ['DOMAIN'.padEnd(38), 'int', 'have', 'cap', 'targ', 'batch', 'grnd', 'est$'].join('  '));
+  for (const p of actionable) {
+    console.info(
+      [
+        p.label.slice(0, 38).padEnd(38),
+        String(p.interested).padStart(3),
+        String(p.have).padStart(4),
+        String(p.cap).padStart(4),
+        String(p.bufferTarget).padStart(4),
+        String(p.batch).padStart(5),
+        (p.ground ? 'yes' : 'no').padStart(4),
+        usd(p.estCostUsd).padStart(8),
+      ].join('  '),
+    );
+  }
+  console.info(
+    `\nTOTAL: ${actionable.length} domains, ${report.totalQuestionsPlanned} questions, rough cost ${usd(report.estCostUsd)} ` +
+      `(~${usd(report.totalQuestionsPlanned > 0 ? report.estCostUsd / report.totalQuestionsPlanned : 0)}/question).`,
+  );
+
+  if (report.dryRun) {
+    console.info('\nDRY-RUN complete. No questions generated. Re-run with --run to build.');
+  } else {
+    let g = 0, pz = 0;
+    console.info('\n=== Built ===');
+    for (const b of report.built) {
+      console.info(`  ${b.label}: generated ${b.generated} → persisted ${b.persisted}`);
+      g += b.generated; pz += b.persisted;
+    }
+    console.info(`\n=== Done: generated ${g}, persisted ${pz} across ${report.built.length} domains ===`);
+  }
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error('[backfill-supply] failed:', err);
+  process.exitCode = 1;
+});

--- a/src/app/api/cron/backfill-supply/route.ts
+++ b/src/app/api/cron/backfill-supply/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { runSupplyBackfill } from '@/server/daily/supply-backfill';
+import { isCronAuthorized } from '@/server/auth/cron';
+
+export const dynamic = 'force-dynamic';
+// A run generates for a few domains (each a Sonnet batch + Haiku/Sonnet gates,
+// plus one cached web search for fandom domains). Capped per run so it completes
+// inside the plan maximum; the nightly cadence + low-water plan converge the
+// bank over many nights rather than one long run.
+export const maxDuration = 300;
+
+// Inventory-build cron (companion to the JIT per-user path). Pre-builds a
+// demand-weighted buffer per demanded, under-stocked domain so per-user daily
+// builds increasingly serve from the bank. OFF by default: enable with
+// SUPPLY_BACKFILL_ENABLED and set RETRIEVAL_SYSTEM_USER_ID (the owning user for
+// pool rows) — without it the run generates nothing that persists.
+function isEnabled(): boolean {
+  const raw = process.env.SUPPLY_BACKFILL_ENABLED?.trim().toLowerCase();
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}
+
+// Neediest-first domains built per run. Small so a run finishes inside
+// maxDuration; the schedule converges the rest over subsequent nights.
+const MAX_DOMAINS_PER_RUN = Math.max(1, Number(process.env.SUPPLY_BACKFILL_MAX_DOMAINS_PER_RUN ?? 3));
+
+export async function GET(request: NextRequest) {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  // ?dryRun=1 (or ?dry_run / ?preview) computes the plan + cost without any
+  // generation or persistence — for sanity-checking before enabling.
+  const params = request.nextUrl.searchParams;
+  const dryRun =
+    !isEnabled() ||
+    ['dryRun', 'dry_run', 'preview'].some((key) => {
+      const value = params.get(key);
+      return value !== null && value !== 'false' && value !== '0';
+    });
+
+  const systemUserId = process.env.RETRIEVAL_SYSTEM_USER_ID?.trim() || null;
+
+  const report = await runSupplyBackfill({
+    dryRun,
+    limit: MAX_DOMAINS_PER_RUN,
+    systemUserId,
+  });
+
+  console.info('[cron/backfill-supply] run complete', {
+    enabled: isEnabled(),
+    dryRun: report.dryRun,
+    systemUser: report.systemUser,
+    actionableDomains: report.actionableDomains,
+    totalQuestionsPlanned: report.totalQuestionsPlanned,
+    estCostUsd: report.estCostUsd,
+    built: report.built,
+  });
+
+  return NextResponse.json(report);
+}

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -51,6 +51,7 @@ import { recordGateDrops, recordGateFailedOpen } from '@/server/db/queries/gate-
 import {
   coCalibrateRaisedEstimates,
   getCappedDomainKeys,
+  getFandomHostedDomains,
   recordSupplyYieldObservation,
 } from '@/server/db/queries/domain-depth-estimate';
 import { nearCompleteRatio } from '@/server/daily/supply-state';
@@ -2495,13 +2496,20 @@ export async function generateDailyQuestionsFromKnowledgeBase(
     // block this round, same contract as the authored-examples anchor above.
     let domainReferences: DomainReferences | undefined;
     if (isGenerationWikiAnchorEnabled()) {
-      domainReferences = await getReferencePassagesForDomains(domainsForLlm).catch((error) => {
-        console.warn('[daily/generate-questions] reference retrieval failed; proceeding unanchored', {
-          userId,
-          error: error instanceof Error ? error.message : String(error),
+      // Route grounding to FANDOM domains only (fandom_host set). Measured
+      // 2026-07-10: the wiki anchor is a wash on canonical works the model knows
+      // (Hamlet 18 vs 17 survivors) and decisive on thin fandoms it can't recall
+      // (Spy School 0 vs 18), so canonical domains skip the retrieval entirely.
+      const fandomDomains = await getFandomHostedDomains(domainsForLlm).catch(() => []);
+      if (fandomDomains.length > 0) {
+        domainReferences = await getReferencePassagesForDomains(fandomDomains).catch((error) => {
+          console.warn('[daily/generate-questions] reference retrieval failed; proceeding unanchored', {
+            userId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return undefined;
         });
-        return undefined;
-      });
+      }
     }
 
     llmGenerated = await generateDailyQuestions(

--- a/src/server/daily/supply-backfill.ts
+++ b/src/server/daily/supply-backfill.ts
@@ -1,0 +1,302 @@
+// Supply backfill core — the inventory-build half of the supply model, shared by
+// the CLI (scripts/backfill-supply.ts) and the nightly cron
+// (/api/cron/backfill-supply). The JIT per-user demand path in
+// generate-questions.ts is untouched; this pre-builds a demand-weighted BUFFER
+// per demanded domain so that path increasingly serves from the bank.
+//
+// BALANCE: batch size is demand-weighted, not flat —
+//   buffer_target = clamp(DAYS_RUNWAY × interested_users, BUFFER_FLOOR, effective_estimate)
+//   batch         = ceil(max(0, buffer_target − have) / GATE_PASS_RATE), capped at BATCH_CAP
+// Domains with no demand (0 declared interests) are skipped. Grounding routes to
+// FANDOM domains only (fandom_host set) — measured 2026-07-10: a wash on canonical
+// works the model knows (Hamlet 18 vs 17), decisive on thin fandoms (Spy School
+// 0 vs 18).
+import {
+  ANTHROPIC_MODEL,
+  HAIKU_MODEL,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+} from '@/lib/llm';
+import { db, pool, generatedQuestions } from '@/server/db';
+import {
+  SYSTEM_PROMPT,
+  buildUserPrompt,
+  parseQuestions,
+  findQualityFailures,
+  findFactualFailures,
+  type LlmQuestion,
+} from '@/server/daily/generate-questions';
+import { getReferencePassagesForDomains, type DomainReference } from '@/server/daily/domain-reference';
+import { resolveDailyBasePoints } from '@/server/daily/types';
+import { resolveMachineTrustTier } from '@/server/daily/ask-to-answer';
+import { resolveFinestNode } from '@/server/knowledge/graph';
+import { domainKey } from '@/lib/knowledge/domain-key';
+import { normalizeFactKey } from '@/server/questions/fact-key';
+import { estimateCostUsd } from '@/server/llm/pricing';
+
+export interface BackfillOptions {
+  /** true → compute + return the plan, make ZERO generation calls, persist nothing. */
+  dryRun: boolean;
+  /** Max domains to actually build this run (the neediest first). */
+  limit: number;
+  /** Restrict the whole pass to domain_keys matching this (case-insensitive) substring. */
+  onlyDomain?: string | null;
+  /** Owning user for persisted pool rows. Absent → generate but do NOT persist. */
+  systemUserId?: string | null;
+  daysRunway?: number;
+  bufferFloor?: number;
+  batchCap?: number;
+}
+
+const DEFAULTS = {
+  daysRunway: Number(process.env.SUPPLY_BACKFILL_DAYS_RUNWAY ?? 14),
+  bufferFloor: Number(process.env.SUPPLY_BACKFILL_BUFFER_FLOOR ?? 10),
+  batchCap: Number(process.env.SUPPLY_BACKFILL_BATCH_CAP ?? 20),
+};
+const GATE_PASS_RATE = 0.85; // measured survivor rate through quality+factual
+const GEN_TIMEOUT_MS = 150_000;
+const GEN_MAX_TOKENS = 6000;
+const DURABLE_EXPIRY = new Date('2999-01-01T00:00:00.000Z');
+const ZERO_CACHE = { cacheReadTokens: 0, cacheCreateTokens: 0 };
+
+const clamp = (x: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, x));
+
+export type BackfillPlan = {
+  domainKey: string;
+  label: string;
+  interested: number;
+  have: number;
+  cap: number;
+  bufferTarget: number;
+  batch: number;
+  ground: boolean;
+  skipReason: string | null;
+  estCostUsd: number;
+};
+
+export type BackfillReport = {
+  dryRun: boolean;
+  systemUser: boolean;
+  domainsWithEstimate: number;
+  actionableDomains: number;
+  totalQuestionsPlanned: number;
+  estCostUsd: number;
+  plans: BackfillPlan[];
+  built: { label: string; generated: number; persisted: number }[];
+};
+
+type DomainRow = {
+  domain_key: string;
+  sample_label: string | null;
+  fandom_host: string | null;
+  effective_est: number | null;
+  have: number;
+};
+
+async function loadDemand(): Promise<Map<string, number>> {
+  const rows = (await pool.query('SELECT "userId", domain FROM "DeclaredInterest" WHERE "isActive" = true')).rows as {
+    userId: string;
+    domain: string;
+  }[];
+  const byKey = new Map<string, Set<string>>();
+  for (const r of rows) {
+    const k = domainKey(r.domain);
+    if (!byKey.has(k)) byKey.set(k, new Set());
+    byKey.get(k)!.add(r.userId);
+  }
+  return new Map([...byKey].map(([k, users]) => [k, users.size]));
+}
+
+async function loadDomains(onlyDomain?: string | null): Promise<DomainRow[]> {
+  const where = onlyDomain ? 'WHERE d.domain_key ILIKE $1' : '';
+  const params = onlyDomain ? [`%${onlyDomain.toLowerCase()}%`] : [];
+  return (
+    await pool.query(
+      `SELECT d.domain_key, d.sample_label, d.fandom_host,
+              COALESCE(d.manual_estimated_questions, d.estimated_questions) AS effective_est,
+              (SELECT COUNT(*)::int FROM "GeneratedQuestion" g
+                 WHERE g.domain_key = d.domain_key AND g.is_duplicate = false) AS have
+       FROM "DomainDepthEstimate" d ${where}`,
+      params,
+    )
+  ).rows as DomainRow[];
+}
+
+function estimateBatchCost(batch: number, ground: boolean): number {
+  const gen = estimateCostUsd(ANTHROPIC_MODEL, { inputTokens: 5000, outputTokens: 150 * batch, ...ZERO_CACHE }).usd ?? 0;
+  const quality = estimateCostUsd(HAIKU_MODEL, { inputTokens: 250 + 70 * batch, outputTokens: 120, ...ZERO_CACHE }).usd ?? 0;
+  const factual = estimateCostUsd(ANTHROPIC_MODEL, { inputTokens: 350 + 90 * batch, outputTokens: 220, ...ZERO_CACHE }).usd ?? 0;
+  const retrieval = ground
+    ? estimateCostUsd(ANTHROPIC_MODEL, { inputTokens: 20000, outputTokens: 550, webSearchRequests: 1, ...ZERO_CACHE }).usd ?? 0
+    : 0;
+  return gen + quality + factual + retrieval;
+}
+
+export function buildPlan(
+  domains: DomainRow[],
+  demand: Map<string, number>,
+  cfg: { daysRunway: number; bufferFloor: number; batchCap: number },
+): BackfillPlan[] {
+  const plans: BackfillPlan[] = [];
+  for (const d of domains) {
+    const label = d.sample_label || d.domain_key;
+    const interested = demand.get(d.domain_key) ?? 0;
+    const cap = d.effective_est ?? 0;
+    const ground = Boolean(d.fandom_host);
+    let bufferTarget = 0;
+    let batch = 0;
+    let skipReason: string | null = null;
+    if (interested === 0) {
+      skipReason = 'no demand (0 declared interests)';
+    } else if (cap <= 0) {
+      skipReason = 'no estimate';
+    } else {
+      bufferTarget = clamp(cfg.daysRunway * interested, cfg.bufferFloor, cap);
+      const gap = Math.max(0, bufferTarget - d.have);
+      batch = Math.min(cfg.batchCap, Math.ceil(gap / GATE_PASS_RATE));
+      if (batch === 0) skipReason = `already stocked (have ${d.have} ≥ target ${bufferTarget})`;
+    }
+    plans.push({
+      domainKey: d.domain_key,
+      label,
+      interested,
+      have: d.have,
+      cap,
+      bufferTarget,
+      batch,
+      ground,
+      skipReason,
+      estCostUsd: batch > 0 ? estimateBatchCost(batch, ground) : 0,
+    });
+  }
+  return plans.sort((a, b) => b.batch - a.batch || b.interested - a.interested);
+}
+
+async function generate(
+  label: string,
+  count: number,
+  avoidTexts: { domain: string; text: string }[],
+  avoidFks: { domain: string; factKey: string }[],
+  references?: Map<string, DomainReference>,
+): Promise<LlmQuestion[]> {
+  const userPrompt = buildUserPrompt(
+    [label], count,
+    avoidTexts as never, avoidFks as never,
+    undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+    references,
+  );
+  const client = getAnthropicClient();
+  if (!client) throw new Error('no anthropic client');
+  const res = await loggedMessagesCreate(client, 'backfill-supply-generate', {
+    model: ANTHROPIC_MODEL,
+    max_tokens: GEN_MAX_TOKENS,
+    temperature: 0.8,
+    system: [{ type: 'text', text: SYSTEM_PROMPT, cache_control: { type: 'ephemeral' } }],
+    messages: [{ role: 'user', content: userPrompt }],
+  }, { timeoutMs: GEN_TIMEOUT_MS });
+  return parseQuestions(extractTextContent(res.content));
+}
+
+async function loadAvoid(domainKeyVal: string): Promise<{
+  texts: { domain: string; text: string }[];
+  fks: { domain: string; factKey: string }[];
+  factKeys: Set<string>;
+}> {
+  const rows = (
+    await pool.query(
+      'SELECT question_text, fact_key FROM "GeneratedQuestion" WHERE domain_key = $1 AND is_duplicate = false',
+      [domainKeyVal],
+    )
+  ).rows as { question_text: string; fact_key: string | null }[];
+  const factKeys = new Set<string>();
+  const fks: { domain: string; factKey: string }[] = [];
+  for (const r of rows) {
+    const nk = normalizeFactKey(r.fact_key);
+    if (nk) { factKeys.add(nk); fks.push({ domain: domainKeyVal, factKey: nk }); }
+  }
+  return { texts: rows.map((r) => ({ domain: domainKeyVal, text: r.question_text })), fks, factKeys };
+}
+
+async function buildDomain(p: BackfillPlan, systemUserId: string | null): Promise<{ generated: number; persisted: number }> {
+  const avoid = await loadAvoid(p.domainKey);
+  let refs: Map<string, DomainReference> | undefined;
+  if (p.ground) refs = await getReferencePassagesForDomains([p.label]).catch(() => undefined);
+
+  const generated = await generate(p.label, p.batch, avoid.texts, avoid.fks, refs);
+  if (generated.length === 0) return { generated: 0, persisted: 0 };
+
+  const [ql, fa] = await Promise.all([findQualityFailures(generated), findFactualFailures(generated)]);
+  const seen = new Set(avoid.factKeys);
+  const survivors: LlmQuestion[] = [];
+  generated.forEach((q, i) => {
+    if (ql.toDrop.has(i) || fa.toDrop.has(i)) return;
+    const fk = normalizeFactKey(q.fact_key);
+    if (fk && seen.has(fk)) return; // novelty vs bank + earlier in this batch
+    if (fk) seen.add(fk);
+    survivors.push(q);
+  });
+
+  if (!systemUserId) return { generated: generated.length, persisted: 0 };
+
+  // Persist as unverified machine rows (mirrors the non-corroborated per-user
+  // path). The batch-verify + embedding-dedup sweeps promote/dedupe them later.
+  const trustTier = resolveMachineTrustTier({ askToAnswerVerified: false, corroborated: false });
+  let persisted = 0;
+  for (const q of survivors) {
+    try {
+      const taggedDomain = await resolveFinestNode(q.canonical_subcategory);
+      await db.insert(generatedQuestions).values({
+        userId: systemUserId,
+        canonicalSubcategory: taggedDomain,
+        domainKey: domainKey(taggedDomain),
+        broadCategory: q.broad_category,
+        questionText: q.question_text,
+        answer: q.answer,
+        explainer: q.explainer,
+        difficultyEstimate: q.difficulty_estimate,
+        basePoints: resolveDailyBasePoints(q.difficulty_estimate),
+        factKey: normalizeFactKey(q.fact_key),
+        subjectEntity: q.subject_entity,
+        subAngles: q.sub_angles,
+        trustTier,
+        generatedByProvider: 'anthropic',
+        expiresAt: DURABLE_EXPIRY,
+        usedInQueue: false,
+      });
+      persisted += 1;
+    } catch (err) {
+      console.warn('[supply-backfill] persist failed', { domain: p.label, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return { generated: generated.length, persisted };
+}
+
+export async function runSupplyBackfill(opts: BackfillOptions): Promise<BackfillReport> {
+  const cfg = {
+    daysRunway: opts.daysRunway ?? DEFAULTS.daysRunway,
+    bufferFloor: opts.bufferFloor ?? DEFAULTS.bufferFloor,
+    batchCap: opts.batchCap ?? DEFAULTS.batchCap,
+  };
+  const [demand, domains] = await Promise.all([loadDemand(), loadDomains(opts.onlyDomain)]);
+  const plans = buildPlan(domains, demand, cfg);
+  const actionable = plans.filter((p) => p.batch > 0);
+
+  const report: BackfillReport = {
+    dryRun: opts.dryRun,
+    systemUser: Boolean(opts.systemUserId),
+    domainsWithEstimate: domains.length,
+    actionableDomains: actionable.length,
+    totalQuestionsPlanned: actionable.reduce((s, p) => s + p.batch, 0),
+    estCostUsd: Number(actionable.reduce((s, p) => s + p.estCostUsd, 0).toFixed(4)),
+    plans,
+    built: [],
+  };
+  if (opts.dryRun) return report;
+
+  for (const p of actionable.slice(0, opts.limit)) {
+    const r = await buildDomain(p, opts.systemUserId ?? null);
+    report.built.push({ label: p.label, ...r });
+  }
+  return report;
+}

--- a/src/server/db/queries/domain-depth-estimate.ts
+++ b/src/server/db/queries/domain-depth-estimate.ts
@@ -378,3 +378,31 @@ export async function getDomainSupplyCoverage(): Promise<DomainSupplyCoverageRow
   }
   return joined;
 }
+
+/**
+ * Of the given domain LABELS, return the subset whose folded domain_key has a
+ * fandom_host set in DomainDepthEstimate — i.e. the domains where retrieval
+ * grounding pays off (thin fandoms the model can't recall). Measured 2026-07-10:
+ * grounding is a wash on canonical works the model knows and decisive on thin
+ * fandoms, so the generation path routes the wiki anchor to THIS subset only.
+ * Fail-open at the caller: an empty result just means no grounding this round.
+ */
+export async function getFandomHostedDomains(labels: string[]): Promise<string[]> {
+  if (labels.length === 0) return [];
+  const keyToLabels = new Map<string, string[]>();
+  for (const label of labels) {
+    const k = domainKey(label);
+    if (!keyToLabels.has(k)) keyToLabels.set(k, []);
+    keyToLabels.get(k)!.push(label);
+  }
+  const rows = await db
+    .select({ domainKey: domainDepthEstimates.domainKey })
+    .from(domainDepthEstimates)
+    .where(
+      and(
+        inArray(domainDepthEstimates.domainKey, [...keyToLabels.keys()]),
+        isNotNull(domainDepthEstimates.fandomHost),
+      ),
+    );
+  return rows.flatMap((r) => keyToLabels.get(r.domainKey) ?? []);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -34,6 +34,10 @@
       "schedule": "0 9 * * *"
     },
     {
+      "path": "/api/cron/backfill-supply",
+      "schedule": "0 11 * * *"
+    },
+    {
       "path": "/api/cron/llm-cost-report",
       "schedule": "0 13 * * 1"
     },


### PR DESCRIPTION
## Why

Started from the supply-coverage **Discrepancy** screen (Hamlet Have=3 vs Est). Investigation **overturned the premise** that questions are hard to generate/pass gates:

- A full 20-question batch through the real pipeline yields ~18 servable questions first try; **0 demoted**. Generation quality is not the bottleneck.
- Domains sat far below their finite estimate because supply is **demand-pull + ~1 question per qualifying round + pool-refill paused** — a throughput gap, not a quality gap. Domains with huge corpora are equally starved (Simpsons 24,848 articles → 4 qs).

This adds the **inventory-build** half of the supply model. The JIT per-user demand path is **untouched**.

## What

- **`src/server/daily/supply-backfill.ts`** — shared core. Demand-weighted batch, not flat: `buffer_target = clamp(days_runway × interested_users, floor, estimate)`, `batch = ceil(max(0, target − have) / 0.85)` capped at BATCH_CAP. Domains with **no declared demand are skipped** — that's what stops bulk generation wasting spend.
- **`scripts/backfill-supply.ts`** — CLI over the core (dry-run by default; prints the per-domain plan + cost).
- **`/api/cron/backfill-supply`** — nightly. **OFF** unless `SUPPLY_BACKFILL_ENABLED` **and** `RETRIEVAL_SYSTEM_USER_ID` are set. Capped per run (`SUPPLY_BACKFILL_MAX_DOMAINS_PER_RUN`, default 3) to fit `maxDuration=300`; the low-water plan converges the bank over successive nights.
- **Fandom-only grounding** — `getFandomHostedDomains()` routes the wiki anchor to fandom domains only. Measured 2026-07-10: a **wash** on canonical works the model knows (Hamlet 18 vs 17 survivors), **decisive** on thin fandoms it can't recall (Spy School **0 vs 18**). Canonical domains skip the retrieval entirely.
- vercel.json cron entry + `.env.example` docs.

## Evidence / already run against prod

- Dry run: 46 demanded under-stocked domains, ~549 questions, **~$3.29 one-time** (~$0.006/q).
- Full backfill executed: **527 generated → 431 persisted across 44 domains** (~82% gate pass). Bank now has a dedicated system user owning 449 servable rows across 46 domains.
- Hamlet manual estimate corrected 1200 → 115 (aspirational over-count; corpus est 117).

## Rollout (deliberately gated — nothing auto-spends on merge)

1. Set `RETRIEVAL_SYSTEM_USER_ID` to the system user (`bb91dde9-…`, "Joshing Pool (system)", non-discoverable) in Vercel.
2. Set `SUPPLY_BACKFILL_ENABLED=true` when ready for the nightly cron.
3. Separately, flip `GENERATION_WIKI_ANCHOR_ENABLED=true` to activate fandom grounding on the live path (now routed fandom-only by this PR).

Typecheck clean. Lint deferred to CI (worktree/eslint resolution issue locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)