### PR TITLE
Admin fixes: bulk re-attribution to House + domain re-categorization

### DIFF
--- a/src/app/admin/questions/AdminQuestionsClient.tsx
+++ b/src/app/admin/questions/AdminQuestionsClient.tsx
@@ -227,6 +227,11 @@ function EditForm({
   const [insideJoke, setInsideJoke] = useState(detail.insideJoke ?? '');
   const [category, setCategory] = useState(detail.category);
   const [visibility, setVisibility] = useState(detail.visibility);
+  // The domain / knowledge label shown on the card (canonicalSubcategory). Editing
+  // it fixes a mis-tagged question (e.g. a Sesame-Street question filed under
+  // "New Testament"). Empty falls back to the current value — the domain can be
+  // changed but not cleared here.
+  const [domain, setDomain] = useState(detail.canonicalSubcategory ?? '');
   // Author: 'person' keeps the current human creator; 'house' re-sources to the
   // house author. Only a person-authored row can switch (a house/LLM row has no
   // person to switch back to without a picker), so the control is read-only then.
@@ -258,6 +263,10 @@ function EditForm({
     }
     if (category !== detail.category) patch.category = category;
     if (visibility !== detail.visibility) patch.visibility = visibility;
+    const trimmedDomain = domain.trim();
+    if (trimmedDomain && trimmedDomain !== (detail.canonicalSubcategory ?? '')) {
+      patch.canonicalSubcategory = trimmedDomain;
+    }
     // Re-attribution: only person → house is a real transition.
     if (detail.authorIsPerson && authorChoice === 'house') patch.attribution = 'house';
     return patch;
@@ -301,7 +310,12 @@ function EditForm({
         body: JSON.stringify({ action: 'edit', id: detail.id, ...patch }),
       });
       if (!res.ok) {
-        setError(`Save failed (${res.status}).`);
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        setError(
+          body?.error === 'generic_domain'
+            ? 'That domain is too generic — use a specific label (not “general”, “trivia”, etc.).'
+            : `Save failed (${res.status}).`,
+        );
         setBusy(false);
         return;
       }
@@ -371,6 +385,16 @@ function EditForm({
             Already house/non-person — reassigning to a specific person isn&apos;t supported here.
           </p>
         ) : null}
+      </div>
+      <div className="mb-3">
+        <label className={labelClass} style={labelStyle}>
+          Domain (subcategory)
+        </label>
+        <input className={inputClass} style={inputStyle} value={domain} onChange={(e) => setDomain(e.target.value)} />
+        <p className="mt-1 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          The label shown above the question (e.g. “Sesame Street”). Fixes a mis-tagged domain.
+          Category above is the top-level bucket; this is the specific one.
+        </p>
       </div>
       <div className="mb-3 flex gap-3">
         <div className="flex-1">

--- a/src/app/api/admin/questions/__tests__/route.test.ts
+++ b/src/app/api/admin/questions/__tests__/route.test.ts
@@ -92,6 +92,25 @@ describe('admin questions mutation route — actions (admin)', () => {
     expect(editMock).not.toHaveBeenCalled();
   });
 
+  it('dispatches a domain (canonicalSubcategory) edit', async () => {
+    const res = await post({ action: 'edit', id: 'q1', canonicalSubcategory: 'Sesame Street' });
+    expect(res.status).toBe(200);
+    expect(editMock).toHaveBeenCalledWith('q1', expect.objectContaining({ canonicalSubcategory: 'Sesame Street' }));
+  });
+
+  it('surfaces a rejected generic domain as 400', async () => {
+    editMock.mockResolvedValue({ ok: false, reason: 'generic_domain' });
+    const res = await post({ action: 'edit', id: 'q1', canonicalSubcategory: 'general' });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'generic_domain' });
+  });
+
+  it('rejects an empty domain string before dispatch', async () => {
+    const res = await post({ action: 'edit', id: 'q1', canonicalSubcategory: '   ' });
+    expect(res.status).toBe(400);
+    expect(editMock).not.toHaveBeenCalled();
+  });
+
   it('dispatches a re-attribution to house', async () => {
     const res = await post({ action: 'edit', id: 'q1', attribution: 'house' });
     expect(res.status).toBe(200);

--- a/src/app/api/admin/questions/route.ts
+++ b/src/app/api/admin/questions/route.ts
@@ -35,6 +35,10 @@ const editSchema = z.object({
   insideJoke: z.string().trim().max(2000).nullable().optional(),
   category: z.enum(CATEGORIES).optional(),
   visibility: z.enum(['public', 'friends', 'private']).optional(),
+  // The domain / knowledge label shown on the card (e.g. re-tagging a
+  // Sesame-Street question mis-filed under "New Testament"). Server-side the
+  // helper rejects generic bucket labels and normalizes to a KnowledgeNode.
+  canonicalSubcategory: z.string().trim().min(1).max(120).optional(),
   // Re-attribution to the house author (creator_id NULL + source house_authored).
   // Only 'house' is settable here — reassigning to a specific person would need a
   // person picker this tool doesn't have.
@@ -95,6 +99,7 @@ export async function POST(request: NextRequest) {
     insideJoke: fields.insideJoke,
     category: fields.category,
     visibility: fields.visibility,
+    canonicalSubcategory: fields.canonicalSubcategory,
     attribution: fields.attribution,
   };
   if (Object.values(patch).every((v) => v === undefined)) {
@@ -102,6 +107,7 @@ export async function POST(request: NextRequest) {
   }
   const result = await adminEditQuestion(id, patch);
   if (!result.ok) {
+    // not_found ⇒ 404; a rejected domain or empty patch ⇒ 400.
     return NextResponse.json({ error: result.reason }, { status: result.reason === 'not_found' ? 404 : 400 });
   }
   return NextResponse.json(result);

--- a/src/server/db/queries/admin-questions.ts
+++ b/src/server/db/queries/admin-questions.ts
@@ -2,6 +2,8 @@ import { and, asc, desc, eq, ilike, inArray, isNotNull, isNull, or, sql, type SQ
 
 import { db, questions, users } from '@/server/db';
 import { resolveAuthorDisplay, parseQuestionSource } from '@/lib/questions-types';
+import { resolveFinestNode } from '@/server/knowledge/graph';
+import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 // B-ADMIN-QUESTIONS-OVERVIEW-01 — the admin-only "what's actually in the pool"
 // audit surface. UNLIKE every player-facing read path, this query is deliberately
@@ -120,6 +122,15 @@ export type AdminEditQuestionInput = {
   insideJoke?: string | null;
   category?: string;
   visibility?: string;
+  // The domain / knowledge label the card shows above the question (e.g. the
+  // mis-tagged "New Testament" on a Sesame-Street question). Written to BOTH
+  // subcategory (raw) and canonicalSubcategory (normalized to the finest
+  // KnowledgeNode) — the pair createQuestion/bulk-upload keep in sync and the
+  // pair domainDisplayName reads from. Guarded against generic bucket labels
+  // (assertSpecificCanonicalSubcategory's blocklist). Metadata, not content —
+  // it does NOT clear the verification stamp (that vouches for the answer, not
+  // the categorization). The top-level category enum is edited separately above.
+  canonicalSubcategory?: string;
   // Re-attribution. 'house' re-sources the question to the labeled non-human
   // house author (creator_id NULL + source 'house_authored') — the same override
   // the crafter "keep" flow applies. NOT a tombstone: authorDeleted stays false
@@ -129,7 +140,10 @@ export type AdminEditQuestionInput = {
   attribution?: 'house';
 };
 
-export type AdminMutationResult = { ok: boolean; reason?: 'not_found' | 'no_fields' };
+export type AdminMutationResult = {
+  ok: boolean;
+  reason?: 'not_found' | 'no_fields' | 'generic_domain';
+};
 
 // Edit a question as an admin. Grading-adjacent fields (question/answer/
 // alternatives/explanation) trigger the same canon editQuestionContent applies:
@@ -171,6 +185,16 @@ export async function adminEditQuestion(
   }
   if (input.visibility !== undefined) {
     values.visibility = input.visibility as typeof questions.$inferInsert.visibility;
+  }
+  if (input.canonicalSubcategory !== undefined) {
+    // Reject generic bucket labels (the same guard every canonical_subcategory
+    // write boundary enforces) before touching the row.
+    const domain = input.canonicalSubcategory.trim();
+    if (isGenericSubcategory(domain)) return { ok: false, reason: 'generic_domain' };
+    // Normalize to the finest existing KnowledgeNode's label (flag-off ⇒
+    // pass-through), mirroring createQuestion. subcategory holds the raw label.
+    values.canonicalSubcategory = await resolveFinestNode(domain);
+    values.subcategory = domain;
   }
   if (input.attribution === 'house') {
     // House marker: creator_id NULL + source 'house_authored' (crafter-keep


### PR DESCRIPTION
## Summary

Two related admin fixes for questions that landed with the wrong metadata, plus a prevention step so the first one stops recurring.

### 1. Attribution — questions wrongly attributed to a person
Admin bulk uploads defaulted the author to the uploading admin, so pool questions rendered under a personal byline instead of the House identity.

- **Cure:** the admin Questions table (`/admin/questions`) gains an **Author** name filter, row checkboxes on live person-authored rows (plus a page-wide select-all), and a two-step-confirmed **Attribute to House (Joshing)** bulk action. New `reattribute_house` route action, capped at 200 ids/request. Reuses the exact single-row marker: `creator_id NULL` + `source 'house_authored'`, `authorDeleted` stays false, verification stamp untouched. Already-house/deleted rows in a selection are reported as skipped, not errors.
- **Prevention:** the bulk-upload author picker gains a **"House (Joshing) — no personal byline"** option and now defaults to it; the route accepts the `HOUSE_AUTHOR.id` sentinel and creates rows via `createQuestion`'s existing `attributedSource: 'house_authored'` path (crafter-keep precedent). Attributing to a specific admin is now the explicit choice.

This revises the route's "no bulk actions" note (Decision C) for this one act only; everything else stays per-row.

### 2. Categorization — questions filed under the wrong domain
A question could show the wrong domain label — e.g. a Sesame-Street question ("What does Ernie say to entice fish?") tagged **New Testament**. The editor could change the top-level category enum but not the granular domain (`canonical_subcategory`) the card displays.

- The admin edit form gains a **Domain (subcategory)** field. `adminEditQuestion` rejects generic bucket labels via the existing `isGenericSubcategory` guard, normalizes to the finest KnowledgeNode with `resolveFinestNode`, and writes both `subcategory` (raw) and `canonical_subcategory` (normalized) — the pair `createQuestion`/bulk-upload keep in sync and `domainDisplayName` reads from. It's metadata, not content, so the verification stamp is untouched. The route validates a non-empty label and surfaces the `generic_domain` rejection as 400.

## Notes / out of scope
- Both re-attribution and domain edits are **one-way manual overrides** — no house→person picker, no "re-run the LLM categorizer" button (the categorizer is what mis-filed the domain).
- Neither change retroactively moves **mastery events** already recorded (personal authored-mastery, or per-domain aggregates under the old label); future activity uses the corrected metadata. Historical cleanup would be a separate change.

## Testing
- `npx tsc -p tsconfig.typecheck.json` — clean
- `npm run lint` — no new warnings in touched files
- Vitest: admin questions route/client, questions server, and canonical-subcategory suites pass, including new tests for the bulk action (dispatch, empty-list and over-cap rejection), the domain edit (dispatch, generic-label 400, empty-domain rejection), and house re-attribution.

No DB credentials in the build env, so flows weren't driven end-to-end; verification is typecheck + lint + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mLuxmyuZ6sTT4D6CBebeZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019mLuxmyuZ6sTT4D6CBebeZ)_