### PR TITLE
feat(supply): serving backstop, grounding source-routing, and demand-gated backfill

### DIFF
--- a/src/server/daily/__tests__/domain-reference.test.ts
+++ b/src/server/daily/__tests__/domain-reference.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildRetrievalUserMessage,
   parseReferenceResponse,
   questionLeaksPassageText,
+  resolveReferenceSourcePreference,
 } from '@/server/daily/domain-reference';
 import { buildUserPrompt } from '@/server/daily/generate-questions';
 
@@ -82,6 +84,58 @@ describe('questionLeaksPassageText (decision C guard)', () => {
         passage,
       ),
     ).toBe(true);
+  });
+});
+
+describe('resolveReferenceSourcePreference (Layer 3 source routing)', () => {
+  it('routes a Fandom-sized domain (basis fandom:*) to fandom', () => {
+    expect(
+      resolveReferenceSourcePreference({ basis: 'fandom:scoped-categories', fandomHost: null, wikipediaTitle: null }),
+    ).toBe('fandom');
+  });
+
+  it('routes a domain with a resolved fandom_host to fandom even without a fandom basis', () => {
+    expect(
+      resolveReferenceSourcePreference({ basis: 'wp:sections', fandomHost: 'zelda.fandom.com', wikipediaTitle: null }),
+    ).toBe('fandom');
+  });
+
+  it('keeps a Wikipedia-sectioned real-world domain on wikipedia', () => {
+    expect(
+      resolveReferenceSourcePreference({ basis: 'wp:sections', fandomHost: null, wikipediaTitle: 'Hamlet' }),
+    ).toBe('wikipedia');
+  });
+
+  it('defaults an unsized/hint-less domain to wikipedia (unchanged behavior)', () => {
+    expect(resolveReferenceSourcePreference(undefined)).toBe('wikipedia');
+    expect(resolveReferenceSourcePreference({ basis: null, fandomHost: '  ', wikipediaTitle: null })).toBe('wikipedia');
+  });
+});
+
+describe('buildRetrievalUserMessage (Layer 3 search scoping)', () => {
+  it('scopes a fandom fetch to the resolved wiki host', () => {
+    const msg = buildRetrievalUserMessage(
+      'The Legend of Zelda: Tears of the Kingdom',
+      { basis: 'fandom:scoped-categories', fandomHost: 'zelda.fandom.com', wikipediaTitle: null },
+      'fandom',
+    );
+    expect(msg).toContain('zelda.fandom.com');
+    expect(msg).toContain('search there first');
+  });
+
+  it('scopes a wikipedia fetch to the resolved article title', () => {
+    const msg = buildRetrievalUserMessage(
+      'Hamlet',
+      { basis: 'wp:sections', fandomHost: null, wikipediaTitle: 'Hamlet' },
+      'wikipedia',
+    );
+    expect(msg).toContain('"Hamlet"');
+  });
+
+  it('degrades to a bare domain line when no scoping hint is present', () => {
+    const msg = buildRetrievalUserMessage('Tennis', undefined, 'wikipedia');
+    expect(msg).toContain('Domain: Tennis');
+    expect(msg).not.toContain('fandom.com');
   });
 });
 

--- a/src/server/daily/__tests__/queue-floor.test.ts
+++ b/src/server/daily/__tests__/queue-floor.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE } from '@/server/daily/types';
+import { DAILY_BONUS_SLOT_MAX, DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE } from '@/server/daily/types';
 
 // fillDailyQueueForUser orchestrates DB pickers + LLM generation; every one of
 // those touches @/server/db, which throws at module load without a connection
