### PR TITLE
Knowledge page: retire Configure into the portrait, remove-from-map, detail-card polish

### DIFF
--- a/src/components/knowledge/KnowledgePeaksView.tsx
+++ b/src/components/knowledge/KnowledgePeaksView.tsx
@@ -771,8 +771,6 @@ export function PeakDetailCard({
     parent.value === undefined &&
     !parent.mastered;
 
-  const actionButton =
-    'inline-flex min-h-10 items-center gap-1.5 rounded-full border px-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
 
   const confirmAdd = async (id: string, name: string) => {
     setPhase({ step: 'adding', id, name });
@@ -821,12 +819,10 @@ export function PeakDetailCard({
         type="button"
         disabled={busy || added}
         onClick={() => void inlineAdd(id, name)}
-        className="inline-flex min-h-8 flex-none items-center gap-1 rounded-full border px-3 text-xs disabled:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        style={
-          added
-            ? { borderColor: 'var(--border)', color: 'var(--text-muted)' }
-            : { borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }
-        }
+        // Compact sibling of .btn-ghost (same corners/border/type, row-friendly
+        // height) — the full 44px system ghost overwhelms a single text row.
+        className="inline-flex min-h-9 flex-none items-center gap-1 rounded-[var(--radius-xs)] border bg-background px-3 text-sm font-medium text-foreground transition hover:bg-muted disabled:pointer-events-none disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        style={added ? { color: 'var(--text-muted)' } : undefined}
         aria-label={
           added
             ? `${name} added to your map`
@@ -883,8 +879,7 @@ export function PeakDetailCard({
             <button
               type="button"
               onClick={() => setPhase({ step: 'idle' })}
-              className={actionButton}
-              style={{ borderColor: 'var(--brand-navy)', background: 'var(--brand-navy)', color: 'var(--brand-card)' }}
+              className="btn-primary"
             >
               Done
             </button>
@@ -899,16 +894,14 @@ export function PeakDetailCard({
             <button
               type="button"
               onClick={() => void confirmAdd(phase.id, name)}
-              className={actionButton}
-              style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+              className="btn-primary"
             >
               Try again
             </button>
             <button
               type="button"
               onClick={() => setPhase({ step: 'idle' })}
-              className={actionButton}
-              style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+              className="btn-ghost"
             >
               Back
             </button>
@@ -945,16 +938,14 @@ export function PeakDetailCard({
           <button
             type="button"
             onClick={() => void confirmAdd(node.id, node.name)}
-            className={actionButton}
-            style={{ borderColor: 'var(--brand-navy)', background: 'var(--brand-navy)', color: 'var(--brand-card)' }}
+            className="btn-primary gap-1.5"
           >
             <Plus className="size-4" aria-hidden /> Add it
           </button>
           <button
             type="button"
             onClick={onClose}
-            className={actionButton}
-            style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+            className="btn-ghost"
           >
             Not now
           </button>
@@ -1158,7 +1149,18 @@ export function PeakDetailCard({
                     )}
                   </span>
                   <span className="min-w-0">
-                    <span className="block font-serif text-[15px] leading-tight">{title}</span>
+                    {/* Rotation mark rides right of the label (D-FREQUENCY-MARK-01);
+                        on the selected navy row it flips to card color to stay
+                        visible. */}
+                    <span className="flex items-center gap-2 font-serif text-[15px] leading-tight">
+                      {title}
+                      <FrequencyMark
+                        frequency={value}
+                        color={selectedFreq ? 'var(--brand-card)' : fieldColor(node.field)}
+                        size={12}
+                        decorative
+                      />
+                    </span>
                     <span
                       className={selectedFreq ? 'block text-xs opacity-80' : 'block text-xs'}
                       style={selectedFreq ? undefined : { color: 'var(--text-muted)' }}
@@ -1202,16 +1204,14 @@ export function PeakDetailCard({
                   type="button"
                   disabled={adoptBusy}
                   onClick={() => void confirmAdopt()}
-                  className={actionButton}
-                  style={{ borderColor: 'var(--brand-navy)', background: 'var(--brand-navy)', color: 'var(--brand-card)' }}
+                  className="btn-primary gap-1.5"
                 >
                   <Plus className="size-4" aria-hidden /> {adoptBusy ? 'Adding…' : 'Add it'}
                 </button>
                 <button
                   type="button"
                   onClick={() => setAdoptConfirm(false)}
-                  className={actionButton}
-                  style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+                  className="btn-ghost"
                 >
                   Not now
                 </button>
@@ -1221,8 +1221,7 @@ export function PeakDetailCard({
             <button
               type="button"
               onClick={() => setAdoptConfirm(true)}
-              className={actionButton}
-              style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+              className="btn-ghost gap-1.5"
             >
               <Plus className="size-4" aria-hidden /> Add to my map
             </button>

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -359,6 +359,21 @@ export function PortraitDomainCircle({
       }}
     >
       <div style={{ position: 'relative', width: size, height: size }}>
+        {/* Hairline ring OUTSIDE the bubble's depth-opacity: the gradient fill
+            (22%→12% tint × opacity ≥ 0.22) bottoms out near-invisible on cream
+            for low-point domains, so the ring is what keeps every circle
+            findable. Fill opacity still carries the depth signal. */}
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 0,
+            borderRadius: '50%',
+            border: `1px solid color-mix(in srgb, ${dc.primary} 45%, transparent)`,
+            pointerEvents: 'none',
+            opacity: dimForHidden ? 0.4 : undefined,
+          }}
+        />
         <KnowledgeBubble
           diameter={size}
           tint={dc.primary}


### PR DESCRIPTION
## Summary

Follow-ups to the knowledge-page work merged via #1513, culminating in retiring the Configure page (`/daily/setup`) into the knowledge portrait's rotation module.

### Retire Configure into the knowledge page

- **Remove from map** — a quiet link below the "Never" option in the domain detail pop-up. Clicking swaps in a can't-be-undone warning with a `.btn-danger` confirm. The removal writes the same subcategory exclusion Configure's drag-to-remove wrote, and the knowledge read (`getKnowledgePageData` + bulk variant) now filters excluded domains so removal sticks across the portrait, friend view, and overview. Re-declaring the interest clears the exclusion (`addDeclaredInterest`), so "add it back" revives a removed domain — also fixing the latent Configure-era re-add dead-end.
- **Add a territory** — Configure's suggestions block (nearby-territory ghost circles with a rotating window) and "Create your own" (the existing declared-interests modal) now live under the portrait. `GhostTerritoryCircle` extracted to a shared component.
- **First-territory empty state** — the "map is ready for its first territory" moment renders on `/knowledge` when the map is empty.
- **Route + links** — `/daily/setup` 302s to `/knowledge` (`TerritorySetupClient` stays on disk, unrouted). All entries retarget: TodaysFiveCard/RefineYourGame customize pills, FeedList frequency toast, first-session/first-game panels, the daily 409 redirect, the reminder email's interests URL, KnowledgeOverviewClient. The custom-round (`domainMode=custom`) links retire with the page: the domain page's "Answer questions in X" card is dropped (same call as #1514's play-now removal); unrouted bubble-map cards point at `/daily`.

### Detail card & portrait polish

- Frequency marks on the "How often it shows up" rows (right of the label per D-FREQUENCY-MARK-01; flips to card color on the selected navy row).
- Card add/confirm buttons moved onto the canonical button system: `.btn-primary` for Add it/Done/Try again, `.btn-ghost` for Not now/Back/Add to my map, compact ghost for the inline "+ Add" pills.
- Hairline category ring on portrait circles so low-point domains (fill ~5% effective tint at the depth-opacity floor) stay findable.

## Testing

- `npx tsc -p tsconfig.typecheck.json` clean; ESLint clean on touched files; all four ratchets pass
- Full `vitest`: 2,243 pass. Two failures are pre-existing on a clean tree (`FriendsHubPage.test.tsx` copy assertion, `daily/answer` route-test mock missing `ANTHROPIC_MODEL`) — verified identical with these changes stashed
- `add-declared-interest` tests extended to cover the exclusion-clearing revive path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD6uzHk1VHJe83kDi1r6Hr