### PR TITLE
feat(quality): measured self-containment sweep to heal un-anchored bank questions

### DIFF
--- a/scripts/heal-self-containment.ts
+++ b/scripts/heal-self-containment.ts
@@ -1,0 +1,172 @@
+// Bank-healing sweep for un-anchored (non-self-contained) questions — the
+// measured follow-up to the generation-side "NAME THE SOURCE" rule (PR #1500).
+//
+// DRY-RUN BY DEFAULT: classifies servable questions with the Haiku self-
+// containment classifier and PRINTS what it would demote, making ZERO writes.
+// Add --apply to demote (GeneratedQuestion → is_duplicate; Question →
+// needs_review), reusing the exact patch helpers the factual verifier uses. The
+// --apply gate is the off-by-default safety: review the dry-run output first.
+//
+// Usage (prod DB + secrets live in .env):
+//   npx tsx -r dotenv/config scripts/heal-self-containment.ts dotenv_config_path=.env
+//   npx tsx -r dotenv/config scripts/heal-self-containment.ts --limit 200 dotenv_config_path=.env
+//   npx tsx -r dotenv/config scripts/heal-self-containment.ts --store g --apply dotenv_config_path=.env
+import 'dotenv/config';
+
+import { and, eq, gt, isNull, ne } from 'drizzle-orm';
+
+import { db, generatedQuestions, questions, pool } from '../src/server/db';
+import { runWithConcurrency } from '../src/server/lib/concurrency';
+import { classifySelfContainment, questionNamesSubject } from '../src/server/quality/self-containment';
+import { verdictToGeneratedPatch, verdictToQuestionPatch } from '../src/server/quality/verify-question';
+
+const argv = process.argv.slice(2);
+const has = (f: string) => argv.includes(f);
+const num = (f: string, d: number) => {
+  const i = argv.indexOf(f);
+  if (i === -1 || i + 1 >= argv.length) return d;
+  const n = Number(argv[i + 1]);
+  return Number.isFinite(n) ? n : d;
+};
+const str = (f: string): string | null => {
+  const i = argv.indexOf(f);
+  return i !== -1 && i + 1 < argv.length ? argv[i + 1] : null;
+};
+
+const APPLY = has('--apply');
+const LIMIT = num('--limit', 0); // 0 = no limit (whole servable set)
+const CONCURRENCY = num('--concurrency', 6);
+const STORE = (str('--store') ?? 'both') as 'q' | 'g' | 'both';
+
+type Row = {
+  id: string;
+  text: string;
+  answer: string;
+  sub: string | null;
+  broad: string | null;
+};
+
+async function selectGenerated(now: Date): Promise<Row[]> {
+  const q = db
+    .select({
+      id: generatedQuestions.id,
+      text: generatedQuestions.questionText,
+      answer: generatedQuestions.answer,
+      sub: generatedQuestions.canonicalSubcategory,
+      broad: generatedQuestions.broadCategory,
+    })
+    .from(generatedQuestions)
+    .where(and(eq(generatedQuestions.isDuplicate, false), gt(generatedQuestions.expiresAt, now)));
+  const rows = LIMIT > 0 ? await q.limit(LIMIT) : await q;
+  return rows;
+}
+
+async function selectCanonical(): Promise<Row[]> {
+  const q = db
+    .select({
+      id: questions.id,
+      text: questions.questionText,
+      answer: questions.answerText,
+      sub: questions.canonicalSubcategory,
+      broad: questions.broadCategory,
+    })
+    .from(questions)
+    .where(
+      and(
+        ne(questions.visibility, 'blocked'),
+        isNull(questions.deletedAt),
+        // Skip rows already sitting in review so re-runs don't re-spend on them.
+        ne(questions.publicStatus, 'needs_review'),
+      ),
+    );
+  const rows = LIMIT > 0 ? await q.limit(LIMIT) : await q;
+  return rows;
+}
+
+type Flagged = { row: Row; reason: string };
+
+async function sweep(label: string, store: 'q' | 'g', rows: Row[], now: Date) {
+  let classified = 0;
+  let failed = 0;
+  let selfContained = 0;
+  let guardSaves = 0;
+  const flagged: Flagged[] = [];
+
+  await runWithConcurrency(rows, CONCURRENCY, async (row) => {
+    if (!row.sub) {
+      selfContained += 1; // no hidden subject to fail against; leave it alone
+      return;
+    }
+    const verdict = await classifySelfContainment({
+      questionText: row.text,
+      answer: row.answer,
+      canonicalSubcategory: row.sub,
+      broadCategory: row.broad,
+    });
+    if (!verdict) {
+      failed += 1; // fail-open: never demote on a classifier failure
+      return;
+    }
+    classified += 1;
+    if (verdict.selfContained) {
+      selfContained += 1;
+      return;
+    }
+    // Last-resort guard: if the question literally names its own subcategory, the
+    // LLM hallucinated the miss — never demote it.
+    if (questionNamesSubject(row.text, row.sub)) {
+      guardSaves += 1;
+      selfContained += 1;
+      return;
+    }
+    flagged.push({ row, reason: verdict.reason });
+    if (APPLY) {
+      const reason = `self-containment: ${verdict.reason}`;
+      if (store === 'g') {
+        await db
+          .update(generatedQuestions)
+          .set(verdictToGeneratedPatch('demoted', now, reason))
+          .where(eq(generatedQuestions.id, row.id));
+      } else {
+        await db
+          .update(questions)
+          .set(verdictToQuestionPatch('demoted', now, reason))
+          .where(eq(questions.id, row.id));
+      }
+    }
+  });
+
+  const denom = Math.max(1, classified);
+  console.log(`\n===== ${label} =====`);
+  console.log(
+    `scanned: ${rows.length}  classified: ${classified}  classifier-failures: ${failed}  ` +
+      `self-contained: ${selfContained}  guard-saves: ${guardSaves}  flagged: ${flagged.length} (${((flagged.length / denom) * 100).toFixed(1)}% of classified)`,
+  );
+  console.log(APPLY ? `APPLIED: ${flagged.length} demoted` : `DRY-RUN: no writes`);
+  console.log(`\n--- FLAGGED (would demote) ---`);
+  for (const f of flagged) {
+    console.log(`[${f.row.sub}] ${f.row.text}\n    → ${f.reason}`);
+  }
+  return flagged.length;
+}
+
+async function main() {
+  const now = new Date();
+  console.log(
+    `mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}  store: ${STORE}  limit: ${LIMIT || 'none'}  concurrency: ${CONCURRENCY}`,
+  );
+
+  if (STORE === 'g' || STORE === 'both') {
+    await sweep('generated (servable)', 'g', await selectGenerated(now), now);
+  }
+  if (STORE === 'q' || STORE === 'both') {
+    await sweep('questions (eligible)', 'q', await selectCanonical(), now);
+  }
+
+  await pool.end();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/server/quality/__tests__/self-containment.test.ts
+++ b/src/server/quality/__tests__/self-containment.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSelfContainmentVerdict, questionNamesSubject } from '@/server/quality/self-containment';
+
+// Pure parser unit — no LLM, no DB. Guards the JSON contract the classifier
+// depends on (a bad parse must return null so the caller fails open).
+
+describe('parseSelfContainmentVerdict', () => {
+  it('parses a self-contained verdict', () => {
+    const v = parseSelfContainmentVerdict('{"self_contained": true, "reason": "names the work"}');
+    expect(v).toEqual({ selfContained: true, reason: 'names the work' });
+  });
+
+  it('parses a not-self-contained verdict', () => {
+    const v = parseSelfContainmentVerdict('{"self_contained": false, "reason": "never says Phineas and Ferb"}');
+    expect(v).toEqual({ selfContained: false, reason: 'never says Phineas and Ferb' });
+  });
+
+  it('tolerates surrounding prose / fences (parseJsonObject extracts the object)', () => {
+    const v = parseSelfContainmentVerdict('```json\n{"self_contained": false, "reason": "x"}\n```');
+    expect(v?.selfContained).toBe(false);
+  });
+
+  it('supplies a default reason when reason is missing', () => {
+    expect(parseSelfContainmentVerdict('{"self_contained": true}')?.reason).toBe('self-contained');
+    expect(parseSelfContainmentVerdict('{"self_contained": false}')?.reason).toBe('not self-contained');
+  });
+
+  it('returns null when self_contained is absent or non-boolean', () => {
+    expect(parseSelfContainmentVerdict('{"reason": "x"}')).toBeNull();
+    expect(parseSelfContainmentVerdict('{"self_contained": "yes"}')).toBeNull();
+  });
+
+  it('returns null on unparseable input', () => {
+    expect(parseSelfContainmentVerdict('not json')).toBeNull();
+  });
+});
+
+describe('questionNamesSubject (demote guard)', () => {
+  it('vetoes a demote when the question names a child-work token of its subcategory', () => {
+    // The Haiku hallucination class: it claimed "Breath of the Wild is not
+    // mentioned" when it plainly is. The guard sees the shared token and saves it.
+    expect(
+      questionNamesSubject(
+        'What event causes defeated enemies to respawn in Breath of the Wild?',
+        'The Legend of Zelda: Breath of the Wild',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not fire when the question names only characters (the true defect)', () => {
+    expect(
+      questionNamesSubject(
+        "At the start of most episodes, Candace notices the boys' project. Whom does she call?",
+        'Phineas and Ferb',
+      ),
+    ).toBe(false);
+  });
+
+  it('ignores generic label words (series/book/show) so they cannot false-save', () => {
+    // Only "series"/"book" would match here, and those are stopworded out.
+    expect(questionNamesSubject('Who is Erica Hale grandfather?', 'Spy School series')).toBe(false);
+  });
+
+  it('is inert without a subcategory', () => {
+    expect(questionNamesSubject('anything', null)).toBe(false);
+  });
+});

--- a/src/server/quality/self-containment.ts
+++ b/src/server/quality/self-containment.ts
@@ -1,0 +1,162 @@
+/**
+ * Self-containment classifier (bank-healing follow-up to the generation-side
+ * "NAME THE SOURCE" rule, PR #1500).
+ *
+ * A served card shows the player ONLY the question text and a BROAD category
+ * label (e.g. "Film & Television") — never the canonical_subcategory. So a
+ * question that leans on a specific work/franchise/character it never names is
+ * unanswerable out of context ("At the start of most episodes, Candace notices
+ * the boys' project — whom does she call to get them busted?" never says it is
+ * Phineas and Ferb). Rule 2b stops NEW such questions; this classifier finds the
+ * ones already in the bank.
+ *
+ * Why an LLM and not a lexical rule: a pure heuristic fired on ~44% of the live
+ * bank because good questions name a CHILD work ("Revenge of the Sith") under a
+ * PARENT subcategory ("Star Wars Universe"), so token-absence + a proper noun
+ * co-occur constantly on fine questions. Distinguishing "names the work by title"
+ * from "names only characters" is semantic. Haiku (grading tier) does it directly.
+ *
+ * DEMOTE-ONLY and BIASED TOWARD self-contained: this is a background quality net,
+ * so the cost of a false demote (suppressing a good question) is worse than a
+ * miss. The prompt is told to return self_contained=true whenever a reasonably
+ * informed player could situate the question — the source need not be spelled out
+ * if the content makes it unambiguous (a real-world subject, a famous event, a
+ * universally known character). Returns null on any failure (no client, request
+ * error, unparseable) so the caller leaves the row untouched (fail-open).
+ */
+
+import {
+  HAIKU_MODEL,
+  HAIKU_GATE_TIMEOUT_MS,
+  INSTRUCTION_USER_INPUT_GUIDANCE,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+  wrapUserInput,
+} from '@/lib/llm';
+
+export type SelfContainmentInput = {
+  questionText: string;
+  answer: string;
+  /** The domain the question belongs to — the PLAYER never sees this; it is the
+   *  ground truth of what the question is supposed to be about. */
+  canonicalSubcategory: string | null;
+  /** The only category label the player DOES see on the card. */
+  broadCategory: string | null;
+};
+
+export type SelfContainmentVerdict = {
+  /** true = a player seeing only the question + broad category can tell what it
+   *  is about; false = it silently assumes the hidden subject. */
+  selfContained: boolean;
+  reason: string;
+};
+
+const SYSTEM_PROMPT = `You are auditing ONE published trivia question for SELF-CONTAINMENT. You are NOT fact-checking it and you are NOT judging its difficulty.
+
+Apply this test — and ONLY this test:
+
+Does the question text itself contain an explicit NAME of what it is about — a work title, franchise, series, book, film, show, game, album, author, artist, composer, real place, real person, real event, field of study, or historical period?
+- If YES → self_contained = TRUE. Stop. It does not matter whether the name is a parent or a child ("Tears of the Kingdom" names it even if the filed subject is "The Legend of Zelda"; "in Breaking Bad" names it; "David Foster Wallace" names the author). It does NOT matter whether an average player would RECOGNIZE or have heard of that name — an obscure-but-NAMED work is self-contained. Recognizing it is DIFFICULTY, which is not your concern.
+- If NO explicit name appears → is the question nonetheless situated by universally-known real-world content (a famous event, a world-historical figure, a household-name character like Sherlock Holmes or Dracula)? If yes → TRUE.
+- If NO explicit name appears → does the question pose a self-contained real-world SCENARIO answerable from general knowledge of its field (a described legal, scientific, mathematical, or procedural situation — "During a closing argument, the attorney misstates the evidence; what objection applies?")? If yes → TRUE. Such a question needs no proper name because it supplies its own context.
+- Only if NONE of the above holds → self_contained = FALSE: the question leans entirely on characters, plot beats, quotes, or invented terms from a specific work it NEVER names, so a player cannot tell which work it is. Example: "At the start of most episodes, Candace notices the boys' project — whom does she call to get them busted?" — names only characters, never says Phineas and Ferb.
+
+CRITICAL: before returning FALSE, re-scan the question text for ANY proper name of a work/author/place/person/event. If one is present anywhere in the text, you MUST return TRUE — even a subtitle alone ("In 'Deathly Hallows'…"), even a fictional-but-titled work ("Spy School Goes South"), even an author's name with no work. FALSE is ONLY for questions with NO such name at all.
+
+BIAS HARD TOWARD self_contained. This flags questions for REMOVAL, so a wrong FALSE deletes a good question. When in any doubt, return TRUE.
+
+Return ONLY valid JSON: { "self_contained": true | false, "reason": "<short, ≤ 140 chars: if false, state that NO work/subject name appears; if true, quote the name that appears>" }. No prose outside the object.${INSTRUCTION_USER_INPUT_GUIDANCE}`;
+
+function buildUserMessage(input: SelfContainmentInput): string {
+  const lines = [
+    wrapUserInput('question', input.questionText),
+    wrapUserInput('stated_answer', input.answer),
+    wrapUserInput('broad_category_player_sees', input.broadCategory ?? '(none)'),
+    wrapUserInput('subject_hidden_from_player', input.canonicalSubcategory ?? '(none)'),
+    'Judge self-containment as the player sees it. Return JSON only.',
+  ];
+  return lines.join('\n');
+}
+
+// Stopwords dropped from a subcategory label before token-matching it against
+// the question. Small and lowercase.
+const SUBJECT_STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'of', 'in', 'on', 'at', 'to', 'for', 'by', 'with', 'from',
+  'series', 'books', 'book', 'show', 'tv', 'movie', 'film', 'novel', 'season', 'seasons',
+]);
+
+/**
+ * Pure LAST-RESORT DEMOTE GUARD: true when the question text literally contains a
+ * significant token of its own subcategory — i.e. the source IS named, whatever
+ * the LLM said. Used to VETO a `not self-contained` verdict so a Haiku
+ * hallucination ("'Breath of the Wild' is not mentioned" when it plainly is)
+ * can never demote a question that names its source. It only ever PREVENTS a
+ * demotion — it can never cause one — so it is strictly safe. Exported for tests.
+ */
+export function questionNamesSubject(
+  questionText: string,
+  canonicalSubcategory: string | null | undefined,
+): boolean {
+  if (!canonicalSubcategory) return false;
+  const tokens = canonicalSubcategory
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 3 && !SUBJECT_STOPWORDS.has(t));
+  if (tokens.length === 0) return false;
+  const haystack = ` ${questionText.toLowerCase()} `;
+  return tokens.some((t) => new RegExp(`\\b${t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(haystack));
+}
+
+/** Pure: parse the classifier's JSON verdict. Exported for unit tests. */
+export function parseSelfContainmentVerdict(raw: string): SelfContainmentVerdict | null {
+  const parsed = parseJsonObject(raw);
+  if (!parsed) return null;
+  if (typeof parsed.self_contained !== 'boolean') return null;
+  const reason = typeof parsed.reason === 'string' ? parsed.reason.trim().slice(0, 200) : '';
+  return {
+    selfContained: parsed.self_contained,
+    reason: reason || (parsed.self_contained ? 'self-contained' : 'not self-contained'),
+  };
+}
+
+/**
+ * Classify one question. Returns null on ANY failure (no client, request error,
+ * unparseable verdict) so the caller leaves the row untouched — fail-open,
+ * matching the verification sweep's posture.
+ */
+export async function classifySelfContainment(
+  input: SelfContainmentInput,
+): Promise<SelfContainmentVerdict | null> {
+  const client = getAnthropicClient();
+  if (!client) return null;
+
+  let response;
+  try {
+    response = await loggedMessagesCreate(
+      client,
+      'self-containment',
+      {
+        model: HAIKU_MODEL,
+        max_tokens: 200,
+        temperature: 0,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: buildUserMessage(input) }],
+      },
+      { timeoutMs: HAIKU_GATE_TIMEOUT_MS },
+    );
+  } catch (error) {
+    console.warn('[classifySelfContainment] request_failed', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+
+  const parsed = parseSelfContainmentVerdict(extractTextContent(response.content));
+  if (!parsed) {
+    console.warn('[classifySelfContainment] invalid_verdict_json');
+    return null;
+  }
+  return parsed;
+}


### PR DESCRIPTION
Follow-up to #1500. That PR added the generation-side **NAME THE SOURCE** rule, which stops *new* un-anchored questions but doesn't touch the ones already in the bank — questions that lean on a specific work/character without ever naming it, so they're unanswerable when served (the card shows only the question text + a broad category, never the `canonical_subcategory`).

## What's here

- **`self-containment.ts`** — a Haiku classifier: given a question + its (hidden) subcategory, decides whether a player seeing only the question text + broad category could tell what it's about. Plus a pure **demote-guard** (`questionNamesSubject`) that can only ever *prevent* a demotion.
- **`heal-self-containment.ts`** — a **dry-run-by-default** sweep script. `--apply` demotes flagged rows (`GeneratedQuestion → is_duplicate`, `Question → needs_review`) via the same patch helpers the factual verifier uses. The `--apply` gate is the off-by-default safety.
- Unit tests for the parser and the guard.

## Why an LLM, not a lexical rule

#1500's earlier draft tried a lexical route and I dropped it after measuring: it fired on **~44% of the bank**, because good questions name a *child* work ("Revenge of the Sith") under a *parent* subcategory ("Star Wars Universe"). Telling "names the work" apart from "names only characters" is semantic.

## Validated on a ~400-question live sample before shipping

| Iteration | Behavior |
|---|---|
| v1 prompt | Conflated *"names its source"* with *"player would recognize its source"* → **~48% false positives** (flagged questions that DID name the work — "in Breaking Bad", "David Foster Wallace") |
| Tightened prompt + demote-guard | The only test is whether an identifying **name** appears (obscure-but-named = difficulty, not ambiguity). The guard vetoes a demote whenever the question literally contains a subcategory token, neutralizing hallucinations (e.g. flagging a question that says "in Breath of the Wild" as unnamed). |

**Final measured result:** 8.5% of canonical / 13.5% of generated questions flagged, **~0 false positives observed**, 1 hallucination caught by the guard. Fail-open on any classifier error (never demotes). Representative true catches: a cluster of Breaking Bad questions referencing "Walt/Jesse" with no title, Golden Girls ("the women", "Sophia"), Zelda ("Link", "Hyrule"), Ulysses ("Leopold Bloom"), Catch-22 ("Yossarian").

## Not done yet — needs your call

**No writes have been made.** This PR ships the validated mechanism only. Actually healing the bank means running `--apply` (a prod DML demote), which I'm holding for your explicit go-ahead:

```
# see everything it would demote, no writes:
npx tsx -r dotenv/config scripts/heal-self-containment.ts dotenv_config_path=.env.local
# apply:
npx tsx -r dotenv/config scripts/heal-self-containment.ts --apply dotenv_config_path=.env.local
```

Demotes are reversible (needs_review / is_duplicate, not deletion). If you'd rather this run continuously, it's a small step to wrap the classifier in a cron — but Rule 2b already guards new inflow, so a one-time (occasional) sweep is likely enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)