### PR TITLE
Revisit: full-screen one-at-a-time review mode with range filter

### DIFF
--- a/src/app/recovered/page.tsx
+++ b/src/app/recovered/page.tsx
@@ -10,13 +10,14 @@ import { getRecoveredQuestionsForUser } from '@/server/db/queries/recovered-ques
  *
  * A personal, profile-resident pool of the questions the viewer got wrong and
  * then later got right. Self-initiated from the profile — never pushed, no
- * "due" badge, no streak. The surface deals ONE question at a time from a
- * server-shuffled deck: reveal the answer, move to the next, or dismiss the
- * question out of circulation (reversible; the dismissed shelf lists them all
- * with Restore). The how-far-back filter is plain links over a `?range=`
- * search param — a reload deals a fresh shuffle. The deck interaction lives in
- * the RecoveredDeck client island; the pool itself stays read-only (see the
- * query module), with dismiss/restore as the surface's only write.
+ * "due" badge, no streak. The page is a LANDING (count, Start, the dismissed
+ * shelf); Start opens a full-screen review MODE that deals one question at a
+ * time from the shuffled deck — Cancel (X) top right, a sticky Show answer /
+ * Next bar at the bottom, Dismiss to take a question out of circulation
+ * (reversible; the shelf lists them all with Restore). The how-far-back
+ * filter is plain links over a `?range=` search param. The interaction lives
+ * in the RecoveredDeck client island; the pool itself stays read-only (see
+ * the query module), with dismiss/restore as the surface's only write.
  */
 export const dynamic = 'force-dynamic';
 