@@ -232,5 +232,120 @@ describe('fillDailyQueueForUser — minimum-size floor', () => {
     // One initial generation + two top-up rounds reaching the target.
     expect(mocks.generateDailyQuestionsFromKnowledgeBase).toHaveBeenCalledTimes(3);
     expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
+  });
+});
+
+// A friend-domain candidate as getFriendDomainsForBonus returns it — the
+// orchestrator reads `.domain` and `.presenceSources[0]` (via toBonusPresence).
+function friendDomain(domain: string, sourceId = `src-${domain}`) {
+  return {
+    domain,
+    presenceSources: [{ userId: sourceId, displayName: `Owner of ${domain}`, lastActivityAt: null }],
+  } as never;
+}
+// A freshly generated friend question as generateBonusQuestionsForDomains returns it.
+function friendQ(domain: string, id = `f-${domain}`) {
+  return { domain, question: genq(id, domain) };
+}
+
+// The persisted BONUS slots (bot rows carrying a presence_source_id).
+function persistedBonusSlots(): Array<Record<string, unknown>> {
+  return persistedSlots().filter((slot) => Boolean(slot.presence_source_id));
+}
+
+describe('fillDailyQueueForUser — short-core serving backstop (Layer 1)', () => {
+  it('promotes friend-domain questions into CORE when the own palette lands short, then fills +2', async () => {
+    // Own palette yields only 4 distinct questions and never recovers a 5th.
+    mocks.generateDailyQuestionsFromKnowledgeBase
+      .mockResolvedValueOnce([genq('q1'), genq('q2'), genq('q3'), genq('q4')])
+      .mockResolvedValue([genq('q1')]);
+    // Three friend domains are available; each generates one fresh question.
+    mocks.getFriendDomainsForBonus.mockResolvedValue([
+      friendDomain('Chess'),
+      friendDomain('Opera'),
+      friendDomain('Sushi'),
+    ]);
+    mocks.generateBonusQuestionsForDomains.mockResolvedValue([
+      friendQ('Chess'),
+      friendQ('Opera'),
+      friendQ('Sushi'),
+    ]);
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    // One friend question is promoted into the core to reach the full five (the
+    // 4 own questions + 1 friend), and the remaining two become +2 bonus slots.
+    const core = persistedBotSlots();
+    expect(core).toHaveLength(DAILY_QUEUE_SIZE);
+    expect(core.map((slot) => slot.generated_question_id)).toEqual([
+      'q1',
+      'q2',
+      'q3',
+      'q4',
+      'f-Chess',
+    ]);
+    expect(persistedBonusSlots().map((slot) => slot.generated_question_id)).toEqual([
+      'f-Opera',
+      'f-Sushi',
+    ]);
+  });
+
+  it('requests coreShortfall + DAILY_BONUS_SLOT_MAX friend domains so the +2 is not cannibalized', async () => {
+    mocks.generateDailyQuestionsFromKnowledgeBase
+      .mockResolvedValueOnce([genq('q1'), genq('q2'), genq('q3')]) // 2 short
+      .mockResolvedValue([genq('q1')]);
+    mocks.getFriendDomainsForBonus.mockResolvedValue([]);
+    mocks.generateBonusQuestionsForDomains.mockResolvedValue([]);
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    // Core short by 2 → asks for 2 + DAILY_BONUS_SLOT_MAX candidates.
+    expect(mocks.getFriendDomainsForBonus).toHaveBeenCalledWith(
+      USER,
+      2 + DAILY_BONUS_SLOT_MAX,
+      expect.anything(),
+    );
+  });
+
+  it('uses every friend question for core (0 bonus) when the shortfall consumes them all', async () => {
+    mocks.generateDailyQuestionsFromKnowledgeBase
+      .mockResolvedValueOnce([genq('q1'), genq('q2'), genq('q3'), genq('q4')])
+      .mockResolvedValue([genq('q1')]);
+    mocks.getFriendDomainsForBonus.mockResolvedValue([friendDomain('Chess')]);
+    // Only one friend question materializes — it must go to CORE, not bonus.
+    mocks.generateBonusQuestionsForDomains.mockResolvedValue([friendQ('Chess')]);
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
+    expect(persistedBonusSlots()).toHaveLength(0);
+  });
+
+  it('leaves a FULL core untouched — friend questions all become +2 bonus (unchanged behavior)', async () => {
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq('q1'), genq('q2'), genq('q3'), genq('q4'), genq('q5'),
+    ]);
+    mocks.getFriendDomainsForBonus.mockResolvedValue([
+      friendDomain('Chess'),
+      friendDomain('Opera'),
+    ]);
+    mocks.generateBonusQuestionsForDomains.mockResolvedValue([
+      friendQ('Chess'),
+      friendQ('Opera'),
+    ]);
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    // Core is the five own questions; both friend questions are bonus.
+    expect(persistedBotSlots().map((slot) => slot.generated_question_id)).toEqual([
+      'q1', 'q2', 'q3', 'q4', 'q5',
+    ]);
+    expect(persistedBonusSlots()).toHaveLength(DAILY_BONUS_SLOT_MAX);
+    // Core full → asks only for the standard +2 (coreShortfall 0).
+    expect(mocks.getFriendDomainsForBonus).toHaveBeenCalledWith(
+      USER,
+      DAILY_BONUS_SLOT_MAX,
+      expect.anything(),
+    );
   });
 });

