### PR TITLE
fix(crafter): exclude self-containment demotions from machine-futility

### DIFF
--- a/src/app/admin/crafter/CrafterClient.tsx
+++ b/src/app/admin/crafter/CrafterClient.tsx
@@ -315,16 +315,21 @@ function DomainRow({ row, onCraft }: { row: CrafterWorklistRow; onCraft: () => v
           ) : null}
           {/* The machine-futility story: WHY this row outranks its heat-mates.
               The machine failing here is exactly where a human is
-              irreplaceable — a costly domain, not just a thin one. */}
+              irreplaceable — a costly domain, not just a thin one. The rate
+              counts only SUBSTANTIVE verifier rejections (fact/spoiler/quality);
+              self-containment "name-the-source" demotions are excluded upstream
+              (they're a salvageable formatting slip, not the machine struggling
+              with the subject), so this number can be trusted at face value. */}
           {row.demotionRate !== null && row.demotionRate > 0 ? (
             <div className="mt-0.5 text-xs" style={{ color: 'var(--danger)' }}>
-              the machine struggles here — {Math.round(row.demotionRate * 100)}% of its questions
-              get pulled by the verifier ({row.machineDemoted} of {row.machineVerified})
-              {row.generationStruggling ? ' · generation keeps timing out' : ''}
+              the verifier rejects the machine here — {row.machineDemoted} of{' '}
+              {row.machineVerified} fact-checked questions came back wrong (
+              {Math.round(row.demotionRate * 100)}%)
+              {row.generationStruggling ? ' · and generation keeps timing out' : ''}
             </div>
           ) : row.generationStruggling ? (
             <div className="mt-0.5 text-xs" style={{ color: 'var(--danger)' }}>
-              the machine struggles here — generation keeps timing out
+              the machine can’t generate here — refill keeps timing out
             </div>
           ) : null}
         </div>

--- a/src/server/db/queries/crafter-demand.ts
+++ b/src/server/db/queries/crafter-demand.ts
@@ -152,7 +152,22 @@ export async function getExpensiveDomains(): Promise<ExpensiveDomain[]> {
         demoted: sql<number>`count(*) filter (where ${generatedQuestions.verificationVerdict} = 'demoted')::int`,
       })
       .from(generatedQuestions)