--- a/src/components/recovered/RecoveredDeck.tsx
+++ b/src/components/recovered/RecoveredDeck.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowDownToLine, Undo2, X } from 'lucide-react';
+import { Undo2, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import type { RecoveredQuestion } from '@/server/db/queries/recovered-questions';
@@ -238,9 +238,8 @@ export function RecoveredDeck({ deck: initialDeck, dismissed: initialDismissed, 
                     type="button"
                     onClick={dismissCurrent}
                     disabled={busy}
-                    className="inline-flex items-center gap-1.5 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
+                    className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
                   >
-                    <ArrowDownToLine className="size-3.5" aria-hidden="true" />
                     Dismiss — take it out of circulation
                   </button>
                 </div>

--- a/src/components/recovered/RecoveredDeck.tsx
+++ b/src/components/recovered/RecoveredDeck.tsx
@@ -1,18 +1,19 @@
 'use client';
 
-import { ArrowDownToLine, Undo2 } from 'lucide-react';
-import { useState } from 'react';
+import { ArrowDownToLine, Undo2, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 import type { RecoveredQuestion } from '@/server/db/queries/recovered-questions';
 
 /**
  * D-REVIEW-RECOVERED-01 (Decision B + revised C) — the one-at-a-time review
- * deck. The player sits with one question, recalls the answer in their head,
- * reveals the canonical answer to check themselves (no grader, no verdict),
- * then moves to the next. Dismiss takes a question out of circulation via the
- * existing set-aside API; the dismissed shelf below lists everything dismissed
- * and offers Restore. Deck order arrives pre-shuffled from the server; "Go
- * again" reshuffles client-side.
+ * MODE. The page itself is a landing (count + Start + the dismissed shelf);
+ * starting a review opens a full-screen takeover: Cancel (X) in the upper
+ * right, the question centered in a scrollable body, and a sticky two-button
+ * bar at the bottom — Show/Hide answer and Next — that never moves. The reveal
+ * is still no-check (no grader, no verdict); Dismiss takes the question out of
+ * circulation via the existing set-aside API, and the dismissed shelf on the
+ * landing lists everything dismissed with Restore.
  */
 
 function shuffle<T>(items: T[]): T[] {
@@ -33,7 +34,7 @@ type Props = {
 
 function RevealBody({ question }: { question: RecoveredQuestion }) {
   return (
-    <div className="mt-3 space-y-2 text-sm">
+    <div className="mt-4 space-y-2 border-t pt-4 text-sm">
       <p className="font-medium text-foreground">
         <span className="font-semibold">Answer:</span> {question.answer}
       </p>
@@ -50,12 +51,38 @@ function RevealBody({ question }: { question: RecoveredQuestion }) {
 export function RecoveredDeck({ deck: initialDeck, dismissed: initialDismissed, rangeLabel }: Props) {
   const [deck, setDeck] = useState(initialDeck);
   const [dismissed, setDismissed] = useState(initialDismissed);
+  const [playing, setPlaying] = useState(false);
   const [index, setIndex] = useState(0);
   const [revealed, setRevealed] = useState(false);
   const [busy, setBusy] = useState(false);
 
-  const current = index < deck.length ? deck[index] : null;
-  const finished = deck.length > 0 && current === null;
+  const current = playing && index < deck.length ? (deck[index] ?? null) : null;
+
+  // The takeover owns the screen: no background scroll, Escape exits.
+  useEffect(() => {
+    if (!playing) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setPlaying(false);
+    }
+    document.addEventListener('keydown', onKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [playing]);
+
+  function start() {
+    setDeck((d) => shuffle(d)); // a fresh order every session
+    setIndex(0);
+    setRevealed(false);
+    setPlaying(true);
+  }
+
+  function exit() {
+    setPlaying(false);
+  }
 
   function next() {
     setRevealed(false);
@@ -109,57 +136,16 @@ export function RecoveredDeck({ deck: initialDeck, dismissed: initialDismissed, 
 
   return (
     <div className="mt-6">
-      {current ? (
-        <article className="card p-4">
-          <div className="flex items-baseline justify-between gap-3">
-            <p className="font-mono text-[0.62rem] uppercase tracking-[0.06em] text-muted-foreground">
-              {current.category}
-            </p>
-            <p className="font-mono text-[0.62rem] uppercase tracking-[0.06em] text-muted-foreground">
-              {index + 1} of {deck.length}
-            </p>
-          </div>
-
-          <p className="mt-2 font-serif text-lg font-medium leading-snug text-foreground">
-            {current.questionText}
+      {/* ── Landing ─────────────────────────────────────────────────────── */}
+      {deck.length > 0 ? (
+        <section className="card flex flex-col items-start gap-4 p-5">
+          <p className="text-sm text-muted-foreground">
+            <span className="font-semibold text-foreground">{deck.length}</span>
+            {deck.length === 1 ? ' question' : ' questions'} in circulation
+            {rangeLabel ? ` from the ${rangeLabel}` : ''}.
           </p>
-
-          {revealed ? (
-            <>
-              <RevealBody question={current} />
-              <div className="mt-4">
-                <button type="button" className="btn-primary" onClick={next}>
-                  Next
-                </button>
-              </div>
-            </>
-          ) : (
-            <div className="mt-4">
-              <button type="button" className="btn-primary" onClick={() => setRevealed(true)}>
-                Show answer
-              </button>
-            </div>
-          )}
-
-          <div className="mt-3 flex justify-end">
-            <button
-              type="button"
-              onClick={dismissCurrent}
-              disabled={busy}
-              className="inline-flex items-center gap-1.5 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
-            >
-              <ArrowDownToLine className="size-3.5" aria-hidden="true" />
-              Dismiss
-            </button>
-          </div>
-        </article>
-      ) : finished ? (
-        <section className="flex min-h-48 flex-col items-center justify-center gap-4 text-center text-sm text-muted-foreground">
-          <p>
-            That&rsquo;s all {deck.length} of them — every one a question you turned around.
-          </p>
-          <button type="button" className="btn-primary" onClick={goAgain}>
-            Shuffle and go again
+          <button type="button" className="btn-primary w-full sm:w-auto" onClick={start}>
+            Start revisiting
           </button>
         </section>
       ) : (
@@ -174,6 +160,7 @@ export function RecoveredDeck({ deck: initialDeck, dismissed: initialDismissed, 
         </section>
       )}
 
+      {/* ── Dismissed shelf ─────────────────────────────────────────────── */}
       {dismissed.length > 0 ? (
         <details className="group mt-10">
           <summary className="cursor-pointer select-none list-none font-mono text-[0.62rem] uppercase tracking-[0.06em] text-muted-foreground underline-offset-2 hover:text-foreground [&::-webkit-details-marker]:hidden">
@@ -214,6 +201,96 @@ export function RecoveredDeck({ deck: initialDeck, dismissed: initialDismissed, 
             ))}
           </section>
         </details>
+      ) : null}
+
+      {/* ── Full-screen review mode ─────────────────────────────────────── */}
+      {playing ? (
+        <div
+          className="fixed inset-0 z-[70] flex flex-col bg-background"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Revisit review"
+        >
+          <header
+            className="flex items-center justify-between border-b px-4 py-2"
+            style={{ paddingTop: 'max(0.5rem, env(safe-area-inset-top))' }}
+          >
+            <p className="font-mono text-[0.62rem] uppercase tracking-[0.06em] text-muted-foreground">
+              {current ? `${index + 1} of ${deck.length}` : 'Revisit'}
+            </p>
+            <button type="button" className="btn-icon" aria-label="Exit review" onClick={exit}>
+              <X className="size-5" aria-hidden="true" />
+            </button>
+          </header>
+
+          <div className="flex-1 overflow-y-auto px-5 py-8">
+            {current ? (
+              <div className="mx-auto max-w-2xl">
+                <p className="font-mono text-[0.62rem] uppercase tracking-[0.06em] text-muted-foreground">
+                  {current.category}
+                </p>
+                <p className="mt-3 font-serif text-2xl font-medium leading-snug text-foreground">
+                  {current.questionText}
+                </p>
+                {revealed ? <RevealBody question={current} /> : null}
+                <div className="mt-8">
+                  <button
+                    type="button"
+                    onClick={dismissCurrent}
+                    disabled={busy}
+                    className="inline-flex items-center gap-1.5 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
+                  >
+                    <ArrowDownToLine className="size-3.5" aria-hidden="true" />
+                    Dismiss — take it out of circulation
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex h-full items-center justify-center text-center text-sm text-muted-foreground">
+                {deck.length > 0
+                  ? `That’s all ${deck.length} of them — every one a question you turned around.`
+                  : 'Nothing left in circulation — everything here is dismissed.'}
+              </div>
+            )}
+          </div>
+
+          {/* Sticky action bar — the two buttons never move. */}
+          <footer
+            className="border-t bg-background px-4 pt-3"
+            style={{ paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom))' }}
+          >
+            <div className="mx-auto grid max-w-2xl grid-cols-2 gap-3">
+              {current ? (
+                <>
+                  <button
+                    type="button"
+                    className="btn-ghost min-h-12"
+                    onClick={() => setRevealed((r) => !r)}
+                  >
+                    {revealed ? 'Hide answer' : 'Show answer'}
+                  </button>
+                  <button type="button" className="btn-primary" onClick={next}>
+                    Next
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    className="btn-ghost min-h-12"
+                    onClick={goAgain}
+                    disabled={deck.length === 0}
+                  >
+                    Go again
+                  </button>
+                  <button type="button" className="btn-primary" onClick={exit}>
+                    Done
+                  </button>
+                </>
+              )}
+            </div>
+          </footer>
+        </div>
       ) : null}
     </div>
   );

--- a/src/components/recovered/__tests__/RecoveredDeck.test.tsx
+++ b/src/components/recovered/__tests__/RecoveredDeck.test.tsx
@@ -4,14 +4,14 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { RecoveredDeck } from '../RecoveredDeck';
 import type { RecoveredQuestion } from '@/server/db/queries/recovered-questions';
 
-// D-REVIEW-RECOVERED-01 (Decision B + revised C) — the one-at-a-time deck.
-// SSR-renderable assertions (initial state only; interaction is client-side):
-//   - exactly ONE deck question is visible at a time, with a position counter;
-//   - the answer is NOT in the initial markup (revealed on demand — no-check
-//     reveal, no form, no grading);
+// D-REVIEW-RECOVERED-01 (Decision B + revised C) — landing + full-screen mode.
+// SSR-renderable assertions (initial state only; the takeover itself is
+// client-side interaction):
+//   - the page lands on a count + Start CTA, with NO question text and no
+//     answers in the initial markup (questions are dealt inside the mode);
 //   - dismissed questions live on a collapsed shelf with a Restore action;
 //   - the three empty registers (cold start / bounded range / all dismissed)
-//     each render their own copy.
+//     each render their own copy, and Start disappears with an empty deck.
 
 function question(over: Partial<RecoveredQuestion> = {}): RecoveredQuestion {
   return {
@@ -33,8 +33,8 @@ const DECK = [
   question({ id: 'me-2', questionId: 'q-2', questionText: 'Largest planet?', answer: 'Jupiter' }),
 ];
 
-describe('RecoveredDeck — one at a time', () => {
-  it('shows only the first question, a counter, and no answer or form up front', () => {
+describe('RecoveredDeck — landing', () => {
+  it('shows the circulation count and Start, with no question or answer up front', () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
 
@@ -42,20 +42,25 @@ describe('RecoveredDeck — one at a time', () => {
       <RecoveredDeck deck={DECK} dismissed={[]} rangeLabel={null} />,
     );
 
-    expect(html).toContain('Who wrote the Storia d’Italia?');
-    expect(html).not.toContain('Largest planet?'); // one at a time
-    expect(html).toContain('1 of 2');
-    expect(html).toContain('Show answer');
-    expect(html).toContain('Dismiss');
+    expect(html).toContain('questions in circulation');
+    expect(html).toContain('Start revisiting');
 
-    // No-check reveal: the answer arrives only when asked for, and nothing is
-    // graded — no form, no input, no network call on first paint.
+    // Questions are dealt inside the full-screen mode, not on the landing.
+    expect(html).not.toContain('Who wrote the Storia d’Italia?');
+    expect(html).not.toContain('Largest planet?');
     expect(html).not.toContain('Francesco Guicciardini');
     expect(html).not.toContain('<form');
     expect(html).not.toContain('<input');
     expect(fetchSpy).not.toHaveBeenCalled();
 
     vi.unstubAllGlobals();
+  });
+
+  it('names the active range in the count line', () => {
+    const html = renderToStaticMarkup(
+      <RecoveredDeck deck={DECK} dismissed={[]} rangeLabel="past week" />,
+    );
+    expect(html).toContain('from the past week');
   });
 
   it('lists dismissed questions on a collapsed shelf with a Restore action', () => {
@@ -85,10 +90,13 @@ describe('RecoveredDeck — one at a time', () => {
     );
     expect(html).not.toContain('Dismissed (');
   });
+});
 
+describe('RecoveredDeck — empty registers', () => {
   it('renders the cold-start register when there is nothing at all', () => {
     const html = renderToStaticMarkup(<RecoveredDeck deck={[]} dismissed={[]} rangeLabel={null} />);
     expect(html).toContain('will gather here as you play');
+    expect(html).not.toContain('Start revisiting');
   });
 
   it('renders the bounded-empty register when a range window comes up empty', () => {


### PR DESCRIPTION
Reworks the Revisit surface (`/recovered`, "The ones you turned around") from a recency-ordered card list into a full-screen, one-at-a-time review mode.

## What changed

- **Landing page**: `/recovered` now shows a how-far-back filter (past week / month / 3 months / year / all time, via a `?range=` search param), the count of questions in circulation for that window, a **Start revisiting** button, and the dismissed shelf.
- **Full-screen review mode**: Start opens a takeover that covers the whole screen — position counter top left, Cancel (X) top right (Escape works too), background scroll locked. Questions are dealt one at a time in a random order (fresh shuffle per session).
- **Sticky bottom actions**: a fixed two-button bar — **Show/Hide answer** and **Next** — that never moves, with safe-area inset padding. The question and revealed answer scroll independently between header and bar.
- **Dismiss / restore**: a plain text link inside the mode takes the current question out of circulation (reuses the existing `/api/recovered/set-aside` route). The **Dismissed (N)** shelf on the landing lists everything dismissed — always all-time, so a range filter never hides a dismissal — each with an answer reveal and a Restore action. End of deck shows **Go again / Done** in the same two button slots.
- **Query**: `getRecoveredQuestionsForUser` now returns `{ deck, dismissed }` — deck shuffled (Fisher–Yates) and bounded by `withinDays`; dismissed kept recency-ordered and unbounded. Still read-only; dismiss/restore remain the surface's only writes.
- **Dev-server fix (drive-by)**: reworded literal `rounded-[…]` radius-token strings in `CLAUDE.md`, `scripts/check-radius-ratchet.mjs`, and the radius-ratchet workflow comments — Tailwind v4 scans every non-gitignored file, and the `*` inside those literals compiled into invalid CSS that 500'd every page in `next dev` (production builds unaffected). Also adds `.claude/skills/verify/SKILL.md` documenting the local-run recipe (local Postgres, migration quirks, session minting).

`RecoveredCard` and `SetAsideButton` are superseded by the `RecoveredDeck` client island.

## Testing

- Unit: 20 tests pass (query pool definition, deck/dismissed split, range bounding, shuffle; landing/empty-state SSR renders). Typecheck, lint, and all four design ratchets clean.
- Runtime: drove the full flow in a browser against a seeded local Postgres — start → reveal → next → dismiss inside the mode (DB row written) → restore from the shelf (row reinstated) → end-of-deck → go again → Escape back to the landing. Verified the bottom bar's pixel position is identical before reveal, after reveal, and after advancing, and that dev compiles with no CSS parse errors and no scan workarounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sodjzgVcHf6Yb4VUCDnbb

---
_Generated by [Claude Code](https://claude.ai/code/session_019sodjzgVcHf6Yb4VUCDnbb)_