### PR TITLE
feat(daily): rest a topic for ~21 days from the game summary

### DIFF
--- a/drizzle/0124_domain_rest_until.sql
+++ b/drizzle/0124_domain_rest_until.sql
@@ -1,0 +1,21 @@
+-- 0124: rest_until on USER_DOMAIN_EXCLUSIONS (D-DOMAIN-REST-01).
+--
+-- "Rest a topic" — the game-summary action that pulls a domain out of
+-- circulation for ~21 days and then lets it come back on its own. Modeled as a
+-- domain-exclusion with an expiry, so it reuses the existing suppression path
+-- rather than a parallel mechanism:
+--   • rest_until IS NULL   → permanent exclusion (the old "Mute" semantics).
+--   • rest_until > now()   → resting; still suppressed.
+--   • rest_until <= now()  → expired; the read path stops matching the row, so
+--                            the domain returns with NO cron — expiry is
+--                            evaluated at queue-build time
+--                            (getExcludedKnowledgeDomains).
+--
+-- Additive + nullable → existing rows (permanent mutes) keep NULL and are
+-- unaffected. Mirrored by a defensive guard in src/instrumentation.ts
+-- (precedent: the migration 0036 scope-column guard on this same table).
+--
+-- Rollback:
+--   ALTER TABLE "USER_DOMAIN_EXCLUSIONS" DROP COLUMN IF EXISTS "rest_until";
+ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
+  ADD COLUMN IF NOT EXISTS "rest_until" timestamp with time zone;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -869,6 +869,13 @@
 			"when": 1787184000000,
 			"tag": "0123_mastery_calibration_snapshot",
 			"breakpoints": true
+		},
+		{
+			"idx": 124,
+			"version": "7",
+			"when": 1787270400000,
+			"tag": "0124_domain_rest_until",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/app/api/users/domain-exclusions/__tests__/rest-days.test.ts
+++ b/src/app/api/users/domain-exclusions/__tests__/rest-days.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// getDomainRestDays reads process.env at call time, so it's testable without a
+// DB. Route module imports pull in @/server/db (no connection string in tests),
+// so stub it to a no-op shape — we only exercise the pure config helper.
+vi.mock('@/server/db', () => ({ db: {}, userDomainExclusions: {} }));
+vi.mock('@/server/auth/session', () => ({ getSession: vi.fn() }));
+
+import { getDomainRestDays } from '@/app/api/users/domain-exclusions/route';
+
+const ORIGINAL = process.env.DOMAIN_REST_DAYS;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.DOMAIN_REST_DAYS;
+  else process.env.DOMAIN_REST_DAYS = ORIGINAL;
+});
+
+describe('getDomainRestDays', () => {
+  it('defaults to 21 when unset', () => {
+    delete process.env.DOMAIN_REST_DAYS;
+    expect(getDomainRestDays()).toBe(21);
+  });
+
+  it('honors a positive override', () => {
+    process.env.DOMAIN_REST_DAYS = '30';
+    expect(getDomainRestDays()).toBe(30);
+  });
+
+  it('falls back to 21 for non-numeric, zero, or negative values', () => {
+    for (const bad of ['abc', '0', '-5', '']) {
+      process.env.DOMAIN_REST_DAYS = bad;
+      expect(getDomainRestDays()).toBe(21);
+    }
+  });
+});

--- a/src/app/api/users/domain-exclusions/route.ts
+++ b/src/app/api/users/domain-exclusions/route.ts
@@ -7,6 +7,15 @@ import { db, userDomainExclusions } from '@/server/db';
 
 export const dynamic = 'force-dynamic';
 
