### PR TITLE
fix(quality): catch acronym-expansion answers leaking their short form

### DIFF
--- a/src/server/daily/__tests__/answer-leak-gate.test.ts
+++ b/src/server/daily/__tests__/answer-leak-gate.test.ts
@@ -55,6 +55,53 @@ describe('findAnswerLeaks', () => {
     expect([...result.toDrop].sort()).toEqual([0, 1]);
   });
 
+  it('drops an answer whose acronym short form is shown in the question (UX-design leak)', () => {
+    // Reported 2026-07-15: the answer spells out an acronym the stem already
+    // shows in short form. "User Experience (UX) design" collapses to "UX
+    // design", which is verbatim in the stem — the whole-answer substring test
+    // missed it because the stem never contains the expansion "User Experience".
+    const result = findAnswerLeaks([
+      q(
+        "In UX design, what term refers to the overall process of researching, designing, and improving the quality of a user's interaction with a product or service?",
+        'User Experience (UX) design',
+      ),
+    ]);
+    expect([...result.toDrop]).toEqual([0]);
+    expect(result.reasons[0]).toContain('User Experience (UX) design');
+  });
+
+  it('keeps an acronym-expansion answer whose short form is NOT in the question', () => {
+    // Same answer shape, but the stem never shows "UX design", so nothing leaks.
+    const result = findAnswerLeaks([
+      q(
+        'What field studies how people perceive, feel about, and interact with products they use?',
+        'User Experience (UX) design',
+      ),
+    ]);
+    expect(result.toDrop.size).toBe(0);
+  });
+
+  it('keeps a "what does the acronym stand for" question whose stem must show the acronym', () => {
+    // The acronym-collapse must NOT fire on bare-acronym expansions: a define-
+    // the-acronym question necessarily shows the acronym, and its answer is the
+    // expansion. Dropping these would delete a whole legitimate question type.
+    const result = findAnswerLeaks([
+      q('What does GPU stand for in computer hardware?', 'Graphics Processing Unit (GPU)'),
+      q('In finance, what does the acronym ROI represent?', 'Return on Investment (ROI)'),
+    ]);
+    expect(result.toDrop.size).toBe(0);
+  });
+
+  it('keeps an initials-identification question even when the stem contains the initials', () => {
+    // "Franklin D. Roosevelt (FDR)" collapses to the bare acronym "FDR". Even
+    // though the stem says "FDR", that is the SUBJECT being identified, not a
+    // leak — the answer is the full name. Must be kept.
+    const result = findAnswerLeaks([
+      q('Which U.S. president is commonly referred to by the initials FDR?', 'Franklin D. Roosevelt (FDR)'),
+    ]);
+    expect(result.toDrop.size).toBe(0);
+  });
+
   it('keeps a clean question whose answer is absent from the setup', () => {
     const result = findAnswerLeaks([
       q('What cognitive bias makes recent information feel more important?', 'Recency bias'),

--- a/src/server/questions/self-answering.ts
+++ b/src/server/questions/self-answering.ts
@@ -5,6 +5,19 @@ const COMBINING_DIACRITICS = /[̀-ͯ]/g;
 // the bare noun ("the episode 'Fly'"), so we strip it and re-test the core.
 const LEADING_ARTICLE = /^(?:a|an|the) /;
 
+// A run of Capitalized expansion words immediately followed by a parenthetical
+// acronym: "User Experience (UX)". When an answer spells out an acronym it also
+// shows ("User Experience (UX) design"), the whole-answer substring test misses
+// a question that shows only the SHORT form ("In UX design, what term…") because
+// the question never contains the expansion ("User Experience"). Collapsing the
+// expansion down to the acronym recovers the short form ("UX design") so it can
+// substring-match. We do NOT verify the acronym's letters against the expansion:
+// UX = User eXperience shows the acronym need not be strict initials, so a
+// parenthetical acronym sitting after a capitalized run is signal enough. The
+// acronym must be ALL-UPPERCASE (2–8 letters) so a lowercase prose aside like
+// "(in)" or "(the)" inside an answer can never be mistaken for one.
+const ACRONYM_EXPANSION = /(?:\b[A-Z][A-Za-z.'-]*\s*){1,6}\(([A-Z]{2,8})\)/;
+
 function normalize(value: string): string {
   return value
     .normalize('NFKD')
@@ -20,6 +33,30 @@ function containsNormalizedAnswer(normalizedQuestion: string, normalizedAnswer: 
   return ` ${normalizedQuestion} `.includes(` ${normalizedAnswer} `);
 }
 
+// "User Experience (UX) design" → "UX design": collapse the expansion words
+// preceding a parenthetical acronym down to the acronym alone. Returns the
+// NORMALIZED short form, or null when no such pattern exists / it collapses to a
+// bare acronym. Operates on the RAW candidate (before normalize strips the
+// parentheses and capitalization the pattern needs).
+//
+// CRITICAL guard against false demotes: we only return a short form when it is
+// the acronym PLUS at least one trailing token (≥ 2 normalized tokens). An
+// answer that is just an expansion of a bare acronym ("Graphics Processing Unit
+// (GPU)", "Franklin D. Roosevelt (FDR)") collapses to the bare acronym, and a
+// legitimate "what does GPU stand for?" / "which president is known as FDR?"
+// question MUST show that acronym — flagging it would delete a good question.
+// Requiring a trailing token means we only fire when the question contains the
+// answer's full short phrase ("UX design"), which is a genuine leak.
+function acronymShortForm(candidate: string): string | null {
+  const match = candidate.match(ACRONYM_EXPANSION);
+  if (!match) return null;
+  const collapsed = candidate.replace(match[0], match[1]);
+  if (collapsed === candidate) return null;
+  const normalized = normalize(collapsed);
+  if (!normalized.includes(' ')) return null; // bare acronym → not a leak signal
+  return normalized;
+}
+
 function answerLeaksIntoQuestion(normalizedQuestion: string, candidate: string): boolean {
   const normalizedAnswer = normalize(candidate);
   if (containsNormalizedAnswer(normalizedQuestion, normalizedAnswer)) return true;
@@ -27,6 +64,13 @@ function answerLeaksIntoQuestion(normalizedQuestion: string, candidate: string):
   // omits; strip it and re-test so the core noun phrase is still caught.
   const stripped = normalizedAnswer.replace(LEADING_ARTICLE, '');
   if (stripped !== normalizedAnswer && containsNormalizedAnswer(normalizedQuestion, stripped)) {
+    return true;
+  }
+  // "User Experience (UX) design" leaks into "In UX design, what term…": the
+  // question shows the acronym short form even though the answer spells it out.
+  // acronymShortForm already returns the normalized, multi-token form (or null).
+  const shortForm = acronymShortForm(candidate);
+  if (shortForm && containsNormalizedAnswer(normalizedQuestion, shortForm)) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Problem

A served card showed the answer in plain sight: **"In UX design, what term refers to the overall process of researching, designing, and improving the quality of a user's interaction with a product or service?"** → answer **"User Experience (UX) design"**.

The deterministic answer-leak gate (`textContainsAnswer` in `self-answering.ts`) does a **whole-answer substring match**, so it only catches the answer sitting *inside* the question. Here the answer is a **superset** of what the stem shows: the stem contains `UX design`, but never the full `User Experience UX design`, so the gate passed it. The stem literally shows `UX` (the acronym the answer expands) and `design` — fully reconstructible.

## Fix

Add an **acronym short-form collapse**: `Expansion (ACRONYM) rest` → `ACRONYM rest` (`User Experience (UX) design` → `UX design`), tested as an extra leak candidate against the stem.

Because this gate **drops** questions, the change is tightened hard against false demotes:
- **Only fires with a trailing token** (short form must be acronym **+** ≥1 word). A bare-acronym expansion (`Graphics Processing Unit (GPU)`, `Franklin D. Roosevelt (FDR)`) collapses to just the acronym and is ignored — so *"what does GPU stand for?"* / *"known by the initials FDR"* define-questions, which **must** show the acronym and whose answer **is** the expansion, are never flagged.
- **Acronym must be ALL-UPPERCASE** (`[A-Z]{2,8}`), so a lowercase prose aside like `(in)`/`(the)` inside an answer can't be mistaken for one.

## Scope / safety

- Affects **new questions only** — runs at create-time and daily-generation; **no retroactive bank sweep**.
- Pure (no LLM, no DB), can't hang or fail open.
- One benign ripple: the subcategory de-leak path (`llm.ts:975`) now also treats a subcategory that equals the answer's short form (e.g. `UX Design`) as a leak and runs its existing, fail-safe de-leak retry (keeps the original label if it can't improve it).

## Tests

`answer-leak-gate.test.ts`: the reported case now drops; added regressions for the false-positive classes above (define-the-acronym, initials-identification, short-form-absent). All suites green.

The single live card was already corrected directly in prod (dropped the leading `In UX design,` clause); this PR stops the shape from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZwN82TS8N8Gjgn9qnkjJ4