### PR TITLE
fix(supply): dry-domain report — stocked override, clamp rendering, downward co-calibration

### DIFF
--- a/src/app/admin/supply/page.tsx
+++ b/src/app/admin/supply/page.tsx
@@ -185,7 +185,15 @@ export default async function AdminSupplyPage() {
                     </td>
                     <td className="py-2 pr-3 text-right">{entry.realized}</td>
                     <td className="py-2 pr-3 text-right">
-                      {entry.estimatedQuestions ?? '—'}
+                      {entry.estimatedQuestions == null ? (
+                        '—'
+                      ) : entry.estimateClamped ? (
+                        <span title="Corpus count hit the sizing ceiling — the topic is at least this big, not measured at it.">
+                          ≥{entry.estimatedQuestions}
+                        </span>
+                      ) : (
+                        entry.estimatedQuestions
+                      )}
                       {entry.manualEstimatedQuestions != null ? (
                         <span
                           className="block text-xs"
@@ -196,7 +204,10 @@ export default async function AdminSupplyPage() {
                         </span>
                       ) : null}
                     </td>
-                    <td className="py-2 pr-3 text-right">{pctLabel(entry.ratio)}</td>
+                    <td className="py-2 pr-3 text-right">
+                      {/* Coverage of a ceiling clamp is meaningless — suppress it. */}
+                      {entry.estimateClamped ? '—' : pctLabel(entry.ratio)}
+                    </td>
                     <td className="py-2 pr-3 text-right">{entry.consecutiveDryRounds}</td>
                     <td className="py-2 pr-3">{entry.confidence ?? '—'}</td>
                     <td className="py-2 pr-3" style={{ color: 'var(--text-muted)' }}>

--- a/src/server/daily/__tests__/supply-coverage.test.ts
+++ b/src/server/daily/__tests__/supply-coverage.test.ts
@@ -16,7 +16,9 @@ function row(overrides: Partial<DomainSupplyCoverageRow>): DomainSupplyCoverageR
     consecutiveDryRounds: 0,
     lastYieldAt: null,
     generationCappedAt: null,
+    fandomHost: null,
     realized: 10,
+    servable: 0,
     ...overrides,
   };
 }
@@ -132,5 +134,37 @@ describe('summarizeSupplyCoverage (the shared #5 surface summary)', () => {
     expect(summary.entries).toHaveLength(0);
     expect(summary.discrepancies).toHaveLength(0);
     expect(summary.counts.discrepancy).toBe(0);
+  });
+
+  it('a stocked bank keeps a counter-dry domain out of the alarm list (backfill-supplied)', () => {
+    // The 2026-07-13 false-alarm shape: dry counter climbed (only the JIT path
+    // writes it) while the nightly backfill kept the domain stocked. Servable
+    // stock ≥ the floor → classifies filling, no discrepancy.
+    const summary = summarizeSupplyCoverage([
+      row({
+        domainKey: 'sesame street',
+        sampleLabel: 'Sesame Street',
+        realized: 15,
+        estimatedQuestions: 1200,
+        consecutiveDryRounds: 5,
+        servable: 14,
+      }),
+    ]);
+    expect(summary.entries[0].state).toBe('filling');
+    expect(summary.discrepancies).toHaveLength(0);
+  });
+
+  it('flags a ceiling-clamped corpus estimate; a manual override is never clamped', () => {
+    const summary = summarizeSupplyCoverage([
+      // SIZE_CEIL is 1200: a corpus estimate at the ceiling means "at least".
+      row({ domainKey: 'star trek', estimatedQuestions: 1200 }),
+      row({ domainKey: 'wtc', estimatedQuestions: 198 }),
+      // The same number set by hand is a human target, not a clamp.
+      row({ domainKey: 'manual', estimatedQuestions: 1200, manualEstimatedQuestions: 1200 }),
+    ]);
+    const byKey = new Map(summary.entries.map((entry) => [entry.domainKey, entry]));
+    expect(byKey.get('star trek')?.estimateClamped).toBe(true);
+    expect(byKey.get('wtc')?.estimateClamped).toBe(false);
+    expect(byKey.get('manual')?.estimateClamped).toBe(false);
   });
 });