--- a/src/server/daily/__tests__/supply-backfill.test.ts
+++ b/src/server/daily/__tests__/supply-backfill.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPlan } from '@/server/daily/supply-backfill';
+
+// buildPlan is the pure, demand-weighted planning core of the supply backfill.
+// These exercise the Layer 4 correctness fix: the buffer is gated on WORST-CASE
+// SERVABLE stock (have − own_max), not total inventory, so a domain one heavy
+// player mined out (the bank excludes a viewer's own rows) is backfilled instead
+// of reading as "stocked" to everyone but them.
+
+const cfg = { daysRunway: 14, bufferFloor: 10, batchCap: 20 };
+
+// A DomainRow literal (the type is module-private; the shape is asserted here).
+// Defaults to DRY (consecutive_dry_rounds 5) so the servable-stock tests exercise
+// the buffer path; the proven-demand gate is covered explicitly below.
+function row(overrides: Partial<Parameters<typeof buildPlan>[0][number]>) {
+  return {
+    domain_key: 'd',
+    sample_label: 'D',
+    fandom_host: null,
+    effective_est: 1200,
+    have: 0,
+    own_max: 0,
+    consecutive_dry_rounds: 5,
+    ...overrides,
+  };
+}
+
+describe('buildPlan — worst-case servable stock (Layer 4)', () => {
+  it('backfills a single-heavy-user domain the total-inventory model called "stocked" (Zelda: TotK)', () => {
+    // have 16 but one player owns 13 → they are served only 3. Target 14 (14d × 1
+    // interested). Old logic: 16 ≥ 14 → skip. New logic: servable 3 < 14 → batch.
+    const [plan] = buildPlan(
+      [row({ domain_key: 'zelda', sample_label: 'Zelda: TotK', effective_est: 1200, have: 16, own_max: 13, fandom_host: 'zelda.fandom.com' })],
+      new Map([['zelda', 1]]),
+      cfg,
+    );
+    expect(plan.skipReason).toBeNull();
+    // gap = 14 − 3 = 11; batch = ceil(11 / 0.85) = 13 (< batchCap 20).
+    expect(plan.batch).toBe(13);
+    expect(plan.ground).toBe(true); // fandom_host set → grounded generation
+    expect(plan.have).toBe(16); // display still shows total inventory
+  });
+
+  it('treats own_max = have (one owner) as zero servable → full-buffer batch', () => {
+    const [plan] = buildPlan(
+      [row({ domain_key: 'solo', have: 8, own_max: 8, effective_est: 500 })],
+      new Map([['solo', 1]]),
+      cfg,
+    );
+    // servable 0 → gap 14 → batch = ceil(14 / 0.85) = 17.
+    expect(plan.batch).toBe(17);
+    expect(plan.skipReason).toBeNull();
+  });
+
+  it('still skips a genuinely well-stocked domain (servable ≥ target)', () => {
+    const [plan] = buildPlan(
+      [row({ domain_key: 'rich', have: 30, own_max: 2, effective_est: 500 })],
+      new Map([['rich', 1]]),
+      cfg,
+    );
+    // servable 28 ≥ target 14 → skip, message names servable (not total).
+    expect(plan.batch).toBe(0);
+    expect(plan.skipReason).toContain('servable 28');
+  });
+
+  it('scales the buffer with demand across multiple interested users', () => {
+    const [plan] = buildPlan(
+      [row({ domain_key: 'pop', have: 30, own_max: 6, effective_est: 500 })],
+      new Map([['pop', 3]]),
+      cfg,
+    );
+    // target = clamp(14 × 3, 10, 500) = 42; servable = 24; gap 18 → batch = min(20, 22) = 20.
+    expect(plan.batch).toBe(20);
+  });
+
+  it('skips a domain with no demand regardless of stock', () => {
+    const [plan] = buildPlan([row({ domain_key: 'nobody', have: 0, own_max: 0 })], new Map(), cfg);
+    expect(plan.batch).toBe(0);
+    expect(plan.skipReason).toBe('no demand (0 declared interests)');
+  });
+
+  it('skips an unsized domain (no estimate) even with demand', () => {
+    const [plan] = buildPlan(
+      [row({ domain_key: 'unsized', effective_est: null, have: 0, own_max: 0 })],
+      new Map([['unsized', 5]]),
+      cfg,
+    );
+    expect(plan.batch).toBe(0);
+    expect(plan.skipReason).toBe('no estimate');
+  });
+});
+
+describe('buildPlan — proven-demand (dry) gate (default on)', () => {
+  it('skips a declared-but-not-exhausted domain when onlyDry (default)', () => {
+    // Servable-short (would get a batch) but never run dry → not worth spend.
+    const [plan] = buildPlan(
+      [row({ domain_key: 'declared', have: 0, own_max: 0, consecutive_dry_rounds: 0 })],
+      new Map([['declared', 1]]),
+      cfg, // onlyDry defaults true, dryK defaults 3
+    );
+    expect(plan.batch).toBe(0);
+    expect(plan.skipReason).toContain('not exhausted');
+  });
+
+  it('backfills the same domain in predictive mode (onlyDry=false)', () => {
+    const [plan] = buildPlan(
+      [row({ domain_key: 'declared', have: 0, own_max: 0, consecutive_dry_rounds: 0 })],
+      new Map([['declared', 1]]),
+      { ...cfg, onlyDry: false },
+    );
+    expect(plan.batch).toBeGreaterThan(0);
+    expect(plan.skipReason).toBeNull();
+  });
+
+  it('backfills a proven-dry domain even under the default gate (Zelda: TotK)', () => {
+    const [plan] = buildPlan(
+      [row({ domain_key: 'zelda', have: 16, own_max: 13, effective_est: 1200, consecutive_dry_rounds: 4, fandom_host: 'zelda.fandom.com' })],
+      new Map([['zelda', 1]]),
+      cfg,
+    );
+    expect(plan.skipReason).toBeNull();
+    expect(plan.batch).toBe(13);
+  });
+
+  it('respects a custom dryK threshold', () => {
+    const [plan] = buildPlan(
+      [row({ domain_key: 'edge', have: 0, own_max: 0, consecutive_dry_rounds: 2 })],
+      new Map([['edge', 1]]),
+      { ...cfg, dryK: 2 },
+    );
+    expect(plan.skipReason).toBeNull();
+    expect(plan.batch).toBeGreaterThan(0);
+  });
+});