-      .where(isNotNull(generatedQuestions.verificationVerdict))
+      // Substantive verdicts only. Self-containment ("names-the-source") demotions
+      // are EXCLUDED from both numerator and denominator: they're a uniform
+      // formatting rule, not subject difficulty — already prevented at generation
+      // (Rule 2b) and one-click salvageable (prepend the title), so counting them
+      // as machine futility falsely routes fine domains (Breaking Bad, Avatar, …)
+      // to "curate by hand". A one-time healing sweep dumping same-day demotions
+      // must not masquerade as "the machine struggles here". Excluding from the
+      // denominator too keeps a domain's REAL error rate undiluted (4 factual
+      // misses among 4 substantive verdicts reads 100%, not 33% padded by 8
+      // formatting demotions).
+      .where(
+        and(
+          isNotNull(generatedQuestions.verificationVerdict),
+          sql`(${generatedQuestions.verificationReason} is null or ${generatedQuestions.verificationReason} not ilike 'self-containment%')`,
+        ),
+      )
       .groupBy(generatedQuestions.canonicalSubcategory),
     db
       .select({

--- a/src/server/db/queries/crafter-demand.ts
+++ b/src/server/db/queries/crafter-demand.ts
@@ -87,6 +87,20 @@ const FUTILITY_MIN_VERIFIED = 4;
 // machine can't even generate here" (mirrors the refill cooldown's own signal).
 const STRUGGLING_TIMEOUTS = 2;
 
+// Machine-futility counts only SUBSTANTIVE verifier verdicts. Self-containment
+// ("names-the-source") demotions are excluded from BOTH the demoted numerator and
+// the verified denominator: they're a uniform formatting rule, not subject
+// difficulty — already prevented at generation (Rule 2b) and one-click salvageable
+// (prepend the title). A one-time healing sweep dumping same-day demotions into a
+// handful of subcategories (73 of 98 all-time demotions, 2026-07-12) otherwise
+// masquerades as "the machine struggles here" and routes factually-fine domains
+// (Breaking Bad, Avatar, Phineas & Ferb) to "curate by hand". Excluding them from
+// the denominator too keeps a domain's REAL error rate undiluted (4 factual misses
+// among 4 substantive verdicts reads 100%, not 33% padded by formatting demotions).
+// Used by BOTH getExpensiveDomains (weekly email) and getCrafterWorklist
+// (dashboard), so the two never drift.
+const SUBSTANTIVE_VERDICT_ONLY = sql`(${generatedQuestions.verificationReason} is null or ${generatedQuestions.verificationReason} not ilike 'self-containment%')`;
+
 /**
  * Sort key for machine futility, pure and exported for tests: demotion rate
  * (when the sample supports one) plus a flat bump when generation itself is
@@ -152,22 +166,8 @@ export async function getExpensiveDomains(): Promise<ExpensiveDomain[]> {
         demoted: sql<number>`count(*) filter (where ${generatedQuestions.verificationVerdict} = 'demoted')::int`,
       })
       .from(generatedQuestions)
-      // Substantive verdicts only. Self-containment ("names-the-source") demotions
-      // are EXCLUDED from both numerator and denominator: they're a uniform
-      // formatting rule, not subject difficulty — already prevented at generation
-      // (Rule 2b) and one-click salvageable (prepend the title), so counting them
-      // as machine futility falsely routes fine domains (Breaking Bad, Avatar, …)
-      // to "curate by hand". A one-time healing sweep dumping same-day demotions
-      // must not masquerade as "the machine struggles here". Excluding from the
-      // denominator too keeps a domain's REAL error rate undiluted (4 factual
-      // misses among 4 substantive verdicts reads 100%, not 33% padded by 8
-      // formatting demotions).
-      .where(
-        and(
-          isNotNull(generatedQuestions.verificationVerdict),
-          sql`(${generatedQuestions.verificationReason} is null or ${generatedQuestions.verificationReason} not ilike 'self-containment%')`,
-        ),
-      )
+      // Substantive verdicts only (see SUBSTANTIVE_VERDICT_ONLY).
+      .where(and(isNotNull(generatedQuestions.verificationVerdict), SUBSTANTIVE_VERDICT_ONLY))
       .groupBy(generatedQuestions.canonicalSubcategory),
     db
       .select({
@@ -413,6 +413,8 @@ export async function getCrafterWorklist(
       return [] as ClusterLabel[];
     }),
     // Futility, quality half: per-domain verifier outcomes on machine questions.
+    // Substantive verdicts only (see SUBSTANTIVE_VERDICT_ONLY) — a formatting
+    // sweep must not read as "the machine struggles here" on the dashboard.
     db
       .select({
         domain: generatedQuestions.canonicalSubcategory,
@@ -424,6 +426,7 @@ export async function getCrafterWorklist(
         and(
           inArray(generatedQuestions.canonicalSubcategory, domains),
           isNotNull(generatedQuestions.verificationVerdict),
+          SUBSTANTIVE_VERDICT_ONLY,
         ),
       )
       .groupBy(generatedQuestions.canonicalSubcategory),


### PR DESCRIPTION
## The problem

The crafter dashboard's "Subjects too expensive for the machine — curate these" list flagged **Breaking Bad, Avatar, and Phineas & Ferb** at the top with *"the machine struggles here — 89–92% of its questions get pulled by the verifier."* That's misleading.

`getExpensiveDomains` ranks domains by their **all-time** demotion rate (`demoted ÷ verified`). I pulled the actual demotion reasons for all three domains — **100% of them are one thing:**

> `self-containment: No work title appears — "Walt and Jesse" are character names only; the series is never named.`

Not one factual error, spoiler, or fabrication. The questions are substantively fine; they just wrote *"What did Walt and Jesse…"* instead of *"In Breaking Bad, what did Walt and Jesse…"*.

## Why it skewed the list

Corpus-wide, demotions split:

| Demotion kind | Rows | Domains | When |
|---|---|---|---|
| **self-containment** (names-the-source) | 73 | 9 | **all on 2026-07-12** |
| other (factual / spoiler / real errors) | 25 | 21 | spread over 2 weeks |

All 73 self-containment demotions landed in a **single day** — the one-time healing sweep — concentrated in 9 subcategories. That's exactly why those 9 rocketed to the top. The metric counts every demotion equally and all-time, so **a one-time policy sweep masqueraded as intrinsic subject difficulty.** And the recommended remediation ("author by hand") is wrong: these are already prevented at generation (Rule 2b) and are one-click salvageable (prepend the title).

## The fix

Exclude `verification_reason ILIKE 'self-containment%'` from **both** the demoted numerator and the verified denominator in the futility query. Excluding from the denominator too keeps a domain's real error rate undiluted — 4 factual misses among 4 substantive verdicts should read 100%, not 33% padded by 8 formatting demotions.

The pure `futilityScore` / `curationVerdict` functions are unchanged (their tests still pass, 13/13).

## Validation (against prod)

- Breaking Bad / Avatar / Phineas & Ferb → **0 substantive demotions**; each drops below the sample floor and leaves the list.
- After excluding the sweep, **no domain crosses the 0.34 futility threshold** at the sample floor — the whole demotion-rate list was the sweep. The 25 genuine errors are spread ~1 per domain across 21 domains, none systematic.
- Only real generation-**timeout** domains (`RetrievalDomainHealth`) would surface now — the honest signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)