### PR TITLE
Revisit mode: flag a question via the existing report flow

### DIFF
--- a/src/app/api/content-reports/__tests__/route.test.ts
+++ b/src/app/api/content-reports/__tests__/route.test.ts
@@ -131,6 +131,14 @@ describe('POST /api/content-reports', () => {
     expect(insertContentReportMock).not.toHaveBeenCalled();
   });
 
+  it('accepts the recovered review surface', async () => {
+    const res = await post({ ...validIncorrect, surface: 'recovered' });
+    expect(res.status).toBe(200);
+    expect(insertContentReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({ surface: 'recovered' }),
+    );
+  });
+
   it('soft-429s at the daily cap without writing', async () => {
     countContentReportsTodayMock.mockResolvedValueOnce(10);
     const res = await post(validIncorrect);

--- a/src/app/api/content-reports/route.ts
+++ b/src/app/api/content-reports/route.ts
@@ -30,7 +30,7 @@ const incorrectSchema = z.object({
   incorrectKind: z.enum(['answer_key', 'premise']),
   note: z.string().trim().min(1),
   suggestedAnswer: z.string().trim().min(1).optional(),
-  surface: z.enum(['round_recap', 'lately_result', 'answered_list', 'feed']),
+  surface: z.enum(['round_recap', 'lately_result', 'answered_list', 'feed', 'recovered']),
   ...target,
 });
 
@@ -42,7 +42,7 @@ const inappropriateSchema = z.object({
   incorrectKind: z.undefined().optional(),
   suggestedAnswer: z.undefined().optional(),
   note: z.string().trim().min(1),
-  surface: z.enum(['round_recap', 'lately_result', 'answered_list', 'feed']),
+  surface: z.enum(['round_recap', 'lately_result', 'answered_list', 'feed', 'recovered']),
   ...target,
 });
 

--- a/src/components/questions/AnsweredRowActions.tsx
+++ b/src/components/questions/AnsweredRowActions.tsx
@@ -17,7 +17,7 @@ export function AnsweredRowActions({
   onReportSubmitted,
 }: {
   target: ReportReasonTarget;
-  surface?: 'round_recap' | 'lately_result' | 'answered_list';
+  surface?: 'round_recap' | 'lately_result' | 'answered_list' | 'recovered';
   // Optional: fires once on a successful report so a surface can react (e.g. the
   // round-recap hides a card reported as inappropriate, matching daily-summary).
   // The answered-list caller omits it and the menu just closes, as before.

--- a/src/components/recovered/RecoveredDeck.tsx
+++ b/src/components/recovered/RecoveredDeck.tsx
@@ -3,6 +3,7 @@
 import { Undo2, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
+import { AnsweredRowActions } from '@/components/questions/AnsweredRowActions';
 import type { RecoveredQuestion } from '@/server/db/queries/recovered-questions';
 
 /**
@@ -218,9 +219,30 @@ export function RecoveredDeck({ deck: initialDeck, dismissed: initialDismissed, 
             <p className="font-mono text-[0.62rem] uppercase tracking-[0.06em] text-muted-foreground">
               {current ? `${index + 1} of ${deck.length}` : 'Revisit'}
             </p>
-            <button type="button" className="btn-icon" aria-label="Exit review" onClick={exit}>
-              <X className="size-5" aria-hidden="true" />
-            </button>
+            <div className="flex items-center gap-1">
+              {current ? (
+                // The same ⋯ report menu the answered list and round recap use
+                // ("This is incorrect" / "This is inappropriate" → the shared
+                // ReportReasonSheet). Keyed by the card so menu/sheet state
+                // never carries over to the next question. A card reported as
+                // inappropriate vanishes from the session (matching the recap);
+                // an incorrect one stays — the sheet acknowledges quietly.
+                <AnsweredRowActions
+                  key={current.id}
+                  target={{ questionId: current.questionId }}
+                  surface="recovered"
+                  onReportSubmitted={(category) => {
+                    if (category !== 'inappropriate') return;
+                    const reported = current;
+                    setDeck((d) => d.filter((q) => q.id !== reported.id));
+                    setRevealed(false);
+                  }}
+                />
+              ) : null}
+              <button type="button" className="btn-icon" aria-label="Exit review" onClick={exit}>
+                <X className="size-5" aria-hidden="true" />
+              </button>
+            </div>
           </header>
 
           <div className="flex-1 overflow-y-auto px-5 py-8">

--- a/src/components/report/ReportReasonSheet.tsx
+++ b/src/components/report/ReportReasonSheet.tsx
@@ -28,7 +28,7 @@ export function ReportReasonSheet({
 }: {
   category: ReportCategory
   target: ReportReasonTarget
-  surface: 'round_recap' | 'lately_result' | 'answered_list' | 'feed'
+  surface: 'round_recap' | 'lately_result' | 'answered_list' | 'feed' | 'recovered'
   onClose: () => void
   // Fires once on a successful submit (including an idempotent duplicate). For
   // 'inappropriate' the parent removes the card from view; for 'incorrect' the card

--- a/src/server/db/queries/content-reports.ts
+++ b/src/server/db/queries/content-reports.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, gte, inArray, isNull, ne, notExists, or, sql } from
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 
 import { contentReports, db, generatedQuestions, questions, users } from '@/server/db';
+import { pgErrorCode } from '@/server/db/pg-error';
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { type QuestionSource, resolveAuthorDisplay } from '@/lib/questions-types';
 
@@ -34,16 +35,15 @@ export type InsertContentReportInput = {
 export type InsertContentReportResult = 'inserted' | 'duplicate';
 
 // Postgres unique_violation. The ContentReport_one_open_per_{question,generated_question}
-// partial unique indexes raise this when an open report already exists.
+// partial unique indexes raise this when an open report already exists. Read via
+// pgErrorCode: drizzle wraps the pg error in a DrizzleQueryError whose `.code`
+// describes the wrapper — the Postgres code sits on `.cause`, so checking
+// `err.code` directly turned every idempotent re-report into a 500 instead of
+// the documented quiet 'duplicate' success.
 const PG_UNIQUE_VIOLATION = '23505';
 
 function isUniqueViolation(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'code' in err &&
-    (err as { code?: unknown }).code === PG_UNIQUE_VIOLATION
-  );
+  return pgErrorCode(err) === PG_UNIQUE_VIOLATION;
 }
 
 export async function insertContentReport(


### PR DESCRIPTION
Follow-up to #1498 (this commit landed on the branch just after that PR merged).

## What changed

- **Flag a question from the review mode**: the full-screen Revisit takeover now carries the same ⋯ actions menu used on the answered list and round recap — "This is incorrect" / "This is inappropriate" → the shared `ReportReasonSheet` → `/api/content-reports`. Reports land with a new `recovered` surface value (plain text column — no migration). A card reported as inappropriate vanishes from the session, matching the recap; an incorrect one stays. The menu is keyed per card so sheet state never leaks across questions.
- **Fixes a latent duplicate-report 500 on every report surface**: `insertContentReport` checked `err.code` directly, but drizzle wraps pg errors in a `DrizzleQueryError` whose Postgres code sits on `.cause` — so the documented idempotent re-report path (submitting against a question that already has your open report) returned 500 instead of the quiet duplicate success. Now reads through the existing `pgErrorCode` helper.

## Testing

- Unit: route test added for the `recovered` surface; existing content-report and recovered-deck suites pass. Typecheck and lint clean.
- Runtime: drove both flows in a browser against a seeded local Postgres — the incorrect path lands a `ContentReport` row (category, kind, note, suggested answer, `surface='recovered'`) and the card stays; the inappropriate path lands its row and the card vanishes in place (deck counter 1 of 4 → 1 of 3) with the sticky bottom bar intact; re-reporting the same question now returns 200/duplicate instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sodjzgVcHf6Yb4VUCDnbb

---
_Generated by [Claude Code](https://claude.ai/code/session_019sodjzgVcHf6Yb4VUCDnbb)_