### PR TITLE
Drop decorative wrapping quotes from question cards

### DIFF
--- a/src/components/profile/AuthoredQuestionsFeed.tsx
+++ b/src/components/profile/AuthoredQuestionsFeed.tsx
@@ -125,13 +125,7 @@ function ProfileQuestionRow({
       ) : null}
 
       <p className="mt-2 font-serif text-[20px] font-semibold leading-[28px] tracking-[0.04em] text-[var(--brand-ink)]">
-        <span aria-hidden className="opacity-60">
-          &ldquo;
-        </span>
         {item.questionText}
-        <span aria-hidden className="opacity-60">
-          &rdquo;
-        </span>
       </p>
 
       {answered ? (

--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -71,13 +71,7 @@ export function MyQuestionCard({
         </div>
 
         <p className="mt-2 break-words font-serif text-[20px] font-semibold leading-[28px] tracking-[0.04em] text-[var(--brand-ink)]">
-          <span aria-hidden className="opacity-60">
-            &ldquo;
-          </span>
           {question.text}
-          <span aria-hidden className="opacity-60">
-            &rdquo;
-          </span>
         </p>
 
         {answerersLine ? (


### PR DESCRIPTION
The Your Questions and authored-questions cards wrapped question text in
aria-hidden ldquo/rdquo spans. Questions that themselves contain quotation
marks (e.g. quoting a source) rendered with doubled quotes, and the
Answered tab already shows question text unquoted.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KBT5miCw3Ct1U4pp3S4cou