--- a/src/server/daily/domain-reference.ts
+++ b/src/server/daily/domain-reference.ts
@@ -69,7 +69,39 @@ const RETRIEVAL_TIMEOUT_MS = Math.max(
 
 const PASSAGE_MAX_CHARS = 1200;
 
-const RETRIEVAL_SYSTEM_PROMPT = `You retrieve ONE compact reference passage of established facts about a trivia domain, for grounding question generation. Use the web_search tool (it is restricted to Wikipedia and Fandom).
+// Which source the retriever should lead with for a domain. Default is
+// Wikipedia-first (the historic behavior + good for real-world topics). A deep
+// fan domain — sized off its Fandom category tree — must lead with FANDOM
+// in-universe canon instead, or it gets a shallow "game-as-product" Wikipedia
+// blurb (release date, studio, sales) that yields almost no fan-salient
+// questions. See resolveReferenceSourcePreference.
+export type ReferenceSourcePreference = 'wikipedia' | 'fandom';
+
+// Per-domain routing input, mirroring DomainDepthEstimate's resolution provenance.
+export type ReferenceRoutingHint = {
+  basis: string | null;
+  fandomHost: string | null;
+  wikipediaTitle: string | null;
+};
+
+/**
+ * Pure: pick the lead source for a domain from how it was SIZED. A domain sized
+ * off Fandom (basis `fandom:*`) or with a resolved dedicated Fandom wiki host is
+ * a deep fan domain whose questions live in in-universe canon — lead with Fandom.
+ * Everything else (Wikipedia-sectioned real-world topics, or unsized domains with
+ * no hint) keeps the Wikipedia-first default. Exported for unit tests.
+ */
+export function resolveReferenceSourcePreference(
+  hint: ReferenceRoutingHint | undefined,
+): ReferenceSourcePreference {
+  if (!hint) return 'wikipedia';
+  if (hint.fandomHost && hint.fandomHost.trim()) return 'fandom';
+  if (hint.basis && hint.basis.trim().toLowerCase().startsWith('fandom')) return 'fandom';
+  return 'wikipedia';
+}
+
+// The Wikipedia-first prompt (default / real-world topics).
+const RETRIEVAL_SYSTEM_PROMPT_WIKIPEDIA = `You retrieve ONE compact reference passage of established facts about a trivia domain, for grounding question generation. Use the web_search tool (it is restricted to Wikipedia and Fandom).
 
 Source tiering — NOT equal votes:
 1. Prefer Wikipedia. It is the primary anchor.
@@ -81,6 +113,50 @@ Write the passage yourself as plain factual sentences (max ${PASSAGE_MAX_CHARS} 
 Return ONE JSON object only, no prose outside it:
 { "found": true | false, "source": "wikipedia" | "fandom", "source_url": "<page url>", "passage": "<the passage>" }
 - found=false (omit the other fields) when neither source has real coverage.`;
+
+// The Fandom-first prompt (deep fan domains sized off a Fandom corpus). Leads
+// with in-universe canon and deliberately maximizes the DENSITY and VARIETY of
+// concrete facts in the single passage — the same 1,200 chars should surface as
+// many distinct, question-able facts as possible across characters, locations,
+// items/mechanics, events/story, and lore, because for these domains a shallow
+// overview is exactly what produces zero usable questions. Wikipedia is demoted
+// to at most high-level framing.
+const RETRIEVAL_SYSTEM_PROMPT_FANDOM = `You retrieve ONE dense reference passage of established IN-UNIVERSE facts about a deep fan domain (a game, show, book series, or franchise), for grounding trivia question generation. Use the web_search tool (it is restricted to Wikipedia and Fandom).
+
+Source tiering — NOT equal votes:
+1. Prefer FANDOM. This domain's questions live in its in-universe canon — characters, locations, items, abilities/mechanics, quests/events, factions, and lore. Read ONLY canon / factual sections. NEVER use Trivia, Behind the Scenes, Speculation, production/development, sales/reception, or fan-theory material.
+2. Use Wikipedia only for high-level framing if Fandom is thin — never as the primary anchor for a deep fan domain.
+3. If neither source has real in-universe coverage, say so — do not improvise from memory.
+
+Pack the passage with as MANY distinct, concrete, specific facts as fit (max ${PASSAGE_MAX_CHARS} characters), spread ACROSS facets — characters and who they are, named locations, specific items/abilities and what they do, specific quests/events and outcomes, factions, and named lore. Prefer the specific over the general: proper nouns, exact relationships, exact effects. No opinions, no production/meta facts (release date, studio, voice cast, sales), no plot-summary padding.
+
+Return ONE JSON object only, no prose outside it:
+{ "found": true | false, "source": "wikipedia" | "fandom", "source_url": "<page url>", "passage": "<the passage>" }
+- found=false (omit the other fields) when neither source has real in-universe coverage.`;
+
+function retrievalSystemPrompt(pref: ReferenceSourcePreference): string {
+  return pref === 'fandom' ? RETRIEVAL_SYSTEM_PROMPT_FANDOM : RETRIEVAL_SYSTEM_PROMPT_WIKIPEDIA;
+}
+
+/**
+ * Pure: the per-domain user message, scoped by any resolved source pages so the
+ * search lands on the right wiki instead of guessing. Exported for unit tests.
+ */
+export function buildRetrievalUserMessage(
+  domain: string,
+  hint: ReferenceRoutingHint | undefined,
+  pref: ReferenceSourcePreference,
+): string {
+  const lines = [`Domain: ${domain}`];
+  if (pref === 'fandom' && hint?.fandomHost?.trim()) {
+    lines.push(`This domain's canon lives on the Fandom wiki at ${hint.fandomHost.trim()} — search there first.`);
+  }
+  if (pref === 'wikipedia' && hint?.wikipediaTitle?.trim()) {
+    lines.push(`The primary Wikipedia article is titled "${hint.wikipediaTitle.trim()}".`);
+  }
+  lines.push('Retrieve the reference passage. JSON only.');
+  return lines.join('\n');
+}
 
 export type DomainReference = { source: 'wikipedia' | 'fandom'; passage: string };
 export type DomainReferences = ReadonlyMap<string, DomainReference>;
