### PR TITLE
Handle session refresh for admin content reports

### DIFF
--- a/src/app/admin/reports/AdminReportsClient.tsx
+++ b/src/app/admin/reports/AdminReportsClient.tsx
@@ -434,14 +434,51 @@ function RerunProgress() {
   );
 }
 
-async function postAdminAction(body: Record<string, unknown>): Promise<string | null> {
-  try {
-    const res = await fetch('/api/admin/content-reports', {
+// A 401 here comes from the proxy (src/proxy.ts), never the route (which 404s
+// non-admins): the session cookie went bad under an open tab. Retrying the
+// action can't succeed, so say what actually fixes it instead of a bare code.
+const SESSION_EXPIRED_MESSAGE = 'Your session has expired — reload the page and sign in again.';
+
+function proxyErrorCode(res: Response): Promise<string | null> {
+  return res
+    .clone()
+    .json()
+    .then((body: { error?: unknown }) => (typeof body.error === 'string' ? body.error : null))
+    .catch(() => null);
+}
+
+// POST to the admin endpoint, transparently repairing the repairable 401: the
+// proxy rejects a legacy JWT missing the `inv` claim with
+// {error: 'session_refresh_required'}, and /api/auth/refresh-session (excluded
+// from the proxy matcher) re-mints the cookie from the live DB session — so
+// one refresh + one retry fixes it without a re-login. A plain
+// 'unauthenticated' 401 (expired/cleared cookie) is not repairable here;
+// callers surface SESSION_EXPIRED_MESSAGE for any 401 that survives.
+async function postContentReports(body: Record<string, unknown>): Promise<Response> {
+  const send = () =>
+    fetch('/api/admin/content-reports', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify(body),
     });
+  const res = await send();
+  if (res.status !== 401 || (await proxyErrorCode(res)) !== 'session_refresh_required') {
+    return res;
+  }
+  // redirect: 'manual' — the endpoint sets the cookie then redirects; the
+  // Set-Cookie has landed by the redirect, so the target page isn't needed.
+  await fetch('/api/auth/refresh-session', {
+    credentials: 'include',
+    redirect: 'manual',
+  }).catch(() => null);
+  return send();
+}
+
+async function postAdminAction(body: Record<string, unknown>): Promise<string | null> {
+  try {
+    const res = await postContentReports(body);
+    if (res.status === 401) return SESSION_EXPIRED_MESSAGE;
     if (!res.ok) return `Action failed (${res.status}).`;
     return null;
   } catch {
@@ -523,23 +560,20 @@ function EditPanel({
     setPending('rerun');
     setError(null);
     try {
-      const res = await fetch('/api/admin/content-reports', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          action: 'rerun_verify',
-          questionText: questionText.trim(),
-          answerText: answerText.trim() || undefined,
-          canonicalSubcategory,
-          broadCategory,
-        }),
+      const res = await postContentReports({
+        action: 'rerun_verify',
+        questionText: questionText.trim(),
+        answerText: answerText.trim() || undefined,
+        canonicalSubcategory,
+        broadCategory,
       });
       if (!res.ok) {
         setError(
-          res.status === 503
-            ? 'The machine is unavailable right now — try again shortly.'
-            : `Re-run failed (${res.status}).`,
+          res.status === 401
+            ? SESSION_EXPIRED_MESSAGE
+            : res.status === 503
+              ? 'The machine is unavailable right now — try again shortly.'
+              : `Re-run failed (${res.status}).`,
         );
         return;
       }
@@ -569,20 +603,15 @@ function EditPanel({
     setPending('approve');
     setError(null);
     try {
-      const res = await fetch('/api/admin/content-reports', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          action: 'approve',
-          target,
-          questionText: questionText.trim(),
-          answerText: answerText.trim(),
-          explanation: showExplanation ? explanation.trim() || null : undefined,
-        }),
+      const res = await postContentReports({
+        action: 'approve',
+        target,
+        questionText: questionText.trim(),
+        answerText: answerText.trim(),
+        explanation: showExplanation ? explanation.trim() || null : undefined,
       });
       if (!res.ok) {
-        setError(`Approve failed (${res.status}).`);
+        setError(res.status === 401 ? SESSION_EXPIRED_MESSAGE : `Approve failed (${res.status}).`);
         setPending(null);
         return;
       }


### PR DESCRIPTION
## Summary
Adds transparent session recovery for admin content report actions when the proxy detects an expired JWT missing the `inv` claim. The fix automatically refreshes the session cookie and retries the request, while properly surfacing a user-friendly message for truly expired sessions that cannot be recovered.

## Key Changes
- **New `postContentReports()` function:** Centralizes POST requests to `/api/admin/content-reports` with built-in session recovery logic. Detects `session_refresh_required` errors from the proxy, calls `/api/auth/refresh-session` to re-mint the cookie, and retries the request.
- **New `proxyErrorCode()` helper:** Extracts error codes from proxy responses to distinguish between recoverable (`session_refresh_required`) and unrecoverable (expired/cleared cookie) 401 errors.
- **New `SESSION_EXPIRED_MESSAGE` constant:** User-friendly message for 401 errors that survive recovery attempts, replacing bare HTTP status codes.
- **Refactored `postAdminAction()`:** Now delegates to `postContentReports()` and handles the final 401 response with the session expired message.
- **Updated `EditPanel` handlers:** Both `rerun_verify` and `approve` actions now use `postContentReports()` and properly handle 401 responses with the session expired message.

## Implementation Details
- The session refresh uses `redirect: 'manual'` to avoid following the endpoint's redirect, since the Set-Cookie header lands before the redirect and the target page isn't needed.
- Recovery only attempts once: if the refresh fails or the retry still returns 401, the user sees `SESSION_EXPIRED_MESSAGE` and must reload and sign in again.
- The logic preserves existing error handling for other failure modes (503, network errors, etc.).

https://claude.ai/code/session_01S66bqYAMwzxu4VTjXwSQLT