### PR TITLE
fix(daily): serve live question text over the assignment-time slot snapshot

### DIFF
--- a/src/app/api/daily/queue/route.ts
+++ b/src/app/api/daily/queue/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { countDailyQueues, getTodaysDailyQueue } from '@/server/db/queries/daily';
+import { countDailyQueues, getTodaysDailyQueue, refreshQueueSlotQuestionTexts } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
 import { DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
@@ -35,7 +35,7 @@ function partitionGenericSlots(slots: QueueSlot[]): { kept: QueueSlot[]; dropped
   return { kept, dropped };
 }
 
-function serializeQueue(
+async function serializeQueue(
   queue: NonNullable<Awaited<ReturnType<typeof getTodaysDailyQueue>>>,
   difficultyMode: string,
   userId: string,
@@ -73,7 +73,10 @@ function serializeQueue(
   return {
     queue_id: queue.id,
     queue_date: queue.queueDate,
-    slots: kept,
+    // Serve live question text (slot.question_text is an assignment-time
+    // snapshot; grading resolves the live row, so an admin edit made after
+    // assignment must reach the display too).
+    slots: await refreshQueueSlotQuestionTexts(kept),
     difficulty_mode: difficultyMode,
     is_first_daily: isFirstDaily,
   };
@@ -132,7 +135,7 @@ export async function GET() {
     return withTiming(NextResponse.json({ queue: null, slots: [], building: true }));
   }
 
-  return withTiming(NextResponse.json(serializeQueue(queue, prefs.difficulty, userId, totalQueues)));
+  return withTiming(NextResponse.json(await serializeQueue(queue, prefs.difficulty, userId, totalQueues)));
 }
 
 export async function POST() {
@@ -173,7 +176,8 @@ export async function POST() {
     return NextResponse.json({ error: 'queue_not_created' }, { status: 500 });
   }
 
+  const serialized = await serializeQueue(queue, prefs.difficulty, userId, totalQueues);
   timing.measure('total', startedAt);
   logServerTiming('daily/queue:POST', timing, { outcome: 'built' });
-  return NextResponse.json(serializeQueue(queue, prefs.difficulty, userId, totalQueues));
+  return NextResponse.json(serialized);
 }

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -373,6 +373,50 @@ export async function getTodaysDailyQueue(userId: string): Promise<DailyQueueRow
 }
 
 /**
+ * Overwrite each slot's denormalized `question_text` with the live text from
+ * its source row (GeneratedQuestion or canonical Question). Slots snapshot the
+ * text at assignment time, so an admin edit made after assignment never reaches
+ * the player otherwise — but grading always resolves the live row, so serving
+ * the snapshot risks grading against an answer the displayed question no longer
+ * asks for. Read-time only (nothing is persisted); a slot whose source row is
+ * gone keeps its snapshot, which is also why history surfaces (archive,
+ * summary, content reports) deliberately stay snapshot-first.
+ */
+export async function refreshQueueSlotQuestionTexts(slots: QueueSlot[]): Promise<QueueSlot[]> {
+  const generatedIds = [...new Set(slots.map((slot) => slot.generated_question_id).filter((id): id is string => Boolean(id)))];
+  const canonicalIds = [...new Set(slots.filter((slot) => !slot.generated_question_id).map((slot) => slot.question_id).filter((id): id is string => Boolean(id)))];
+  if (generatedIds.length === 0 && canonicalIds.length === 0) return slots;
+
+  const [generatedRows, canonicalRows] = await Promise.all([
+    generatedIds.length > 0
+      ? db
+          .select({ id: generatedQuestions.id, questionText: generatedQuestions.questionText })
+          .from(generatedQuestions)
+          .where(inArray(generatedQuestions.id, generatedIds))
+      : Promise.resolve<{ id: string; questionText: string }[]>([]),
+    canonicalIds.length > 0
+      ? db
+          .select({ id: canonicalQuestions.id, questionText: canonicalQuestions.questionText })
+          .from(canonicalQuestions)
+          .where(inArray(canonicalQuestions.id, canonicalIds))
+      : Promise.resolve<{ id: string; questionText: string }[]>([]),
+  ]);
+  const liveTextById = new Map(
+    [...generatedRows, ...canonicalRows]
+      .filter((row) => row.questionText)
+      .map((row) => [row.id, row.questionText]),
+  );
+
+  return slots.map((slot) => {
+    const sourceId = slot.generated_question_id ?? slot.question_id;
+    const liveText = sourceId ? liveTextById.get(sourceId) : undefined;
+    return liveText && liveText !== slot.question_text
+      ? { ...slot, question_text: liveText }
+      : slot;
+  });
+}
+
+/**
  * Atomically claim the daily reminder email for a queue so concurrent cron
  * retries can't double-send. The single UPDATE flips email_reminder_sent_at
  * from null to now() only if it is still null, and RETURNs the row iff this
@@ -756,7 +800,12 @@ async function getDailyCatchupItems(
           expiresAt,
           expiresSoon: expiresWithin24Hours(expiresAt),
           questionId: question.id,
-          questionText: slot.question_text || question.questionText,
+          // Live text first: catch-up items are still answerable, and the
+          // answer/explainer beside them are read live — a post-assignment
+          // admin edit must reach the text too, or the player is graded
+          // against an answer the displayed question no longer asks for.
+          // The slot snapshot is only a fallback for a vanished row.
+          questionText: question.questionText || slot.question_text,
           correctAnswer: question.answer,
           alternateAnswers: [] as string[],
           explanation: question.explainer,
@@ -800,7 +849,8 @@ async function getDailyCatchupItems(
         expiresAt,
         expiresSoon: expiresWithin24Hours(expiresAt),
         questionId: question.id,
-        questionText: slot.question_text || question.questionText,
+        // Live-first for the same reason as the generated branch above.
+        questionText: question.questionText || slot.question_text,
         correctAnswer: question.answerText,
         alternateAnswers: question.acceptedAlternatives ?? [],
         explanation,


### PR DESCRIPTION
## Problem

Admin edits to a question never reached players for already-assigned items. `DailyQueue` slots snapshot `question_text` at assignment time, and both the daily five and catch-up rendered the snapshot first — while the answer/explainer beside it (and grading) resolve the live row. So after an edit, a player could see the **old question text but be graded against the new answer** (observed on a 3-day-old catch-up card).

## Fix

- **Catch-up** (`getDailyCatchupItems`, both generated + canonical branches): flip precedence to `question.questionText || slot.question_text` — live text wins; the snapshot remains a fallback for a vanished source row. The feed-sourced catch-up branch already read live text, and the catch-up answer route grades from the same item, so displayed and graded text stay consistent.
- **Today's five** (`/api/daily/queue` GET + POST): the route served slots straight from the queue JSON with no join, so a new `refreshQueueSlotQuestionTexts()` helper overwrites slot text from the live `GeneratedQuestion`/`Question` rows at read time. Two batched `inArray` selects; nothing is persisted. On POST, serialization moved above the `total` Server-Timing measure so the span still covers it.

## Deliberately unchanged

- History surfaces — archive, daily summary, content reports, breadcrumb, recheck — stay snapshot-first: they record what the player actually saw (the load-bearing comments in `archive.ts` / `content-reports.ts` document this).
- The `slot_changed` re-display response in the answer route (bonus-insert re-index race) still returns snapshot text; it self-corrects on the next queue fetch.

## Testing

- `vitest run src/server/db/queries/__tests__ src/server/daily/__tests__ src/app/api/daily`: 604 passed. The one failing file (`answer/__tests__/route.test.ts`, `vi.mock` missing `ANTHROPIC_MODEL`) fails identically on clean HEAD — pre-existing, unrelated.
- Re-ran the catch-up/query suites on this main-based branch: 38 files / 229 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STvDHVrXNYPsG9CP37jnb7