### PR TITLE
feat(quality): auto-chase demotions with salvage proposals + explicit card states

### DIFF
--- a/scripts/salvage-demoted.ts
+++ b/scripts/salvage-demoted.ts
@@ -4,10 +4,14 @@
  * A sample of the queue showed ~80% of demotions are not wrong answers — they
  * are one removable/wrong fact (usually a decorative aside in the explainer)
  * while the ask + headline answer are correct. For each demoted Question this
- * proposes the MINIMAL fix (proposeSalvage), re-verifies the PROPOSED version
- * (verifyQuestion directly — so we check our exact edit against the existing
- * answer), and stores a proposal. Nothing is applied: a human approves each
- * ready diff in the review queue (conservative). Broken cores → 'unsalvageable'.
+ * proposes the MINIMAL fix, re-verifies the PROPOSED version, and stores a
+ * proposal. Nothing is applied: a human approves each ready diff in the review
+ * queue (conservative). Broken cores → 'unsalvageable'.
+ *
+ * The pipeline itself lives in src/server/quality/salvage-sweep.ts and ALSO runs
+ * automatically from the batch-verify cron after each demotion batch (default
+ * ON; SALVAGE_ON_DEMOTE_ENABLED=false reverts). This script remains the manual
+ * entry point for bulk backfills and dry-run auditing.
  *
  * Read-only by default (proposes + prints a triage census). Run from repo root:
  *   node --import tsx --env-file=.env --env-file=.env.local scripts/salvage-demoted.ts          # dry-run: propose + census, persist nothing
@@ -19,131 +23,32 @@
 import 'dotenv/config';
 
 import { pool } from '../src/server/db';
-import { getMachineDemotionsForReview } from '../src/server/db/queries/machine-demotions';
-import {
-  questionIdsWithProposal,
-  upsertSalvageProposal,
-} from '../src/server/db/queries/salvage-proposals';
-import { proposeSalvage } from '../src/server/quality/salvage-question';
-import { verifyQuestion } from '../src/server/quality/verify-question';
+import { runSalvageSweep } from '../src/server/quality/salvage-sweep';
 
 const WRITE = process.argv.includes('--write');
 const CONCURRENCY = 5;
-// --limit N: process only the first N of the queue (validation runs).
+// --limit N: process only the first N un-proposed items (validation runs).
 const LIMIT_ARG = process.argv.find((a) => a.startsWith('--limit='));
