### PR TITLE
Make admin pages clearer: grouped nav, shared glossary, consistent actions

### DIFF
--- a/src/app/admin/AdminTabs.tsx
+++ b/src/app/admin/AdminTabs.tsx
@@ -2,84 +2,119 @@
 
 import Link from 'next/link';
 
-// One nav for the crafter tool's rooms — the overview landing (/admin),
-// Panel B (/admin/crafter), the review queue (/admin/reports), and the
-// knowledge-graph authoring surface (/admin/knowledge). Shared so the pages
-// read as one tool, not ad-hoc admin routes that happen to link at each other.
+// The admin nav, organized around the four JOBS the tool does rather than one
+// flat route list (D-ADMIN-USABILITY-01):
+//   Review queue — flagged/demoted questions waiting on a human call
+//   Author       — write questions by hand (Crafter) or import a CSV
+//   Library      — the full question pool audit table
+//   Domains      — one subject-structure section with three views:
+//                  Tree (knowledge graph) · Supply · Merge suggestions
+// Pages keep their existing routes and `active` keys; this component maps each
+// key to its section and, where a section has views, renders a second row of
+// sub-tabs styled as underline links so they can't be mistaken for top nav.
+export type AdminTabKey =
+  | 'overview'
+  | 'crafter'
+  | 'bulk-upload'
+  | 'reports'
+  | 'knowledge'
+  | 'questions'
+  | 'supply'
+  | 'domains';
+
+type Section = 'overview' | 'review' | 'author' | 'library' | 'domains';
+
+const SECTION_OF: Record<AdminTabKey, Section> = {
+  overview: 'overview',
+  reports: 'review',
+  crafter: 'author',
+  'bulk-upload': 'author',
+  questions: 'library',
+  knowledge: 'domains',
+  supply: 'domains',
+  domains: 'domains',
+};
+
+const SECTIONS: Array<{ key: Section; label: string; href: string }> = [
+  { key: 'overview', label: 'Overview', href: '/admin' },
+  { key: 'review', label: 'Review queue', href: '/admin/reports' },
+  { key: 'author', label: 'Author', href: '/admin/crafter' },
+  { key: 'library', label: 'Library', href: '/admin/questions' },
+  { key: 'domains', label: 'Domains', href: '/admin/knowledge' },
+];
+
+const SUBTABS: Partial<Record<Section, Array<{ key: AdminTabKey; label: string; href: string }>>> =
+  {
+    author: [
+      { key: 'crafter', label: 'Write questions', href: '/admin/crafter' },
+      { key: 'bulk-upload', label: 'Import CSV', href: '/admin/bulk-upload' },
+    ],
+    domains: [
+      { key: 'knowledge', label: 'Tree', href: '/admin/knowledge' },
+      { key: 'supply', label: 'Supply', href: '/admin/supply' },
+      { key: 'domains', label: 'Merge suggestions', href: '/admin/domains' },
+    ],
+  };
+
 export function AdminTabs({
   active,
   needingReviewCount,
 }: {
-  active: 'overview' | 'crafter' | 'reports' | 'knowledge' | 'questions' | 'supply' | 'domains';
+  active: AdminTabKey;
   needingReviewCount?: number;
 }) {
+  const activeSection = SECTION_OF[active];
+  const subtabs = SUBTABS[activeSection];
+
   const tabClass = 'rounded-md border px-3 py-1.5 text-sm font-medium';
   const activeStyle = { borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' } as const;
   const idleStyle = { borderColor: 'var(--border)', color: 'var(--text-muted)' } as const;
 
   return (
-    <nav className="flex flex-wrap gap-2" aria-label="Crafter sections">
-      <Link
-        href="/admin"
-        className={tabClass}
-        style={active === 'overview' ? activeStyle : idleStyle}
-        aria-current={active === 'overview' ? 'page' : undefined}
-      >
-        Overview
-      </Link>
-      {/* The poetic name ("Where your craft is wanted") stays on the page
-          itself — nav labels say what a page IS. */}
-      <Link
-        href="/admin/crafter"
-        className={tabClass}
-        style={active === 'crafter' ? activeStyle : idleStyle}
-        aria-current={active === 'crafter' ? 'page' : undefined}
-      >
-        Crafter
-      </Link>
-      <Link
-        href="/admin/reports"
-        className={tabClass}
-        style={active === 'reports' ? activeStyle : idleStyle}
-        aria-current={active === 'reports' ? 'page' : undefined}
-      >
-        Questions needing you
-        {needingReviewCount !== undefined && needingReviewCount > 0 ? (
-          <span style={{ color: 'var(--danger)' }}> · {needingReviewCount}</span>
-        ) : null}
-      </Link>
-      <Link
-        href="/admin/knowledge"
-        className={tabClass}
-        style={active === 'knowledge' ? activeStyle : idleStyle}
-        aria-current={active === 'knowledge' ? 'page' : undefined}
-      >
-        Knowledge graph
-      </Link>
-      <Link
-        href="/admin/questions"
-        className={tabClass}
-        style={active === 'questions' ? activeStyle : idleStyle}
-        aria-current={active === 'questions' ? 'page' : undefined}
-      >
-        Questions
-      </Link>
-      <Link
-        href="/admin/supply"
-        className={tabClass}
-        style={active === 'supply' ? activeStyle : idleStyle}
-        aria-current={active === 'supply' ? 'page' : undefined}
-      >
-        Domain supply
-      </Link>
-      <Link
-        href="/admin/domains"
-        className={tabClass}
-        style={active === 'domains' ? activeStyle : idleStyle}
-        aria-current={active === 'domains' ? 'page' : undefined}
-      >
-        Domain merges
-      </Link>
-    </nav>
+    <div className="flex flex-col gap-2">
+      <nav className="flex flex-wrap gap-2" aria-label="Admin sections">
+        {SECTIONS.map((section) => (
+          <Link
+            key={section.key}
+            href={section.href}
+            className={tabClass}
+            style={activeSection === section.key ? activeStyle : idleStyle}
+            aria-current={activeSection === section.key ? 'page' : undefined}
+          >
+            {section.label}
+            {section.key === 'review' &&
+            needingReviewCount !== undefined &&
+            needingReviewCount > 0 ? (
+              <span style={{ color: 'var(--danger)' }}> · {needingReviewCount}</span>
+            ) : null}
+          </Link>
+        ))}
+      </nav>
+      {subtabs ? (
+        // Sub-views of the active section — underline style, deliberately
+        // different from the bordered top tabs so the two levels read apart.
+        <nav
+          className="flex flex-wrap gap-4 border-b pb-1"
+          style={{ borderColor: 'var(--border)' }}
+          aria-label={`${SECTIONS.find((s) => s.key === activeSection)?.label ?? 'Section'} views`}
+        >
+          {subtabs.map((tab) => (
+            <Link
+              key={tab.key}
+              href={tab.href}
+              className="-mb-1.5 border-b-2 px-0.5 pb-1 text-sm font-medium"
+              style={
+                active === tab.key
+                  ? { borderColor: 'var(--brand-navy)', color: 'var(--brand-ink)' }
+                  : { borderColor: 'transparent', color: 'var(--text-muted)' }
+              }
+              aria-current={active === tab.key ? 'page' : undefined}
+            >
+              {tab.label}
+            </Link>
+          ))}
+        </nav>
+      ) : null}
+    </div>
   );
 }

--- a/src/app/admin/InfoTerm.tsx
+++ b/src/app/admin/InfoTerm.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+
+import { GLOSSARY, type GlossaryKey } from './glossary';
+
+// A term of art with its definition one TAP away — the admin pages are used on
+// phones, so meaning must never live only in a hover tooltip. Renders its
+// children with a dotted underline; tapping toggles a small popover with the
+// glossary definition (or an inline `def`). Closes on outside tap or Escape.
+export function InfoTerm({
+  term,
+  def,
+  children,
+  style,
+  className,
+}: {
+  /** Glossary key — the shared definition set in glossary.ts. */
+  term?: GlossaryKey;
+  /** Inline definition for one-off terms not worth a glossary entry. */
+  def?: string;
+  children: ReactNode;
+  /** Passed to the trigger so tone (color) matches the surrounding label. */
+  style?: CSSProperties;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLSpanElement>(null);
+  const definition = term ? GLOSSARY[term] : def;
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  if (!definition) return <span style={style}>{children}</span>;
+
+  return (
+    <span ref={rootRef} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className={
+          'cursor-help underline decoration-dotted underline-offset-2 ' + (className ?? '')
+        }
+        style={style}
+        title={definition}
+      >
+        {children}
+      </button>
+      {open ? (
+        <span
+          role="note"
+          className="absolute left-0 top-full z-[70] mt-1 block w-max max-w-[min(18rem,80vw)] rounded-md border px-3 py-2 text-left text-xs font-normal normal-case leading-relaxed tracking-normal shadow-[var(--shadow-overlay)]"
+          style={{
+            background: 'var(--brand-card)',
+            borderColor: 'var(--border)',
+            color: 'var(--brand-ink-700)',
+            whiteSpace: 'normal',
+          }}
+        >
+          {definition}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/app/admin/bulk-upload/BulkUploadClient.tsx
+++ b/src/app/admin/bulk-upload/BulkUploadClient.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import { AdminTabs } from '@/app/admin/AdminTabs';
+
 // Per-line error returned by /api/admin/bulk-upload-questions.
 type RowError = { line: number; message: string };
 
@@ -80,10 +82,20 @@ export function BulkUploadClient({
   return (
     <main className="mx-auto min-h-dvh max-w-3xl px-4 pt-6 pb-24">
       <header className="mb-5">
-        <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">Bulk upload questions</h1>
+        <div className="mb-3">
+          <AdminTabs active="bulk-upload" />
+        </div>
+        <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">Import CSV</h1>
         <p className="text-muted-foreground mt-1 text-sm">
-          Upload a CSV to create questions in bulk. They are saved as verified and public, attributed
-          to the selected admin author.
+          Create questions in bulk from a CSV, attributed to the selected admin author.
+        </p>
+        <p
+          className="mt-2 rounded-md px-3 py-2 text-sm font-medium"
+          style={{ background: 'var(--warning-surface)', color: 'var(--brand-ink)' }}
+        >
+          Uploads publish immediately: every created row is saved as{' '}
+          <strong>verified and public</strong> — no review step. Run{' '}
+          <strong>Validate (dry run)</strong> first.
         </p>
       </header>
 

--- a/src/app/admin/crafter/CrafterClient.tsx
+++ b/src/app/admin/crafter/CrafterClient.tsx
@@ -43,10 +43,11 @@ export function CrafterClient({
         <div className="mb-3">
           <AdminTabs active="crafter" needingReviewCount={needingReviewCount} />
         </div>
-        {/* The voice lives here; the nav tab says what the page is ("Crafter"). */}
+        {/* Plain function in the title; the voice lives in the subtitle. */}
         <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">
-          Where your craft is wanted
+          Write questions
         </h1>
+        <p className="text-muted-foreground mt-0.5 text-sm italic">Where your craft is wanted.</p>
       </header>
 
       {crafting ? (
@@ -97,7 +98,7 @@ function GateCalibrationReadout({ calibration }: { calibration: GateCalibration 
   return (
     <section className="mt-8">
       <h2 className="mb-1 font-serif text-lg font-semibold text-[var(--brand-ink)]">
-        Machine doubt calibration
+        How often the machine&apos;s doubts were right
       </h2>
       {totalVerdicts === 0 ? (
         <p className="text-muted-foreground text-sm">
@@ -151,9 +152,11 @@ const FLAG_LABEL: Record<string, string> = {
   tier_mismatch: 'tier mismatch',
 };
 
+// Plain-speech demand labels (the old "wanted & thin" / "getting there" read
+// as riddles): how much a human's authoring would matter here right now.
 const HEAT_LABEL: Record<CrafterWorklistRow['heat'], string> = {
-  high: 'wanted & thin',
-  mid: 'getting there',
+  high: 'high need',
+  mid: 'some need',
   low: 'niche',
   covered: 'covered',
 };
@@ -279,31 +282,28 @@ function DomainRow({ row, onCraft }: { row: CrafterWorklistRow; onCraft: () => v
           </div>
           {noHumanStory ? (
             <div className="mt-0.5 text-xs text-[var(--brand-ink-700)]">
-              <button
-                type="button"
-                onClick={() => void togglePlayers()}
-                className="underline-offset-2 hover:underline"
-                title="Show who's playing here and flip author invitations"
-              >
-                {row.activePlayers} people are playing here
-              </button>{' '}
-              and no human has ever written for them.
+              {row.activePlayers} people are playing here and no human has ever written for them.
               <span className="text-muted-foreground"> · {row.machineDepth} machine questions</span>
             </div>
           ) : (
             <div className="text-muted-foreground mt-0.5 text-xs">
-              <button
-                type="button"
-                onClick={() => void togglePlayers()}
-                className="underline-offset-2 hover:underline"
-                title="Show who's playing here and flip author invitations"
-              >
-                {row.activePlayers} player{row.activePlayers === 1 ? '' : 's'} active
-              </button>{' '}
-              · {row.machineDepth} machine · {row.humanAuthored} human-authored
+              {row.activePlayers} player{row.activePlayers === 1 ? '' : 's'} active ·{' '}
+              {row.machineDepth} machine · {row.humanAuthored} human-authored
               {row.lastActivity ? ` · last played ${new Date(row.lastActivity).toLocaleDateString()}` : ''}
             </div>
           )}
+          {/* The player list used to hide behind the count text itself — an
+              invisible affordance. Now it's a real button. */}
+          <button
+            type="button"
+            onClick={() => void togglePlayers()}
+            aria-expanded={open}
+            className="mt-1 inline-flex min-h-7 items-center rounded-md border px-2 text-xs font-medium"
+            style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+            title="See who's playing here and invite them to author"
+          >
+            {open ? 'Hide players ▴' : 'Players & invitations ▾'}
+          </button>
           {row.clusterLabels.length > 0 ? (
             <div className="text-muted-foreground mt-0.5 text-xs">
               with variant labels: {row.clusterMachineDepth} machine · {row.clusterHumanAuthored}{' '}

--- a/src/app/admin/domains/DomainMergeClient.tsx
+++ b/src/app/admin/domains/DomainMergeClient.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FragmentationPair } from '@/server/db/queries/domain-fragmentation';
 import type { MergePreview } from '@/server/db/queries/domain-merges';
 import type { DomainQuestionPeek } from '@/server/db/queries/knowledge-graph';
+import { InfoTerm } from '@/app/admin/InfoTerm';
 
 // D-DOMAIN-MERGE-REVIEW-REDESIGN-01 — the consolidated near-duplicate review
 // surface. It fuses the two earlier takes: the progressive-disclosure UX (the
@@ -283,21 +284,21 @@ export function DomainMergeClient({ pairs }: { pairs: FragmentationPair[] }) {
 
 function graphBadge(hasNode: boolean) {
   return hasNode ? (
-    <span
+    <InfoTerm
+      term="in_graph"
       className="ml-1 shrink-0 rounded-sm border px-1 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
       style={{ borderColor: 'var(--success)', color: 'var(--success)' }}
-      title="This label has an authored territory on the Knowledge graph page"
     >
-      in graph
-    </span>
+      in tree
+    </InfoTerm>
   ) : (
-    <span
+    <InfoTerm
+      term="label_only"
       className="ml-1 shrink-0 rounded-sm border px-1 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
       style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
-      title="A raw question label — not in the knowledge graph. Nest or merge adds it."
     >
       label only
-    </span>
+    </InfoTerm>
   );
 }
 
@@ -367,12 +368,13 @@ function MergeRow({
               {star === 'B' ? <StarKeep /> : null}
               {graphBadge(pair.hasNodeB)}
             </span>
-            <span
-              className="ml-auto shrink-0 text-xs font-semibold"
-              style={{ color: 'var(--brand-ink-700)' }}
-              title="Trigram similarity"
-            >
-              {pct(pair.similarity)}
+            <span className="ml-auto shrink-0 text-xs font-semibold">
+              <InfoTerm
+                def="How alike the two spellings are (trigram similarity) — the reason this pair was suggested."
+                style={{ color: 'var(--brand-ink-700)' }}
+              >
+                {pct(pair.similarity)} alike
+              </InfoTerm>
             </span>
           </div>
           <div className="flex flex-wrap gap-x-4 text-xs" style={{ color: 'var(--text-muted)' }}>
@@ -685,7 +687,7 @@ function LabelPeek({ label }: { label: string }) {
               <span style={{ color: 'var(--brand-ink)' }}>{q.text}</span>{' '}
               <span style={{ color: 'var(--text-muted)' }}>
                 — {q.answer}
-                {q.source === 'bank' ? ' · bank' : ''}
+                {q.source === 'bank' ? ' · machine bank' : ''}
                 {q.suppressed ? ' · out of circulation' : ''}
               </span>
             </li>

--- a/src/app/admin/domains/page.tsx
+++ b/src/app/admin/domains/page.tsx
@@ -30,23 +30,15 @@ export default async function AdminDomainsPage() {
         <AdminTabs active="domains" />
         <div>
           <h1 className="font-serif text-2xl font-semibold" style={{ color: 'var(--brand-ink)' }}>
-            Domain merges
+            Merge suggestions
           </h1>
           <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
-            Candidates here are <strong>raw labels from the question corpus</strong> — what the
-            categorizer filed questions under — paired by spelling similarity. Most are not on the
-            Knowledge graph page (that shows only territories you authored; the chips mark which
-            is which). Each row collapses to two controls — <strong>Merge / Nest</strong> opens
-            the decision, <strong>Dismiss</strong> retires the pair. Expand and the four choices
-            group by the real question: <strong>same scope</strong> → pick which spelling survives
-            (the other folds into it everywhere, graph included); <strong>different scope</strong>{' '}
-            (a work inside its series or genre) → <strong>Nest</strong> it — both labels become
-            graph territories with the edge drawn, and the pair leaves this list.{' '}
-            <strong>Dismiss</strong> is permanent (a genuinely-different pair never resurfaces),
-            while a merge or nest shows an <strong>Undo</strong> toast for a few seconds before it
-            commits. Each side shows its question count and a <strong>see</strong> peek;{' '}
-            <strong>★ keep</strong> marks the side holding more questions; <strong>Preview</strong>{' '}
-            shows the exact rows a merge would move before anything changes.
+            Pairs of near-duplicate <strong>labels from the question corpus</strong>, matched by
+            spelling. For each pair, decide: the <strong>same thing</strong> → merge them into one
+            spelling; <strong>one inside the other</strong> → nest it; <strong>genuinely
+            different</strong> → dismiss the pair for good. Merges and nests show a few-second
+            Undo before committing; a dismiss is permanent. Tap <em>see</em> on either side to
+            read its actual questions before deciding.
           </p>
         </div>
       </div>

--- a/src/app/admin/glossary.ts
+++ b/src/app/admin/glossary.ts
@@ -1,0 +1,83 @@
+// One shared vocabulary for the admin tool. Every term of art an admin page
+// shows (status enums, flags, jargon chips) should carry one of these
+// definitions via <InfoTerm>, so meaning never lives only in a hover tooltip
+// (the admin pages are used on phones, where there is no hover).
+//
+// Naming canon (D-ADMIN-USABILITY-01): the automated fact-checker is called
+// the VERIFIER everywhere — never "the machine" or "the LLM" — and raw enum
+// values (soft_finite, vet/cron, generated) never render verbatim.
+
+export const GLOSSARY = {
+  // ── The verifier ───────────────────────────────────────────────────────────
+  verifier:
+    'The automated fact-checker. It generates a fresh answer, checks it against sources, and pulls (demotes) questions that fail.',
+
+  // ── Question provenance ────────────────────────────────────────────────────
+  canonical_question:
+    'A question in the main pool (human- or house-authored, or promoted there).',
+  machine_drafted:
+    'A question from the generated store — drafted by the machine, not a person.',
+  removed_automatically:
+    'Blocked by an automated vetting verdict or scheduled sweep, not by a human.',
+
+  // ── Question flags (Library) ───────────────────────────────────────────────
+  trust_tier:
+    'How far this question has been vetted: unverified → machine verified (passed the verifier) → human validated (a person checked it) → author confirmed.',
+  verdict:
+    "The verifier's last ruling: ok (passed) · demoted (pulled from circulation) · unverifiable (couldn't settle it) · skipped (not checked).",
+  visibility:
+    'Who can be served this question: public · friends · private · blocked (removed by moderation).',
+  tombstone:
+    'The author deleted their account. The question stays, attributed neutrally to the house.',
+  perishable:
+    'Tied to a point in time — its answer can go stale (e.g. "current champion").',
+  nobody_correct:
+    'Asked several times and nobody has ever answered it correctly — a possible bad answer key.',
+  duplicate: 'Flagged as a near-copy of another question in the pool.',
+  soft_deleted:
+    'Soft-deleted: hidden from players but kept inspectable under "Show deleted", and restorable.',
+
+  // ── Supply states (Domains → Supply) ───────────────────────────────────────
+  supply_ran_dry:
+    'Generation went dry far short of a trusted size estimate — a supply problem to investigate, not a finished domain.',
+  supply_estimate_too_low:
+    'Generation has reached (or beaten) the size estimate and is still producing — the estimate is probably too low; raise it.',
+  supply_filling: 'Generation is still producing normally, below the size estimate.',
+  supply_likely_complete:
+    'Went dry close to its estimate — believed complete ("resting"). Still re-probed occasionally in case new material appears.',
+  supply_unsized:
+    'No size estimate yet — run Re-estimate (the corpus resolver) or set one by hand to classify it.',
+  supply_capped:
+    'Generation is switched off for this domain by hand. Existing questions still serve, and it never raises a supply alarm.',
+  supply_estimate:
+    'How many questions this domain is believed to support, from the corpus resolver — or a manual override, which always wins.',
+  supply_confidence: 'How much to trust the size estimate, as reported by the corpus resolver.',
+  supply_basis: 'What the corpus resolver grounded the size estimate on.',
+  dry_rounds:
+    'Consecutive generation rounds that produced nothing new here. Feeds the supply state.',
+
+  // ── Knowledge tree ─────────────────────────────────────────────────────────
+  territory:
+    'A subject area in the knowledge tree (e.g. "Beethoven"). Questions file under territories; players master them.',
+  unfiled:
+    'A label with questions but no territory in the tree yet — real content waiting to be filed.',
+  pts_to_master:
+    'The mastery target for this territory, in points. A player masters it at 75% of this number. Color shows size: green small, gold moderate, red large.',
+  pts_available:
+    'Points currently earnable here (difficulty-weighted, rolled up through the subtree for parents). Compare against the mastery target.',
+  exhausted:
+    'Generation has dried up here: the machine keeps repeating itself and few servable facts remain, so supply is frozen below what mastering needs. A human decision is needed — author more, merge it up, or shrink the target.',
+  duplicates_rate:
+    'The share of generated questions here that came back as duplicates. High = fresh facts are getting hard to find.',
+  thin_leaf: 'Too few questions to stand alone — a candidate to move under a broader parent.',
+  in_graph: 'This label has an authored territory in the knowledge tree.',
+  label_only:
+    'A raw label from the question corpus — not in the knowledge tree. Merging or nesting adds it.',
+
+  // ── Review queue ───────────────────────────────────────────────────────────
+  player_report: 'A player flagged this question as inappropriate or incorrect.',
+  verifier_demotion:
+    'The verifier pulled this question out of circulation after a failed fact-check; it waits here for your call.',
+} as const;
+
+export type GlossaryKey = keyof typeof GLOSSARY;

--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -17,6 +17,7 @@ import {
 
 import type { KnowledgeEdgeRow, KnowledgeNodeRow } from '@/server/db/queries/knowledge-graph';
 import { AdminTabs } from '@/app/admin/AdminTabs';
+import { InfoTerm } from '@/app/admin/InfoTerm';
 
 // B-KNOWLEDGE-ADMIN-01 P1 — nodes, edges, thresholds, edge types. Internal ops
 // idiom (AdminReportsClient precedent). Every commit here is a deliberate
@@ -66,11 +67,13 @@ export type SupplyReadout = {
   capped: boolean;
 };
 
+// Same plain-speech vocabulary as the Supply view's STATE_LABEL — the two
+// surfaces must speak the same words for the same states.
 const SUPPLY_STATE_TEXT: Record<SupplyReadout['state'], string> = {
-  discrepancy: '⚠ discrepancy',
-  raise_estimate: 'raise estimate',
+  discrepancy: '⚠ ran dry early',
+  raise_estimate: 'estimate too low',
   filling: 'filling',
-  soft_finite: 'resting',
+  soft_finite: 'likely complete',
   unsized: 'unsized',
 };
 
@@ -94,7 +97,7 @@ function SupplyChip({ domainKeyValue, supply }: { domainKeyValue: string; supply
       href={`/admin/supply#supply-${domainKeyValue}`}
       className="underline-offset-2 hover:underline"
       style={{ color: tone }}
-      title="Generation supply for this exact area (made / estimated) — tap for its full supply row: estimate basis, dry rounds, cap and re-size actions"
+      title="Generation supply for this exact area (made / estimated) — tap for its full Supply row: estimate basis, dry rounds, cap and re-estimate actions"
     >
       supply: {text} →
     </a>
@@ -129,17 +132,14 @@ export function KnowledgeAdminClient({
           <AdminTabs active="knowledge" />
         </div>
         <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">
-          Knowledge graph
+          Territory tree
         </h1>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          The whole map: <strong>the tree is what you&apos;ve authored</strong>; every other area
-          with questions waits in <strong>Unfiled areas</strong> below until you add it. Under
-          every name: the points to master it (color-coded by size — green small, gold moderate,
-          red large; edit via ⋯), how many questions live there, and the points currently
-          available — both rolled up through the subtree for parents. <em>⟳ duplicates</em> marks
-          where new questions are hard to find; <em>⛔ exhausted</em> marks a tapped-out area at
-          the expansion gate (author more to refill it). Nothing here touches questions or any
-          player&apos;s mastery.
+          The subject structure you&apos;ve authored — every{' '}
+          <InfoTerm term="territory">territory</InfoTerm>, its children, and its mastery target.
+          Areas with questions but no territory yet wait in{' '}
+          <InfoTerm term="unfiled">Unfiled areas</InfoTerm> below. Tap any underlined stat or flag
+          for what it means. Nothing here touches questions or any player&apos;s mastery.
         </p>
       </header>
 
@@ -774,14 +774,17 @@ function KnowledgeTreeEditor({
         </div>
       ) : null}
       {confirmMerge ? (
+        // Deliberately NOT the same quiet card as the move/flip/pick bars — a
+        // merge is the one irreversible act here, and it must look like one.
         <div className="fixed inset-x-0 bottom-0 z-[60] flex justify-center p-3">
           <div
-            className="flex w-full max-w-lg flex-wrap items-center gap-2 rounded-xl border px-3 py-2.5 text-[13px] shadow-[var(--shadow-overlay)]"
-            style={{ background: 'var(--brand-card)', borderColor: 'var(--danger)', color: 'var(--brand-ink-700)' }}
+            className="flex w-full max-w-lg flex-wrap items-center gap-2 rounded-xl border-2 px-3 py-2.5 text-[13px] shadow-[var(--shadow-overlay)]"
+            style={{ background: 'var(--destructive-surface, var(--brand-card))', borderColor: 'var(--danger)', color: 'var(--brand-ink)' }}
             aria-live="polite"
           >
             <span className="w-full">
-              Fold <strong>{confirmMerge.sourceLabel}</strong> into{' '}
+              <strong style={{ color: 'var(--danger)' }}>⚠ Irreversible merge.</strong> Fold{' '}
+              <strong>{confirmMerge.sourceLabel}</strong> into{' '}
               <strong>{confirmMerge.targetLabel}</strong>? Its questions, player progress, and
               history move over, and <strong>{confirmMerge.sourceLabel}</strong> ceases to exist.
               This cannot be undone.
@@ -794,10 +797,10 @@ function KnowledgeTreeEditor({
                 void act({ action: 'merge_node', sourceDomainKey: m.sourceKey, targetDomainKey: m.targetKey });
               }}
               disabled={busy}
-              className="inline-flex min-h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
-              style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
+              className="inline-flex min-h-9 items-center rounded-md border px-3 text-sm font-semibold disabled:opacity-50"
+              style={{ borderColor: 'var(--danger)', background: 'var(--danger)', color: 'var(--brand-cream-page)' }}
             >
-              Merge them
+              Merge — cannot be undone
             </button>
             <button
               type="button"
@@ -1066,21 +1069,17 @@ function UnfiledAreas({
                     {area.points.toLocaleString()} pts available
                   </span>
                   {area.exhausted ? (
-                    <span
-                      className="font-semibold"
-                      style={{ color: 'var(--danger)' }}
-                      title="Exhausted — few servable facts remain despite generation"
-                    >
+                    <InfoTerm term="exhausted" className="font-semibold" style={{ color: 'var(--danger)' }}>
                       ⛔ exhausted
-                    </span>
+                    </InfoTerm>
                   ) : showDup ? (
-                    <span
+                    <InfoTerm
+                      def={`${Math.round(dupRate * 100)}% of the questions generated here came back as duplicates (${area.genDupes} of ${area.genTotal}) — fresh facts are getting hard to find.`}
                       className="font-medium"
                       style={{ color: dupRateColor(dupRate) }}
-                      title={`${Math.round(dupRate * 100)}% of generated questions here came back as duplicates (${area.genDupes}/${area.genTotal})`}
                     >
                       ⟳ {Math.round(dupRate * 100)}% duplicates
-                    </span>
+                    </InfoTerm>
                   ) : null}
                   <SupplyChip domainKeyValue={area.domainKey} supply={supplyByKey[area.domainKey]} />
                 </span>
@@ -1212,8 +1211,9 @@ function ExhaustedWorklist({
             <strong>shrink the target</strong> to what the topic can really yield,{' '}
             <strong>merge it up</strong> into a broader parent if it&apos;s too granular to
             stand alone, or <strong>hand-author / ground</strong> more if it&apos;s a rich
-            topic the machine just failed. Leaves already holding enough to master are
-            hidden — nothing to decide there.
+            topic the machine just failed. The <em>best guess</em> on each row is a
+            heuristic, not a verdict — all three levers stay open. Leaves already holding
+            enough to master are hidden — nothing to decide there.
           </p>
           <ul className="space-y-1 px-2 pb-2">
           {leaves.map((key) => {
@@ -1266,7 +1266,7 @@ function ExhaustedWorklist({
                   · {depthByKey[key] ?? 0} Qs{dupPct !== null ? ` · ${dupPct}% dup` : ''}
                 </div>
                 <div className="mt-1 text-xs" style={{ color: 'var(--brand-ink-700)' }}>
-                  <span style={{ color: 'var(--danger)' }}>→ likely:</span>{' '}
+                  <span style={{ color: 'var(--danger)' }}>→ best guess:</span>{' '}
                   {exhaustedDecisionHint(
                     node.masteryThreshold ?? null,
                     pointsByKey[key] ?? 0,
@@ -1583,13 +1583,13 @@ function TreeRow({
               {/* "This is too small" — a thin leaf that isn't already nested is a
                   condense-me candidate (Move it under a parent). */}
               {!isParentish && (depthByKey[nodeKey] ?? 0) < THIN_LEAF_THRESHOLD && parentCount === 0 ? (
-                <span
+                <InfoTerm
+                  term="thin_leaf"
                   className="shrink-0 rounded-sm px-1.5 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
                   style={{ color: 'var(--warning)', background: 'var(--warning-surface)' }}
-                  title="Too few questions to stand alone — Move it under a broader parent"
                 >
                   thin
-                </span>
+                </InfoTerm>
               ) : null}
             </span>
             {/* The stats line — spelled out, not abbreviated ("stats hard to
@@ -1597,52 +1597,41 @@ function TreeRow({
                 points available (both rolled up through the subtree for
                 parents), then the escalating supply flag. */}
             <span className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs">
-              <span
+              <InfoTerm
+                term="pts_to_master"
                 className="font-medium"
                 style={{ color: node.masteryThreshold ? thresholdColor(node.masteryThreshold) : 'var(--warning)' }}
-                title={
-                  node.masteryThreshold
-                    ? `Mastery threshold: ${node.masteryThreshold.toLocaleString()} pts (a player masters this at 75% of it)`
-                    : 'No mastery target set — tap ⋯ → Edit to set one'
-                }
               >
                 {node.masteryThreshold
                   ? `${node.masteryThreshold.toLocaleString()} pts to master`
                   : 'no mastery target'}
-              </span>
+              </InfoTerm>
               <span className="text-muted-foreground" title="Questions filed in this area (rolled up through the subtree for parents)">
                 {depthByKey[nodeKey] ?? 0} questions
               </span>
-              <span
-                className="text-muted-foreground"
-                title="Points currently earnable here (difficulty-weighted, rolled up) — eyeball against the mastery target"
-              >
+              <InfoTerm term="pts_available" className="text-muted-foreground">
                 {(pointsByKey[nodeKey] ?? 0).toLocaleString()} pts available
-              </span>
+              </InfoTerm>
               {(() => {
                 // Escalating supply signal: EXHAUSTED (at the expansion gate) beats
                 // "hard to source" (high dup) beats nothing.
                 const ex = exhaustedByKey[nodeKey];
                 if (ex?.self) {
                   return (
-                    <span
-                      className="font-semibold"
-                      style={{ color: 'var(--danger)' }}
-                      title="Exhausted — at the narrow-KB expansion gate: few servable facts remain despite generation, so the system stops serving fresh questions here and offers area-expansion instead. Author more by hand to refill it."
-                    >
+                    <InfoTerm term="exhausted" className="font-semibold" style={{ color: 'var(--danger)' }}>
                       ⛔ exhausted
-                    </span>
+                    </InfoTerm>
                   );
                 }
                 if (ex && ex.descendants > 0) {
                   return (
-                    <span
+                    <InfoTerm
+                      def={`${ex.descendants} sub-area${ex.descendants === 1 ? '' : 's'} inside this one ${ex.descendants === 1 ? 'is' : 'are'} exhausted — generation dried up there and a human decision is needed.`}
                       className="font-medium"
                       style={{ color: 'var(--danger)' }}
-                      title={`${ex.descendants} sub-area${ex.descendants === 1 ? '' : 's'} here ${ex.descendants === 1 ? 'is' : 'are'} exhausted (at the expansion gate)`}
                     >
                       ⛔ {ex.descendants} exhausted
-                    </span>
+                    </InfoTerm>
                   );
                 }
                 const g = genStatsByKey[nodeKey];
@@ -1651,13 +1640,13 @@ function TreeRow({
                 if (rate < HARD_TO_SOURCE_MIN_RATE) return null; // only flag where it's hard
                 const pct = Math.round(rate * 100);
                 return (
-                  <span
+                  <InfoTerm
+                    def={`${pct}% of the questions generated here came back as duplicates (${g.dupes} of ${g.total}) — fresh facts are getting hard to find.`}
                     className="font-medium"
                     style={{ color: dupRateColor(rate) }}
-                    title={`${pct}% of generated questions here came back as duplicates — new ones are hard to find (${g.dupes}/${g.total} generated)`}
                   >
                     ⟳ {pct}% duplicates
-                  </span>
+                  </InfoTerm>
                 );
               })()}
               <SupplyChip domainKeyValue={nodeKey} supply={supplyByKey[nodeKey]} />
@@ -1972,7 +1961,7 @@ function QuestionsPeek({
               <span className="text-[var(--brand-ink)]">{q.text}</span>{' '}
               <span className="text-muted-foreground">
                 — {q.answer}
-                {q.source === 'bank' ? ' · bank' : ''}
+                {q.source === 'bank' ? ' · machine bank' : ''}
                 {q.suppressed ? ' · out of circulation' : ''}
               </span>
             </li>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -11,17 +11,18 @@ import { getMachineDemotionsForReview } from '@/server/db/queries/machine-demoti
 import { getDomainFragmentationCandidates } from '@/server/db/queries/domain-fragmentation';
 import { getAllQuestionsForAdmin } from '@/server/db/queries/admin-questions';
 import { listKnowledgeGraph } from '@/server/db/queries/knowledge-graph';
+import { getCrafterWorklist } from '@/server/db/queries/crafter-demand';
 import { buildSupplyCoverageSummary } from '@/server/daily/supply-coverage';
 
 import { AdminTabs } from './AdminTabs';
 
 export const dynamic = 'force-dynamic';
 
-// The admin landing — "where is the work?" at a glance. One card per tab, each
-// carrying the live counts its page computes, so a curator sees the queue
-// pressure across ALL surfaces without visiting six routes. Every read is
+// The admin landing — "where is the work?" at a glance, grouped by the four
+// jobs the tool does (Review / Author / Library / Domains) so the cards mirror
+// the nav. Each card carries the live counts its page computes; every read is
 // fail-open (a card shows "—" instead of breaking the others) and reuses the
-// exact query its tab uses, so the numbers here always agree with the pages.
+// exact query its page uses, so the numbers here always agree with the pages.
 // Same admin gate as every /admin page: ADMIN_USER_IDS or a 404 that never
 // reveals the route.
 
@@ -73,13 +74,24 @@ function OverviewCard({
   );
 }
 
+function GroupHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2
+      className="mb-2 mt-5 text-[11px] font-semibold uppercase tracking-[0.08em] first:mt-0"
+      style={{ color: 'var(--text-muted)' }}
+    >
+      {children}
+    </h2>
+  );
+}
+
 export default async function AdminOverviewPage() {
   const session = await getSession();
   if (!session || !isAdminUser(session.userId)) notFound();
 
   // Every read independent + fail-open: one broken surface must not blank the
-  // other five cards. null ⇒ that card renders "—".
-  const [reports, demotions, blocked, supply, mergePairs, graph, questionsPage] =
+  // other cards. null ⇒ that card renders "—".
+  const [reports, demotions, blocked, supply, mergePairs, graph, questionsPage, crafterWorklist] =
     await Promise.all([
       getOpenReportsForReview().catch(() => null),
       getMachineDemotionsForReview().catch(() => null),
@@ -88,6 +100,7 @@ export default async function AdminOverviewPage() {
       getDomainFragmentationCandidates().catch(() => null),
       listKnowledgeGraph().catch(() => null),
       getAllQuestionsForAdmin({ pageSize: 1 }).catch(() => null),
+      getCrafterWorklist(session.userId).catch(() => null),
     ]);
 
   const n = (value: number | null | undefined): string =>
@@ -98,6 +111,7 @@ export default async function AdminOverviewPage() {
       ? null
       : (reports?.length ?? 0) + (demotions?.length ?? 0);
   const readyFixCount = demotions?.filter((d) => d.proposal).length ?? null;
+  const highNeedCount = crafterWorklist?.filter((row) => row.heat === 'high').length ?? null;
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-8">
@@ -113,30 +127,77 @@ export default async function AdminOverviewPage() {
         </div>
       </div>
 
+      <GroupHeading>Review</GroupHeading>
       <div className="grid gap-3 sm:grid-cols-2">
         <OverviewCard
           href="/admin/reports"
-          title="Questions needing you"
-          description="Player reports and machine demotions waiting on a human call."
+          title="Review queue"
+          description="Player reports and verifier demotions waiting on a human call."
           stats={[
             { value: n(openCount), label: 'needing review', tone: openCount ? 'danger' : undefined },
             { value: n(readyFixCount), label: 'with a ready fix', tone: readyFixCount ? 'navy' : undefined },
             { value: n(blocked?.length), label: 'blocked / actioned' },
           ]}
         />
+      </div>
+
+      <GroupHeading>Author</GroupHeading>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <OverviewCard
+          href="/admin/crafter"
+          title="Write questions"
+          description="Where your craft is wanted — active domains ranked by how much hand-authoring would matter."
+          stats={[
+            {
+              value: n(highNeedCount),
+              label: 'domains in high need',
+              tone: highNeedCount ? 'danger' : undefined,
+            },
+            { value: n(crafterWorklist?.length), label: 'active domains' },
+          ]}
+        />
+        <OverviewCard
+          href="/admin/bulk-upload"
+          title="Import CSV"
+          description="Create questions in bulk from a CSV. Uploads publish immediately as verified and public."
+          stats={[]}
+        />
+      </div>
+
+      <GroupHeading>Library</GroupHeading>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <OverviewCard
+          href="/admin/questions"
+          title="Questions"
+          description="The full canonical pool — inspect, edit, soft-delete."
+          stats={[{ value: n(questionsPage?.total), label: 'questions' }]}
+        />
+      </div>
+
+      <GroupHeading>Domains</GroupHeading>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <OverviewCard
+          href="/admin/knowledge"
+          title="Tree"
+          description="The authored territory structure — nodes, edges, mastery targets."
+          stats={[
+            { value: n(graph?.nodes.length), label: 'territories' },
+            { value: n(graph?.edges.length), label: 'edges' },
+          ]}
+        />
         <OverviewCard
           href="/admin/supply"
-          title="Domain supply"
-          description="Size estimates vs realized generation; discrepancies are supply problems, not completion."
+          title="Supply"
+          description="Size estimates vs realized generation — which domains ran dry early, and which beat their estimates."
           stats={[
             {
               value: n(supply?.counts.discrepancy),
-              label: 'discrepancies',
+              label: 'ran dry early',
               tone: supply?.counts.discrepancy ? 'danger' : undefined,
             },
             {
               value: n(supply?.counts.raise_estimate),
-              label: 'raise estimate',
+              label: 'estimate too low',
               tone: supply?.counts.raise_estimate ? 'navy' : undefined,
             },
             { value: n(supply?.cappedCount), label: 'capped' },
@@ -144,8 +205,8 @@ export default async function AdminOverviewPage() {
         />
         <OverviewCard
           href="/admin/domains"
-          title="Domain merges"
-          description="Near-duplicate labels awaiting a same-scope-or-siblings call. The graph follows a merge automatically."
+          title="Merge suggestions"
+          description="Near-duplicate labels awaiting a call: merge, nest, or dismiss. The tree follows a merge automatically."
           stats={[
             {
               value: n(mergePairs?.length),
@@ -153,27 +214,6 @@ export default async function AdminOverviewPage() {
               tone: mergePairs?.length ? 'navy' : undefined,
             },
           ]}
-        />
-        <OverviewCard
-          href="/admin/knowledge"
-          title="Knowledge graph"
-          description="The authored territory structure — nodes, edges, thresholds."
-          stats={[
-            { value: n(graph?.nodes.length), label: 'territories' },
-            { value: n(graph?.edges.length), label: 'edges' },
-          ]}
-        />
-        <OverviewCard
-          href="/admin/questions"
-          title="Questions"
-          description="The full canonical pool — inspect, edit, soft-delete."
-          stats={[{ value: n(questionsPage?.total), label: 'questions' }]}
-        />
-        <OverviewCard
-          href="/admin/crafter"
-          title="Crafter"
-          description="Where your craft is wanted — the territories asking for hand-written questions."
-          stats={[]}
         />
       </div>
     </main>

--- a/src/app/admin/questions/AdminQuestionsClient.tsx
+++ b/src/app/admin/questions/AdminQuestionsClient.tsx
@@ -4,6 +4,7 @@ import { useState, type ReactNode } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { AdminTabs } from '@/app/admin/AdminTabs';
+import { InfoTerm } from '@/app/admin/InfoTerm';
 import { CATEGORIES } from '@/lib/questions-types';
 import type {
   AdminQuestionDetail,
@@ -26,6 +27,12 @@ import type {
 const TRUST_TIERS = ['unverified', 'machine_verified', 'human_validated', 'author_confirmed'];
 const VISIBILITIES = ['public', 'friends', 'private', 'blocked'];
 const VERDICTS = ['ok', 'demoted', 'unverifiable', 'skipped'];
+
+// Enum values render in plain words ('machine verified', not the raw
+// 'machine_verified') — the underscore form is a database detail.
+function humanize(value: string | null | undefined): string {
+  return value ? value.replace(/_/g, ' ') : '—';
+}
 
 function fmtDate(iso: string): string {
   return iso.slice(0, 10);
@@ -61,17 +68,44 @@ function Badge({ label, tone }: { label: string; tone?: 'muted' | 'danger' | 'na
 }
 
 function FlagBadges({ row }: { row: AdminQuestionRow }) {
-  const flags: { label: string; tone: 'danger' | 'warning' | 'muted' }[] = [];
-  if (row.deletedAt) flags.push({ label: 'deleted', tone: 'danger' });
-  if (row.authorDeleted) flags.push({ label: 'tombstone', tone: 'muted' });
-  if (row.nobodyCorrectFlag) flags.push({ label: 'nobody-correct', tone: 'warning' });
-  if (row.isDuplicate) flags.push({ label: 'duplicate', tone: 'warning' });
-  if (row.perishable) flags.push({ label: 'perishable', tone: 'muted' });
+  const flags: { label: string; tone: 'danger' | 'warning' | 'muted'; hint: string }[] = [];
+  if (row.deletedAt)
+    flags.push({
+      label: 'deleted',
+      tone: 'danger',
+      hint: 'Soft-deleted — hidden from players, restorable from Inspect',
+    });
+  if (row.authorDeleted)
+    flags.push({
+      label: 'author left',
+      tone: 'muted',
+      hint: 'The author deleted their account; the question stays, attributed to the house',
+    });
+  if (row.nobodyCorrectFlag)
+    flags.push({
+      label: 'nobody correct',
+      tone: 'warning',
+      hint: 'Nobody has ever answered this correctly — possible bad answer key',
+    });
+  if (row.isDuplicate)
+    flags.push({
+      label: 'duplicate',
+      tone: 'warning',
+      hint: 'Flagged as a near-copy of another question',
+    });
+  if (row.perishable)
+    flags.push({
+      label: 'perishable',
+      tone: 'muted',
+      hint: 'Tied to a point in time — its answer can go stale',
+    });
   if (flags.length === 0) return <span style={{ color: 'var(--text-muted)' }}>—</span>;
   return (
     <span className="flex flex-wrap gap-1">
       {flags.map((f) => (
-        <Badge key={f.label} label={f.label} tone={f.tone} />
+        <span key={f.label} title={f.hint}>
+          <Badge label={f.label} tone={f.tone} />
+        </span>
       ))}
     </span>
   );
@@ -198,14 +232,17 @@ function EditForm({
   const [authorChoice, setAuthorChoice] = useState<'person' | 'house'>(detail.authorIsPerson ? 'person' : 'house');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Consequential-save gate: instead of a browser confirm() dialog, warnings
+  // render inline and Save becomes a two-step act (standard admin pattern —
+  // irreversible or grading-adjacent actions get an explicit visible confirm).
+  const [confirming, setConfirming] = useState(false);
 
-  async function save() {
+  // Build a patch of only the fields that actually changed.
+  function buildPatch(): Record<string, unknown> {
     const altsArray = acceptedAlternatives
       .split('\n')
       .map((s) => s.trim())
       .filter(Boolean);
-
-    // Build a patch of only the fields that actually changed.
     const patch: Record<string, unknown> = {};
     if (questionText.trim() !== detail.questionText) patch.questionText = questionText.trim();
     if (answerText.trim() !== detail.answerText) patch.answerText = answerText.trim();
@@ -218,30 +255,37 @@ function EditForm({
     if (category !== detail.category) patch.category = category;
     if (visibility !== detail.visibility) patch.visibility = visibility;
     // Re-attribution: only person → house is a real transition.
-    const toHouse = detail.authorIsPerson && authorChoice === 'house';
-    if (toHouse) patch.attribution = 'house';
+    if (detail.authorIsPerson && authorChoice === 'house') patch.attribution = 'house';
+    return patch;
+  }
 
+  // The consequences worth a second look before they persist.
+  function warningsFor(patch: Record<string, unknown>): string[] {
+    const warnings: string[] = [];
+    if ('answerText' in patch || 'acceptedAlternatives' in patch) {
+      warnings.push(
+        'This changes the answer key or accepted alternatives — it changes how past and future answers grade.',
+      );
+    }
+    if ('attribution' in patch) {
+      warnings.push(
+        `The author changes from "${detail.authorLabel}" to House. Their authorship is dropped (it leaves their authored list, renders as house content) and can't be restored from this tool.`,
+      );
+    }
+    return warnings;
+  }
+
+  async function save() {
+    const patch = buildPatch();
     if (Object.keys(patch).length === 0) {
       setError('No changes to save.');
+      setConfirming(false);
       return;
     }
-
-    // Grading-adjacent guard: confirm before changing how answers grade.
-    const gradingChanged = 'answerText' in patch || 'acceptedAlternatives' in patch;
-    if (gradingChanged) {
-      const ok = window.confirm(
-        'This changes the answer key or accepted alternatives, which changes how past and future answers grade. Save?',
-      );
-      if (!ok) return;
-    }
-
-    // Re-attribution guard: dropping the person link renders the question as house
-    // content and is not reversible from this tool.
-    if (toHouse) {
-      const ok = window.confirm(
-        `Change author from "${detail.authorLabel}" to House? This drops the person's authorship (it leaves their authored list and renders as house content) and can't be reversed here.`,
-      );
-      if (!ok) return;
+    if (warningsFor(patch).length > 0 && !confirming) {
+      setError(null);
+      setConfirming(true);
+      return;
     }
 
     setBusy(true);
@@ -350,26 +394,60 @@ function EditForm({
         </p>
       ) : null}
 
-      <div className="flex gap-2">
-        <button
-          type="button"
-          disabled={busy}
-          onClick={save}
-          className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
-          style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+      {confirming ? (
+        <div
+          className="mb-3 rounded-md border px-3 py-2 text-[13px] leading-relaxed"
+          style={{ borderColor: 'var(--warning)', background: 'var(--warning-surface)', color: 'var(--brand-ink-700)' }}
         >
-          {busy ? 'Saving…' : 'Save'}
-        </button>
-        <button
-          type="button"
-          disabled={busy}
-          onClick={onCancel}
-          className="rounded-md border px-3 py-1.5 text-sm"
-          style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
-        >
-          Cancel
-        </button>
-      </div>
+          <p className="font-semibold">Before this saves:</p>
+          <ul className="mt-1 list-disc space-y-1 pl-5">
+            {warningsFor(buildPatch()).map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+          <div className="mt-2 flex gap-2">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={save}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+              style={{ borderColor: 'var(--warning)', color: 'var(--brand-ink)' }}
+            >
+              {busy ? 'Saving…' : 'Save anyway'}
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => setConfirming(false)}
+              className="rounded-md border px-3 py-1.5 text-sm"
+              style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+            >
+              Keep editing
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={save}
+            className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+          >
+            {busy ? 'Saving…' : 'Save'}
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onCancel}
+            className="rounded-md border px-3 py-1.5 text-sm"
+            style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -378,12 +456,10 @@ function DetailSheet({ detail, onClose }: { detail: AdminQuestionDetail; onClose
   const router = useRouter();
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
   async function mutate(action: 'delete' | 'restore') {
-    if (action === 'delete' && !window.confirm('Soft-delete this question? It stays inspectable under "show deleted" and can be restored.')) {
-      return;
-    }
     setBusy(true);
     setActionError(null);
     try {
@@ -467,15 +543,41 @@ function DetailSheet({ detail, onClose }: { detail: AdminQuestionDetail; onClose
                   Edit
                 </button>
               ) : null}
-              <button
-                type="button"
-                disabled={busy}
-                onClick={() => mutate('delete')}
-                className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
-                style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
-              >
-                Delete
-              </button>
+              {confirmingDelete ? (
+                <>
+                  <span className="text-[13px]" style={{ color: 'var(--brand-ink-700)' }}>
+                    Soft-delete? Hidden from players; stays under “Show deleted” and restorable.
+                  </span>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => mutate('delete')}
+                    className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+                    style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
+                  >
+                    {busy ? 'Deleting…' : 'Confirm delete'}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => setConfirmingDelete(false)}
+                    className="rounded-md border px-3 py-1.5 text-sm"
+                    style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+                  >
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => setConfirmingDelete(true)}
+                  className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+                  style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
+                >
+                  Delete
+                </button>
+              )}
             </>
           )}
         </div>
@@ -645,11 +747,11 @@ export function AdminQuestionsClient({
 
   const isDeleted = result.showDeleted;
 
-  const boolFilters: { key: string; label: string }[] = [
-    { key: 'nobodyCorrect', label: 'Nobody correct' },
-    { key: 'duplicate', label: 'Duplicate' },
-    { key: 'tombstone', label: 'Tombstone' },
-    { key: 'perishable', label: 'Perishable' },
+  const boolFilters: { key: string; label: string; term: 'nobody_correct' | 'duplicate' | 'tombstone' | 'perishable' }[] = [
+    { key: 'nobodyCorrect', label: 'Nobody correct', term: 'nobody_correct' },
+    { key: 'duplicate', label: 'Duplicate', term: 'duplicate' },
+    { key: 'tombstone', label: 'Author left', term: 'tombstone' },
+    { key: 'perishable', label: 'Perishable', term: 'perishable' },
   ];
 
   return (
@@ -658,7 +760,12 @@ export function AdminQuestionsClient({
       <div className="mb-3">
         <AdminTabs active="questions" />
       </div>
-      <h1 className="mb-4 font-serif text-2xl font-semibold text-[var(--brand-ink)]">Questions</h1>
+      <h1 className="mb-1 font-serif text-2xl font-semibold text-[var(--brand-ink)]">Questions</h1>
+      <p className="mb-4 text-sm" style={{ color: 'var(--text-muted)' }}>
+        Every question in the pool — human, house, and machine-drafted, plus soft-deleted rows.{' '}
+        <strong>Inspect</strong> opens the full record; edit, delete, and restore live there.
+        Filters combine, and apply across the whole pool.
+      </p>
 
       {/* Filter bar. Every control combines (AND) with the others server-side. */}
       <form
@@ -698,7 +805,7 @@ export function AdminQuestionsClient({
         </label>
 
         <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.04em]" style={{ color: 'var(--text-muted)' }}>
-          Trust tier
+          <InfoTerm term="trust_tier">Trust tier</InfoTerm>
           <select
             value={searchParams.get('trustTier') ?? ''}
             onChange={(e) => setFilter('trustTier', e.target.value || null)}
@@ -708,14 +815,14 @@ export function AdminQuestionsClient({
             <option value="">All</option>
             {TRUST_TIERS.map((t) => (
               <option key={t} value={t}>
-                {t}
+                {humanize(t)}
               </option>
             ))}
           </select>
         </label>
 
         <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.04em]" style={{ color: 'var(--text-muted)' }}>
-          Visibility
+          <InfoTerm term="visibility">Visibility</InfoTerm>
           <select
             value={searchParams.get('visibility') ?? ''}
             onChange={(e) => setFilter('visibility', e.target.value || null)}
@@ -732,7 +839,7 @@ export function AdminQuestionsClient({
         </label>
 
         <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.04em]" style={{ color: 'var(--text-muted)' }}>
-          Verdict
+          <InfoTerm term="verdict">Verdict</InfoTerm>
           <select
             value={searchParams.get('verdict') ?? ''}
             onChange={(e) => setFilter('verdict', e.target.value || null)}
@@ -774,7 +881,7 @@ export function AdminQuestionsClient({
               checked={searchParams.get(f.key) === '1'}
               onChange={(e) => toggleFlag(f.key, e.target.checked)}
             />
-            {f.label}
+            <InfoTerm term={f.term}>{f.label}</InfoTerm>
           </label>
         ))}
         <label className="flex items-center gap-1.5">
@@ -857,10 +964,10 @@ export function AdminQuestionsClient({
                     {row.authorIsPerson ? row.authorLabel : <Badge label={row.authorLabel} tone="muted" />}
                   </td>
                   <td className={`${CELL} whitespace-nowrap`}>{row.source}</td>
-                  <td className={`${CELL} whitespace-nowrap`}>{row.trustTier}</td>
+                  <td className={`${CELL} whitespace-nowrap`}>{humanize(row.trustTier)}</td>
                   <td className={`${CELL} whitespace-nowrap`}>{row.visibility}</td>
-                  <td className={`${CELL} whitespace-nowrap`}>{row.publicStatus}</td>
-                  <td className={`${CELL} whitespace-nowrap`}>{row.verificationVerdict ?? '—'}</td>
+                  <td className={`${CELL} whitespace-nowrap`}>{humanize(row.publicStatus)}</td>
+                  <td className={`${CELL} whitespace-nowrap`}>{humanize(row.verificationVerdict)}</td>
                   <td className={`${CELL} text-right tabular-nums`}>{row.askedCount}</td>
                   <td className={`${CELL} text-right tabular-nums`}>{row.correctCount}</td>
                   <td className={`${CELL} text-right tabular-nums`}>{fmtRate(row)}</td>

--- a/src/app/admin/reports/AdminReportsClient.tsx
+++ b/src/app/admin/reports/AdminReportsClient.tsx
@@ -9,6 +9,12 @@ import type { AdminReviewReport, BlockedReviewItem } from '@/server/db/queries/c
 import type { MachineDemotionReviewItem } from '@/server/db/queries/machine-demotions';
 import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
 import { AdminTabs } from '@/app/admin/AdminTabs';
+import { InfoTerm } from '@/app/admin/InfoTerm';
+
+// Human labels for the two question stores — the raw table names ('question' /
+// 'generated') read as opaque status words, so they never render verbatim.
+const TARGET_LABEL = { question: 'canonical', generated: 'machine-drafted' } as const;
+const TARGET_TERM = { question: 'canonical_question', generated: 'machine_drafted' } as const;
 
 // Deliberately minimal — an internal ops tool, not a product surface. Two views:
 // the NEEDING-REVIEW queue (B-CRAFTER-LIFECYCLE-01 Phase 1: player reports and
@@ -138,29 +144,25 @@ export function AdminReportsClient({
 
   const hiddenKey = (key: string) => cleared.has(key) || staged?.key === key;
 
-  // One queue, two streams. Player inappropriate reports stay pinned first
-  // (high-priority, matching the query's ordering); everything else — incorrect
-  // reports and machine demotions — merges oldest-first so the longest-suppressed
-  // content is reviewed soonest.
-  const inappropriate = reports.filter(
-    (r) => r.category === 'inappropriate' && !hiddenKey(`report:${r.id}`),
-  );
-  const rest: Array<
-    | { kind: 'report'; at: number; report: AdminReviewReport }
-    | { kind: 'demotion'; at: number; item: MachineDemotionReviewItem }
-  > = [
-    ...reports
-      .filter((r) => r.category !== 'inappropriate' && !hiddenKey(`report:${r.id}`))
-      .map((report) => ({ kind: 'report' as const, at: new Date(report.createdAt).getTime(), report })),
-    ...demotions
-      .filter((item) => !hiddenKey(`demotion:${item.questionId}`))
-      .map((item) => ({
-        kind: 'demotion' as const,
-        at: item.verifiedAt ? new Date(item.verifiedAt).getTime() : 0,
-        item,
-      })),
-  ].sort((a, b) => a.at - b.at);
-  const openCount = inappropriate.length + rest.length;
+  // One queue, two labelled sections (the streams used to interleave, telling
+  // the reader nothing about why the order was what it was). Player reports:
+  // inappropriate pinned first (high-priority), then oldest-first. Demotions:
+  // oldest-first, so the longest-suppressed content is reviewed soonest.
+  const visibleReports = reports
+    .filter((r) => !hiddenKey(`report:${r.id}`))
+    .sort((a, b) => {
+      const aPin = a.category === 'inappropriate' ? 0 : 1;
+      const bPin = b.category === 'inappropriate' ? 0 : 1;
+      return aPin - bPin || new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+  const visibleDemotions = demotions
+    .filter((item) => !hiddenKey(`demotion:${item.questionId}`))
+    .sort(
+      (a, b) =>
+        (a.verifiedAt ? new Date(a.verifiedAt).getTime() : 0) -
+        (b.verifiedAt ? new Date(b.verifiedAt).getTime() : 0),
+    );
+  const openCount = visibleReports.length + visibleDemotions.length;
   // D-QUALITY-SALVAGE-01: how many demotions have a ready one-click fix waiting.
   const readyFixCount = demotions.filter(
     (item) => item.proposal && !hiddenKey(`demotion:${item.questionId}`),
@@ -172,12 +174,17 @@ export function AdminReportsClient({
         <div className="mb-3">
           <AdminTabs active="reports" needingReviewCount={openCount} />
         </div>
-        <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">
-          Questions needing you
-        </h1>
+        <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">Review queue</h1>
         <p className="text-muted-foreground mt-2 text-sm">
-          Two streams, one queue: players reported these, or the verifier pulled them pending your
-          call. Nothing here is deleted — flagged questions sit out of circulation until you act.
+          Questions out of circulation, waiting on your call — reported by a player or pulled by
+          the verifier. Nothing here is deleted until you decide.
+        </p>
+        <p className="text-muted-foreground mt-1.5 text-xs leading-relaxed">
+          Your calls: <strong>Uphold</strong> agrees with a report and removes the question ·{' '}
+          <strong>Dismiss</strong> closes a report <em>permanently</em> ·{' '}
+          <strong>Edit &amp; re-run</strong> fixes it and re-verifies · <strong>Restore</strong>{' '}
+          puts it back unchanged · <strong>Retire</strong> shelves it (recoverable). One-tap calls
+          show a 6-second Undo before anything is sent.
         </p>
         {readyFixCount > 0 ? (
           <p className="mt-2 text-sm font-medium text-[var(--success)]">
@@ -185,7 +192,7 @@ export function AdminReportsClient({
             clean — look for “Approve fix”.
           </p>
         ) : null}
-        <div className="mt-3 flex gap-2">
+        <div className="mt-3 flex gap-4 border-b pb-px" style={{ borderColor: 'var(--border)' }}>
           <TabButton active={view === 'open'} onClick={() => setView('open')}>
             Needing review ({openCount})
           </TabButton>
@@ -198,10 +205,18 @@ export function AdminReportsClient({
       {view === 'open' ? (
         <div className="space-y-3">
           {openCount === 0 ? (
-            <p className="text-muted-foreground text-sm">Nothing needing review.</p>
+            <p className="text-muted-foreground text-sm">
+              Nothing needing review — new player reports and verifier demotions land here.
+            </p>
           ) : (
             <>
-              {inappropriate.map((report) => (
+              {visibleReports.length > 0 ? (
+                <SectionHeading
+                  label={`Player reports (${visibleReports.length})`}
+                  term="player_report"
+                />
+              ) : null}
+              {visibleReports.map((report) => (
                 <ReportRow
                   key={report.id}
                   report={report}
@@ -209,30 +224,30 @@ export function AdminReportsClient({
                   onStage={stageAction}
                 />
               ))}
-              {rest.map((entry) =>
-                entry.kind === 'report' ? (
-                  <ReportRow
-                    key={entry.report.id}
-                    report={entry.report}
-                    onCleared={() => clear(`report:${entry.report.id}`)}
-                    onStage={stageAction}
-                  />
-                ) : (
-                  <DemotionRow
-                    key={entry.item.questionId}
-                    item={entry.item}
-                    onCleared={() => clear(`demotion:${entry.item.questionId}`)}
-                    onStage={stageAction}
-                  />
-                ),
-              )}
+              {visibleDemotions.length > 0 ? (
+                <SectionHeading
+                  label={`Verifier demotions (${visibleDemotions.length})`}
+                  term="verifier_demotion"
+                />
+              ) : null}
+              {visibleDemotions.map((item) => (
+                <DemotionRow
+                  key={item.questionId}
+                  item={item}
+                  onCleared={() => clear(`demotion:${item.questionId}`)}
+                  onStage={stageAction}
+                />
+              ))}
             </>
           )}
         </div>
       ) : (
         <div className="space-y-3">
           {blocked.length === 0 ? (
-            <p className="text-muted-foreground text-sm">Nothing blocked.</p>
+            <p className="text-muted-foreground text-sm">
+              Nothing blocked — content removed by an upheld report, a vetting verdict, or a sweep
+              lands here and can be un-blocked.
+            </p>
           ) : (
             blocked.map((item) =>
               hiddenKey(`blocked:${item.target.table}:${item.target.id}`) ? null : (
@@ -289,6 +304,8 @@ export function AdminReportsClient({
   );
 }
 
+// In-page view switcher — underline style, deliberately different from the
+// bordered nav pills above so it can't be mistaken for site navigation.
 function TabButton({
   active,
   onClick,
@@ -302,15 +319,34 @@ function TabButton({
     <button
       type="button"
       onClick={onClick}
-      className="rounded-md border px-3 py-1.5 text-sm font-medium"
+      className="border-b-2 px-0.5 pb-1 text-sm font-medium"
       style={
         active
-          ? { borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }
-          : { borderColor: 'var(--border)', color: 'var(--text-muted)' }
+          ? { borderColor: 'var(--brand-navy)', color: 'var(--brand-ink)' }
+          : { borderColor: 'transparent', color: 'var(--text-muted)' }
       }
     >
       {children}
     </button>
+  );
+}
+
+// A labelled stream divider for the open queue, with the definition one tap
+// away (the provenance chips alone made the mixed list hard to scan).
+function SectionHeading({
+  label,
+  term,
+}: {
+  label: string;
+  term: 'player_report' | 'verifier_demotion';
+}) {
+  return (
+    <h2
+      className="pt-1 text-[11px] font-semibold uppercase tracking-[0.08em]"
+      style={{ color: 'var(--text-muted)' }}
+    >
+      <InfoTerm term={term}>{label}</InfoTerm>
+    </h2>
   );
 }
 
@@ -538,7 +574,7 @@ function EditPanel({
       if (!res.ok) {
         setError(
           res.status === 503
-            ? 'The machine is unavailable right now — try again shortly.'
+            ? 'The verifier is unavailable right now — try again shortly.'
             : `Re-run failed (${res.status}).`,
         );
         return;
@@ -691,7 +727,7 @@ function EditPanel({
           </span>
           <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[var(--brand-ink-700)]">
             <span>
-              LLM answer: <strong>{rerun.suggestedAnswer}</strong>
+              Verifier&rsquo;s answer: <strong>{rerun.suggestedAnswer}</strong>
             </span>
             {rerun.suggestedAnswer.trim().toLowerCase() !== answerText.trim().toLowerCase() ? (
               <button
@@ -712,8 +748,8 @@ function EditPanel({
         </div>
       ) : (
         <p className="text-muted-foreground text-[0.7rem]">
-          Re-run the machine to get a fresh answer and a fact-check, then approve it back into
-          circulation.
+          Re-run the verifier to get a fresh answer and a fact-check — Approve unlocks once it
+          passes.
         </p>
       )}
 
@@ -725,13 +761,13 @@ function EditPanel({
           className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
           style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
         >
-          {pending === 'rerun' ? 'Re-running…' : rerun ? 'Re-run again' : 'Re-run through the LLM'}
+          {pending === 'rerun' ? 'Re-running…' : rerun ? 'Re-run again' : 'Re-run the verifier'}
         </button>
         <button
           type="button"
           onClick={() => void approve()}
           disabled={pending !== null || !canApprove}
-          title={canApprove ? undefined : 'Re-run the machine first, then approve'}
+          title={canApprove ? undefined : 'Re-run the verifier first, then approve'}
           className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
           style={{ borderColor: 'var(--success)', color: 'var(--success)' }}
         >
@@ -795,10 +831,8 @@ function ReportRow({
       key: `report:${report.id}`,
       label:
         action === 'uphold'
-          ? report.category === 'inappropriate'
-            ? 'Report upheld — content removed'
-            : 'Report upheld'
-          : 'Report dismissed',
+          ? 'Report upheld — question removed from circulation'
+          : 'Report dismissed — permanent once this fades',
       body: {
         reportId: report.id,
         action,
@@ -818,12 +852,13 @@ function ReportRow({
     <article className="rounded-md border p-4 text-sm" style={{ borderColor: 'var(--border)' }}>
       <div className="flex flex-wrap items-center gap-2">
         {/* Player stream chip — reporter provenance. */}
-        <span
+        <InfoTerm
+          term="player_report"
           className="rounded-sm border px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.08em]"
           style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
         >
           Player report
-        </span>
+        </InfoTerm>
         <span
           className="rounded-sm border px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.08em]"
           style={
@@ -836,7 +871,10 @@ function ReportRow({
           {kindLabel ? ` · ${kindLabel}` : ''}
         </span>
         <span className="text-muted-foreground text-[0.7rem] uppercase tracking-[0.06em]">
-          {report.target.table} · {new Date(report.createdAt).toLocaleString()}
+          <InfoTerm term={TARGET_TERM[report.target.table]}>
+            {TARGET_LABEL[report.target.table]}
+          </InfoTerm>{' '}
+          · {new Date(report.createdAt).toLocaleString()}
         </span>
       </div>
 
@@ -887,6 +925,7 @@ function ReportRow({
           <button
             type="button"
             onClick={() => act('uphold')}
+            title="Agree with the report — the question is removed from circulation"
             className="rounded-md border px-3 py-1.5 text-sm font-medium"
             style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
           >
@@ -905,6 +944,7 @@ function ReportRow({
           <button
             type="button"
             onClick={() => act('dismiss')}
+            title="Close this report for good — a dismissed report cannot be re-opened (Undo is only the 6-second toast)"
             className="rounded-md border px-3 py-1.5 text-sm font-medium"
             style={{ borderColor: 'var(--border)' }}
           >
@@ -1006,12 +1046,13 @@ function DemotionRow({
   return (
     <article className="rounded-md border p-4 text-sm" style={{ borderColor: 'var(--border)' }}>
       <div className="flex flex-wrap items-center gap-2">
-        <span
+        <InfoTerm
+          term="verifier_demotion"
           className="rounded-sm border px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.08em]"
           style={{ borderColor: 'var(--warning)', color: 'var(--warning)' }}
         >
           Verifier
-        </span>
+        </InfoTerm>
         <span
           className="rounded-sm border px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.08em]"
           style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
@@ -1130,6 +1171,7 @@ function DemotionRow({
           <button
             type="button"
             onClick={() => act('retire_demoted')}
+            title="Shelve it softly — stays out of circulation but can be brought back later"
             className="rounded-md border px-3 py-1.5 text-sm font-medium"
             style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
           >
@@ -1139,6 +1181,7 @@ function DemotionRow({
             <button
               type="button"
               onClick={rejectFix}
+              title="Discard the suggested fix — the question stays here for a manual call"
               className="rounded-md px-2 py-1.5 text-xs font-medium"
               style={{ color: 'var(--text-muted)' }}
             >
@@ -1202,10 +1245,17 @@ function BlockedRow({
           {badge.label}
         </span>
         <span className="text-muted-foreground text-[0.7rem] uppercase tracking-[0.06em]">
-          {item.target.table}
-          {item.actionedAt
-            ? ` · removed ${new Date(item.actionedAt).toLocaleString()}`
-            : ' · removed (vet/cron)'}
+          <InfoTerm term={TARGET_TERM[item.target.table]}>
+            {TARGET_LABEL[item.target.table]}
+          </InfoTerm>
+          {item.actionedAt ? (
+            ` · removed ${new Date(item.actionedAt).toLocaleString()}`
+          ) : (
+            <>
+              {' · '}
+              <InfoTerm term="removed_automatically">removed automatically</InfoTerm>
+            </>
+          )}
         </span>
       </div>
 

--- a/src/app/admin/supply/SupplyRowActions.tsx
+++ b/src/app/admin/supply/SupplyRowActions.tsx
@@ -106,10 +106,10 @@ export function SupplyRowActions({
         className={buttonClass}
         style={buttonStyle}
         disabled={busy}
-        onClick={() => post({ action: 'resize', domainKey }, 'Re-size')}
-        title="Re-run the corpus resolver for this domain"
+        onClick={() => post({ action: 'resize', domainKey }, 'Re-estimate')}
+        title="Re-run the corpus resolver to size this domain again"
       >
-        Re-size
+        Re-estimate
       </button>
       <button
         type="button"
@@ -117,9 +117,9 @@ export function SupplyRowActions({
         style={buttonStyle}
         disabled={busy}
         onClick={() => setEditing(true)}
-        title="Manually set the estimate (wins over the corpus number)"
+        title="Set the estimate by hand — a manual estimate wins over the corpus number"
       >
-        Set est.
+        Set estimate
       </button>
       {manualEstimatedQuestions != null ? (
         <button

--- a/src/app/admin/supply/page.tsx
+++ b/src/app/admin/supply/page.tsx
@@ -5,6 +5,8 @@ import { isAdminUser } from '@/server/auth/admin';
 import { buildSupplyCoverageSummary } from '@/server/daily/supply-coverage';
 import type { SupplyState } from '@/server/daily/supply-state';
 import { AdminTabs } from '../AdminTabs';
+import { InfoTerm } from '../InfoTerm';
+import type { GlossaryKey } from '../glossary';
 import { SupplyRowActions } from './SupplyRowActions';
 
 export const dynamic = 'force-dynamic';
@@ -17,13 +19,26 @@ export const dynamic = 'force-dynamic';
 // override — the override wins over the corpus number everywhere and shows here
 // with the corpus value alongside. Same admin gate as every /admin page:
 // ADMIN_USER_IDS or a 404 that doesn't reveal the route.
+//
+// State labels are plain speech, never the raw enum (soft_finite etc.); each
+// carries its glossary definition one tap away via <InfoTerm>. Keep these in
+// lockstep with SUPPLY_STATE_TEXT in KnowledgeAdminClient — the tree's supply
+// chips must speak the same words.
 
 const STATE_LABEL: Record<SupplyState, string> = {
-  discrepancy: 'Discrepancy',
-  raise_estimate: 'Raise estimate',
+  discrepancy: 'Ran dry early',
+  raise_estimate: 'Estimate too low',
   filling: 'Filling',
-  soft_finite: 'Resting (believed complete)',
+  soft_finite: 'Likely complete',
   unsized: 'Unsized',
+};
+
+const STATE_TERM: Record<SupplyState, GlossaryKey> = {
+  discrepancy: 'supply_ran_dry',
+  raise_estimate: 'supply_estimate_too_low',
+  filling: 'supply_filling',
+  soft_finite: 'supply_likely_complete',
+  unsized: 'supply_unsized',
 };
 
 const STATE_COLOR: Record<SupplyState, string> = {
@@ -74,14 +89,10 @@ export default async function AdminSupplyPage() {
             Domain supply
           </h1>
           <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
-            Corpus-grounded size estimate vs realized generation.{' '}
-            <strong>Every knowledge area appears here</strong> — the same population as the
-            Knowledge graph page, seen through the supply lens. Un-sized areas read{' '}
-            <strong>Unsized</strong> (biggest first) until you Re-size or set an estimate. A{' '}
-            <strong>discrepancy</strong> is a domain that went dry far short of a trusted
-            estimate — a supply problem, not completion. Resting domains are believed complete
-            and stay re-probeable. <strong>Cap</strong> a domain to stop generating new
-            questions for it entirely — existing questions still serve, and it stops alarming.
+            How question generation is doing per domain: what it has <strong>made</strong> vs the{' '}
+            <strong>estimated</strong> size of the topic. Same population as the Tree view, seen
+            through the supply lens — tap any state or column name for what it means. Sorted
+            alarm-first.
           </p>
         </div>
       </div>
@@ -93,27 +104,27 @@ export default async function AdminSupplyPage() {
       ) : (
         <>
           <div className="mb-4 flex flex-wrap gap-3 text-sm" style={{ color: 'var(--text-muted)' }}>
-            <span>
-              <strong style={{ color: 'var(--danger)' }}>{summary.counts.discrepancy}</strong>{' '}
-              discrepancy
-            </span>
-            <span>
+            <InfoTerm term="supply_ran_dry">
+              <strong style={{ color: 'var(--danger)' }}>{summary.counts.discrepancy}</strong> ran
+              dry early
+            </InfoTerm>
+            <InfoTerm term="supply_estimate_too_low">
               <strong style={{ color: 'var(--brand-navy)' }}>{summary.counts.raise_estimate}</strong>{' '}
-              raise estimate
-            </span>
-            <span>
+              estimate too low
+            </InfoTerm>
+            <InfoTerm term="supply_filling">
               <strong>{summary.counts.filling}</strong> filling
-            </span>
-            <span>
-              <strong>{summary.counts.soft_finite}</strong> resting
-            </span>
-            <span>
+            </InfoTerm>
+            <InfoTerm term="supply_likely_complete">
+              <strong>{summary.counts.soft_finite}</strong> likely complete
+            </InfoTerm>
+            <InfoTerm term="supply_unsized">
               <strong>{summary.counts.unsized}</strong> unsized
-            </span>
+            </InfoTerm>
             {summary.cappedCount > 0 ? (
-              <span>
+              <InfoTerm term="supply_capped">
                 <strong style={{ color: 'var(--danger)' }}>{summary.cappedCount}</strong> capped
-              </span>
+              </InfoTerm>
             ) : null}
           </div>
 
@@ -126,12 +137,24 @@ export default async function AdminSupplyPage() {
                 >
                   <th className="py-2 pr-3 font-medium">Domain</th>
                   <th className="py-2 pr-3 font-medium">State</th>
-                  <th className="py-2 pr-3 text-right font-medium">Have</th>
-                  <th className="py-2 pr-3 text-right font-medium">Est.</th>
-                  <th className="py-2 pr-3 text-right font-medium">Coverage</th>
-                  <th className="py-2 pr-3 text-right font-medium">Dry rounds</th>
-                  <th className="py-2 pr-3 font-medium">Confidence</th>
-                  <th className="py-2 pr-3 font-medium">Basis</th>
+                  <th className="py-2 pr-3 text-right font-medium">Made</th>
+                  <th className="py-2 pr-3 text-right font-medium">
+                    <InfoTerm term="supply_estimate">Estimate</InfoTerm>
+                  </th>
+                  <th className="py-2 pr-3 text-right font-medium">
+                    <InfoTerm def="Made ÷ estimate — how much of the believed topic size has been generated.">
+                      Coverage
+                    </InfoTerm>
+                  </th>
+                  <th className="py-2 pr-3 text-right font-medium">
+                    <InfoTerm term="dry_rounds">Dry rounds</InfoTerm>
+                  </th>
+                  <th className="py-2 pr-3 font-medium">
+                    <InfoTerm term="supply_confidence">Confidence</InfoTerm>
+                  </th>
+                  <th className="py-2 pr-3 font-medium">
+                    <InfoTerm term="supply_basis">Basis</InfoTerm>
+                  </th>
                   <th className="py-2 font-medium">Actions</th>
                 </tr>
               </thead>
@@ -145,15 +168,18 @@ export default async function AdminSupplyPage() {
                     style={{ borderColor: 'var(--border-light)' }}
                   >
                     <td className="py-2 pr-3">{entry.label}</td>
-                    <td className="py-2 pr-3" style={{ color: STATE_COLOR[entry.state] }}>
-                      {STATE_LABEL[entry.state]}
+                    <td className="py-2 pr-3">
+                      <InfoTerm
+                        term={STATE_TERM[entry.state]}
+                        style={{ color: STATE_COLOR[entry.state] }}
+                      >
+                        {STATE_LABEL[entry.state]}
+                      </InfoTerm>
                       {entry.generationCapped ? (
-                        <span
-                          className="block text-xs font-semibold"
-                          style={{ color: 'var(--danger)' }}
-                          title="Capped — excluded from generation; existing questions still serve, and it never fires the discrepancy alarm"
-                        >
-                          ⛔ capped
+                        <span className="block text-xs font-semibold">
+                          <InfoTerm term="supply_capped" style={{ color: 'var(--danger)' }}>
+                            ⛔ capped
+                          </InfoTerm>
                         </span>
                       ) : null}
                     </td>


### PR DESCRIPTION
Same functionality everywhere; presentation reworked around six changes:

1. Nav reorganized by job — Overview / Review queue / Author / Library /
   Domains, with underline sub-tabs (Author: Write questions, Import CSV;
   Domains: Tree, Supply, Merge suggestions). Bulk upload finally in the nav.
   Overview cards grouped the same way; Crafter card gains live stats.
2. Shared glossary + tap-friendly <InfoTerm> popover so every term of art
   (trust tier, exhausted, dry rounds, capped, tombstone…) explains itself
   in place — no more hover-only tooltips on a phone-first tool.
3. One vocabulary: the automated checker is "the verifier" everywhere (was
   verifier/the machine/the LLM); raw enums no longer render (soft_finite →
   "likely complete", discrepancy → "ran dry early", vet/cron → "removed
   automatically", target table names → canonical / machine-drafted), and
   the Tree's supply chips speak the same words as the Supply page.
4. Consistent action safety: window.confirm replaced with inline confirms
   (question delete, grading/attribution edits); irreversible acts say so
   (report Dismiss, territory merge bar restyled as the one danger act);
   toasts state consequences ("removed from circulation", "permanent").
5. State machines visible: the review queue splits into labelled Player
   reports / Verifier demotions sections with an outcome legend; Supply
   states renamed to plain speech with definitions on tap.
6. Quick wins: wall-of-text intros on Domains/Supply/Knowledge cut to a
   sentence; crafter heat labels in plain words; player-invite list gets a
   real button; CSV upload warns loudly that rows publish immediately;
   in-page view toggles restyled so they can't be mistaken for site nav.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y3aT7jxxE2bXeLDqYWNa7h