### PR TITLE
fix(cost-report): reattribute the 5 unmapped LLM scopes out of "Other"

### DIFF
--- a/src/server/db/queries/__tests__/llm-cost-report-taxonomy.test.ts
+++ b/src/server/db/queries/__tests__/llm-cost-report-taxonomy.test.ts
@@ -21,7 +21,7 @@ import {
   bucketForScope,
 } from '@/server/db/queries/llm-cost-report';
 
-// Scopes observed in the live LlmUsageEvent ledger (30-day snapshot, 2026-07-06).
+// Scopes observed in the live LlmUsageEvent ledger (7-day snapshot, 2026-07-13).
 // Every one must resolve to a NAMED bucket — none may fall into "Other / unmapped",
 // which is what let the whole verification pipeline + topic-sizing hide from the
 // weekly digest. A new scope added to the codebase should be added to a bucket
@@ -38,6 +38,11 @@ const LIVE_SCOPES = [
   'interests-expand', 'interests-proofread', 'categorize-deleak',
   // Flag-gated / lower-volume scopes that must still be named when they fire:
   'domain-reference', 'nearness-tree',
+  // Previously in "Other / unmapped" (2026-07-13 reattribution): the Haiku
+  // self-containment healing sweep (its own bucket), supply backfill + two legacy
+  // generation experiments (→ generate), and the domain-size resolver (→ sizing).
+  'self-containment', 'backfill-supply-generate', 'fill-rich-generate',
+  'hamlet-ab-generate', 'domain-size-resolve',
 ];
 
 describe('LLM cost-report surface taxonomy', () => {

--- a/src/server/db/queries/llm-cost-report.ts
+++ b/src/server/db/queries/llm-cost-report.ts
@@ -49,7 +49,18 @@ export const SURFACE_BUCKETS: SurfaceBucket[] = [
     key: 'generate',
     label: 'Generating questions',
     playerFacing: false,
-    scopes: ['generate-questions', 'pool-refill-generate', 'multitudes', 'crafter-draft'],
+    scopes: [
+      'generate-questions',
+      'pool-refill-generate',
+      'multitudes',
+      'crafter-draft',
+      // Demand-weighted supply backfill (src/server/daily/supply-backfill.ts) plus
+      // two legacy generation experiments (fill-rich, hamlet A/B) that still have
+      // rows in history. All are question generation — was in "Other / unmapped".
+      'backfill-supply-generate',
+      'fill-rich-generate',
+      'hamlet-ab-generate',
+    ],
   },
   {
     key: 'quality',
@@ -67,6 +78,17 @@ export const SURFACE_BUCKETS: SurfaceBucket[] = [
       'salvage-propose',
       'enrich-variants',
     ],
+  },
+  {
+    key: 'self-containment',
+    label: 'Making questions self-contained',
+    playerFacing: false,
+    // The name-the-source healing sweep (src/server/quality/self-containment.ts):
+    // a Haiku pass that rewrites/flags questions referencing an unnamed source. A
+    // one-off, migration-shaped backfill rather than steady-state per-question
+    // cost, so it gets its own line instead of inflating "Checking question
+    // quality" — kept visible because it's the single largest scope by call count.
+    scopes: ['self-containment'],
   },
   {
     key: 'verify',
@@ -118,6 +140,9 @@ export const SURFACE_BUCKETS: SurfaceBucket[] = [
       'mastery-threshold-points',
       'knowledge-structure-proposal',
       'nearness-tree',
+      // Trusted domain-size estimate (src/server/daily/domain-size-estimate.ts) —
+      // the "Est." column on the supply readout. Was in "Other / unmapped".
+      'domain-size-resolve',
     ],
   },
   {


### PR DESCRIPTION
## What

"Other / unmapped" was the single biggest line on the weekly LLM cost digest — **4,968 calls / ~\$9.50 (44% of weekly spend)** — but it's not a mystery bucket. It's the catch-all for `scope` strings that emit `LlmUsageEvent` rows without an entry in `SURFACE_BUCKETS`. Five scopes had drifted out of the taxonomy; they reconcile to the dashboard's count and dollars exactly:

| Scope | Calls | ~USD | Now mapped to |
|---|---|---|---|
| `self-containment` (Haiku healing sweep) | 4,697 | \$5.11 | **Making questions self-contained** (new bucket) |
| `backfill-supply-generate` (Sonnet) | 57 | \$3.06 | Generating questions |
| `domain-size-resolve` (Haiku) | 202 | \$0.19 | Sizing & structuring topics |
| `fill-rich-generate` (legacy Sonnet exp.) | 8 | \$0.74 | Generating questions |
| `hamlet-ab-generate` (legacy Sonnet A/B) | 4 | \$0.40 | Generating questions |

## Why a dedicated bucket for self-containment

It's ~\$5 on its own and is a **one-off, migration-shaped healing sweep** (the name-the-source backfill), not steady-state per-question cost. Folding it into "Checking question quality" would make routine quality-checking look like it suddenly tripled. Its own line keeps the digest honest.

## Changes

- `src/server/db/queries/llm-cost-report.ts` — new `self-containment` surface; `backfill-supply-generate` / `fill-rich-generate` / `hamlet-ab-generate` → `generate`; `domain-size-resolve` → `sizing`.
- `llm-cost-report-taxonomy.test.ts` — refreshed the `LIVE_SCOPES` snapshot (2026-07-13) so the "nothing hides in Other" guard covers the five scopes and catches future drift.

## Notes

- Cost is derived at read time from the ledger, so **next week's digest reprices history automatically** — no backfill. "Other" should drop to ~\$0.
- Taxonomy test passes (6/6).
- Known limitation: the guard only catches a scope after it lands in the ledger and a human re-snapshots `LIVE_SCOPES`. A follow-up could derive the allowlist from the `dispatchLlmText` call sites at build time so it can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)