-const LIMIT = LIMIT_ARG ? Math.max(1, Number(LIMIT_ARG.split('=')[1]) || 0) : Infinity;
-
-type Outcome = 'ready' | 'reverify_failed' | 'unsalvageable' | 'skipped_existing';
-
-async function processOne(item: {
-  questionId: string;
-  questionText: string;
-  correctAnswer: string;
-  explanation: string | null;
-  verificationReason: string | null;
-  canonicalSubcategory: string | null;
-  broadCategory: string | null;
-}): Promise<{ outcome: Outcome; note: string }> {
-  const proposal = await proposeSalvage({
-    questionText: item.questionText,
-    answer: item.correctAnswer,
-    explanation: item.explanation,
-    verificationReason: item.verificationReason ?? 'demoted (reason not captured)',
-    canonicalSubcategory: item.canonicalSubcategory,
-    broadCategory: item.broadCategory,
-  });
-
-  if (proposal.kind === 'unsalvageable') {
-    if (WRITE) {
-      await upsertSalvageProposal({
-        questionId: item.questionId,
-        targetTable: 'question',
-        kind: 'unsalvageable',
-        proposedStem: null,
-        proposedExplanation: null,
-        reverifyOutcome: 'demoted',
-        reverifyReason: proposal.note,
-        status: 'unsalvageable',
-      });
-    }
-    return { outcome: 'unsalvageable', note: proposal.note };
-  }
-
-  // Re-verify the PROPOSED version against the EXISTING answer (verifyQuestion
-  // directly — rerunQuestion would regenerate the answer + overwrite our
-  // proposed explainer). Fall back to originals for the field we didn't touch.
-  const reverify = await verifyQuestion({
-    questionText: proposal.proposedStem ?? item.questionText,
-    answer: item.correctAnswer,
-    explanation: proposal.proposedExplanation ?? item.explanation ?? undefined,
-    canonicalSubcategory: item.canonicalSubcategory ?? undefined,
-    broadCategory: item.broadCategory ?? undefined,
-    dimensions: ['false_premise', 'extra_fact'],
-  });
-
-  // Only a proposal that now PASSES becomes 'ready'; anything else is not shown.
-  const passed = reverify?.outcome === 'ok';
-  if (WRITE) {
-    await upsertSalvageProposal({
-      questionId: item.questionId,
-      targetTable: 'question',
-      kind: proposal.kind,
-      proposedStem: proposal.proposedStem,
-      proposedExplanation: proposal.proposedExplanation,
-      reverifyOutcome: reverify?.outcome ?? 'unverifiable',
-      reverifyReason: reverify?.reason ?? 'reverify unavailable',
-      status: passed ? 'ready' : 'unsalvageable',
-    });
-  }
-  return {
-    outcome: passed ? 'ready' : 'reverify_failed',
-    note: `${proposal.kind}: ${proposal.note}${passed ? '' : ` → reverify=${reverify?.outcome ?? 'none'}`}`,
-  };
-}
+const LIMIT = LIMIT_ARG ? Math.max(1, Number(LIMIT_ARG.split('=')[1]) || 0) : undefined;
 
 async function main() {
-  const fullQueue = await getMachineDemotionsForReview();
-  const queue = Number.isFinite(LIMIT) ? fullQueue.slice(0, LIMIT) : fullQueue;
-  const already = await questionIdsWithProposal(queue.map((q) => q.questionId));
-  const todo = queue.filter((q) => !already.has(q.questionId));
+  const summary = await runSalvageSweep({
+    persist: WRITE,
+    limit: LIMIT,
+    concurrency: CONCURRENCY,
+    onItem: (item, result) => {
+      const stem = item.questionText.slice(0, 60).replace(/\s+/g, ' ');
+      console.log(`  [${result.outcome}] ${stem}… — ${result.note}`);
+    },
+  });
 
   console.log(
-    `[salvage] queue=${queue.length} already_proposed=${already.size} to_process=${todo.length} mode=${WRITE ? 'WRITE' : 'DRY-RUN'}`,
+    `\n[salvage] queue=${summary.queued} already_proposed=${summary.alreadyProposed} processed=${summary.processed} mode=${WRITE ? 'WRITE' : 'DRY-RUN'}`,
   );
-
-  const tally: Record<Outcome, number> = {
-    ready: 0,
-    reverify_failed: 0,
-    unsalvageable: 0,
-    skipped_existing: already.size,
-  };
-
-  for (let i = 0; i < todo.length; i += CONCURRENCY) {
-    const chunk = todo.slice(i, i + CONCURRENCY);
-    const results = await Promise.all(
-      chunk.map(async (item) => {
-        try {
-          return await processOne(item);
-        } catch (error) {
-          return {
-            outcome: 'reverify_failed' as Outcome,
-            note: `error: ${error instanceof Error ? error.message : String(error)}`,
-          };
-        }
-      }),
-    );
-    results.forEach((r, j) => {
-      tally[r.outcome]++;
-      const stem = chunk[j].questionText.slice(0, 60).replace(/\s+/g, ' ');
-      console.log(`  [${r.outcome}] ${stem}… — ${r.note}`);
-    });
-  }
-
-  console.log('\n[salvage] census:', JSON.stringify(tally));
-  const salvageable = tally.ready;
-  const pct = todo.length ? Math.round((salvageable / todo.length) * 100) : 0;
+  console.log('[salvage] census:', JSON.stringify(summary));
+  const pct = summary.processed ? Math.round((summary.ready / summary.processed) * 100) : 0;
   console.log(
-    `[salvage] ${salvageable}/${todo.length} processed became one-click-ready (${pct}%). ${WRITE ? 'Persisted.' : 'Dry-run — re-run with --write to persist.'}`,
+    `[salvage] ${summary.ready}/${summary.processed} processed became one-click-ready (${pct}%). ${WRITE ? 'Persisted.' : 'Dry-run — re-run with --write to persist.'}`,
   );
 }
 

