### PR TITLE
Hide 'More context' link when the explanation isn't actually clamped

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { X } from 'lucide-react';
@@ -345,6 +345,20 @@ function CatchupResultDots({ records }: { records: CatchupBatchRecord[] }) {
 
 function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
   const [isExplainerOpen, setIsExplainerOpen] = useState(false);
+  // Only offer "More context" when the 3-line clamp is actually hiding text;
+  // for short explanations there is no more context and the link is noise.
+  const [isExplainerClamped, setIsExplainerClamped] = useState(false);
+  const explainerRef = useRef<HTMLParagraphElement | null>(null);
+  useEffect(() => {
+    if (isExplainerOpen) return;
+    const el = explainerRef.current;
+    if (!el) return;
+    const measure = () => setIsExplainerClamped(el.scrollHeight > el.clientHeight + 1);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [isExplainerOpen, record.explanation]);
   // Parity with the daily-summary recap (round_recap surface): a card the viewer
   // reports as inappropriate vanishes — the card going away is the feedback. An
   // "incorrect" report leaves the card in place (the sheet acknowledges it itself).
@@ -447,6 +461,7 @@ function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
         <section className="mt-5 pl-1">
           <h3 className="text-sm font-semibold text-[var(--brand-ink)]">Why this is the answer</h3>
           <p
+            ref={explainerRef}
             className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]"
             style={
               isExplainerOpen
@@ -461,7 +476,7 @@ function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
           >
             {record.explanation}
           </p>
-          {!isExplainerOpen ? (
+          {!isExplainerOpen && isExplainerClamped ? (
             <button
               type="button"
               onClick={() => setIsExplainerOpen(true)}

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -634,6 +634,20 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
   }, [])
 
   const [isExplainerOpen, setIsExplainerOpen] = useState(false)
+  // Only offer "More context" when the 3-line clamp is actually hiding text;
+  // for short explanations there is no more context and the link is noise.
+  const [isExplainerClamped, setIsExplainerClamped] = useState(false)
+  const explainerRef = useRef<HTMLParagraphElement | null>(null)
+  useEffect(() => {
+    if (isExplainerOpen) return
+    const el = explainerRef.current
+    if (!el) return
+    const measure = () => setIsExplainerClamped(el.scrollHeight > el.clientHeight + 1)
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [isExplainerOpen, question.explanation])
   const statusLabel = question.isSkipped
     ? 'Skipped'
     : question.isCorrect
@@ -754,6 +768,7 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
             Why this is the answer
           </h3>
           <p
+            ref={explainerRef}
             className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]"
             style={
               isExplainerOpen
@@ -768,7 +783,7 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
           >
             {question.explanation}
           </p>
-          {!isExplainerOpen ? (
+          {!isExplainerOpen && isExplainerClamped ? (
             <button
               type="button"
               onClick={() => setIsExplainerOpen(true)}


### PR DESCRIPTION
The recap cards rendered 'More context →' for every explanation, even
ones that fit fully within the 3-line clamp — clicking revealed nothing.
Measure overflow of the clamped paragraph (with a ResizeObserver for
width changes) and only render the link when text is truly hidden. The
link still disappears once expanded.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016eDGZ8kSAr4zo5hgnAJtgR