### PR TITLE
fix(supply): stop mislabeling rich exhausted leaves; auto-fill them

### DIFF
--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -65,6 +65,11 @@ export type SupplyReadout = {
   estimatedQuestions: number | null;
   ratio: number | null;
   capped: boolean;
+  /** Corpus-resolved size estimate + fandom host — the richness signals that tell
+   * an exhausted leaf apart: a deep-corpus / fandom-backed topic that ran dry is a
+   * generator failure (author/ground it), not a too-granular leaf (merge it up). */
+  corpusEstimatedQuestions: number | null;
+  fandomHost: string | null;
 };
 
 // Same plain-speech vocabulary as the Supply view's STATE_LABEL — the two
@@ -914,6 +919,7 @@ function KnowledgeTreeEditor({
           pointsByKey={pointsByKey}
           depthByKey={depthByKey}
           genStatsByKey={genStatsByKey}
+          supplyByKey={supplyByKey}
           onJump={jumpToInstance}
         />
       ) : null}
@@ -1148,14 +1154,34 @@ function RootDropZone({ dragActive }: { dragActive: boolean }) {
 // no world knowledge, so a genuinely rich topic the generator simply failed (a
 // handful of Simpsons Qs) looks identical to a truly finite one. All three levers
 // stay open on every row; this only leads with the most probable one.
+// A topic is RICH when the corpus sizer found real breadth — a dedicated Fandom
+// wiki, or a corpus estimate well above the granular floor. Distinguishes a rich
+// leaf the generator merely FAILED on (a handful of Simpsons Qs at 50% dup) from
+// a genuinely too-granular one, which the bare question count cannot.
+const RICH_CORPUS_ESTIMATE = 60;
+function isRichTopic(supply: SupplyReadout | undefined): boolean {
+  if (!supply) return false;
+  return supply.fandomHost != null || (supply.corpusEstimatedQuestions ?? 0) >= RICH_CORPUS_ESTIMATE;
+}
+
 function exhaustedDecisionHint(
   threshold: number | null,
   avail: number,
   qs: number,
   parentLabel: string | null,
+  rich: boolean,
 ): string {
   if (threshold == null) {
     return 'no mastery target set — set one to size it, or merge up / hand-author';
+  }
+  // A RICH topic (deep corpus / dedicated fandom wiki) that ran dry is almost
+  // always the generator failing to mine it, NOT a leaf too granular to stand
+  // alone — so lead with author/ground, and never suggest merging it away. This
+  // is the Simpsons/Hamlet class: a "handful of Qs" that actually has hundreds.
+  if (rich) {
+    return parentLabel
+      ? `rich topic the generator stalled on — hand-author or ground more (don't merge it into ${parentLabel})`
+      : 'rich topic the generator stalled on — hand-author or ground more';
   }
   if (qs < THIN_LEAF_THRESHOLD && parentLabel) {
     return `likely too granular — merge up into ${parentLabel} (or hand-author, if it's actually a rich topic)`;
@@ -1173,6 +1199,7 @@ function ExhaustedWorklist({
   pointsByKey,
   depthByKey,
   genStatsByKey,
+  supplyByKey,
   onJump,
 }: {
   leaves: string[];
@@ -1181,6 +1208,7 @@ function ExhaustedWorklist({
   pointsByKey: Record<string, number>;
   depthByKey: Record<string, number>;
   genStatsByKey: Record<string, { total: number; dupes: number }>;
+  supplyByKey: Record<string, SupplyReadout>;
   onJump: (childKey: string, parentKey: string | null) => void;
 }) {
   const [open, setOpen] = useState(true);
@@ -1272,6 +1300,7 @@ function ExhaustedWorklist({
                     pointsByKey[key] ?? 0,
                     depthByKey[key] ?? 0,
                     firstParent ? parentLabel : null,
+                    isRichTopic(supplyByKey[key]),
                   )}
                 </div>
                 {peekKey === key ? (

--- a/src/app/admin/knowledge/page.tsx
+++ b/src/app/admin/knowledge/page.tsx
@@ -162,6 +162,8 @@ export default async function AdminKnowledgePage() {
       estimatedQuestions: entry.estimatedQuestions,
       ratio: entry.ratio,
       capped: entry.generationCapped,
+      corpusEstimatedQuestions: entry.corpusEstimatedQuestions,
+      fandomHost: entry.fandomHost,
     };
   }
 

--- a/src/server/daily/supply-backfill.ts
+++ b/src/server/daily/supply-backfill.ts
@@ -108,6 +108,33 @@ async function loadDemand(): Promise<Map<string, number>> {
   return new Map([...byKey].map(([k, users]) => [k, users.size]));
 }
 
+// A corpus estimate at/above this (or any dedicated fandom wiki) marks a topic
+// as genuinely RICH — kept in lockstep with the worklist's isRichTopic gate.
+const RICH_CORPUS_ESTIMATE = 60;
+
+// DEMONSTRATED demand: leaf nodes that are live mastery targets (a threshold is
+// set — a player progresses through them) whose domain is RICH (fandom-backed or
+// deep corpus). These are the Simpsons/HP-Book-3 class: real demand that arrives
+// via a mastered PARENT, so no one declares the leaf directly, yet it must stay
+// stocked. Gating on richness keeps genuinely-granular leaves OUT — those still
+// want a human merge/shrink decision, not more generation. Returns folded keys.
+async function loadDemonstratedDemand(): Promise<Set<string>> {
+  const richRows = (await pool.query(
+    'SELECT domain_key FROM "DomainDepthEstimate" WHERE fandom_host IS NOT NULL OR COALESCE(estimated_questions, 0) >= $1',
+    [RICH_CORPUS_ESTIMATE],
+  )).rows as { domain_key: string }[];
+  const rich = new Set(richRows.map((r) => r.domain_key));
+  const leafRows = (await pool.query(
+    `SELECT label FROM "KnowledgeNode" WHERE node_kind = 'leaf' AND mastery_threshold IS NOT NULL`,
+  )).rows as { label: string }[];
+  const out = new Set<string>();
+  for (const r of leafRows) {
+    const k = domainKey(r.label);
+    if (rich.has(k)) out.add(k);
+  }
+  return out;
+}
+
 async function loadDomains(onlyDomain?: string | null): Promise<DomainRow[]> {
   const where = onlyDomain ? 'WHERE d.domain_key ILIKE $1' : '';
   const params = onlyDomain ? [`%${onlyDomain.toLowerCase()}%`] : [];
@@ -278,7 +305,15 @@ export async function runSupplyBackfill(opts: BackfillOptions): Promise<Backfill
     bufferFloor: opts.bufferFloor ?? DEFAULTS.bufferFloor,
     batchCap: opts.batchCap ?? DEFAULTS.batchCap,
   };
-  const [demand, domains] = await Promise.all([loadDemand(), loadDomains(opts.onlyDomain)]);
+  const [demand, demonstrated, domains] = await Promise.all([
+    loadDemand(),
+    loadDemonstratedDemand(),
+    loadDomains(opts.onlyDomain),
+  ]);
+  // Fold DEMONSTRATED demand (rich mastery-path leaves) into the declared count:
+  // a leaf nobody declared but a player is mastering counts as ≥1 interested, so
+  // it earns a buffer instead of being skipped for "no demand".
+  for (const key of demonstrated) demand.set(key, Math.max(demand.get(key) ?? 0, 1));
   const plans = buildPlan(domains, demand, cfg);
   const actionable = plans.filter((p) => p.batch > 0);
 

--- a/src/server/daily/supply-coverage.ts
+++ b/src/server/daily/supply-coverage.ts
@@ -31,6 +31,9 @@ export interface SupplyCoverageEntry {
   lastYieldAt: Date | null;
   /** Admin generation cap (0121): true = excluded from generation, never alarms. */
   generationCapped: boolean;
+  /** Dedicated Fandom wiki host, when the sizer found one — a richness signal
+   * (a fandom-backed leaf that ran dry is a generator failure, not a granular topic). */
+  fandomHost: string | null;
 }
 
 export interface SupplyCoverageSummary {
@@ -77,6 +80,7 @@ export function summarizeSupplyCoverage(
       consecutiveDryRounds: row.consecutiveDryRounds,
       lastYieldAt: row.lastYieldAt,
       generationCapped: row.generationCappedAt != null,
+      fandomHost: row.fandomHost,
     };
   });
 

--- a/src/server/db/queries/domain-depth-estimate.ts
+++ b/src/server/db/queries/domain-depth-estimate.ts
@@ -294,6 +294,9 @@ export type DomainSupplyCoverageRow = {
   lastYieldAt: Date | null;
   /** Admin generation cap stamp (0121); non-null = capped, excluded from generation. */
   generationCappedAt: Date | null;
+  /** Dedicated Fandom wiki host, when the sizer found one — a richness signal:
+   * a leaf with a fandom is a rich topic the generator can mine, not a granular one. */
+  fandomHost: string | null;
   /** Distinct facts generated for the domain, bank-wide (all users). */
   realized: number;
 };
@@ -334,6 +337,7 @@ export async function getDomainSupplyCoverage(): Promise<DomainSupplyCoverageRow
       consecutiveDryRounds: sql<number>`coalesce(${domainDepthEstimates.consecutiveDryRounds}, 0)::int`,
       lastYieldAt: domainDepthEstimates.lastYieldAt,
       generationCappedAt: domainDepthEstimates.generationCappedAt,
+      fandomHost: domainDepthEstimates.fandomHost,
       realized: sql<number>`coalesce(${realized.realized}, 0)::int`,
     })
     .from(domainDepthEstimates)
@@ -373,6 +377,7 @@ export async function getDomainSupplyCoverage(): Promise<DomainSupplyCoverageRow
       consecutiveDryRounds: 0,
       lastYieldAt: null,
       generationCappedAt: null,
+      fandomHost: null,
       realized: 0,
     });
   }


### PR DESCRIPTION
## Why

The **Exhausted — needs a decision** worklist told the operator to *merge up / too granular* for **The Simpsons** (4 Qs, 50% dup, a 24,848-article fandom) and **Harry Potter Book 3** (4 Qs, 69% dup, 1,024-article fandom). Both are the opposite of granular — they're rich topics the generator simply **failed** to mine, exactly like Hamlet. The heuristic judged granularity by *question count*, which can't tell a rich-but-starved leaf from a truly finite one (its own comment admitted this).

Proven by filling them manually: **Simpsons 4→54, HP Book 3 4→54** (50 novel questions each in ~4 rounds). Neither was exhausted or granular — both were demand-coupling failures.

## Two fixes

**1. Heuristic no longer mislabels rich topics.** `exhaustedDecisionHint` now takes a `rich` signal — a dedicated **fandom wiki** or a **corpus estimate ≥ 60** — and for a rich leaf that ran dry leads with *"rich topic the generator stalled on — hand-author or ground more (don't merge it into …)"*. "Too granular — merge up" is reserved for leaves with a small corpus and no fandom. Plumbs `fandom_host` + the corpus estimate through the chain: `getDomainSupplyCoverage` → `SupplyCoverageEntry` → `SupplyReadout` → the hint (`isRichTopic`).

**2. The backfill now covers them.** `supply-backfill` gated on *declared* interest only, so these leaves (0 declared users, but real demand via a mastered **parent**) were skipped. Added **demonstrated demand**: leaf nodes that are live mastery targets (a threshold is set) whose domain is rich. They now earn a buffer and auto-fill on the nightly cron instead of waiting for a human. The richness gate keeps genuinely-granular leaves **out** — those still want a merge/shrink decision, not more generation. Bounded: **38 domains** today.

## Net effect

The worklist stops recommending you merge away rich topics, and the ones that are just generation-failures restock themselves — so the decision queue shrinks to only *genuinely* finite leaves.

Typecheck clean. (Simpsons + HP Book 3 already stocked to 54 each via the manual fill; owned by the system user.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)