--- a/src/app/admin/reports/AdminReportsClient.tsx
+++ b/src/app/admin/reports/AdminReportsClient.tsx
@@ -1110,19 +1110,45 @@ function DemotionRow({
         {item.verificationReason ?? 'reason not captured (demoted before reasons were stored)'}
       </p>
 
-      {/* D-QUALITY-SALVAGE-01: a machine-proposed minimal fix that already
-          re-verified clean. Conservative — "Review fix" opens the same edit panel
-          pre-filled; the human still re-runs + approves. Nothing auto-applies. */}
+      {/* D-QUALITY-SALVAGE-01: the salvage sweep now chases every demotion
+          automatically (batch-verify cron), so each card tells the human exactly
+          where the machine got to: a ready fix (green, one click), a triage
+          verdict (no safe fix — genuinely needs a human), or still pending. */}
+      {!proposal && item.triage && !editing ? (
+        <div
+          className="mt-2 rounded-md border px-3 py-2 text-[13px]"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          <p className="font-semibold" style={{ color: 'var(--brand-ink-700)' }}>
+            No safe machine fix — needs your call
+          </p>
+          <p className="text-muted-foreground mt-0.5">
+            The machine tried and couldn&apos;t produce a fix that passes fact-check — the answer
+            or premise itself may be at fault.
+            {item.triage.reason ? ` Its note: ${item.triage.reason}` : ''}
+          </p>
+        </div>
+      ) : null}
+      {!proposal && !item.triage && !editing ? (
+        <p className="text-muted-foreground mt-2 text-[12px] italic">
+          Machine fix pending — the salvage sweep proposes one automatically after the next verify
+          run. Waiting is free; only step in now if this row is urgent.
+        </p>
+      ) : null}
+      {/* A machine-proposed minimal fix that already re-verified clean.
+          Conservative — "Review fix" opens the same edit panel pre-filled; the
+          human still re-runs + approves. Nothing auto-applies. */}
       {proposal && !editing ? (
         <div
           className="mt-2 rounded-md border px-3 py-2 text-[13px]"
           style={{ borderColor: 'var(--success)', background: 'var(--success-surface, transparent)' }}
         >
           <p className="font-semibold text-[var(--success)]">
-            Suggested fix — verifier re-checked, now passes
+            Machine fix ready — verifier re-checked, now passes
           </p>
           <p className="text-muted-foreground mt-0.5">
-            {proposal.kind === 'extra_fact_explainer' ? 'Explainer' : 'Question'} · {proposal.reverifyReason ?? 'minimal edit'}
+            {proposal.kind === 'extra_fact_explainer' ? 'Explainer' : 'Question'} edited · {proposal.reverifyReason ?? 'minimal edit'} · Approve returns it
+            to circulation with no further re-run.
           </p>
           {proposal.proposedStem ? (
             <p className="mt-1 text-[var(--brand-ink)]">

--- a/src/app/api/cron/batch-verify-questions/route.ts
+++ b/src/app/api/cron/batch-verify-questions/route.ts
@@ -10,6 +10,11 @@ import {
   type PrefilterOptions,
 } from '@/server/quality/verification-prefilter';
 import {
+  isSalvageOnDemoteEnabled,
+  runSalvageSweep,
+  type SalvageSweepSummary,
+} from '@/server/quality/salvage-sweep';
+import {
   harvestVerifyBatches,
   isBatchVerifyAsyncEnabled,
   submitVerifyBatch,
@@ -103,6 +108,32 @@ function selectPending(limit: number, now: Date): Promise<[PendingRow[], Pending
       ))
       .limit(limit),
   ]) as Promise<[PendingRow[], PendingRow[]]>;
+}
+
+// D-QUALITY-SALVAGE-01: after the sweep stamps demotions, chase them with the
+// salvage pipeline so the review queue already carries one-click "Approve fix"
+// proposals when a human opens it. Capped per run to stay inside maxDuration —
+// the sweep skips already-proposed rows, so anything left over (cap hit, error,
+// or a platform kill mid-salvage) self-heals on the next cron pass. Best-effort
+// by contract: a salvage fault never fails the verify sweep.
+const SALVAGE_MAX_PER_RUN = Math.max(1, Number(process.env.SALVAGE_ON_DEMOTE_MAX_PER_RUN ?? 8));
+
+type SalvageReport =
+  | { enabled: false }
+  | ({ enabled: true } & SalvageSweepSummary)
+  | { enabled: true; error: string };
+
+async function chaseDemotionsWithSalvage(): Promise<SalvageReport> {
+  if (!isSalvageOnDemoteEnabled()) return { enabled: false };
+  try {
+    const summary = await runSalvageSweep({ persist: true, limit: SALVAGE_MAX_PER_RUN });
+    return { enabled: true, ...summary };
+  } catch (error) {
+    console.warn('[cron/batch-verify-questions] salvage sweep failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { enabled: true, error: error instanceof Error ? error.message : String(error) };
+  }
 }
 
 async function stampQuestion(rowId: string, verdict: VerificationVerdict, now: Date, reason?: string) {
@@ -244,6 +275,10 @@ async function runAsyncSweep(now: Date, options: PrefilterOptions) {
     }
   }
 
+  // Fresh demotions landed at harvest time above; propose their fixes now so
+  // the review queue is one-click by the time the human gets there.
+  const salvage = await chaseDemotionsWithSalvage();
+
   return NextResponse.json({
     mode: 'async',
     harvest: {
@@ -257,6 +292,7 @@ async function runAsyncSweep(now: Date, options: PrefilterOptions) {
       stampFailures: harvested.stampFailures,
     },
     submit: { ...submitTallies, batch: submitted },
+    salvage,
   });
 }
 
@@ -335,5 +371,8 @@ async function runSyncSweep(now: Date, options: PrefilterOptions) {
     }
   });
 
-  return NextResponse.json({ question: questionTally, generated: generatedTally });
+  // Chase this run's demotions with salvage proposals (see chaseDemotionsWithSalvage).
+  const salvage = await chaseDemotionsWithSalvage();
+
+  return NextResponse.json({ question: questionTally, generated: generatedTally, salvage });
 }

--- a/src/server/db/queries/machine-demotions.ts
+++ b/src/server/db/queries/machine-demotions.ts
@@ -6,7 +6,7 @@ import {
   resolveActiveIncorrectReportsForGenerated,
   resolveActiveIncorrectReportsForQuestion,
 } from '@/server/db/queries/content-reports';
-import { getReadyProposalsForQuestions, type SalvageProposalRow } from '@/server/db/queries/salvage-proposals';
+import { getLatestProposalsForQuestions, type SalvageProposalRow } from '@/server/db/queries/salvage-proposals';
 import { type QuestionSource, resolveAuthorDisplay } from '@/lib/questions-types';
 
 // B-CRAFTER-LIFECYCLE-01 Phase 1 — the MACHINE stream of the admin review queue.
@@ -48,6 +48,11 @@ export type MachineDemotionReviewItem = {
   // D-QUALITY-SALVAGE-01: a machine-proposed, pre-re-verified minimal fix awaiting
   // one-click approval. Present only when a 'ready' proposal exists for this row.
   proposal: SalvageProposalRow | null;
+  // The machine looked and found NO safe minimal fix (answer/premise at fault, or
+  // the proposed edit failed re-verification) — this card genuinely needs human
+  // judgment. Null alongside a null proposal ⇒ the salvage sweep hasn't reached
+  // this row yet. Mutually exclusive with `proposal`.
+  triage: { reason: string | null } | null;
 };
 
 // Demoted canonical questions awaiting a human call, oldest demotion first
@@ -85,22 +90,26 @@ export async function getMachineDemotionsForReview(): Promise<MachineDemotionRev
     )
     .orderBy(asc(questions.verifiedAt));
 
