### PR TITLE
fix(daily): honor Resting in custom mode and keep the Often boost alive

### DIFF
--- a/src/app/api/daily/preferences/domain-frequency/__tests__/route.test.ts
+++ b/src/app/api/daily/preferences/domain-frequency/__tests__/route.test.ts
@@ -78,12 +78,64 @@ describe('POST /api/daily/preferences/domain-frequency', () => {
 
     expect(response.status).toBe(200);
     // Canonical KB casing is used for the new entry; existing entries survive.
+    // Tagging a KB domain with an active frequency also enrolls it in the
+    // custom-mode selection (territory-model invariant: selectedDomains =
+    // every tagged, non-rested domain).
     expect(updateDailyPreferencesMock).toHaveBeenCalledWith('user-1', {
       domainPreferenceFrequency: { Dune: 'often', 'Harry Potter Book 3': 'blue_moon' },
+      selectedDomains: ['Dune', 'Harry Potter Book 3'],
     });
     const body = await response.json();
     expect(body.previousFrequency).toBeNull();
     expect(invalidateUntouchedDailyQueuesMock).toHaveBeenCalledWith('user-1');
+  });
+
+  it('resting removes the domain from the custom-mode selection', async () => {
+    const response = await POST(request({ domain: 'Dune', frequency: 'resting' }));
+
+    expect(response.status).toBe(200);
+    expect(updateDailyPreferencesMock).toHaveBeenCalledWith('user-1', {
+      domainPreferenceFrequency: { Dune: 'resting' },
+      selectedDomains: [],
+    });
+  });
+
+  it('undoing a rest (frequency null after resting) restores the domain to the selection', async () => {
+    getDailyPreferencesMock.mockResolvedValue({
+      userId: 'user-1',
+      difficulty: 'adaptive',
+      domainMode: 'custom',
+      // Dune was rested via this endpoint: tagged resting AND already out of the list.
+      selectedDomains: [],
+      domainPreferenceFrequency: { Dune: 'resting' },
+      updatedAt: null,
+    });
+
+    const response = await POST(request({ domain: 'Dune', frequency: null }));
+
+    expect(response.status).toBe(200);
+    expect(updateDailyPreferencesMock).toHaveBeenCalledWith('user-1', {
+      domainPreferenceFrequency: {},
+      selectedDomains: ['Dune'],
+    });
+  });
+
+  it('leaves selectedDomains untouched in random mode', async () => {
+    getDailyPreferencesMock.mockResolvedValue({
+      userId: 'user-1',
+      difficulty: 'adaptive',
+      domainMode: 'random',
+      selectedDomains: [],
+      domainPreferenceFrequency: {},
+      updatedAt: null,
+    });
+
+    const response = await POST(request({ domain: 'Dune', frequency: 'resting' }));
+
+    expect(response.status).toBe(200);
+    expect(updateDailyPreferencesMock).toHaveBeenCalledWith('user-1', {
+      domainPreferenceFrequency: { Dune: 'resting' },
+    });
   });
 
   it('captures the prior frequency case-insensitively', async () => {

--- a/src/app/api/daily/preferences/domain-frequency/route.ts
+++ b/src/app/api/daily/preferences/domain-frequency/route.ts
@@ -57,8 +57,36 @@ export async function POST(request: NextRequest) {
   }
   if (frequency) nextFrequencyByDomain[matched] = frequency;
 
+  // Keep selectedDomains in lockstep for custom-mode players. The territory-
+  // setup save derives selectedDomains = every tagged, non-rested domain; this
+  // endpoint must preserve that invariant or a domain rested here keeps
+  // competing for daily slots via the stale list (observed in prod 2026-07-12:
+  // two rested domains held ~6 core slots in a week). Resting removes the
+  // domain from the list; tagging it with any active frequency — or undoing a
+  // rest back to the default — restores it, provided it's a real KB domain.
+  let nextSelectedDomains: string[] | undefined;
+  if (preferences.domainMode === 'custom') {
+    const inSelection = preferences.selectedDomains.some(
+      (existing) => existing.toLowerCase() === domainKey,
+    );
+    if (frequency === 'resting' && inSelection) {
+      nextSelectedDomains = preferences.selectedDomains.filter(
+        (existing) => existing.toLowerCase() !== domainKey,
+      );
+    } else if (frequency !== 'resting' && !inSelection) {
+      const isKnownDomain = knowledgeBase.some(
+        (entry) => entry.domain.toLowerCase() === domainKey,
+      );
+      const shouldRestore = frequency !== null || previousFrequency === 'resting';
+      if (isKnownDomain && shouldRestore) {
+        nextSelectedDomains = [...preferences.selectedDomains, matched];
+      }
+    }
+  }
+
   const updated = await updateDailyPreferences(session.userId, {
     domainPreferenceFrequency: nextFrequencyByDomain,
+    ...(nextSelectedDomains ? { selectedDomains: nextSelectedDomains } : {}),
   });
 
   // Frequency is a question-defining input, so drop untouched pre-built queues;

--- a/src/server/daily/__tests__/domain-selection.test.ts
+++ b/src/server/daily/__tests__/domain-selection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { domainKey } from '@/lib/knowledge/domain-key';
 import {
+  domainFrequencyWeight,
   domainWeeklyCap,
   dropCappedDomains,
   selectCustomDomainsForRound,
@@ -142,6 +143,52 @@ describe('selectCustomDomainsForRound', () => {
     const out = selectCustomDomainsForRound(['A', 'B'], f, recentCounts, 2, seeded(3));
     expect(new Set(out)).toEqual(new Set(['A', 'B']));
   });
+
+  it('never picks a rested domain, even when it leaked into the selection', () => {
+    // Stray-row case (prod 2026-07-12): a domain tagged 'resting' still present
+    // in selectedDomains must never win a draw — no starvation fallback.
+    const f = { Rested: 'resting', Open: 'blue_moon' };
+    for (let i = 0; i < 100; i += 1) {
+      const out = selectCustomDomainsForRound(['Rested', 'Open'], f, new Map(), 2, seeded(i + 1));
+      expect(out).toEqual(['Open']);
+    }
+  });
+
+  it('returns [] when every selected domain is rested (caller owns the fallback)', () => {
+    const f = { A: 'resting', B: 'resting' };
+    expect(selectCustomDomainsForRound(['A', 'B'], f, new Map(), 2, seeded(1))).toEqual([]);
+  });
+
+  it('keeps an often domain ahead of a fresh sometimes domain after a few serves (tier-scaled damping)', () => {
+    // Regression for the flat 1/(1+recent) damping: Often with 3 recent
+    // questions used to weigh 1.0 vs a fresh Sometimes at 2.0 and lose ~2:1.
+    // Tier-scaled damping keeps it at 16/7 ≈ 2.3 vs 2.0 — a slight favorite.
+    const f = { Often: 'often', FreshSometimes: 'sometimes' };
+    const recentCounts = recent({ Often: 3 });
+    let oftenFirst = 0;
+    const TRIALS = 3000;
+    for (let i = 0; i < TRIALS; i += 1) {
+      const [chosen] = selectCustomDomainsForRound(
+        ['Often', 'FreshSometimes'], f, recentCounts, 1, seeded(i + 1),
+      );
+      if (chosen === 'Often') oftenFirst += 1;
+    }
+    // Expected share 16/7 / (16/7 + 2) ≈ 53%; assert it at least holds even.
+    expect(oftenFirst / TRIALS).toBeGreaterThan(0.5);
+  });
+});
+
+describe('domainFrequencyWeight', () => {
+  it('maps tags to weights, including a REAL zero for resting (not the default)', () => {
+    expect(domainFrequencyWeight('often')).toBe(4);
+    expect(domainFrequencyWeight('sometimes')).toBe(2);
+    expect(domainFrequencyWeight('blue_moon')).toBe(1);
+    // Regression: the old `||` fallback swallowed the 0 and rested domains
+    // competed at 'sometimes' weight.
+    expect(domainFrequencyWeight('resting')).toBe(0);
+    expect(domainFrequencyWeight(undefined)).toBe(2);
+    expect(domainFrequencyWeight('garbage')).toBe(2);
+  });
 });
 
 describe('domainWeeklyCap', () => {
@@ -149,6 +196,7 @@ describe('domainWeeklyCap', () => {
     expect(domainWeeklyCap('often')).toBe(7);
     expect(domainWeeklyCap('sometimes')).toBe(3);
     expect(domainWeeklyCap('blue_moon')).toBe(1);
+    expect(domainWeeklyCap('resting')).toBe(0);
     expect(domainWeeklyCap(undefined)).toBe(5);
     expect(domainWeeklyCap('garbage')).toBe(5);
   });

--- a/src/server/daily/domain-selection.ts
+++ b/src/server/daily/domain-selection.ts
@@ -10,29 +10,41 @@ import { domainKey } from '@/lib/knowledge/domain-key';
 export const DOMAIN_PER_WEEK_CAP = 5;
 
 // Per-domain frequency knobs (Game settings: often / sometimes / blue_moon /
-// resting). 'resting' is filtered out upstream — it never reaches selection.
+// resting).
 //
 // Base sampling weight: how strongly a domain competes to be in a given day's
 // palette. 'often' draws ~2x a 'sometimes' domain, ~4x a 'blue_moon' one. Unset
-// is treated as 'sometimes' (the neutral middle).
+// is treated as 'sometimes' (the neutral middle). 'resting' is weight 0, NOT the
+// default: the setup save keeps rested domains out of selectedDomains, but the
+// single-domain frequency endpoint didn't always sync the list, and prod rows
+// written through it carried rested strays that competed at 'sometimes' weight
+// (observed 2026-07-12: two rested domains took ~6 core slots in a week).
 const DOMAIN_FREQUENCY_WEIGHT: Record<string, number> = {
   often: 4,
   sometimes: 2,
   blue_moon: 1,
+  resting: 0,
 };
 const DEFAULT_DOMAIN_WEIGHT = DOMAIN_FREQUENCY_WEIGHT.sometimes;
 
 // Frequency-scaled weekly cap: hard backstop on how many questions a single
 // domain may yield in the trailing 7 days, so a fact-rich domain can't dominate
-// the rotation regardless of sampling luck.
+// the rotation regardless of sampling luck. 'resting' is 0 for the same
+// stray-row reason as its 0 sampling weight above.
 const DOMAIN_WEEKLY_CAP_BY_FREQUENCY: Record<string, number> = {
   often: 7,
   sometimes: 3,
   blue_moon: 1,
+  resting: 0,
 };
 
 export function domainFrequencyWeight(frequency: string | undefined): number {
-  return (frequency && DOMAIN_FREQUENCY_WEIGHT[frequency]) || DEFAULT_DOMAIN_WEIGHT;
+  // Explicit `in` check so the legitimate 0 for 'resting' isn't swallowed by a
+  // truthiness fallback to the default weight.
+  if (frequency !== undefined && frequency in DOMAIN_FREQUENCY_WEIGHT) {
+    return DOMAIN_FREQUENCY_WEIGHT[frequency];
+  }
+  return DEFAULT_DOMAIN_WEIGHT;
 }
 
 /**
@@ -52,7 +64,11 @@ export function dropCappedDomains(
 }
 
 export function domainWeeklyCap(frequency: string | undefined): number {
-  return (frequency && DOMAIN_WEEKLY_CAP_BY_FREQUENCY[frequency]) || DOMAIN_PER_WEEK_CAP;
+  // Same explicit `in` check as domainFrequencyWeight: 'resting' maps to a real 0.
+  if (frequency !== undefined && frequency in DOMAIN_WEEKLY_CAP_BY_FREQUENCY) {
+    return DOMAIN_WEEKLY_CAP_BY_FREQUENCY[frequency];
+  }
+  return DOMAIN_PER_WEEK_CAP;
 }
 
 // Kill switch for the custom-mode weighted daily pick (Change 1+2). Defaults ON;
@@ -98,10 +114,18 @@ export function weightedSampleWithoutReplacement<T>(
  * recency-aware sample of just the day's domains. Handing generation a SHORT list
  * (≈ the round's count) is what stops the model from over-mining the meaty few.
  *
- * Per domain: drop it if it already hit its frequency-scaled weekly cap, then
- * weight it by `frequencyWeight / (1 + recentCount7d)` so a domain mined hard this
- * week sinks and fresh ones rise (cross-day rotation). If the cap empties the set,
- * fall back to the uncapped list rather than starve the queue.
+ * Per domain: drop it if it's rested or already hit its frequency-scaled weekly
+ * cap, then weight it by `w² / (w + recentCount7d)` where w is the frequency
+ * weight — recency damping scaled to the tier. The old flat `w / (1 + recent)`
+ * cancelled the 'often' boost after a couple of serves: an often domain with 3
+ * recent questions (4/4 = 1.0) ranked BELOW a fresh 'sometimes' domain (2.0),
+ * so the 4:2:1 tags only held while everything was equally fresh. Dividing the
+ * recency count by the tier's own weight (w²/(w+r) = w/(1+r/w)) makes each tier
+ * absorb serves in proportion to its target share: often with 3 recent is
+ * 16/7 ≈ 2.3, still ahead of fresh sometimes at 2.0. Fresh domains keep the
+ * exact 4:2:1 ratio, and within a tier the least-mined domain still ranks first.
+ * If the cap empties the set, fall back to the uncapped list rather than starve
+ * the queue.
  */
 export function selectCustomDomainsForRound(
   selectedDomains: string[],
@@ -110,21 +134,32 @@ export function selectCustomDomainsForRound(
   count: number,
   rng: () => number = Math.random,
 ): string[] {
-  if (selectedDomains.length === 0) return [];
+  // 'resting' means "won't be asked" — drop rested domains outright, with NO
+  // starvation fallback (unlike the weekly cap below): serving a rested domain
+  // is a preference violation, not a supply problem. Normally redundant — the
+  // setup save and the domain-frequency endpoint both keep rested domains out
+  // of selectedDomains — but rows written before the endpoint synced the list
+  // still carry strays. An empty result here falls through to the caller's
+  // own palette fallback.
+  const active = selectedDomains.filter(
+    (domain) => frequencyByDomain[domain] !== 'resting',
+  );
+  if (active.length === 0) return [];
 
   const recentFor = (domain: string) => recentCounts.get(domainKey(domain)) ?? 0;
   const underCap = (domain: string) =>
     recentFor(domain) < domainWeeklyCap(frequencyByDomain[domain]);
 
   // Apply the weekly cap, but never let it empty the palette (starvation guard).
-  const eligible = selectedDomains.some(underCap)
-    ? selectedDomains.filter(underCap)
-    : selectedDomains;
+  const eligible = active.some(underCap) ? active.filter(underCap) : active;
 
-  const weighted = eligible.map((domain) => ({
-    item: domain,
-    weight: domainFrequencyWeight(frequencyByDomain[domain]) / (1 + recentFor(domain)),
-  }));
+  const weighted = eligible.map((domain) => {
+    const weight = domainFrequencyWeight(frequencyByDomain[domain]);
+    return {
+      item: domain,
+      weight: (weight * weight) / (weight + recentFor(domain)),
+    };
+  });
 
   return weightedSampleWithoutReplacement(weighted, count, rng);
 }

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -2225,6 +2225,23 @@ export async function generateDailyQuestionsFromKnowledgeBase(
       (domain) => domain,
     );
     const frequencyByDomain = preferences.domainPreferenceFrequency ?? {};
+    // 'resting' means "won't be asked" in custom mode too. The territory-setup
+    // save keeps rested domains out of selectedDomains, but the single-domain
+    // frequency endpoint didn't always sync the list, so prod rows can carry
+    // rested strays (observed 2026-07-12: two rested domains took ~6 core
+    // slots in a week). Filter here so the weighted path, the legacy path, AND
+    // the short-sample fallback below all honor the tag. If every selected
+    // domain is rested, keep the unfiltered list rather than starve the queue
+    // (mirrors random mode's all-rested fallback).
+    const restingSelected = new Set(
+      Object.entries(frequencyByDomain)
+        .filter(([, frequency]) => frequency === 'resting')
+        .map(([domain]) => domain.toLowerCase()),
+    );
+    const nonResting = selectable.filter(
+      (domain) => !restingSelected.has(domain.toLowerCase()),
+    );
+    const active = nonResting.length > 0 ? nonResting : selectable;
     if (isCustomDomainWeightingEnabled()) {
       // Change 1+2: deterministic, frequency-weighted, recency-aware sample of
       // just the day's domains. Handing generation a SHORT palette (≈ count) is
@@ -2233,17 +2250,17 @@ export async function generateDailyQuestionsFromKnowledgeBase(
       // days. Falls back to the full set inside the helper if the weekly cap
       // would otherwise empty the palette.
       const sampled = selectCustomDomainsForRound(
-        selectable,
+        active,
         frequencyByDomain,
         recentDomainCounts,
         count,
       );
-      domainsForRound = sampled.length > 0 ? sampled : (selectable.length > 0 ? selectable : allDomains);
+      domainsForRound = sampled.length > 0 ? sampled : (active.length > 0 ? active : allDomains);
     } else {
       // Legacy path (CUSTOM_DOMAIN_WEIGHTING=0): order the WHOLE list least-recent
       // first, then by frequency rank, and hand it all to generation. Kept as an
       // instant, no-redeploy rollback for the weighted pick above.
-      const ordered = orderCustomDomainsByLeastRecent(selectable, recentDomainCounts);
+      const ordered = orderCustomDomainsByLeastRecent(active, recentDomainCounts);
       const frequencyRank = (domain: string) => {
         const frequency = frequencyByDomain[domain];
         if (frequency === 'often') return 0;
@@ -2256,9 +2273,9 @@ export async function generateDailyQuestionsFromKnowledgeBase(
   } else {
     // Random mode: pick one domain per category for cross-category variety,
     // with a soft per-domain frequency cap applied via recentDomainCounts.
-    // 'resting' domains are honored here too (custom mode filters them out of
-    // selectedDomains upstream) so "Resting" means "won't be asked" in both
-    // modes; fall back to the full base if everything has been rested.
+    // 'resting' domains are honored here too (custom mode filters them in its
+    // branch above) so "Resting" means "won't be asked" in both modes; fall
+    // back to the full base if everything has been rested.
     const frequencyByDomain = preferences.domainPreferenceFrequency ?? {};
     const resting = new Set(
       Object.entries(frequencyByDomain)

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -412,24 +412,28 @@ async function buildDailyQueueForUser(
   // any vetted public question regardless of the viewer's declared or
   // demonstrated interests.
   //
-  // In random mode, also drop domains the player parked in "Resting" on the
-  // Game settings page. "Resting" means "won't be asked for now" (see the
-  // territory setup zones), and the LLM generator already honors it in both
-  // modes — but the authored/house pickers only filtered by this allow-set, so
-  // a rested category could still leak into the Daily Five via a vetted friend
-  // or house question. Custom mode needs no extra handling here: buildSavePayload
-  // excludes rested domains from selectedDomains upstream, so they're already out.
+  // In BOTH modes, drop domains the player parked in "Resting" on the Game
+  // settings page. "Resting" means "won't be asked for now" (see the territory
+  // setup zones), and the LLM generator already honors it in both modes — but
+  // the authored/house pickers only filter by this allow-set, so a rested
+  // category could still leak into the Daily Five via a vetted friend or house
+  // question. Custom mode normally has no rested entries in selectedDomains
+  // (buildSavePayload excludes them), but the single-domain frequency endpoint
+  // didn't always sync the list, so prod rows written through it carry rested
+  // strays — filter here rather than trust the invariant. The starvation guard
+  // keeps the unfiltered selection if EVERY selected domain is rested,
+  // mirroring the generator's all-rested fallback.
   const restingDomains = new Set(
     Object.entries(preferences.domainPreferenceFrequency ?? {})
       .filter(([, frequency]) => frequency === 'resting')
       .map(([domain]) => domain.toLowerCase()),
   );
+  const notResting = (domain: string) => !restingDomains.has(domain.toLowerCase());
+  const selectedNotResting = preferences.selectedDomains.filter(notResting);
   const allowedSubcategories: ReadonlySet<string> = new Set(
     preferences.domainMode === 'custom'
-      ? preferences.selectedDomains
-      : knowledgeBase
-          .map((domain) => domain.domain)
-          .filter((domain) => !restingDomains.has(domain.toLowerCase())),
+      ? (selectedNotResting.length > 0 ? selectedNotResting : preferences.selectedDomains)
+      : knowledgeBase.map((domain) => domain.domain).filter(notResting),
   );
 
   // Intra-day diversity cap (D: "5-question botany run" / "3-Hamlet day"). One


### PR DESCRIPTION
## Why

Josh's Daily Five was underrepresenting his **Often**-tagged domains. Diagnosis from prod data (2026-07-12) found two compounding causes:

1. **Rested domains were competing for slots.** The single-domain frequency endpoint (reveal-card "rest this" nudge) updated `domain_preference_frequency` without syncing `selectedDomains`, so rested domains stayed in the custom-mode palette. Worse, `domainFrequencyWeight('resting')` fell through the `||` fallback to the default weight 2 — "never ask" competed like a normal *sometimes* domain. Two strays took ~6 core slots in one week.
2. **Flat recency damping cancelled the Often boost.** `w/(1+recent)` dropped an Often domain with 3 recent questions to weight 1.0 — below a fresh Sometimes domain at 2.0 — so the 4:2:1 tags only held while everything was equally fresh.

## What

- `resting` now maps to a **real weight 0** and **weekly cap 0** (explicit `in`-check lookups so the 0 isn't swallowed by truthiness).
- Rested domains are filtered defensively at every custom-mode chokepoint: `selectCustomDomainsForRound` (no starvation fallback — serving a rested domain is a preference violation), the custom branch of `generateDailyQuestionsFromKnowledgeBase` (weighted + legacy paths + short-sample fallback), and the orchestrator's authored/house allow-set.
- The domain-frequency endpoint keeps `selectedDomains` in lockstep for custom-mode players: resting removes the domain; an active tag or a rest-undo restores it (KB-verified, custom mode only).
- Recency damping is now **tier-scaled**: `w²/(w+recent)`. Each tier absorbs serves in proportion to its target share — Often with 3 recent ≈ 2.3, still ahead of fresh Sometimes at 2.0. Fresh domains keep the exact 4:2:1 ratio; within a tier the least-mined domain still ranks first. Weekly caps (7/3/1) remain the hard backstop.

## Data repair

The one-off prod fix (removing the two rested strays from the affected `DailyPreference` row, 31→29 domains) was already applied directly; a drift scan confirmed no other rows were affected.

## Tests

- New regression tests: resting weight/cap are real zeros, rested domains never win a draw (incl. the leaked-stray case), all-rested returns `[]` to the caller's fallback, tier-scaled damping keeps Often ahead after 3 serves, endpoint list-sync (rest removes / undo restores / random mode untouched).
- Full daily suite: 387 passed; the one failure (`src/app/api/daily/answer/__tests__/route.test.ts`) fails identically on main — pre-existing stale `@/lib/llm` mock missing `ANTHROPIC_MODEL`, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XT3vCvhVfApr31VDFrD1F