@@ -126,6 +202,11 @@ export function questionLeaksPassageText(questionText: string, passage: string):
  */
 export async function getReferencePassagesForDomains(
   domains: string[],
+  // Per-domain routing hints (keyed by the EXACT domain string in `domains`).
+  // Absent → Wikipedia-first default, byte-for-byte the prior behavior. A hint
+  // sized off Fandom routes retrieval to the in-universe-canon prompt so a deep
+  // fan domain grounds from the well that sized it (Layer 3).
+  hintByDomain?: ReadonlyMap<string, ReferenceRoutingHint>,
 ): Promise<Map<string, DomainReference>> {
   const result = new Map<string, DomainReference>();
   if (domains.length === 0) return result;
@@ -159,17 +240,19 @@ export async function getReferencePassagesForDomains(
 
   for (const domain of toFetch) {
     try {
+      const hint = hintByDomain?.get(domain);
+      const pref = resolveReferenceSourcePreference(hint);
       const response = await loggedMessagesCreate(
         client,
         'domain-reference',
         {
           model: REFERENCE_MODEL,
           max_tokens: 1500,
-          system: RETRIEVAL_SYSTEM_PROMPT,
+          system: retrievalSystemPrompt(pref),
           messages: [
             {
               role: 'user',
-              content: `Domain: ${domain}\nRetrieve the reference passage. JSON only.`,
+              content: buildRetrievalUserMessage(domain, hint, pref),
             },
           ],
           tools: [

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -52,6 +52,7 @@ import {
   coCalibrateRaisedEstimates,
   getCappedDomainKeys,
   getFandomHostedDomains,
+  getReferenceRoutingHints,
   recordSupplyYieldObservation,
 } from '@/server/db/queries/domain-depth-estimate';
 import { nearCompleteRatio } from '@/server/daily/supply-state';
@@ -2502,7 +2503,19 @@ export async function generateDailyQuestionsFromKnowledgeBase(
       // (Spy School 0 vs 18), so canonical domains skip the retrieval entirely.
       const fandomDomains = await getFandomHostedDomains(domainsForLlm).catch(() => []);
       if (fandomDomains.length > 0) {
-        domainReferences = await getReferencePassagesForDomains(fandomDomains).catch((error) => {
+        // Layer 3 (source routing): these domains are all Fandom-hosted, so ground
+        // them from the SAME well that sized them — the in-universe-canon Fandom
+        // prompt, NOT the Wikipedia-first default that hands a deep fan domain a
+        // shallow game-as-product blurb (the Zelda: TotK 1,200-est / 0-yield case).
+        // The routing hints carry the resolved fandom_host so the search lands on
+        // the right wiki. Fail-open: no hints just means default (Wikipedia) routing.
+        const routingHints = await getReferenceRoutingHints(
+          fandomDomains.map((domain) => domainKey(domain)),
+        ).catch(() => new Map());
+        const hintByDomain = new Map(
+          fandomDomains.map((domain) => [domain, routingHints.get(domainKey(domain))]),
+        );
+        domainReferences = await getReferencePassagesForDomains(fandomDomains, hintByDomain).catch((error) => {
           console.warn('[daily/generate-questions] reference retrieval failed; proceeding unanchored', {
             userId,
             error: error instanceof Error ? error.message : String(error),

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -950,50 +950,87 @@ async function buildDailyQueueForUser(
     position += 1;
   }
 
-  // Daily Five +2 (D-4 §B, the territory ∪ activity reframe). Append up to
-  // DAILY_BONUS_SLOT_MAX bonus slots, each a FRESHLY GENERATED accessible
-  // question in a domain drawn from the durable territory + recent activity of
-  // the people the viewer follows, ranked Both > territory-only > activity-only.
-  // Purely additive: NOT counted toward DAILY_QUEUE_SIZE / the achieved backstop,
-  // never triggers the N<5 generation top-up, and never pads with the viewer's
-  // own domains. If no friend domains qualify (or generation misses) we append
-  // fewer slots (graceful shrink), yielding a 5–7 slot queue. The +2 serves only
-  // fresh questions — never a friend's literal answered question (those live
-  // behind the Lately milestone click-through, D-4 §A).
-  // Resting domains are excluded from the +2 pool too, so "This is {Name}'s bag
-  // but not mine" (which parks the domain in Resting) stops it surfacing as a
-  // bonus, not just in the core five.
+  // Daily Five +2 (D-4 §B, the territory ∪ activity reframe) — AND the short-core
+  // serving backstop (Layer 1, supply-exhaustion fix). Draw a ranked pool of
+  // domains from the durable territory + recent activity of the people the viewer
+  // follows (Both > territory-only > activity-only), generate a fresh accessible
+  // question per domain, then split them two ways:
+  //   1. CORE BACKFILL: if the core came up short of DAILY_QUEUE_SIZE (the viewer's
+  //      OWN palette was tapped out — every top-up round + reserve above is already
+  //      spent by here), promote the first `coreShortfall` friend questions into
+  //      the five as PLAIN CORE slots (buildBotSlot, no presence attribution → they
+  //      genuinely count toward the set per isBonusSlot). This is what stops a dry
+  //      own-palette from serving a 3- or 4-question "Daily Five": a friend-world
+  //      question fills the gap instead. Accessible tier is acceptable here — a
+  //      served five beats a short one.
+  //   2. +2 BONUS: any remaining friend domains (up to DAILY_BONUS_SLOT_MAX) append
+  //      as additive presence-attributed bonus slots exactly as before ("from
+  //      {Name}'s world"), never counted toward the five.
+  // We therefore request coreShortfall + DAILY_BONUS_SLOT_MAX domains so the bonus
+  // isn't cannibalized by the backfill. When the core is already full coreShortfall
+  // is 0 and this is byte-for-byte the old +2 behavior. Friend-sourced only (never
+  // pads with the viewer's own domains); resting domains are excluded from BOTH the
+  // core backfill and the bonus, so "This is {Name}'s bag but not mine" holds. The
+  // pool serves only fresh questions — never a friend's literal answered question
+  // (those live behind the Lately milestone click-through, D-4 §A).
   //
   // Generated BEFORE the single persist so the whole queue (core + bonus) lands
-  // atomically. Wrapped so a bonus-generation failure degrades to a core-only
-  // queue instead of losing the entire build.
+  // atomically. Wrapped so a generation failure degrades to a core-only queue
+  // (possibly still short) instead of losing the entire build.
   try {
-    const bonusDomains = await getFriendDomainsForBonus(
+    // At this point `slots` holds only core slots (bonus is appended below), so its
+    // length IS the core count. A dry own-palette leaves this under DAILY_QUEUE_SIZE.
+    const coreShortfall = Math.max(0, DAILY_QUEUE_SIZE - slots.length);
+    const friendDomains = await getFriendDomainsForBonus(
       userId,
-      DAILY_BONUS_SLOT_MAX,
+      coreShortfall + DAILY_BONUS_SLOT_MAX,
       restingDomains,
     );
-    // Gate the bonus LLM call on the remaining function budget. The +2 is purely
-    // additive, so when little time is left (e.g. a slow core build near the
-    // ceiling) skipping it lets the core queue still persist instead of risking a
-    // mid-bonus kill that would lose the whole build.
-    if (bonusDomains.length > 0 && hasBudgetForAnotherRound(Date.now() - startedAt, durationBudgetMs)) {
+    // Gate the friend-domain LLM call on the remaining function budget. When little
+    // time is left (e.g. a slow core build near the ceiling) skipping it lets the
+    // core queue still persist instead of risking a mid-generation kill that would
+    // lose the whole build. The core backfill is best-effort for the same reason a
+    // short queue is tolerated down to the floor: a served four beats a lost build.
+    if (friendDomains.length > 0 && hasBudgetForAnotherRound(Date.now() - startedAt, durationBudgetMs)) {
       const presenceByDomain = new Map(
-        bonusDomains.map((candidate) => [candidate.domain.toLowerCase(), candidate]),
+        friendDomains.map((candidate) => [candidate.domain.toLowerCase(), candidate]),
       );
-      const generatedBonus = await generateBonusQuestionsForDomains(
+      const generatedFriend = await generateBonusQuestionsForDomains(
         userId,
-        bonusDomains.map((candidate) => candidate.domain),
+        friendDomains.map((candidate) => candidate.domain),
       );
-      for (const { domain, question } of generatedBonus) {
-        const candidate = presenceByDomain.get(domain.toLowerCase());
-        slots.push(buildPresenceSlot(question, toBonusPresence(candidate), position));
-        generatedQuestionIds.push(question.id);
-        position += 1;
+      let promotedToCore = 0;
+      let bonusAppended = 0;
+      for (const { domain, question } of generatedFriend) {
+        if (slots.length < DAILY_QUEUE_SIZE) {
+          // Still short on core → promote into the five as a plain core slot. No
+          // presence attribution: it reads as a normal fifth question, not a "+2".
+          slots.push(buildBotSlot(question, position));
+          generatedQuestionIds.push(question.id);
+          position += 1;
+          promotedToCore += 1;
+        } else if (bonusAppended < DAILY_BONUS_SLOT_MAX) {
+          const candidate = presenceByDomain.get(domain.toLowerCase());
+          slots.push(buildPresenceSlot(question, toBonusPresence(candidate), position));
+          generatedQuestionIds.push(question.id);
+          position += 1;
+          bonusAppended += 1;
+        } else {
+          break;
+        }
+      }
+      if (promotedToCore > 0) {
+        console.info('[daily/queue-orchestrator] backfilled short core from friend domains', {
+          userId,
+          coreShortfall,
+          promotedToCore,
+          bonusAppended,
+          coreAfter: slots.length - bonusAppended,
+        });
       }
     }
   } catch (error) {
-    console.warn('[daily/queue-orchestrator] +2 bonus generation failed; serving core only', {
+    console.warn('[daily/queue-orchestrator] +2 bonus / core-backfill generation failed; serving core only', {
       userId,
       error: error instanceof Error ? error.message : String(error),
     });

--- a/src/server/daily/supply-backfill.ts
+++ b/src/server/daily/supply-backfill.ts
@@ -164,9 +164,18 @@ async function loadDemonstratedDemand(): Promise<Set<string>> {
   return out;
 }
 
-async function loadDomains(onlyDomain?: string | null): Promise<DomainRow[]> {
-  const where = onlyDomain ? 'WHERE d.domain_key ILIKE $1' : '';
-  const params = onlyDomain ? [`%${onlyDomain.toLowerCase()}%`] : [];
+async function loadDomains(onlyDomain?: string | null, systemUserId?: string | null): Promise<DomainRow[]> {
+  // $1 = the system backfill user to EXCLUDE from own_max. Its bank rows serve to
+  // EVERY real viewer (pickBackfill only excludes a viewer's OWN rows, and the
+  // system user is never a viewer), so they are not part of any player's
+  // worst-case self-owned stock. Counting them would make every domain the
+  // backfill fills read as servable = have − system_owned ≈ its few non-system
+  // rows — perpetually "dry to one user" — and re-generate it forever. An empty
+  // string matches no real (uuid) user id, so an unset system user is a no-op.
+  const sysExcl = (systemUserId ?? process.env.RETRIEVAL_SYSTEM_USER_ID)?.trim() || '';
+  const params: string[] = [sysExcl];
+  const where = onlyDomain ? 'WHERE d.domain_key ILIKE $2' : '';
+  if (onlyDomain) params.push(`%${onlyDomain.toLowerCase()}%`);
   return (
     await pool.query(
       `SELECT d.domain_key, d.sample_label, d.fandom_host,
@@ -176,6 +185,7 @@ async function loadDomains(onlyDomain?: string | null): Promise<DomainRow[]> {
               COALESCE((SELECT MAX(cnt)::int FROM (
                  SELECT COUNT(*) AS cnt FROM "GeneratedQuestion" g2
                    WHERE g2.domain_key = d.domain_key AND g2.is_duplicate = false
+                     AND g2.user_id <> $1
                    GROUP BY g2.user_id
               ) owner_counts), 0) AS own_max,
               COALESCE(d.consecutive_dry_rounds, 0) AS consecutive_dry_rounds
@@ -368,7 +378,7 @@ export async function runSupplyBackfill(opts: BackfillOptions): Promise<Backfill
   const [demand, demonstrated, domains] = await Promise.all([
     loadDemand(),
     loadDemonstratedDemand(),
-    loadDomains(opts.onlyDomain),
+    loadDomains(opts.onlyDomain, opts.systemUserId),
   ]);
   // Fold DEMONSTRATED demand (rich mastery-path leaves) into the declared count:
   // a leaf nobody declared but a player is mastering counts as ≥1 interested, so

--- a/src/server/daily/supply-backfill.ts
+++ b/src/server/daily/supply-backfill.ts
@@ -28,9 +28,11 @@ import {
   type LlmQuestion,
 } from '@/server/daily/generate-questions';
 import { getReferencePassagesForDomains, type DomainReference } from '@/server/daily/domain-reference';
+import { getReferenceRoutingHints } from '@/server/db/queries/domain-depth-estimate';
 import { resolveDailyBasePoints } from '@/server/daily/types';
 import { resolveMachineTrustTier } from '@/server/daily/ask-to-answer';
 import { resolveFinestNode } from '@/server/knowledge/graph';
+import { dryRoundsThreshold } from '@/server/daily/supply-state';
 import { domainKey } from '@/lib/knowledge/domain-key';
 import { normalizeFactKey } from '@/server/questions/fact-key';
 import { estimateCostUsd } from '@/server/llm/pricing';
@@ -47,6 +49,15 @@ export interface BackfillOptions {
   daysRunway?: number;
   bufferFloor?: number;
   batchCap?: number;
+  /**
+   * Only backfill domains with PROVEN unmet demand — those a real player already
+   * ran dry on (consecutive_dry_rounds ≥ dryK, the discrepancy signal). Default
+   * true: a merely-declared domain that's still serving fine from its bank is not
+   * worth spend at low scale. Set false (SUPPLY_BACKFILL_ONLY_DRY=false) for the
+   * broader PREDICTIVE mode — pre-fill any servable-short declared domain before a
+   * player hits the wall — once scale justifies the volume.
+   */
+  onlyDry?: boolean;
 }
 
 const DEFAULTS = {
@@ -54,6 +65,13 @@ const DEFAULTS = {
   bufferFloor: Number(process.env.SUPPLY_BACKFILL_BUFFER_FLOOR ?? 10),
   batchCap: Number(process.env.SUPPLY_BACKFILL_BATCH_CAP ?? 20),
 };
+
+// Default ON: spend only where demand is UNMET (a domain went dry), not merely
+// where interest was declared. Disable for predictive pre-fill at scale.
+function isOnlyDryDefault(): boolean {
+  const raw = process.env.SUPPLY_BACKFILL_ONLY_DRY?.trim().toLowerCase();
+  return !(raw === 'false' || raw === '0' || raw === 'no' || raw === 'off');
+}
 const GATE_PASS_RATE = 0.85; // measured survivor rate through quality+factual
 const GEN_TIMEOUT_MS = 150_000;
 const GEN_MAX_TOKENS = 6000;
@@ -92,6 +110,17 @@ type DomainRow = {
   fandom_host: string | null;
   effective_est: number | null;
   have: number;
+  /**
+   * Rows owned by the SINGLE largest contributor to this domain. The bank serves
+   * cross-user (pickBankSource: userId <> viewer), so a domain's neediest declarer
+   * — usually its top contributor — can be served only `have − own_max` of its
+   * rows; their own generations are excluded. Worst-case servable = have − own_max
+   * is what the buffer must actually cover (the Zelda: TotK case, where one player
+   * generated 13 of 16 rows and is served 3).
+   */
+  own_max: number;
+  /** Consecutive offered-but-zero-yield generation rounds (the dry/discrepancy signal). */
+  consecutive_dry_rounds: number;
 };
 
 async function loadDemand(): Promise<Map<string, number>> {
@@ -143,7 +172,13 @@ async function loadDomains(onlyDomain?: string | null): Promise<DomainRow[]> {
       `SELECT d.domain_key, d.sample_label, d.fandom_host,
               COALESCE(d.manual_estimated_questions, d.estimated_questions) AS effective_est,
               (SELECT COUNT(*)::int FROM "GeneratedQuestion" g
-                 WHERE g.domain_key = d.domain_key AND g.is_duplicate = false) AS have
+                 WHERE g.domain_key = d.domain_key AND g.is_duplicate = false) AS have,
+              COALESCE((SELECT MAX(cnt)::int FROM (
+                 SELECT COUNT(*) AS cnt FROM "GeneratedQuestion" g2
+                   WHERE g2.domain_key = d.domain_key AND g2.is_duplicate = false
+                   GROUP BY g2.user_id
+              ) owner_counts), 0) AS own_max,
+              COALESCE(d.consecutive_dry_rounds, 0) AS consecutive_dry_rounds
        FROM "DomainDepthEstimate" d ${where}`,
       params,
     )
@@ -163,14 +198,21 @@ function estimateBatchCost(batch: number, ground: boolean): number {
 export function buildPlan(
   domains: DomainRow[],
   demand: Map<string, number>,
-  cfg: { daysRunway: number; bufferFloor: number; batchCap: number },
+  cfg: { daysRunway: number; bufferFloor: number; batchCap: number; onlyDry?: boolean; dryK?: number },
 ): BackfillPlan[] {
+  const onlyDry = cfg.onlyDry ?? true;
+  const dryK = cfg.dryK ?? 3;
   const plans: BackfillPlan[] = [];
   for (const d of domains) {
     const label = d.sample_label || d.domain_key;
     const interested = demand.get(d.domain_key) ?? 0;
     const cap = d.effective_est ?? 0;
     const ground = Boolean(d.fandom_host);
+    // Worst-case SERVABLE stock, not total inventory: the neediest interested
+    // player is served only the rows they did NOT generate (bank excludes own
+    // rows), so a domain one heavy player mined out reads as stocked to everyone
+    // else yet dry to them. Gate the buffer on what that player can actually see.
+    const servableHave = Math.max(0, d.have - d.own_max);
     let bufferTarget = 0;
     let batch = 0;
     let skipReason: string | null = null;
@@ -178,11 +220,18 @@ export function buildPlan(
       skipReason = 'no demand (0 declared interests)';
     } else if (cap <= 0) {
       skipReason = 'no estimate';
+    } else if (onlyDry && d.consecutive_dry_rounds < dryK) {
+      // Proven-demand gate: only spend where a player actually ran the domain dry
+      // (the discrepancy signal), not merely where it was declared. A declared
+      // domain still serving fine from its bank needs nothing.
+      skipReason = `not exhausted (dry ${d.consecutive_dry_rounds} < ${dryK}); declared, not yet run dry`;
     } else {
       bufferTarget = clamp(cfg.daysRunway * interested, cfg.bufferFloor, cap);
-      const gap = Math.max(0, bufferTarget - d.have);
+      const gap = Math.max(0, bufferTarget - servableHave);
       batch = Math.min(cfg.batchCap, Math.ceil(gap / GATE_PASS_RATE));
-      if (batch === 0) skipReason = `already stocked (have ${d.have} ≥ target ${bufferTarget})`;
+      if (batch === 0) {
+        skipReason = `already stocked (servable ${servableHave} ≥ target ${bufferTarget})`;
+      }
     }
     plans.push({
       domainKey: d.domain_key,
@@ -248,7 +297,16 @@ async function loadAvoid(domainKeyVal: string): Promise<{
 async function buildDomain(p: BackfillPlan, systemUserId: string | null): Promise<{ generated: number; persisted: number }> {
   const avoid = await loadAvoid(p.domainKey);
   let refs: Map<string, DomainReference> | undefined;
-  if (p.ground) refs = await getReferencePassagesForDomains([p.label]).catch(() => undefined);
+  if (p.ground) {
+    // Layer 3 source routing: p.ground means this domain has a fandom_host, so
+    // ground it from its IN-UNIVERSE CANON, not the Wikipedia-first default that
+    // hands a deep fan domain a shallow game-as-product blurb (the Zelda: TotK
+    // 1,200-est / 0-yield case). The routing hint carries the resolved host so the
+    // search lands on the right wiki. Fail-open: a miss just means no reference.
+    const hints = await getReferenceRoutingHints([p.domainKey]).catch(() => new Map());
+    const hintByDomain = new Map([[p.label, hints.get(p.domainKey)]]);
+    refs = await getReferencePassagesForDomains([p.label], hintByDomain).catch(() => undefined);
+  }
 
   const generated = await generate(p.label, p.batch, avoid.texts, avoid.fks, refs);
   if (generated.length === 0) return { generated: 0, persisted: 0 };
@@ -304,6 +362,8 @@ export async function runSupplyBackfill(opts: BackfillOptions): Promise<Backfill
     daysRunway: opts.daysRunway ?? DEFAULTS.daysRunway,
     bufferFloor: opts.bufferFloor ?? DEFAULTS.bufferFloor,
     batchCap: opts.batchCap ?? DEFAULTS.batchCap,
+    onlyDry: opts.onlyDry ?? isOnlyDryDefault(),
+    dryK: dryRoundsThreshold(),
   };
   const [demand, demonstrated, domains] = await Promise.all([
     loadDemand(),

--- a/src/server/db/queries/domain-depth-estimate.ts
+++ b/src/server/db/queries/domain-depth-estimate.ts
@@ -281,6 +281,45 @@ export async function getCappedDomainKeys(): Promise<Set<string>> {
   return new Set(rows.map((row) => row.domainKey));
 }
 
+/**
+ * Grounding source-routing hints per domain key (Layer 3, D-FANDOM-GROUNDING-01
+ * follow-up). The reference-passage retriever defaults to Wikipedia-first, which
+ * hands a DEEP fan domain a shallow "game-as-product" Wikipedia blurb even though
+ * the domain was SIZED off its Fandom category tree — the exact mismatch that let
+ * a 1,200-question domain (Zelda: TotK) serve zero. These hints let the retriever
+ * ground a domain from the SAME well that sized it: a `basis` of `fandom:*` (or a
+ * resolved `fandom_host`) routes to a Fandom-in-universe-canon prompt; otherwise
+ * the Wikipedia-first default stands. `wikipediaTitle`/`fandomHost` further scope
+ * the search when present. Keyed by folded domain_key; a domain with no estimate
+ * row simply has no hint (default routing).
+ */
+export type ReferenceRoutingHint = {
+  basis: string | null;
+  fandomHost: string | null;
+  wikipediaTitle: string | null;
+};
+
+export async function getReferenceRoutingHints(
+  domainKeys: string[],
+): Promise<Map<string, ReferenceRoutingHint>> {
+  if (domainKeys.length === 0) return new Map();
+  const rows = await db
+    .select({
+      domainKey: domainDepthEstimates.domainKey,
+      basis: domainDepthEstimates.basis,
+      fandomHost: domainDepthEstimates.fandomHost,
+      wikipediaTitle: domainDepthEstimates.wikipediaTitle,
+    })
+    .from(domainDepthEstimates)
+    .where(inArray(domainDepthEstimates.domainKey, domainKeys));
+  return new Map(
+    rows.map((row) => [
+      row.domainKey,
+      { basis: row.basis, fandomHost: row.fandomHost, wikipediaTitle: row.wikipediaTitle },
+    ]),
+  );
+}
+
 export type DomainSupplyCoverageRow = {
   domainKey: string;
   sampleLabel: string | null;


### PR DESCRIPTION
## Why

Fixes the **Buttkicker short-queue** case (got 4 core + 2 bonus, not 5). A deep domain — **Zelda: TotK**, sized at 1,200 questions in `DomainDepthEstimate` (668 Fandom articles, high confidence, `discrepancy` state) — served **zero** because live generation is shallow-grounded and only ~17 rows ever materialized (13 the sole declarer's own).

Three root causes, three layers:

### Layer 1 — serving backstop (`queue-orchestrator.ts`)
When the core lands below `DAILY_QUEUE_SIZE` (own palette tapped out), promote friend-world (bonus-pool) questions into the **core five** as plain slots *before* the +2. A dry own-palette never serves a short five again. Requests `coreShortfall + DAILY_BONUS_SLOT_MAX` friend domains so the +2 isn't cannibalized.

### Layer 3 — grounding source-routing (`domain-reference.ts`, `getReferenceRoutingHints`)
Retrieval used to always prefer Wikipedia, handing a deep fan domain a shallow *game-as-product* blurb (release date, studio, sales) — the exact material the generator is told to avoid. Now routes by the domain's sizing `basis`/`fandom_host`: a Fandom-sized domain grounds from **in-universe canon**, scoped to the resolved wiki host. Wired into both the live path and the backfill.

### Layer 2+4 — backfill correctness (`supply-backfill.ts`)
The demand-weighted backfill already existed but under-served the exact case:
- **Servable-stock fix:** buffer gated on worst-case servable (`have − own_max`), not total inventory — the bank excludes a viewer's own rows, so Zelda (16 rows, one player owns 13 → served 3) read as "stocked" but was dry to its sole declarer.
- **Proven-demand gate** (`SUPPLY_BACKFILL_ONLY_DRY`, default on): only backfill domains a player actually ran dry on (`consecutive_dry_rounds ≥ K`), not merely-declared ones.

Dry-run under the gate: **8 domains / 101 questions / ~$0.74** (vs the predictive 74 / $5.59).

## Tests
+20 across `queue-floor` (backstop), `domain-reference` (routing), and a new `supply-backfill` suite (servable-stock + dry gate). `src/` typecheck clean, full daily suite (359) green, lint clean.

## Rollout (not enabled here)
- Layer 1 is **on by default** once merged (no flag) — protects every user immediately.
- Backfill stays gated behind `SUPPLY_BACKFILL_ENABLED` + `RETRIEVAL_SYSTEM_USER_ID`. Flip those to drain the 8 dry domains over a few nights, or run `scripts/backfill-supply.ts --run --domain "zelda"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)