-  const proposals = await getReadyProposalsForQuestions(rows.map((r) => r.questionId));
+  const proposals = await getLatestProposalsForQuestions(rows.map((r) => r.questionId));
 
-  return rows.map((row) => ({
-    questionId: row.questionId,
-    questionText: row.questionText,
-    correctAnswer: row.correctAnswer,
-    explanation: row.explanation,
-    verificationReason: row.verificationReason,
-    verifiedAt: row.verifiedAt,
-    canonicalSubcategory: row.canonicalSubcategory,
-    broadCategory: row.broadCategory,
-    source: row.source,
-    creatorId: row.creatorId,
-    proposal: proposals.get(row.questionId) ?? null,
-    ...resolveAuthorDisplay(row.creatorId, row.source, row.authorName),
-  }));
+  return rows.map((row) => {
+    const latest = proposals.get(row.questionId) ?? null;
+    return {
+      questionId: row.questionId,
+      questionText: row.questionText,
+      correctAnswer: row.correctAnswer,
+      explanation: row.explanation,
+      verificationReason: row.verificationReason,
+      verifiedAt: row.verifiedAt,
+      canonicalSubcategory: row.canonicalSubcategory,
+      broadCategory: row.broadCategory,
+      source: row.source,
+      creatorId: row.creatorId,
+      proposal: latest?.status === 'ready' ? latest : null,
+      triage: latest?.status === 'unsalvageable' ? { reason: latest.reverifyReason } : null,
+      ...resolveAuthorDisplay(row.creatorId, row.source, row.authorName),
+    };
+  });
 }
 
 export type DemotionActionResult =

--- a/src/server/db/queries/salvage-proposals.ts
+++ b/src/server/db/queries/salvage-proposals.ts
@@ -8,6 +8,11 @@ export type SalvageProposalRow = {
   proposedStem: string | null;
   proposedExplanation: string | null;
   reverifyReason: string | null;
+  // 'ready' = a pre-re-verified fix awaiting one-click approval; 'unsalvageable'
+  // = the machine looked and found no safe minimal fix (needs human judgment).
+  // Terminal statuses (applied/rejected) are never returned — the human already
+  // decided those, so the card shows nothing.
+  status: 'ready' | 'unsalvageable';
 };
 
 type InsertSalvageProposal = {
@@ -38,8 +43,12 @@ export async function upsertSalvageProposal(row: InsertSalvageProposal): Promise
   await db.insert(questionSalvageProposals).values(row);
 }
 
-/** The latest live proposal per question id — for the review-queue join. */
-export async function getReadyProposalsForQuestions(
+/**
+ * The latest live-or-triaged proposal per question id — for the review-queue
+ * join. Includes 'unsalvageable' so the card can distinguish "machine looked,
+ * no safe fix — this genuinely needs you" from "machine hasn't looked yet".
+ */
+export async function getLatestProposalsForQuestions(
   questionIds: string[],
 ): Promise<Map<string, SalvageProposalRow>> {
   if (questionIds.length === 0) return new Map();
@@ -50,17 +59,22 @@ export async function getReadyProposalsForQuestions(
       proposedStem: questionSalvageProposals.proposedStem,
       proposedExplanation: questionSalvageProposals.proposedExplanation,
       reverifyReason: questionSalvageProposals.reverifyReason,
+      status: questionSalvageProposals.status,
     })
     .from(questionSalvageProposals)
     .where(
       and(
         inArray(questionSalvageProposals.questionId, questionIds),
-        eq(questionSalvageProposals.status, 'ready'),
+        inArray(questionSalvageProposals.status, ['ready', 'unsalvageable']),
       ),
     )
     .orderBy(desc(questionSalvageProposals.createdAt));
   const out = new Map<string, SalvageProposalRow>();
-  for (const r of rows) if (!out.has(r.questionId)) out.set(r.questionId, r);
+  for (const r of rows) {
+    if (!out.has(r.questionId)) {
+      out.set(r.questionId, r as SalvageProposalRow);
+    }
+  }
   return out;
 }
 