--- a/src/server/daily/__tests__/supply-state.test.ts
+++ b/src/server/daily/__tests__/supply-state.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { classifySupplyState } from '@/server/daily/supply-state';
 
 const base = { realized: 10, estimatedQuestions: 100, confidence: 'high', consecutiveDryRounds: 0 };
-const OPTS = { dryK: 3, nearRatio: 0.7 };
+const OPTS = { dryK: 3, nearRatio: 0.7, stockedFloor: 10 };
 
 describe('classifySupplyState (the four arrows + gates)', () => {
   it('unsized: no estimate → never classified, never alarms', () => {
@@ -65,5 +65,37 @@ describe('classifySupplyState (the four arrows + gates)', () => {
     const shortfall = { realized: 10, estimatedQuestions: 100, confidence: 'high' };
     expect(classifySupplyState({ ...shortfall, consecutiveDryRounds: 2 }, OPTS)).toBe('filling');
     expect(classifySupplyState({ ...shortfall, consecutiveDryRounds: 3 }, OPTS)).toBe('discrepancy');
+  });
+
+  it('a stocked bank overrides the dry counter — the Sesame Street false alarm', () => {
+    // Counter says dry (only the JIT path writes it) but the backfill keeps the
+    // bank stocked: the domain is being supplied, so it classifies filling.
+    const dryButStocked = {
+      realized: 15,
+      estimatedQuestions: 1200,
+      confidence: 'high',
+      consecutiveDryRounds: 5,
+      servableStock: 12,
+    };
+    expect(classifySupplyState(dryButStocked, OPTS)).toBe('filling');
+    // Below the floor the counter stands and the alarm still fires.
+    expect(classifySupplyState({ ...dryButStocked, servableStock: 3 }, OPTS)).toBe('discrepancy');
+    // Callers without a stock read keep the pure counter-driven behavior.
+    expect(classifySupplyState({ ...dryButStocked, servableStock: null }, OPTS)).toBe('discrepancy');
+  });
+
+  it('stocked + past the estimate reads raise_estimate, not soft_finite', () => {
+    expect(
+      classifySupplyState(
+        {
+          realized: 110,
+          estimatedQuestions: 100,
+          confidence: 'high',
+          consecutiveDryRounds: 5,
+          servableStock: 40,
+        },
+        OPTS,
+      ),
+    ).toBe('raise_estimate');
   });
 });

--- a/src/server/daily/supply-backfill.ts
+++ b/src/server/daily/supply-backfill.ts
@@ -28,11 +28,15 @@ import {
   type LlmQuestion,
 } from '@/server/daily/generate-questions';
 import { getReferencePassagesForDomains, type DomainReference } from '@/server/daily/domain-reference';
-import { getReferenceRoutingHints } from '@/server/db/queries/domain-depth-estimate';
+import {
+  coCalibrateLoweredEstimates,
+  getReferenceRoutingHints,
+  recordSupplyYieldObservation,
+} from '@/server/db/queries/domain-depth-estimate';
 import { resolveDailyBasePoints } from '@/server/daily/types';
 import { resolveMachineTrustTier } from '@/server/daily/ask-to-answer';
 import { resolveFinestNode } from '@/server/knowledge/graph';
-import { dryRoundsThreshold } from '@/server/daily/supply-state';
+import { dryRoundsThreshold, nearCompleteRatio } from '@/server/daily/supply-state';
 import { domainKey } from '@/lib/knowledge/domain-key';
 import { normalizeFactKey } from '@/server/questions/fact-key';
 import { estimateCostUsd } from '@/server/llm/pricing';
@@ -304,7 +308,10 @@ async function loadAvoid(domainKeyVal: string): Promise<{
   return { texts: rows.map((r) => ({ domain: domainKeyVal, text: r.question_text })), fks, factKeys };
 }
 
-async function buildDomain(p: BackfillPlan, systemUserId: string | null): Promise<{ generated: number; persisted: number }> {
+async function buildDomain(
+  p: BackfillPlan,
+  systemUserId: string | null,
+): Promise<{ generated: number; persisted: number; survivors: number; persistedKeys: string[] }> {
   const avoid = await loadAvoid(p.domainKey);
   let refs: Map<string, DomainReference> | undefined;
   if (p.ground) {
@@ -319,7 +326,7 @@ async function buildDomain(p: BackfillPlan, systemUserId: string | null): Promis
   }
 
   const generated = await generate(p.label, p.batch, avoid.texts, avoid.fks, refs);
-  if (generated.length === 0) return { generated: 0, persisted: 0 };
+  if (generated.length === 0) return { generated: 0, persisted: 0, survivors: 0, persistedKeys: [] };
 
   const [ql, fa] = await Promise.all([findQualityFailures(generated), findFactualFailures(generated)]);
   const seen = new Set(avoid.factKeys);
@@ -332,12 +339,15 @@ async function buildDomain(p: BackfillPlan, systemUserId: string | null): Promis
     survivors.push(q);
   });
 
-  if (!systemUserId) return { generated: generated.length, persisted: 0 };
+  if (!systemUserId) {
+    return { generated: generated.length, persisted: 0, survivors: survivors.length, persistedKeys: [] };
+  }
 
   // Persist as unverified machine rows (mirrors the non-corroborated per-user
   // path). The batch-verify + embedding-dedup sweeps promote/dedupe them later.
   const trustTier = resolveMachineTrustTier({ askToAnswerVerified: false, corroborated: false });
   let persisted = 0;
+  const persistedKeys: string[] = [];
   for (const q of survivors) {
     try {
       const taggedDomain = await resolveFinestNode(q.canonical_subcategory);
@@ -360,11 +370,12 @@ async function buildDomain(p: BackfillPlan, systemUserId: string | null): Promis
         usedInQueue: false,
       });
       persisted += 1;
+      persistedKeys.push(domainKey(taggedDomain));
     } catch (err) {
       console.warn('[supply-backfill] persist failed', { domain: p.label, error: err instanceof Error ? err.message : String(err) });
     }
   }
