### PR TITLE
chore(cron): retire the daily mastery-v2 calibration email/snapshot

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -48,10 +48,6 @@
     {
       "path": "/api/cron/quality-aggregation",
       "schedule": "0 14 * * 1"
-    },
-    {
-      "path": "/api/cron/mastery-calibration-report",
-      "schedule": "0 11 * * *"
     }
   ]
 }


### PR DESCRIPTION
## What

Removes the `/api/cron/mastery-calibration-report` entry from `vercel.json`, so the daily mastery-v2 calibration report stops running. No more daily email, no more daily `masteryCalibrationSnapshot` row.

## Why

The report ran in **shadow mode** to gate a future flip of `KNOWLEDGE_MASTERY_V2` to prod. Two problems:

1. **It fires on a false premise.** The digest becomes "actionable" (and emails) whenever a node is *unmasterable-at-threshold* — a count computed against **today's bank size** (`pointsPerQuestion × current non-duplicate rows`). Under the demand-pull / finite-set model, that bank count is a moving *floor*, not a ceiling: a node "unmasterable" today is almost always a set still filling toward its target size, not a threshold set too high. So the one metric making the email loud is measuring the wrong thing — and its suggested remedy (lower thresholds to match a transient snapshot) would actively *cheapen* mastery.

2. **The surface gates a flip we have no near-term intent to make.** At current scale, flat per-subcategory v1 mastery is fine. Graph-aware v2 roll-up is option value we can revisit if/when we scale — it doesn't need a daily what-if in the meantime.

## Scope / safety

- **Only** the cron schedule is removed. The route, compute (`mastery-calibration.ts`), email template, and `masteryCalibrationSnapshot` table are left in place and remain **owner-triggerable** on demand.
- The dormant v2 flag/resolver code is **untouched** (flag-off = zero prod cost). Nothing here forecloses flipping v2 later — it just stops the automated nag.
- No schema/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STvDHVrXNYPsG9CP37jnb7