--- a/src/server/quality/__tests__/salvage-sweep.test.ts
+++ b/src/server/quality/__tests__/salvage-sweep.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getQueueMock, alreadyProposedMock, upsertMock, proposeMock, verifyMock } = vi.hoisted(
+  () => ({
+    getQueueMock: vi.fn(async (): Promise<unknown[]> => []),
+    alreadyProposedMock: vi.fn(async () => new Set<string>()),
+    upsertMock: vi.fn(async () => undefined),
+    proposeMock: vi.fn(
+      async (): Promise<{
+        kind: string;
+        proposedStem: string | null;
+        proposedExplanation: string | null;
+        note: string;
+      }> => ({
+        kind: 'extra_fact_explainer',
+        proposedStem: null,
+        proposedExplanation: 'trimmed explainer',
+        note: 'removed the wrong co-founder claim',
+      }),
+    ),
+    verifyMock: vi.fn(
+      async (): Promise<{ outcome: string; reason: string } | null> => ({
+        outcome: 'ok',
+        reason: 'checks out',
+      }),
+    ),
+  }),
+);
+
+vi.mock('@/server/db/queries/machine-demotions', () => ({
+  getMachineDemotionsForReview: getQueueMock,
+}));
+vi.mock('@/server/db/queries/salvage-proposals', () => ({
+  questionIdsWithProposal: alreadyProposedMock,
+  upsertSalvageProposal: upsertMock,
+}));
+vi.mock('@/server/quality/salvage-question', () => ({ proposeSalvage: proposeMock }));
+vi.mock('@/server/quality/verify-question', () => ({ verifyQuestion: verifyMock }));
+
+import {
+  isSalvageOnDemoteEnabled,
+  runSalvageSweep,
+  type SalvageSweepItem,
+} from '@/server/quality/salvage-sweep';
+
+function item(id: string): SalvageSweepItem {
+  return {
+    questionId: id,
+    questionText: `Question ${id}?`,
+    correctAnswer: 'The answer',
+    explanation: 'An explainer with one extra fact.',
+    verificationReason: 'extra_fact error: the explainer smuggles a wrong claim',
+    canonicalSubcategory: 'Detroit Techno',
+    broadCategory: 'Music',
+  };
+}
+
+beforeEach(() => {
+  // Tests override with persistent mockResolvedValue, so a full reset +
+  // re-seeded defaults keeps them from leaking into the next test.
+  vi.resetAllMocks();
+  getQueueMock.mockResolvedValue([]);
+  alreadyProposedMock.mockResolvedValue(new Set());
+  upsertMock.mockResolvedValue(undefined);
+  proposeMock.mockResolvedValue({
+    kind: 'extra_fact_explainer',
+    proposedStem: null,
+    proposedExplanation: 'trimmed explainer',
+    note: 'removed the wrong co-founder claim',
+  });
+  verifyMock.mockResolvedValue({ outcome: 'ok', reason: 'checks out' });
+});
+
+describe('runSalvageSweep', () => {
+  it('proposes, re-verifies, and persists ready proposals for un-proposed demotions', async () => {
+    getQueueMock.mockResolvedValue([item('q1'), item('q2')]);
+    alreadyProposedMock.mockResolvedValue(new Set(['q1']));
+
+    const summary = await runSalvageSweep({ persist: true });
+
+    expect(summary).toEqual({
+      queued: 2,
+      alreadyProposed: 1,
+      processed: 1,
+      ready: 1,
+      reverifyFailed: 0,
+      unsalvageable: 0,
+      errors: 0,
+    });
+    expect(proposeMock).toHaveBeenCalledTimes(1);
+    expect(verifyMock).toHaveBeenCalledTimes(1);
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ questionId: 'q2', status: 'ready', reverifyOutcome: 'ok' }),
+    );
+  });
+
+  it('re-verifies the PROPOSED text against the EXISTING answer', async () => {
+    getQueueMock.mockResolvedValue([item('q1')]);
+    proposeMock.mockResolvedValue({
+      kind: 'extra_fact_stem',
+      proposedStem: 'Trimmed question?',
+      proposedExplanation: null,
+      note: 'removed decorative year',
+    });
+
+    await runSalvageSweep({ persist: true });
+
+    expect(verifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        questionText: 'Trimmed question?',
+        answer: 'The answer',
+        explanation: 'An explainer with one extra fact.',
+        dimensions: ['false_premise', 'extra_fact'],
+      }),
+    );
+  });
+
+  it('stores an unsalvageable proposal without calling the verifier', async () => {
+    getQueueMock.mockResolvedValue([item('q1')]);
+    proposeMock.mockResolvedValue({
+      kind: 'unsalvageable',
+      proposedStem: null,
+      proposedExplanation: null,
+      note: 'the answer itself is wrong',
+    });
+
+    const summary = await runSalvageSweep({ persist: true });
+
+    expect(summary.unsalvageable).toBe(1);
+    expect(verifyMock).not.toHaveBeenCalled();
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ questionId: 'q1', kind: 'unsalvageable', status: 'unsalvageable' }),
+    );
+  });
+
+  it('stores a failed re-verify as unsalvageable (never shows an unproven fix)', async () => {
+    getQueueMock.mockResolvedValue([item('q1')]);
+    verifyMock.mockResolvedValue({ outcome: 'demoted', reason: 'still wrong' });
+
+    const summary = await runSalvageSweep({ persist: true });
+
+    expect(summary.reverifyFailed).toBe(1);
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ questionId: 'q1', status: 'unsalvageable', reverifyOutcome: 'demoted' }),
+    );
+  });
+
+  it('persists nothing in dry-run mode', async () => {
+    getQueueMock.mockResolvedValue([item('q1')]);
+
+    await runSalvageSweep({ persist: false });
+
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it('caps processed items at the limit', async () => {
+    getQueueMock.mockResolvedValue([item('q1'), item('q2'), item('q3')]);
+
+    const summary = await runSalvageSweep({ persist: true, limit: 2 });
+
+    expect(summary.processed).toBe(2);
+    expect(proposeMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('contains an item fault (counted as error, nothing persisted, sweep continues)', async () => {
+    getQueueMock.mockResolvedValue([item('q1'), item('q2')]);
+    proposeMock
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({
+        kind: 'extra_fact_explainer',
+        proposedStem: null,
+        proposedExplanation: 'trimmed',
+        note: 'ok',
+      });
+
+    const summary = await runSalvageSweep({ persist: true, concurrency: 1 });
+
+    expect(summary.errors).toBe(1);
+    expect(summary.ready).toBe(1);
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    expect(upsertMock).toHaveBeenCalledWith(expect.objectContaining({ questionId: 'q2' }));
+  });
+});
+
+describe('isSalvageOnDemoteEnabled', () => {
+  const prior = process.env.SALVAGE_ON_DEMOTE_ENABLED;
+  afterEach(() => {
+    if (prior === undefined) delete process.env.SALVAGE_ON_DEMOTE_ENABLED;
+    else process.env.SALVAGE_ON_DEMOTE_ENABLED = prior;
+  });
+
+  it('defaults ON', () => {
+    delete process.env.SALVAGE_ON_DEMOTE_ENABLED;
+    expect(isSalvageOnDemoteEnabled()).toBe(true);
+  });
+
+  it('turns off only on an explicit false-y value', () => {
+    process.env.SALVAGE_ON_DEMOTE_ENABLED = 'false';
+    expect(isSalvageOnDemoteEnabled()).toBe(false);
+    process.env.SALVAGE_ON_DEMOTE_ENABLED = 'off';
+    expect(isSalvageOnDemoteEnabled()).toBe(false);
+    process.env.SALVAGE_ON_DEMOTE_ENABLED = 'true';
+    expect(isSalvageOnDemoteEnabled()).toBe(true);
+  });
+});

--- a/src/server/quality/salvage-sweep.ts
+++ b/src/server/quality/salvage-sweep.ts
@@ -1,0 +1,183 @@
+/**
+ * Salvage sweep (D-QUALITY-SALVAGE-01) — the shared propose→re-verify→persist
+ * pipeline over the demoted-question review queue.
+ *
+ * Extracted from scripts/salvage-demoted.ts so the batch-verify cron can chase
+ * every fresh demotion with a machine-proposed minimal fix automatically: by the
+ * time a human opens /admin/reports, ~80% of demotion cards already carry a
+ * one-click "Approve fix". The script remains the manual/bulk entry point
+ * (dry-run default); both callers share this exact pipeline.
+ *
+ * Contract (unchanged from the script):
+ *   - Nothing is ever applied to Question rows here — only QuestionSalvageProposal
+ *     rows are written, and only when `persist` is true.
+ *   - A proposal becomes 'ready' ONLY when the re-verified proposed text passes;
+ *     anything else is stored 'unsalvageable' so a bad fix is never offered.
+ *   - Questions that already have ANY proposal are skipped (never re-spend);
+ *     an item that ERRORS persists nothing, so the next sweep retries it.
+ */
+import { getMachineDemotionsForReview } from '@/server/db/queries/machine-demotions';
+import {
+  questionIdsWithProposal,
+  upsertSalvageProposal,
+} from '@/server/db/queries/salvage-proposals';
+import { runWithConcurrency } from '@/server/lib/concurrency';
+import { proposeSalvage } from '@/server/quality/salvage-question';
+import { verifyQuestion } from '@/server/quality/verify-question';
+
+/** DEFAULT ON — set SALVAGE_ON_DEMOTE_ENABLED=false to stop the cron-chained
+ *  sweep without a deploy (the manual script is unaffected by this flag). */
+export function isSalvageOnDemoteEnabled(): boolean {
+  const raw = process.env.SALVAGE_ON_DEMOTE_ENABLED?.trim().toLowerCase();
+  return !(raw === 'false' || raw === '0' || raw === 'no' || raw === 'off');
+}
+
+export type SalvageSweepItem = {
+  questionId: string;
+  questionText: string;
+  correctAnswer: string;
+  explanation: string | null;
+  verificationReason: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+};
+
+export type SalvageItemOutcome = 'ready' | 'reverify_failed' | 'unsalvageable' | 'error';
+
+export type SalvageItemResult = { outcome: SalvageItemOutcome; note: string };
+
+/**
+ * Propose the minimal fix for one demoted question, re-verify the PROPOSED
+ * version against the EXISTING answer, and (when `persist`) store the proposal —
+ * 'ready' only if the re-verify passes. Never edits the question itself.
+ */
+export async function salvageOneDemotedQuestion(
+  item: SalvageSweepItem,
+  persist: boolean,
+): Promise<SalvageItemResult> {
+  const proposal = await proposeSalvage({
+    questionText: item.questionText,
+    answer: item.correctAnswer,
+    explanation: item.explanation,
+    verificationReason: item.verificationReason ?? 'demoted (reason not captured)',
+    canonicalSubcategory: item.canonicalSubcategory,
+    broadCategory: item.broadCategory,
+  });
+
+  if (proposal.kind === 'unsalvageable') {
+    if (persist) {
+      await upsertSalvageProposal({
+        questionId: item.questionId,
+        targetTable: 'question',
+        kind: 'unsalvageable',
+        proposedStem: null,
+        proposedExplanation: null,
+        reverifyOutcome: 'demoted',
+        reverifyReason: proposal.note,
+        status: 'unsalvageable',
+      });
+    }
+    return { outcome: 'unsalvageable', note: proposal.note };
+  }
+
+  // Re-verify the PROPOSED version against the EXISTING answer (verifyQuestion
+  // directly — rerunQuestion would regenerate the answer + overwrite our
+  // proposed explainer). Fall back to originals for the field we didn't touch.
+  const reverify = await verifyQuestion({
+    questionText: proposal.proposedStem ?? item.questionText,
+    answer: item.correctAnswer,
+    explanation: proposal.proposedExplanation ?? item.explanation ?? undefined,
+    canonicalSubcategory: item.canonicalSubcategory ?? undefined,
+    broadCategory: item.broadCategory ?? undefined,
+    dimensions: ['false_premise', 'extra_fact'],
+  });
+
+  // Only a proposal that now PASSES becomes 'ready'; anything else is not shown.
+  const passed = reverify?.outcome === 'ok';
+  if (persist) {
+    await upsertSalvageProposal({
+      questionId: item.questionId,
+      targetTable: 'question',
+      kind: proposal.kind,
+      proposedStem: proposal.proposedStem,
+      proposedExplanation: proposal.proposedExplanation,
+      reverifyOutcome: reverify?.outcome ?? 'unverifiable',
+      reverifyReason: reverify?.reason ?? 'reverify unavailable',
+      status: passed ? 'ready' : 'unsalvageable',
+    });
+  }
+  return {
+    outcome: passed ? 'ready' : 'reverify_failed',
+    note: `${proposal.kind}: ${proposal.note}${passed ? '' : ` → reverify=${reverify?.outcome ?? 'none'}`}`,
+  };
+}
+
+export type SalvageSweepSummary = {
+  /** Demotion cards currently in the review queue. */
+  queued: number;
+  /** Skipped: a proposal (any status) already exists — never re-spend. */
+  alreadyProposed: number;
+  /** Items actually run through the pipeline this sweep (post-skip, post-limit). */
+  processed: number;
+  ready: number;
+  reverifyFailed: number;
+  unsalvageable: number;
+  /** Threw mid-pipeline: nothing persisted, retried by the next sweep. */
+  errors: number;
+};
+
+export type SalvageSweepOptions = {
+  /** false = dry-run: propose + re-verify but write nothing (the script default). */
+  persist: boolean;
+  /** Max items processed (post-skip). Callers on a request deadline set this. */
+  limit?: number;
+  /** LLM-bound workers in flight; keep small inside the cron (DB pool is 5). */
+  concurrency?: number;
+  /** Per-item progress hook (the script's console census). */
+  onItem?: (item: SalvageSweepItem, result: SalvageItemResult) => void;
+};
+
+/**
+ * Run the salvage pipeline over every un-proposed demotion in the review queue,
+ * up to `limit`. Item faults are contained (counted, nothing persisted) so one
+ * bad row never aborts the sweep; leftovers self-heal on the next pass because
+ * the skip guard only skips rows that got a persisted proposal.
+ */
+export async function runSalvageSweep(options: SalvageSweepOptions): Promise<SalvageSweepSummary> {
+  const { persist, limit, concurrency = 3, onItem } = options;
+
+  const queue = await getMachineDemotionsForReview();
+  const already = await questionIdsWithProposal(queue.map((q) => q.questionId));
+  const unproposed = queue.filter((q) => !already.has(q.questionId));
+  const todo = limit !== undefined ? unproposed.slice(0, Math.max(0, limit)) : unproposed;
+
+  const summary: SalvageSweepSummary = {
+    queued: queue.length,
+    alreadyProposed: already.size,
+    processed: todo.length,
+    ready: 0,
+    reverifyFailed: 0,
+    unsalvageable: 0,
+    errors: 0,
+  };
+
+  await runWithConcurrency(todo, concurrency, async (item) => {
+    // runWithConcurrency does not isolate failures — contain them here.
+    let result: SalvageItemResult;
+    try {
+      result = await salvageOneDemotedQuestion(item, persist);
+    } catch (error) {
+      result = {
+        outcome: 'error',
+        note: error instanceof Error ? error.message : String(error),
+      };
+    }
+    if (result.outcome === 'ready') summary.ready += 1;
+    else if (result.outcome === 'reverify_failed') summary.reverifyFailed += 1;
+    else if (result.outcome === 'unsalvageable') summary.unsalvageable += 1;
+    else summary.errors += 1;
+    onItem?.(item, result);
+  });
+
+  return summary;
+}


### PR DESCRIPTION
## Why

Triaging the `/admin/reports` demotion queue by hand means re-doing work the machine already did: ~80% of verifier demotions are one removable extra fact, the salvage pipeline (D-QUALITY-SALVAGE-01, #1426) already proposes + re-verifies the exact minimal edit a human would make — but it only ran via a manual script, so cards sat in the queue with no proposal until someone remembered to run it. Manually editing doesn't even save money: the Edit path re-runs the same verifier LLM call the sweep pays for (~<5¢/question end-to-end), so hand-editing spends minutes of human time to save ~half a cent.

## What

**Auto-chase.** The propose → re-verify → persist pipeline moves from `scripts/salvage-demoted.ts` into a shared module, `src/server/quality/salvage-sweep.ts`, and the batch-verify cron now runs it after stamping demotions in **both** modes (sync inline and async Batch-API harvest).

- **Default ON**; `SALVAGE_ON_DEMOTE_ENABLED=false` reverts without a deploy (same flag convention as the thin-declared verify gate).
- Capped per run (`SALVAGE_ON_DEMOTE_MAX_PER_RUN`, default 8) so the sweep stays inside `maxDuration`. The skip-if-already-proposed guard means leftovers — cap hit, item error, platform kill mid-salvage — self-heal on the next cron pass.
- Best-effort by contract: a salvage fault is logged into the cron's JSON response but never fails the verify sweep.
- The script survives as a thin wrapper over the same pipeline for bulk backfills and dry-run audits.

**Review-queue clarity.** A demotion card with no green fix box was ambiguous — *machine hasn't looked yet* vs *machine looked and gave up* — which call for opposite human actions. Every card now shows exactly one of three machine states:

1. **Machine fix ready** (green) — pre-re-verified minimal edit; copy states that Approve returns it to circulation with no further re-run.
2. **No safe machine fix — needs your call** (new) — `unsalvageable` verdicts were stored but never surfaced; now the card says the machine tried, couldn't produce a fix that passes fact-check, and shows its reason (answer/premise likely at fault).
3. **Machine fix pending** (muted) — the sweep hasn't reached it; waiting is free.

Supporting change: `getReadyProposalsForQuestions` → `getLatestProposalsForQuestions` (also returns `unsalvageable` rows, with `status`); `MachineDemotionReviewItem` gains a mutually-exclusive `triage` field. Terminal statuses (applied/rejected) are still never surfaced — the human already decided those.

## Testing

- New suite `src/server/quality/__tests__/salvage-sweep.test.ts` (9 tests): skip-already-proposed, re-verifies the *proposed* text against the *existing* answer, unsalvageable short-circuits the verifier, failed re-verify persists as unsalvageable (never shows an unproven fix), dry-run persists nothing, limit cap, item-fault containment, flag default-ON semantics.
- Full `src/server/quality` + admin content-reports suites: 96 passed.
- `npx tsc -p tsconfig.typecheck.json`: no errors outside pre-existing stale `.next/` artifacts; ESLint clean on all touched files.

## Notes for review

- No schema/migration changes — reuses `QuestionSalvageProposal` (0115) as-is.
- The cron's sync mode can approach `maxDuration` on heavy runs; a mid-salvage kill is safe (persisted proposals are idempotent, the rest self-heal next pass).
- Generated-store demotions are still intentionally excluded (never served; per the machine-demotions design note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STvDHVrXNYPsG9CP37jnb7