-  return { generated: generated.length, persisted };
+  return { generated: generated.length, persisted, survivors: survivors.length, persistedKeys };
 }
 
 export async function runSupplyBackfill(opts: BackfillOptions): Promise<BackfillReport> {
@@ -401,7 +412,41 @@ export async function runSupplyBackfill(opts: BackfillOptions): Promise<Backfill
 
   for (const p of actionable.slice(0, opts.limit)) {
     const r = await buildDomain(p, opts.systemUserId ?? null);
-    report.built.push({ label: p.label, ...r });
+    report.built.push({ label: p.label, generated: r.generated, persisted: r.persisted });
+
+    // Feed the supply-state machine from THIS path too. The dry-round counter
+    // was written only by the per-user JIT round, so a domain the backfill
+    // restocked every night still read "dry" forever (the 2026-07-13 email:
+    // 10 alarmed domains, 5 of them refilled that same morning). Only the
+    // production persisting run observes — a generate-only run adds no stock.
+    if (opts.systemUserId) {
+      try {
+        if (r.persisted > 0) {
+          // Credit the probed key AND the keys the rows actually landed on —
+          // resolveFinestNode can retag a survivor to a finer node, and that
+          // finer domain's counter deserves the reset too.
+          await recordSupplyYieldObservation({
+            yieldedDomainKeys: [p.domainKey, ...r.persistedKeys],
+            dryDomainKeys: [],
+          });
+        } else if (r.generated > 0) {
+          // A dedicated probe (domain alone, full avoid list, grounded when
+          // possible) produced zero survivors — the strongest dry evidence.
+          await recordSupplyYieldObservation({ yieldedDomainKeys: [], dryDomainKeys: [p.domainKey] });
+          // Downward co-calibration: accept realized as ≈ the realizable size
+          // so the domain rests as soft_finite instead of alarming forever.
+          // Fandom-hosted and admin-overridden rows are excluded inside.
+          await coCalibrateLoweredEstimates([p.domainKey], nearCompleteRatio());
+        }
+        // r.generated === 0 → the model/parse returned nothing at all; that is
+        // an outage signal, not evidence about the domain — record nothing.
+      } catch (err) {
+        console.warn('[supply-backfill] yield observation failed (non-fatal)', {
+          domain: p.label,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
   return report;
 }

--- a/src/server/daily/supply-coverage.ts
+++ b/src/server/daily/supply-coverage.ts
@@ -3,6 +3,7 @@ import {
   type DomainSupplyCoverageRow,
 } from '@/server/db/queries/domain-depth-estimate';
 import { classifySupplyState, type SupplyState } from '@/server/daily/supply-state';
+import { SIZE_CEIL } from '@/server/daily/domain-size-estimate';
 
 /**
  * Shared coverage summary for the supply-state machine's two surfaces
@@ -34,6 +35,17 @@ export interface SupplyCoverageEntry {
   /** Dedicated Fandom wiki host, when the sizer found one — a richness signal
    * (a fandom-backed leaf that ran dry is a generator failure, not a granular topic). */
   fandomHost: string | null;
+  /** Worst-case servable bank stock — the backfill's own "already stocked" number.
+   * Feeds classification (a stocked domain is never dry) and the dashboards. */
+  servable: number;
+  /**
+   * The corpus estimate hit SIZE_CEIL, i.e. it means "at least this big", not a
+   * measured size (Star Trek's 65k wiki articles clamp to 1,200). Surfaces
+   * render the estimate as "≥N" and suppress the coverage percentage — a % of a
+   * clamp reads as near-zero coverage forever and is meaningless. A manual
+   * override is a human-set target, never clamped.
+   */
+  estimateClamped: boolean;
 }
 
 export interface SupplyCoverageSummary {
@@ -63,6 +75,7 @@ export function summarizeSupplyCoverage(
       estimatedQuestions: effectiveEstimate,
       confidence: effectiveConfidence,
       consecutiveDryRounds: row.consecutiveDryRounds,
+      servableStock: row.servable,
     });
     return {
       domainKey: row.domainKey,
@@ -81,6 +94,8 @@ export function summarizeSupplyCoverage(
       lastYieldAt: row.lastYieldAt,
       generationCapped: row.generationCappedAt != null,
       fandomHost: row.fandomHost,
+      servable: row.servable,
+      estimateClamped: !overridden && row.estimatedQuestions != null && row.estimatedQuestions >= SIZE_CEIL,
     };
   });
 

--- a/src/server/daily/supply-state.ts
+++ b/src/server/daily/supply-state.ts
@@ -46,6 +46,17 @@ export const dryRoundsThreshold = (): number => Math.round(numEnv('SUPPLY_DRY_RO
 /** realized/estimate ratio at or above which a dry domain reads as complete. */
 export const nearCompleteRatio = (): number => numEnv('SUPPLY_NEAR_COMPLETE_RATIO', 0.7);
 
+/**
+ * Worst-case servable bank rows at or above which a domain reads as STOCKED —
+ * and a stocked domain is never dry, whatever its counter says. The dry-round
+ * counter is written only by the per-user JIT generation path; the nightly
+ * backfill and bank serving supply a domain without touching it (the 2026-07-13
+ * false-alarm email: 10 "dry" domains that the backfill had restocked that same
+ * morning). Kept in lockstep with the backfill's BUFFER_FLOOR default: report
+ * says stocked ⟺ the backfill's own gate says stocked.
+ */
+export const stockedFloor = (): number => Math.round(numEnv('SUPPLY_STOCKED_FLOOR', 10));
+
 export interface SupplyObservation {
   /** Distinct facts actually generated for the domain (bank-wide). */
   realized: number;
@@ -55,16 +66,28 @@ export interface SupplyObservation {
   confidence: string | null;
   /** Consecutive offered-but-zero-yield generation rounds. */
   consecutiveDryRounds: number;
+  /**
+   * Worst-case SERVABLE bank stock (have − largest single non-system owner),
+   * the same number the backfill's "already stocked" gate uses. Optional so
+   * callers without a stock read keep the pure counter-driven behavior.
+   */
+  servableStock?: number | null;
 }
 
 export function classifySupplyState(
   observation: SupplyObservation,
-  opts?: { dryK?: number; nearRatio?: number },
+  opts?: { dryK?: number; nearRatio?: number; stockedFloor?: number },
 ): SupplyState {
   const { realized, estimatedQuestions, confidence, consecutiveDryRounds } = observation;
   if (estimatedQuestions == null || estimatedQuestions <= 0) return 'unsized';
 
-  const dry = consecutiveDryRounds >= (opts?.dryK ?? dryRoundsThreshold());
+  // A stocked bank overrides the dry counter: the counter only sees the JIT
+  // path, so a domain the backfill keeps stocked would otherwise read dry
+  // forever (its counter can climb but nothing on the serving path resets it).
+  const stocked =
+    observation.servableStock != null &&
+    observation.servableStock >= (opts?.stockedFloor ?? stockedFloor());
+  const dry = !stocked && consecutiveDryRounds >= (opts?.dryK ?? dryRoundsThreshold());
   if (!dry) {
     return realized >= estimatedQuestions ? 'raise_estimate' : 'filling';
   }

--- a/src/server/db/queries/domain-depth-estimate.ts
+++ b/src/server/db/queries/domain-depth-estimate.ts
@@ -3,7 +3,7 @@
 // covers every played canonical_subcategory, not just authored KnowledgeNodes.
 import { and, eq, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
 
-import { db, domainDepthEstimates, generatedQuestions, questions } from '@/server/db';
+import { db, pool, domainDepthEstimates, generatedQuestions, questions } from '@/server/db';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
 export type DepthEstimateRow = {
@@ -174,6 +174,53 @@ export async function coCalibrateRaisedEstimates(
 }
 
 /**
+ * DOWNWARD co-calibration — the mirror of coCalibrateRaisedEstimates, closing
+ * the loop the size estimator's K_PER_SHAPE constants leave open (they assume
+ * every counted work/section sustains 3–5 gate-passing questions, which
+ * overestimates mid-size text domains like a single author or one composition).
+ * Callers pass domains where a DEDICATED backfill probe — the domain alone in
+ * the prompt, full avoid list, grounding when available — just returned ZERO
+ * survivors: the strongest evidence that realizable size ≈ realized. The row's
+ * estimate drops to ceil(realized / nearRatio), exactly the soft_finite
+ * boundary, so the domain reads "resting (believed complete)" instead of
+ * alarming as a discrepancy forever. Guardrails:
+ *  - only lowers (new value < current estimate is in the WHERE);
+ *  - skips manual admin overrides (a human anchor is not ours to move);
+ *  - skips fandom-hosted rows — a fandom-backed domain that runs dry is a
+ *    generator/grounding failure, NOT a small topic; its alarm must survive;
+ *  - skips realized = 0 (nothing observed → nothing to calibrate to);
+ *  - realized = count(distinct fact_key), the same definition the coverage
+ *    read and the upward calibration use.
+ * A later yielding round resets the dry counter and can re-raise the estimate
+ * via coCalibrateRaisedEstimates, so this stays provisional in both directions.
+ * Fire-and-forget telemetry-grade: callers void+catch.
+ */
+export async function coCalibrateLoweredEstimates(
+  domainKeys: string[],
+  nearRatio: number,
+): Promise<void> {
+  const keys = [...new Set(domainKeys)].filter(Boolean);
+  if (keys.length === 0 || !(nearRatio > 0)) return;
+  await db.execute(sql`
+    UPDATE "DomainDepthEstimate" d
+    SET "estimated_questions" = CEIL(r.realized / ${nearRatio}::float8)::int,
+        "calibrated_at" = now()
+    FROM (
+      SELECT "domain_key", count(distinct "fact_key")::int AS realized
+      FROM "GeneratedQuestion"
+      WHERE "fact_key" IS NOT NULL AND "domain_key" = ANY(${keys})
+      GROUP BY "domain_key"
+    ) r
+    WHERE d."domain_key" = r."domain_key"
+      AND d."estimated_questions" IS NOT NULL
+      AND d."manual_estimated_questions" IS NULL
+      AND d."fandom_host" IS NULL
+      AND r.realized > 0
+      AND CEIL(r.realized / ${nearRatio}::float8)::int < d."estimated_questions"
+  `);
+}
+
+/**
  * The display label for a folded domain key, resolved SERVER-SIDE (the resolver
  * and estimate rows must never be seeded from client input): the most common
  * generated spelling, else a human-authored label that folds to the key. Null =
@@ -338,6 +385,14 @@ export type DomainSupplyCoverageRow = {
   fandomHost: string | null;
   /** Distinct facts generated for the domain, bank-wide (all users). */
   realized: number;
+  /**
+   * Worst-case SERVABLE stock: non-duplicate rows minus the largest single
+   * non-system owner's rows (the bank excludes a viewer's own rows, so the
+   * heaviest contributor sees the least). Same numbers as the backfill's
+   * "already stocked" gate — a domain this read calls stocked is one the
+   * backfill would skip, and classifySupplyState treats it as not-dry.
+   */
+  servable: number;
 };
 
 /**
@@ -362,7 +417,7 @@ export async function getDomainSupplyCoverage(): Promise<DomainSupplyCoverageRow
       .where(isNotNull(generatedQuestions.factKey))
       .groupBy(generatedQuestions.domainKey),
   );
-  const joined = await db
+  const joinedRows = await db
     .with(realized)
     .select({
       domainKey: sql<string>`coalesce(${domainDepthEstimates.domainKey}, ${realized.domainKey})`,
@@ -381,6 +436,34 @@ export async function getDomainSupplyCoverage(): Promise<DomainSupplyCoverageRow
     })
     .from(domainDepthEstimates)
     .fullJoin(realized, eq(realized.domainKey, domainDepthEstimates.domainKey));
+
+  // Worst-case servable stock per domain, mirroring the backfill's loadDomains
+  // (have − largest single non-system owner; the system backfill user's rows
+  // serve every real viewer, so they never count as anyone's own stock). An
+  // empty string matches no real user id, so an unset system user is a no-op.
+  const sysExcl = process.env.RETRIEVAL_SYSTEM_USER_ID?.trim() || '';
+  const servableByKey = new Map<string, number>(
+    (
+      (await pool.query(
+        `SELECT domain_key,
+                (SUM(cnt) - COALESCE(MAX(cnt) FILTER (WHERE user_id <> $1), 0))::int AS servable
+         FROM (
+           SELECT domain_key, user_id, COUNT(*)::int AS cnt
+           FROM "GeneratedQuestion"
+           -- Mirror pickBankSource's hard predicates: demotes land as
+           -- is_duplicate = true, and a null fact_key row is never pickable.
+           WHERE is_duplicate = false AND fact_key IS NOT NULL AND domain_key IS NOT NULL
+           GROUP BY domain_key, user_id
+         ) per_owner
+         GROUP BY domain_key`,
+        [sysExcl],
+      )).rows as { domain_key: string; servable: number }[]
+    ).map((row) => [row.domain_key, row.servable]),
+  );
+  const joined: DomainSupplyCoverageRow[] = joinedRows.map((row) => ({
+    ...row,
+    servable: servableByKey.get(row.domainKey) ?? 0,
+  }));
 
   // Human-authored-only areas: live, non-blocked authored questions whose
   // folded key has neither an estimate row nor any generated rows.
@@ -418,6 +501,7 @@ export async function getDomainSupplyCoverage(): Promise<DomainSupplyCoverageRow
       generationCappedAt: null,
       fandomHost: null,
       realized: 0,
+      servable: 0,
     });
   }
   return joined;

--- a/src/server/email/templates/llm-cost-report.ts
+++ b/src/server/email/templates/llm-cost-report.ts
@@ -90,8 +90,13 @@ function supplySectionHtml(supply: SupplyCoverageSummary | null | undefined): st
   const discRows = discrepancies
     .slice(0, 8)
     .map((entry) => {
-      const est = entry.estimatedQuestions == null ? '—' : num(entry.estimatedQuestions);
-      const ratio = entry.ratio == null ? '—' : pct(entry.ratio);
+      // A ceiling-clamped estimate means "at least this big", not a measured
+      // size — show "≥N" and no coverage % (a % of a clamp is meaningless).
+      const est =
+        entry.estimatedQuestions == null
+          ? '—'
+          : `${entry.estimateClamped ? '≥' : ''}${num(entry.estimatedQuestions)}`;
+      const ratio = entry.ratio == null || entry.estimateClamped ? '—' : pct(entry.ratio);
       return `<tr>${td(escapeHtml(entry.label), 'left')}${td(num(entry.realized), 'right')}${td(est, 'right')}${td(ratio, 'right')}</tr>`;
     })
     .join('');
@@ -136,9 +141,13 @@ function supplySectionText(supply: SupplyCoverageSummary | null | undefined): st
       `${supply.discrepancies.length} domain(s) went dry far short of a trusted size estimate (supply problem, not completion):`,
     );
     for (const entry of supply.discrepancies.slice(0, 8)) {
+      const est =
+        entry.estimatedQuestions == null
+          ? '—'
+          : `${entry.estimateClamped ? '≥' : ''}${entry.estimatedQuestions}`;
       lines.push(
-        `- ${entry.label}: ${entry.realized}/${entry.estimatedQuestions ?? '—'} (${
-          entry.ratio == null ? '—' : `${Math.round(entry.ratio * 100)}%`
+        `- ${entry.label}: ${entry.realized}/${est} (${
+          entry.ratio == null || entry.estimateClamped ? '—' : `${Math.round(entry.ratio * 100)}%`
         }), dry ${entry.consecutiveDryRounds} rounds`,
       );
     }


### PR DESCRIPTION
## Problem

The 2026-07-13 weekly digest alarmed on **10 domains "dry far short of a trusted size estimate."** Investigation showed 9 of the 10 were false alarms: the nightly backfill had restocked several of them *that same morning*, and users were being served bank copies daily. Three stacked measurement artifacts:

1. **The dry-round counter only resets via the per-user JIT generation path.** The nightly backfill cron persists rows without touching `consecutive_dry_rounds` / `last_yield_at`, and bank-served domains never enter the fresh palette — so a domain that once hit K dry rounds read dry forever (`last_yield_at` was NULL on all 10 despite fresh rows landing daily).
2. **Five of the ten "estimates" were the `SIZE_CEIL` clamp**, not measured sizes (Star Trek = 65,674 wiki articles × 2.5 → clamped to 1,200). Coverage-% against a clamp reads as 1% forever.
3. **Nothing could ever lower an overestimate**, so mid-size text domains (DFW 265, WTC 198 — K_PER_SHAPE assumes every work/section sustains 3–5 gate-passing questions) could never reach "resting (believed complete)".

## Fixes

- **Backfill feeds the state machine** (`supply-backfill.ts`): a persisting run records yield (resetting the counter, crediting the finest-node keys rows actually landed on) or, on a zero-survivor dedicated probe, a dry round. A generate-nothing round records neither (outage, not evidence).
- **Stocked override** (`supply-state.ts`, `domain-depth-estimate.ts`): classification reads worst-case servable stock — have − largest single non-system owner, mirroring `pickBankSource`'s hard predicates (`is_duplicate = false` covers verification demotes; `fact_key IS NOT NULL`) — and a domain ≥ `SUPPLY_STOCKED_FLOOR` (default 10 = the backfill's buffer floor) is never dry. Report says stocked ⟺ the backfill's own gate says stocked. Servable is self-draining: served copies are owned by the viewer, so consumed stock re-arms both the backfill and the alarm.
- **Clamp rendering** (`supply-coverage.ts`, email template, `/admin/supply`): ceiling-clamped corpus estimates display as **≥1,200** with coverage **—**; manual overrides are never treated as clamped.
- **Downward co-calibration** (`coCalibrateLoweredEstimates`): a zero-survivor dedicated probe lowers the estimate to `ceil(realized / nearRatio)` — exactly the soft-finite boundary — so mined-out domains rest instead of alarming forever. Guardrails: only lowers, skips manual overrides, skips fandom-hosted rows (a fandom-backed domain running dry is a generator failure and must keep alarming), re-raisable by the existing upward calibration.

## Verification

- Replayed prod data through the new classification: the alarm list drops from 10 to **exactly 1** — Meredith Willson Broadway Musicals (servable 0, no declared demand, never probed), the one domain genuinely needing human action.
- `vitest` daily module: 378 passed (new cases for stocked-override, clamp flag, and the raise-vs-rest boundary). Typecheck + lint clean.
- No migration needed (`calibrated_at` exists since 0119).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XT3vCvhVfApr31VDFrD1F