+// D-DOMAIN-REST-01: how long a "Rest a topic" pause lasts before the domain
+// returns to circulation on its own. Env-tunable (adjust without a redeploy);
+// defaults to 21 days. The window is decided SERVER-SIDE so a client can't set
+// its own expiry — the request only signals `rest: true`.
+export function getDomainRestDays(): number {
+  const raw = Number(process.env.DOMAIN_REST_DAYS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 21;
+}
+
 const exclusionPayloadSchema = z.object({
   canonical_subcategory: z
     .string()
@@ -14,6 +23,10 @@ const exclusionPayloadSchema = z.object({
     .min(1)
     .transform((value) => value.replace(/\s+/g, ' ')),
   scope: z.enum(['subcategory', 'broad_category', 'category']).default('subcategory'),
+  // When true, this is a temporary Rest (auto-expires after DOMAIN_REST_DAYS)
+  // rather than a permanent Mute/"Never appear". Optional + defaults false so
+  // existing callers (settings, refine/commit) keep writing permanent rows.
+  rest: z.boolean().default(false),
 });
 
 async function parsePayload(request: NextRequest) {
@@ -34,22 +47,32 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // A Rest sets an expiry DOMAIN_REST_DAYS out; a permanent mute leaves it NULL.
+  // On conflict we UPDATE rest_until (not DoNothing) so re-resting refreshes the
+  // clock, and choosing Rest over an existing permanent mute (or vice versa)
+  // switches the row's kind rather than silently keeping the old one.
+  const restUntil = payload.rest
+    ? new Date(Date.now() + getDomainRestDays() * 24 * 60 * 60 * 1000)
+    : null;
+
   await db
     .insert(userDomainExclusions)
     .values({
       userId: session.userId,
       canonicalSubcategory: payload.canonical_subcategory,
       scope: payload.scope,
+      restUntil,
     })
-    .onConflictDoNothing({
+    .onConflictDoUpdate({
       target: [
         userDomainExclusions.userId,
         userDomainExclusions.scope,
         userDomainExclusions.canonicalSubcategory,
       ],
+      set: { restUntil },
     });
 
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({ ok: true, restUntil });
 }
 
 export async function DELETE(request: NextRequest) {

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -559,14 +559,13 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
   const [isOverflowOpen, setIsOverflowOpen] = useState(false)
   const [rating, setRating] = useState<FeedbackSignal | null>(null)
   const [isFeedbackPending, startFeedbackTransition] = useTransition()
-  const [exclusionState, setExclusionState] = useState<ExclusionState>({
+  const [actionState, setActionState] = useState<PostRoundActionState>({
     kind: 'idle',
   })
   // B-Report-2: which "why" sheet is open, if any. Null = no sheet.
   const [reportCategory, setReportCategory] = useState<'incorrect' | 'inappropriate' | null>(null)
   // Optimistic confirmation that the user flagged this recap as incorrect.
   const [reportedIncorrect, setReportedIncorrect] = useState(false)
-  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const updateFeedback = useCallback(
     (next: FeedbackSignal) => {
@@ -590,48 +589,72 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
     [question.questionId, rating]
   )
 
-  const handleExcludeDomain = useCallback(async () => {
+  // "Rest {domain}" — a temporary pause. Writes a domain-exclusion with an
+  // expiry (D-DOMAIN-REST-01); the server owns the window and returns the
+  // rest_until instant so we can name the return date. Optimistic: the banner
+  // shows immediately and folds in the real date when the POST lands.
+  const handleRestDomain = useCallback(async () => {
     setIsOverflowOpen(false)
-    setExclusionState({ kind: 'confirmed' })
-    undoTimerRef.current = setTimeout(() => {
-      undoTimerRef.current = null
-    }, 5000)
+    setActionState({ kind: 'rested', restUntil: null })
     try {
-      await fetch('/api/users/domain-exclusions', {
+      const response = await fetch('/api/users/domain-exclusions', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ canonical_subcategory: question.domain }),
+        body: JSON.stringify({ canonical_subcategory: question.domain, rest: true }),
       })
+      const body = (await response.json().catch(() => null)) as { restUntil?: string } | null
+      if (response.ok && body?.restUntil) {
+        setActionState((prev) =>
+          prev.kind === 'rested' ? { kind: 'rested', restUntil: body.restUntil! } : prev,
+        )
+      }
     } catch {
-      // Optimistic UI is acceptable here; the next summary load will reflect persisted state.
+      // Optimistic UI is acceptable here; the next summary load reflects persisted state.
     }
   }, [question.domain])
 
-  const handleUndoExcludeDomain = useCallback(async () => {
-    if (undoTimerRef.current) {
-      clearTimeout(undoTimerRef.current)
-      undoTimerRef.current = null
-    }
-    setExclusionState({ kind: 'undone' })
+  // "Move {domain} to Never" — the permanent tier. Reuses the single-domain
+  // frequency endpoint (frequency: 'resting' = the "Never" label), which also
+  // drops the domain from selectedDomains for custom-mode players.
+  const handleNeverDomain = useCallback(async () => {
+    setIsOverflowOpen(false)
+    setActionState({ kind: 'nevered' })
     try {
-      await fetch(
-        `/api/users/domain-exclusions/${encodeURIComponent(question.domain)}`,
-        {
+      await fetch('/api/daily/preferences/domain-frequency', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ domain: question.domain, frequency: 'resting' }),
+      })
+    } catch {
+      // Optimistic UI is acceptable here; the next summary load reflects persisted state.
+    }
+  }, [question.domain])
+
+  // One Undo for whichever action was just taken — delete the Rest row, or clear
+  // the Never frequency back to the default (frequency: null).
+  const handleUndoAction = useCallback(async () => {
+    const undoing = actionState
+    setActionState({ kind: 'undone' })
+    try {
+      if (undoing.kind === 'rested') {
+        await fetch(`/api/users/domain-exclusions/${encodeURIComponent(question.domain)}`, {
           method: 'DELETE',
           credentials: 'include',
-        }
-      )
+        })
+      } else if (undoing.kind === 'nevered') {
+        await fetch('/api/daily/preferences/domain-frequency', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ domain: question.domain, frequency: null }),
+        })
+      }
     } catch {
       // Fire-and-forget; the affordance returns on reload if persistence failed.
     }
-  }, [question.domain])
-
-  useEffect(() => {
-    return () => {
-      if (undoTimerRef.current) clearTimeout(undoTimerRef.current)
-    }
-  }, [])
+  }, [actionState, question.domain])
 
   const [isExplainerOpen, setIsExplainerOpen] = useState(false)
   // Only offer "More context" when the 3-line clamp is actually hiding text;
@@ -797,15 +820,16 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
 
       {note ? <CreatorNote text={note.text} provenance={note.provenance} /> : null}
 
-      {exclusionState.kind === 'confirmed' ? (
+      {actionState.kind === 'rested' || actionState.kind === 'nevered' ? (
         <div className="bg-muted/35 text-muted-foreground mt-4 flex items-center gap-2 rounded-md border px-3 py-2 text-xs">
           <span>
-            {question.domainDisplayName} won&apos;t appear in your daily queue
-            anymore.
+            {actionState.kind === 'rested'
+              ? `Resting ${question.domainDisplayName}${restBackText(actionState.restUntil)}.`
+              : `${question.domainDisplayName} won’t appear anymore.`}
           </span>
           <button
             type="button"
-            onClick={handleUndoExcludeDomain}
+            onClick={handleUndoAction}
             className="ml-auto font-medium tracking-[0.08em] uppercase underline underline-offset-4"
           >
             Undo
@@ -852,8 +876,8 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
         <QuestionCardOverflowMenu
           question={question}
           onClose={() => setIsOverflowOpen(false)}
-          onHideQuestionsLikeThis={handleExcludeDomain}
-          onMuteCategory={handleExcludeDomain}
+          onRest={handleRestDomain}
+          onNever={handleNeverDomain}
           canReport={question.reportTarget !== null}
           onReportIncorrect={() => {
             setIsOverflowOpen(false)
@@ -885,16 +909,16 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
 function QuestionCardOverflowMenu({
   question,
   onClose,
-  onHideQuestionsLikeThis,
-  onMuteCategory,
+  onRest,
+  onNever,
   canReport,
   onReportIncorrect,
   onReportInappropriate,
 }: {
   question: QuestionRecap
   onClose: () => void
-  onHideQuestionsLikeThis: () => void
-  onMuteCategory: () => void
+  onRest: () => void
+  onNever: () => void
   canReport: boolean
   onReportIncorrect: () => void
   onReportInappropriate: () => void
@@ -921,17 +945,17 @@ function QuestionCardOverflowMenu({
         </div>
         <button
           type="button"
-          onClick={onHideQuestionsLikeThis}
+          onClick={onRest}
           className="text-foreground hover:bg-muted flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
         >
-          Hide questions like this
+          Rest {question.domainDisplayName}
         </button>
         <button
           type="button"
-          onClick={onMuteCategory}
+          onClick={onNever}
           className="text-foreground hover:bg-muted flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
         >
-          Mute {question.domainDisplayName}
+          Move {question.domainDisplayName} to Never
         </button>
         <button
           type="button"
@@ -972,7 +996,23 @@ function QuestionCardOverflowMenu({
   )
 }
 
-type ExclusionState =
+// The post-round menu action just taken on this recap card, driving the inline
+// confirmation banner + its Undo. 'rested' carries the server's rest_until (null
+// until the POST returns) so the banner can name the return date.
+type PostRoundActionState =
   | { kind: 'idle' }
-  | { kind: 'confirmed' }
+  | { kind: 'rested'; restUntil: string | null }
+  | { kind: 'nevered' }
   | { kind: 'undone' }
+
+// " — back around Aug 4" for the Rest banner, or '' before the server date lands
+// (or if it's unparseable). Month + day is enough; the exact time isn't useful.
+function restBackText(restUntil: string | null): string {
+  if (!restUntil) return ''
+  const date = new Date(restUntil)
+  if (Number.isNaN(date.getTime())) return ''
+  return ` — back around ${date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })}`
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -851,6 +851,23 @@ export async function register() {
       // creates it before this migration runs.
     }
 
+    // Migration 0124 (D-DOMAIN-REST-01) adds a nullable rest_until column to
+    // USER_DOMAIN_EXCLUSIONS: the game-summary "Rest a topic" action writes an
+    // exclusion with an expiry instead of a permanent one. The queue-build read
+    // path (getExcludedKnowledgeDomains) references this column, so a
+    // preview/production database that records the migration without the column
+    // present would fail there before migrate() can repair it. Additive +
+    // nullable — same repair rationale as the 0036 scope guard above.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
+          ADD COLUMN IF NOT EXISTS "rest_until" timestamptz
+      `);
+    } catch {
+      // USER_DOMAIN_EXCLUSIONS may not exist yet on a fresh database — migrate()
+      // creates it before this migration runs.
+    }
+
     // Migration 0037 adds the EmailOptIn enum and four columns on User for the
     // round-open reminder opt-in (email_opt_in, email_verified, pending_email,
     // reminder_prompt_dismissed_at). If a preview/production database has this

--- a/src/server/daily/__tests__/resting-domains.test.ts
+++ b/src/server/daily/__tests__/resting-domains.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   clearStaleShortTodayQueue: vi.fn(),
   countDailyQueues: vi.fn(),
   getKnowledgeBase: vi.fn(),
+  getExcludedKnowledgeDomains: vi.fn(),
   pickEligibleAuthoredQuestions: vi.fn(),
   pickHouseQuestions: vi.fn(),
   persistDailyQueue: vi.fn(),
@@ -36,6 +37,7 @@ vi.mock('@/server/db/queries/daily', () => ({
   clearStaleShortTodayQueue: mocks.clearStaleShortTodayQueue,
   countDailyQueues: mocks.countDailyQueues,
   getKnowledgeBase: mocks.getKnowledgeBase,
+  getExcludedKnowledgeDomains: mocks.getExcludedKnowledgeDomains,
   pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
   pickHouseQuestions: mocks.pickHouseQuestions,
   getRecentAnsweredAnswerKeys: vi.fn(async () => new Set<string>()),
@@ -97,6 +99,13 @@ beforeEach(() => {
   // Returning player; this suite checks the resting allow-set, not first-run seeding.
   mocks.countDailyQueues.mockResolvedValue(3);
 
+  // No Rested/Muted domains by default; the custom-mode suppression test
+  // overrides this with an active exclusion set.
+  mocks.getExcludedKnowledgeDomains.mockResolvedValue({
+    subcategories: new Set<string>(),
+    broadCategories: new Set<string>(),
+  });
+
   mocks.pickEligibleAuthoredQuestions.mockResolvedValue([]);
   mocks.pickHouseQuestions.mockResolvedValue([]);
   mocks.getFriendAndFoFUserIds.mockResolvedValue({ direct: new Set(), extended: new Set() });
@@ -153,5 +162,36 @@ describe('fillDailyQueueForUser — Game settings categories drive selection', (
     );
     expect(allowed!.has('Jazz')).toBe(true);
     expect(allowed!.has('Opera')).toBe(true);
+  });
+
+  // D-DOMAIN-REST-01: a Rested/Muted domain is an active domain-exclusion, which
+  // custom mode never saw before (it trusts selectedDomains). getExcluded-
+  // KnowledgeDomains returns only ACTIVE exclusions (expired Rests already
+  // dropped), so this covers "Rest {domain}" from the game summary suppressing a
+  // custom-mode player's selected domain.
+  it('excludes Rested/Muted domains from authored + house picks in custom mode', async () => {
+    mocks.getKnowledgeBase.mockResolvedValue([{ domain: 'Jazz' }, { domain: 'Opera' }]);
+    mocks.getDailyPreferences.mockResolvedValue({
+      difficulty: 'adaptive',
+      domainMode: 'custom',
+      selectedDomains: ['Jazz', 'Opera'],
+      domainPreferenceFrequency: {},
+    });
+    // "Jazz" Rested from the game summary → an active subcategory exclusion.
+    mocks.getExcludedKnowledgeDomains.mockResolvedValue({
+      subcategories: new Set(['jazz']),
+      broadCategories: new Set<string>(),
+    });
+
+    await fillDailyQueueForUser(USER);
+
+    for (const picker of [mocks.pickEligibleAuthoredQuestions, mocks.pickHouseQuestions]) {
+      const allowed = picker.mock.calls[0].find(
+        (arg): arg is ReadonlySet<string> => arg instanceof Set,
+      );
+      expect(allowed).toBeDefined();
+      expect(allowed!.has('Jazz')).toBe(false);
+      expect(allowed!.has('Opera')).toBe(true);
+    }
   });
 });

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -7,6 +7,7 @@ import {
   carryForwardQueueWithSlots,
   clearStaleShortTodayQueue,
   countDailyQueues,
+  getExcludedKnowledgeDomains,
   getKnowledgeBase,
   getPriorInWindowDailyQueue,
   getTodaysDailyQueue,
@@ -369,9 +370,10 @@ async function buildDailyQueueForUser(
   // still have unplayed questions — don't regenerate from scratch" (flag-gated).
   if (await topUpAndCarryForwardPartialQueue(userId)) return;
 
-  const [knowledgeBase, preferences] = await Promise.all([
+  const [knowledgeBase, preferences, excludedDomains] = await Promise.all([
     getKnowledgeBase(userId),
     getDailyPreferences(userId),
+    getExcludedKnowledgeDomains(userId),
   ]);
 
   // First Daily Five seeding (PRD prompt 5). We've passed the existing-queue and
@@ -429,10 +431,21 @@ async function buildDailyQueueForUser(
       .map(([domain]) => domain.toLowerCase()),
   );
   const notResting = (domain: string) => !restingDomains.has(domain.toLowerCase());
-  const selectedNotResting = preferences.selectedDomains.filter(notResting);
+  // D-DOMAIN-REST-01: also drop domains the player Rested (a domain-exclusion
+  // with a live expiry) or permanently Muted from the game summary. Random mode
+  // already excludes these via getKnowledgeBase, but custom mode is constrained
+  // to the explicit selectedDomains list, which never sees exclusions — so a
+  // Rested/Muted category would otherwise still leak into a custom-mode Daily
+  // Five through the authored/house pickers (the exact gap the resting filter
+  // above closes for the frequency tier). Rest/Mute write subcategory scope, so
+  // match on the subcategory set; expired Rests are already gone from this set.
+  const notExcluded = (domain: string) =>
+    !excludedDomains.subcategories.has(domain.toLowerCase());
+  const notRestingOrExcluded = (domain: string) => notResting(domain) && notExcluded(domain);
+  const selectedActive = preferences.selectedDomains.filter(notRestingOrExcluded);
   const allowedSubcategories: ReadonlySet<string> = new Set(
     preferences.domainMode === 'custom'
-      ? (selectedNotResting.length > 0 ? selectedNotResting : preferences.selectedDomains)
+      ? (selectedActive.length > 0 ? selectedActive : preferences.selectedDomains)
       : knowledgeBase.map((domain) => domain.domain).filter(notResting),
   );
 

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -145,12 +145,25 @@ function normalizeDomain(value: string): string {
   return value.trim().replace(/\s+/g, ' ');
 }
 
-type ScopedExclusions = {
+export type ScopedExclusions = {
   subcategories: Set<string>;
   broadCategories: Set<string>;
 };
 
-async function getExcludedKnowledgeDomains(userId: string): Promise<ScopedExclusions> {
+// Exported for the queue orchestrator: custom-mode selection is constrained to
+// the player's explicit selectedDomains list, which getKnowledgeBase never
+// touches, so exclusions (permanent Mutes and active Rests) must be re-applied
+// there directly. Returns only ACTIVE exclusions (expired Rests already dropped).
+export async function getExcludedKnowledgeDomains(userId: string): Promise<ScopedExclusions> {
+  // D-DOMAIN-REST-01: a row only excludes while it is ACTIVE — permanent mutes
+  // (rest_until IS NULL) always, and Rest rows only until their expiry. An
+  // expired Rest simply stops matching here, so the domain returns to
+  // circulation on the next queue build with no cron. Evaluated in SQL against
+  // now() so it's consistent with the DB clock.
+  const activeExclusion = and(
+    eq(userDomainExclusions.userId, userId),
+    or(isNull(userDomainExclusions.restUntil), sql`${userDomainExclusions.restUntil} > now()`),
+  );
   let rows: { domain: string; scope: 'subcategory' | 'broad_category' | 'category' }[];
   try {
     rows = await db
@@ -159,12 +172,14 @@ async function getExcludedKnowledgeDomains(userId: string): Promise<ScopedExclus
         scope: userDomainExclusions.scope,
       })
       .from(userDomainExclusions)
-      .where(eq(userDomainExclusions.userId, userId));
+      .where(activeExclusion);
   } catch (error) {
     if (pgErrorCode(error) === '42P01') return { subcategories: new Set(), broadCategories: new Set() };
-    // 42703 = scope column missing on a database where the additive migration
-    // hasn't landed yet. Fall back to a scope='subcategory' read so the feature
-    // degrades to its pre-migration behavior instead of failing.
+    // 42703 = the scope OR rest_until column is missing on a database where the
+    // additive migration (0036 / 0124) hasn't landed yet. Fall back to a
+    // scope='subcategory', treat-all-as-permanent read so the feature degrades
+    // to its pre-migration behavior instead of failing. No Rest rows can exist
+    // before 0124, so treating every row as active is correct in that window.
     if (pgErrorCode(error) === '42703') {
       const legacy = await db
         .select({ domain: userDomainExclusions.canonicalSubcategory })

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1085,6 +1085,11 @@ export const userDomainExclusions = pgTable(
     canonicalSubcategory: text('canonical_subcategory').notNull(),
     scope: domainExclusionScopeEnum('scope').notNull().default('subcategory'),
     excludedAt: timestamp('excluded_at', { withTimezone: true }).notNull().defaultNow(),
+    // D-DOMAIN-REST-01: a temporary "Rest" pulls a domain out of circulation
+    // until this instant, then it returns on its own (expiry is evaluated at
+    // read time in getExcludedKnowledgeDomains — no cron). NULL = a permanent
+    // exclusion (the "Mute"/"Never appear" semantics), which is the default.
+    restUntil: timestamp('rest_until', { withTimezone: true }),
   },
   (table) => [
     unique('USER_DOMAIN_EXCLUSIONS_user_id_scope_canonical_subcategory_key').on(


### PR DESCRIPTION
## What

Adds a **"Rest {domain}"** action to the game-summary overflow menu: it pulls a topic out of circulation for **~21 days** (env-tunable via `DOMAIN_REST_DAYS`), then the topic returns on its own. This is distinct from the permanent **"Never"** tier, which the same menu now reaches via **"Move {domain} to Never"**.

The summary menu's two domain-level actions are now split by timeframe:

| Menu item (before → after) | Effect | Mechanism |
|---|---|---|
| "Mute {domain}" → **"Rest {domain}"** | Temporary, ~21 days, auto-returns | domain-exclusion with expiry |
| "Hide questions like this" → **"Move {domain} to Never"** | Permanent | existing `resting` frequency tier (no new backend) |

## How

Rest is modeled as a domain-exclusion **with an expiry**, reusing the existing suppression path instead of a parallel mechanism:

- **Migration `0124`** adds a nullable `rest_until` to `USER_DOMAIN_EXCLUSIONS` (`NULL` = permanent mute; `> now()` = resting). Boot guard in `instrumentation.ts` + journal entry included. Additive/nullable, so existing permanent mutes are untouched.
- **Read-time expiry, no cron.** `getExcludedKnowledgeDomains` only counts a row while `rest_until IS NULL OR rest_until > now()`, so an expired Rest simply stops matching on the next queue build.
- **Server owns the window.** `POST /api/users/domain-exclusions` takes an optional `rest: true`; the expiry is computed server-side from `DOMAIN_REST_DAYS` (default 21) so it can't be spoofed by the client.
- **Closes a latent gap.** Exclusions were only applied via `getKnowledgeBase` (random mode). Custom mode is constrained to `selectedDomains`, which never saw exclusions — so a Rested/Muted domain still leaked into a custom-mode Daily Five through the authored/house pickers. The orchestrator now filters `selectedDomains` by the active exclusion set too (mirrors the existing `notResting` filter). This also tightens the pre-existing permanent Mute.

## Naming note

The code's `resting` *frequency* value = the permanent **"Never"** label. The new temporary thing is **"Rest"** (an exclusion + expiry). They're opposites — kept deliberately separate.

## Tests
- Custom-mode suppression: a Rested/Muted domain is dropped from the authored + house allow-set in custom mode.
- Env-tunable window: `getDomainRestDays()` defaults to 21 and honors/validates the override.

## Migration note
`rest_until` was applied to the live DB directly (idempotent `ADD COLUMN IF NOT EXISTS`, verified nullable timestamptz) to avoid the migrator re-touching 0121–0123, which currently show as unrecorded in `__drizzle_migrations` on this DB. Flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)