### PR TITLE
fix(auth): honor phone-matched invites in verify-otp

### DIFF
--- a/src/app/api/auth/verify-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/verify-otp/__tests__/route.test.ts
@@ -7,6 +7,7 @@ const {
   findUserSelectMock,
   hasAcceptedInvitationForUserMock,
   getValidInvitationForPhoneMock,
+  getValidPendingInvitationForPhoneMock,
   getInvitePrefillByTokenMock,
   provisionUserInsertMock,
   verifyOtpMock,
@@ -40,6 +41,7 @@ const {
     findUserSelectMock,
     hasAcceptedInvitationForUserMock: vi.fn(async () => false),
     getValidInvitationForPhoneMock: vi.fn(async () => null as unknown),
+    getValidPendingInvitationForPhoneMock: vi.fn(async () => null as unknown),
     getInvitePrefillByTokenMock: vi.fn(async () => null as unknown),
     provisionUserInsertMock,
     verifyOtpMock: vi.fn(async (phone: string, code: string) =>
@@ -71,6 +73,7 @@ vi.mock('@/server/db', () => ({
 vi.mock('@/server/friends/invitations', () => ({
   acceptFriendInvitation: acceptFriendInvitationMock,
   getValidInvitationForPhone: getValidInvitationForPhoneMock,
+  getValidPendingInvitationForPhone: getValidPendingInvitationForPhoneMock,
   getInvitePrefillByToken: getInvitePrefillByTokenMock,
   hasAcceptedInvitationForUser: hasAcceptedInvitationForUserMock,
   INVITATION_ACCEPTANCE_ERROR_MESSAGE: 'This invitation could not be accepted.',
@@ -129,6 +132,7 @@ describe('/api/auth/verify-otp invitation gate', () => {
     provisionUserInsertMock.mockReset()
     hasAcceptedInvitationForUserMock.mockReset()
     getValidInvitationForPhoneMock.mockReset()
+    getValidPendingInvitationForPhoneMock.mockReset()
     getInvitePrefillByTokenMock.mockReset()
     acceptFriendInvitationMock.mockReset()
 
@@ -136,6 +140,7 @@ describe('/api/auth/verify-otp invitation gate', () => {
     provisionUserInsertMock.mockResolvedValue([])
     hasAcceptedInvitationForUserMock.mockResolvedValue(false)
     getValidInvitationForPhoneMock.mockResolvedValue(null)
+    getValidPendingInvitationForPhoneMock.mockResolvedValue(null)
     getInvitePrefillByTokenMock.mockResolvedValue(null)
     acceptFriendInvitationMock.mockResolvedValue({ accepted: true })
   })
@@ -390,6 +395,59 @@ describe('/api/auth/verify-otp invitation gate', () => {
           code: '000000',
           invitationToken: 'invite-token',
         })
+      )
+      const body = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(body.error).toBe('invalid_invitation')
+      expect(createSessionMock).not.toHaveBeenCalled()
+    })
+
+    it('provisions and accepts a phone-matched pending invite when no token or link rode along (B-AUTH-INVITE-PHONEMATCH)', async () => {
+      // Contact-invited user who opened the app directly and typed their
+      // number: request-otp let them through on the phone-match, so they must
+      // clear verify-otp too even with no token/link in the request body.
+      findUserSelectMock.mockResolvedValueOnce([])
+      getValidPendingInvitationForPhoneMock.mockResolvedValueOnce(
+        VALID_INVITATION
+      )
+      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER])
+      acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true })
+
+      const response = await POST(
+        jsonRequest({ phone: '+15559876543', code: '000000' })
+      )
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.user.id).toBe('user-2')
+      expect(body.invitation).toEqual({ accepted: true })
+      expect(provisionUserInsertMock).toHaveBeenCalled()
+      // Claims the resolved invitation by ITS token — the body carried none.
+      expect(acceptFriendInvitationMock).toHaveBeenCalledWith({
+        token: 'invite-token',
+        inviteeUserId: 'user-2',
+        verifiedPhone: '+15559876543',
+      })
+      expect(createSessionMock).toHaveBeenCalledWith('user-2', {
+        invitationAccepted: true,
+        onboardingComplete: false,
+      })
+    })
+
+    it('rejects the phone-match path when the accept races and fails after provisioning', async () => {
+      findUserSelectMock.mockResolvedValueOnce([])
+      getValidPendingInvitationForPhoneMock.mockResolvedValueOnce(
+        VALID_INVITATION
+      )
+      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER])
+      acceptFriendInvitationMock.mockResolvedValueOnce({
+        accepted: false,
+        reason: 'claim_failed',
+      })
+
+      const response = await POST(
+        jsonRequest({ phone: '+15559876543', code: '000000' })
       )
       const body = await response.json()
 

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -14,6 +14,7 @@ import {
   acceptFriendInvitation,
   getInvitePrefillByToken,
   getValidInvitationForPhone,
+  getValidPendingInvitationForPhone,
   INVITATION_ACCEPTANCE_ERROR_MESSAGE,
   INVITE_REQUIRED_MESSAGE,
 } from '@/server/friends/invitations'
@@ -242,10 +243,21 @@ export async function POST(request: Request) {
       })
     }
 
-    // New-user path: an invitation is a hard precondition. Either a
-    // FriendInvitation token (SMS-style) or a per-user invite link
-    // (B-Friends-3) satisfies the gate.
-    if (!hasUsableToken && !userInvite) {
+    // New-user path: an invitation is a hard precondition. It can be
+    // satisfied three ways: a FriendInvitation token (SMS-style), a per-user
+    // invite link (B-Friends-3), or a pending FriendInvitation matched by the
+    // verified phone number. The phone-match path covers contact-invited users
+    // who open the app directly instead of tapping the invite link — the token
+    // never rides along, but the invite is real. request-otp already honors
+    // this phone-match (hasValidPendingInvitationForPhone), so verify-otp must
+    // too; otherwise those users clear the code screen and then hit a false
+    // invite-only wall (B-AUTH-INVITE-PHONEMATCH).
+    const phoneInvitation =
+      !hasUsableToken && !userInvite
+        ? await getValidPendingInvitationForPhone(normalizedPhone)
+        : null
+
+    if (!hasUsableToken && !userInvite && !phoneInvitation) {
       return inviteRequiredRejection()
     }
 
@@ -290,6 +302,22 @@ export async function POST(request: Request) {
         token: userInvite.token,
         inviteeUserId: user.id,
       })
+    } else if (phoneInvitation) {
+      // Phone-matched invite path: claim the specific pending invitation we
+      // resolved above by its token, reusing the same acceptance +
+      // friendship-forming logic as the SMS token flow.
+      invitation = await acceptFriendInvitation({
+        token: phoneInvitation.token,
+        inviteeUserId: user.id,
+        verifiedPhone: normalizedPhone,
+      })
+
+      if (!invitation.accepted) {
+        // The invitation was claimed or cancelled between resolve and accept.
+        // Same posture as the token path: reject rather than mint a session
+        // for a new account with no accepted invitation.
+        return invitationRejection()
+      }
     }
 
     await createSession(user.id, {

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -331,14 +331,14 @@ export async function hasAcceptedInvitationForUser(
   return !!row
 }
 
-export async function hasValidPendingInvitationForPhone(
+export async function getValidPendingInvitationForPhone(
   phoneNumber: string,
   now: Date = new Date()
-): Promise<boolean> {
-  if (!phoneNumber) return false
+): Promise<FriendInvitation | null> {
+  if (!phoneNumber) return null
 
-  const [row] = await db
-    .select({ id: friendInvitations.id })
+  const [invitation] = await db
+    .select()
     .from(friendInvitations)
     .where(
       and(
@@ -348,9 +348,19 @@ export async function hasValidPendingInvitationForPhone(
         gt(friendInvitations.expiresAt, now)
       )
     )
+    // Deterministic pick when the same number was invited more than once:
+    // the invite that lives longest is the most recently sent one.
+    .orderBy(desc(friendInvitations.expiresAt))
     .limit(1)
 
-  return !!row
+  return invitation ?? null
+}
+
+export async function hasValidPendingInvitationForPhone(
+  phoneNumber: string,
+  now: Date = new Date()
+): Promise<boolean> {
+  return Boolean(await getValidPendingInvitationForPhone(phoneNumber, now))
 }
 
 export async function getValidInvitationForPhone({


### PR DESCRIPTION
## Problem

A user Josh invited (Todd, `+13103842497`) was blocked at login with the invite-only wall — **even though he had a valid, pending invite in the DB**.

The invite-only login runs **two** server gates:

| Step | Rule for a brand-new number |
|---|---|
| `request-otp` | Passes if a pending `FriendInvitation` matches **by phone** (`hasValidPendingInvitationForPhone`) — ✅ Todd passed |
| `verify-otp` | Passed **only** with an invitation **token** in the request body or a per-user invite **link** — ❌ Todd failed |

A contact-invited user who opens the app directly and types their number (no token rides along) clears the "Enter your code" screen at step 1, then hits a false `invite_required` 403 at step 2 — which renders as the red invite-only box **on the code screen**. Users who tapped an invite link were fine (the token rode along); Todd navigated directly.

## Fix

Give `verify-otp` a third new-user acceptance path that mirrors what `request-otp` already honors: resolve a valid pending invitation by the verified phone and claim it through the existing `acceptFriendInvitation` flow (marks accepted + forms the friendship).

- **`invitations.ts`** — add `getValidPendingInvitationForPhone` (returns the row); `hasValidPendingInvitationForPhone` now delegates to it (one source of truth, request-otp behavior unchanged).
- **`verify-otp/route.ts`** — phone-match branch before `inviteRequiredRejection()`; claims the resolved invite by its token, with the same accept-race rejection posture as the token path.

## Testing

- `vitest` verify-otp suite: **17/17 pass**, including 2 new tests (happy path + accept-race rejection for the phone-match path).
- Typecheck clean on changed files; lint clean.

## Notes

- The gate is **not widened** — it now accepts the same real invitations `request-otp` already accepts, closing an inconsistency rather than loosening policy.
- Effective for Todd once this reaches production. Until then, an invite **link** (`/u/<handle>/<token>`) is his immediate way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)