### PR TITLE
feat(verify): salvage-aware demotion + expiry-gate fix for the generated bank

### DIFF
--- a/scripts/backfill-verify-generated.ts
+++ b/scripts/backfill-verify-generated.ts
@@ -1,0 +1,110 @@
+import 'dotenv/config';
+
+import { and, eq, isNull, isNotNull, sql } from 'drizzle-orm';
+
+import { db, pool, generatedQuestions } from '../src/server/db';
+import { runWithConcurrency } from '../src/server/lib/concurrency';
+import { prefilterForVerification } from '../src/server/quality/verification-prefilter';
+import {
+  verdictToGeneratedPatch,
+  verifyQuestion,
+} from '../src/server/quality/verify-question';
+import {
+  isSalvageGeneratedOnDemoteEnabled,
+  salvageOrSuppressGeneratedDemote,
+  type GeneratedDemoteRow,
+} from '../src/server/quality/salvage-generated';
+
+// One-time backlog verify over EVERY uncovered generated row (verified_at IS
+// NULL, not suppressed). Deliberately IGNORES the cron's `expires_at > now`
+// filter so the cron-blind past-expiry rows (which still serve — serving is
+// durable) are finally covered. Same prefilter -> verify -> salvage-or-suppress
+// path the cron uses, so behavior is identical; this just clears the backlog in
+// one paced pass instead of trickling ~35/day.
+//
+//   npx tsx scripts/backfill-verify-generated.ts            # DRY RUN (no writes)
+//   npx tsx scripts/backfill-verify-generated.ts --apply    # writes to prod
+//
+// Concurrency kept low (rate limits: a sequential 60-row probe still hit ~17%
+// verifier nulls). Nulls are fail-open — the row is left unstamped and simply
+// re-picked on a later run, never wrongly demoted.
+const APPLY = process.argv.includes('--apply');
+const CONCURRENCY = Math.max(1, Number(process.env.BACKFILL_CONCURRENCY ?? 3));
+const LIMIT = Number(process.env.BACKFILL_LIMIT ?? 0); // 0 = no cap
+
+async function verifyWithRetry(input: Parameters<typeof verifyQuestion>[0]) {
+  const first = await verifyQuestion(input);
+  if (first) return first;
+  return verifyQuestion(input); // one retry — nulls are usually transient rate limits
+}
+
+async function main() {
+  const rows = (await db
+    .select({
+      id: generatedQuestions.id,
+      questionText: generatedQuestions.questionText,
+      answer: generatedQuestions.answer,
+      explanation: generatedQuestions.explainer,
+      canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+      broadCategory: generatedQuestions.broadCategory,
+    })
+    .from(generatedQuestions)
+    .where(and(
+      isNull(generatedQuestions.verifiedAt),
+      eq(generatedQuestions.isDuplicate, false),
+      isNotNull(generatedQuestions.factKey),
+    ))
+    .orderBy(sql`${generatedQuestions.createdAt} desc`)
+    .limit(LIMIT > 0 ? LIMIT : 1_000_000)) as GeneratedDemoteRow[];
+
+  const tally = { scanned: rows.length, skipped: 0, ok: 0, unverifiable: 0, salvaged: 0, suppressed: 0, failed: 0 };
+  const now = new Date();
+  console.log(`${APPLY ? 'APPLY' : 'DRY-RUN'} — ${rows.length} uncovered generated rows; salvage=${isSalvageGeneratedOnDemoteEnabled()}, concurrency=${CONCURRENCY}\n`);
+
+  await runWithConcurrency(rows, CONCURRENCY, async (row) => {
+    try {
+      const decision = prefilterForVerification({
+        questionText: row.questionText,
+        answer: row.answer,
+        explanation: row.explanation,
+        canonicalSubcategory: row.canonicalSubcategory,
+      });
+      if (!decision.needsVerification) {
+        if (APPLY) await db.update(generatedQuestions).set(verdictToGeneratedPatch('skipped', now)).where(eq(generatedQuestions.id, row.id));
+        tally.skipped += 1;
+        return;
+      }
+      const result = await verifyWithRetry({
+        questionText: row.questionText,
+        answer: row.answer,
+        explanation: row.explanation,
+        canonicalSubcategory: row.canonicalSubcategory,
+        broadCategory: row.broadCategory,
+        dimensions: decision.dimensions,
+      });
+      if (!result) { tally.failed += 1; return; } // fail-open, unstamped
+
+      if (result.outcome === 'demoted') {
+        const res = await salvageOrSuppressGeneratedDemote(row, result.reason, now, { persist: APPLY });
+        if (res.action === 'salvaged') { tally.salvaged += 1; console.log(`  SALVAGED  ${row.id}  ${res.note}`); }
+        else { tally.suppressed += 1; console.log(`  SUPPRESS  ${row.id}  ${res.note}`); }
+        return;
+      }
+      if (APPLY) await db.update(generatedQuestions).set(verdictToGeneratedPatch(result.outcome, now, result.reason)).where(eq(generatedQuestions.id, row.id));
+      tally[result.outcome] += 1;
+    } catch (error) {
+      tally.failed += 1;
+      console.warn(`  ERROR     ${row.id}  ${error instanceof Error ? error.message : String(error)}`);
+    }
+  });
+
+  console.log(`\n===== ${APPLY ? 'APPLIED' : 'DRY-RUN'} TALLY =====`);
+  console.log(tally);
+  await pool.end();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  try { await pool.end(); } catch {}
+  process.exit(1);
+});

--- a/src/app/api/cron/batch-verify-questions/route.ts
+++ b/src/app/api/cron/batch-verify-questions/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, isNull, ne } from 'drizzle-orm';
+import { and, eq, isNull, ne } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { db, generatedQuestions, questions } from '@/server/db';
@@ -116,7 +116,7 @@ function fetchGeneratedRow(rowId: string): Promise<GeneratedDemoteRow | null> {
     .then((rows) => rows[0] ?? null);
 }
 
-function selectPending(limit: number, now: Date): Promise<[PendingRow[], PendingRow[]]> {
+function selectPending(limit: number): Promise<[PendingRow[], PendingRow[]]> {
   return Promise.all([
     db
       .select({
@@ -147,7 +147,11 @@ function selectPending(limit: number, now: Date): Promise<[PendingRow[], Pending
       .where(and(
         isNull(generatedQuestions.verifiedAt),
         eq(generatedQuestions.isDuplicate, false),
-        gt(generatedQuestions.expiresAt, now),
+        // NO expires_at gate: the pool is DURABLE (D8) — pickBankSource serves
+        // rows with no age/expiry filter, so a past-expiry row still reaches
+        // players and must still be verifiable. Gating on expires_at > now here
+        // stranded ~65 serving-but-expired rows permanently outside the sweep
+        // (2026-07-15). Verification eligibility must mirror serving eligibility.
       ))
       .limit(limit),
   ]) as Promise<[PendingRow[], PendingRow[]]>;
@@ -276,7 +280,7 @@ async function runAsyncSweep(now: Date, options: PrefilterOptions) {
   let submitted: { providerBatchId: string; requestCount: number } | null = null;
   const submitTallies = { question: emptyTally(0), generated: emptyTally(0) };
   if (harvest.runsStillProcessing === 0) {
-    const [pendingQuestions, pendingGenerated] = await selectPending(ASYNC_BATCH_SIZE, now);
+    const [pendingQuestions, pendingGenerated] = await selectPending(ASYNC_BATCH_SIZE);
     submitTallies.question.scanned = pendingQuestions.length;
     submitTallies.generated.scanned = pendingGenerated.length;
 
@@ -351,7 +355,7 @@ async function runAsyncSweep(now: Date, options: PrefilterOptions) {
 // ─── Sync mode (the original inline path) ────────────────────────────────────
 
 async function runSyncSweep(now: Date, options: PrefilterOptions) {
-  const [pendingQuestions, pendingGenerated] = await selectPending(BATCH_SIZE, now);
+  const [pendingQuestions, pendingGenerated] = await selectPending(BATCH_SIZE);
 
   const questionTally = emptyTally(pendingQuestions.length);
   const generatedTally = emptyTally(pendingGenerated.length);

--- a/src/app/api/cron/batch-verify-questions/route.ts
+++ b/src/app/api/cron/batch-verify-questions/route.ts
@@ -26,6 +26,11 @@ import {
   verifyQuestion,
   type VerificationVerdict,
 } from '@/server/quality/verify-question';
+import {
+  isSalvageGeneratedOnDemoteEnabled,
+  salvageOrSuppressGeneratedDemote,
+  type GeneratedDemoteRow,
+} from '@/server/quality/salvage-generated';
 
 export const dynamic = 'force-dynamic';
 // Each row may make a Sonnet call plus an occasional web search; mirror the
@@ -67,10 +72,48 @@ type PendingRow = {
   broadCategory: string | null;
 };
 
-type Tally = { scanned: number; skipped: number; ok: number; demoted: number; unverifiable: number; failed: number };
+type Tally = {
+  scanned: number;
+  skipped: number;
+  ok: number;
+  demoted: number;
+  unverifiable: number;
+  failed: number;
+  // Generated-only: a demotion that was auto-repaired (re-verified minimal fix
+  // applied) and kept serving, instead of suppressed. See salvage-generated.ts.
+  salvaged: number;
+};
 
 function emptyTally(scanned: number): Tally {
-  return { scanned, skipped: 0, ok: 0, demoted: 0, unverifiable: 0, failed: 0 };
+  return { scanned, skipped: 0, ok: 0, demoted: 0, unverifiable: 0, failed: 0, salvaged: 0 };
+}
+
+// Salvage-aware application of a GENERATED demotion: try to auto-repair (keep
+// serving) before falling back to suppression. Returns the tally bucket touched.
+// Any fault inside resolves to 'demoted' (suppress) — never a silent serve-through.
+async function applyGeneratedDemote(
+  row: GeneratedDemoteRow,
+  reason: string,
+  now: Date,
+): Promise<'salvaged' | 'demoted'> {
+  const res = await salvageOrSuppressGeneratedDemote(row, reason, now);
+  return res.action === 'salvaged' ? 'salvaged' : 'demoted';
+}
+
+function fetchGeneratedRow(rowId: string): Promise<GeneratedDemoteRow | null> {
+  return db
+    .select({
+      id: generatedQuestions.id,
+      questionText: generatedQuestions.questionText,
+      answer: generatedQuestions.answer,
+      explanation: generatedQuestions.explainer,
+      canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+      broadCategory: generatedQuestions.broadCategory,
+    })
+    .from(generatedQuestions)
+    .where(eq(generatedQuestions.id, rowId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
 }
 
 function selectPending(limit: number, now: Date): Promise<[PendingRow[], PendingRow[]]> {
@@ -204,6 +247,15 @@ async function runAsyncSweep(now: Date, options: PrefilterOptions) {
       if (v.store === 'q') {
         await stampQuestion(v.rowId, v.outcome, now, v.reason);
         harvested.question[v.outcome] += 1;
+      } else if (v.outcome === 'demoted' && isSalvageGeneratedOnDemoteEnabled()) {
+        const row = await fetchGeneratedRow(v.rowId);
+        if (row) {
+          const bucket = await applyGeneratedDemote(row, v.reason ?? 'demoted (reason not captured)', now);
+          harvested.generated[bucket] += 1;
+        } else {
+          // Row vanished between submit and harvest — nothing to stamp.
+          harvested.stampFailures += 1;
+        }
       } else {
         await stampGenerated(v.rowId, v.outcome, now, v.reason);
         harvested.generated[v.outcome] += 1;
@@ -358,6 +410,17 @@ async function runSyncSweep(now: Date, options: PrefilterOptions) {
       const resolved = await resolveVerdict(row);
       if (resolved === 'failed') {
         generatedTally.failed += 1;
+        return;
+      }
+      // Salvage-aware: a demoted generated row gets one auto-repair attempt
+      // (keep serving) before suppression. Other verdicts stamp as usual.
+      if (resolved.verdict === 'demoted' && isSalvageGeneratedOnDemoteEnabled()) {
+        const bucket = await applyGeneratedDemote(
+          row,
+          resolved.reason ?? 'demoted (reason not captured)',
+          now,
+        );
+        generatedTally[bucket] += 1;
         return;
       }
       await stampGenerated(row.id, resolved.verdict, now, resolved.reason);

--- a/src/server/quality/__tests__/salvage-generated.test.ts
+++ b/src/server/quality/__tests__/salvage-generated.test.ts
@@ -1,0 +1,81 @@
+import { beforeAll, afterEach, describe, expect, it } from 'vitest';
+
+import type { SalvageProposal } from '@/server/quality/salvage-question';
+
+// Same pure-import guard as verify-question.test.ts: the module pulls in
+// @/server/db (throws without a connection string), but the functions under test
+// never touch the DB. Dummy URL + dynamic import keeps the unit pure.
+let mod: typeof import('@/server/quality/salvage-generated');
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  mod = await import('@/server/quality/salvage-generated');
+});
+
+const stemFix: SalvageProposal = {
+  kind: 'extra_fact_stem',
+  proposedStem: 'fixed stem',
+  proposedExplanation: null,
+  note: 'removed bad year',
+};
+const explainerFix: SalvageProposal = {
+  kind: 'extra_fact_explainer',
+  proposedStem: null,
+  proposedExplanation: 'fixed explainer',
+  note: 'corrected distillery name',
+};
+const unsalvageable: SalvageProposal = {
+  kind: 'unsalvageable',
+  proposedStem: null,
+  proposedExplanation: null,
+  note: 'answer itself is wrong',
+};
+
+describe('decideGeneratedSalvage — apply only a re-verified concrete fix', () => {
+  it('applies a stem fix that re-verified ok', () => {
+    const d = mod.decideGeneratedSalvage(stemFix, 'ok');
+    expect(d).toEqual({ apply: true, proposedStem: 'fixed stem', proposedExplanation: null });
+  });
+
+  it('applies an explainer fix that re-verified ok', () => {
+    const d = mod.decideGeneratedSalvage(explainerFix, 'ok');
+    expect(d.apply).toBe(true);
+  });
+
+  it('suppresses when the proposal is unsalvageable (even if reverify says ok)', () => {
+    expect(mod.decideGeneratedSalvage(unsalvageable, 'ok')).toEqual({ apply: false });
+  });
+
+  it('suppresses when the re-verified fix still does not pass', () => {
+    for (const outcome of ['demoted', 'unverifiable', null] as const) {
+      expect(mod.decideGeneratedSalvage(stemFix, outcome)).toEqual({ apply: false });
+    }
+  });
+
+  it('suppresses a proposal that carries no actual replacement text', () => {
+    const empty: SalvageProposal = { kind: 'extra_fact_stem', proposedStem: null, proposedExplanation: null, note: 'x' };
+    expect(mod.decideGeneratedSalvage(empty, 'ok')).toEqual({ apply: false });
+  });
+});
+
+describe('isSalvageGeneratedOnDemoteEnabled — default ON, off only when explicitly disabled', () => {
+  const KEY = 'SALVAGE_GENERATED_ON_DEMOTE_ENABLED';
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it('defaults ON when unset', () => {
+    expect(mod.isSalvageGeneratedOnDemoteEnabled()).toBe(true);
+  });
+
+  it('is OFF for false/0/no/off, ON otherwise', () => {
+    for (const v of ['false', '0', 'no', 'off', 'FALSE', ' Off ']) {
+      process.env[KEY] = v;
+      expect(mod.isSalvageGeneratedOnDemoteEnabled()).toBe(false);
+    }
+    for (const v of ['true', '1', 'yes', 'anything']) {
+      process.env[KEY] = v;
+      expect(mod.isSalvageGeneratedOnDemoteEnabled()).toBe(true);
+    }
+  });
+});

--- a/src/server/quality/salvage-generated.ts
+++ b/src/server/quality/salvage-generated.ts
@@ -1,0 +1,134 @@
+/**
+ * Salvage-aware demotion for the GENERATED bank (2026-07-15, Josh).
+ *
+ * The batch-verify sweep hard-suppresses a demoted row (is_duplicate=true). For
+ * AUTHORED questions that is chased by the salvage sweep, which proposes a fix a
+ * human approves in /admin/reports. But generated-bank demotions are deliberately
+ * NOT surfaced in that queue (machine-demotions.ts) — so a demoted generated row
+ * goes dark with no salvage and no human review. A read-only dry run over the
+ * uncovered fat-domain backlog showed a meaningful slice of demotions are the
+ * salvageable class (answer correct, one wrong adjacent fact in the explainer —
+ * e.g. Blanton's, Spy Ski School), which would be lost outright.
+ *
+ * Because a generated row is MACHINE-authored (no human's words to preserve — the
+ * reason the salvage sweep is propose-only for Question rows), we can auto-apply a
+ * re-verified minimal fix instead of parking a proposal nobody will approve. The
+ * fix is gated exactly like the sweep's: the PROPOSED text must itself re-verify
+ * `ok` before it is applied, so a bad "fix" can never reach circulation. A row
+ * that can't be salvaged (unsalvageable, or the fix still fails re-verify) is
+ * suppressed exactly as before — nothing that was demoted stays served un-fixed.
+ *
+ * Fail-safe: any proposer/verifier fault resolves to SUPPRESS (the pre-existing
+ * behavior), never to a silent serve-through. Flag-guarded, DEFAULT ON, matching
+ * the sibling SALVAGE_ON_DEMOTE_ENABLED posture; set
+ * SALVAGE_GENERATED_ON_DEMOTE_ENABLED=false to revert to hard-suppress without a
+ * deploy.
+ */
+import { eq } from 'drizzle-orm';
+
+import { db, generatedQuestions } from '@/server/db';
+import { proposeSalvage, type SalvageProposal } from '@/server/quality/salvage-question';
+import { verdictToGeneratedPatch, verifyQuestion } from '@/server/quality/verify-question';
+
+export function isSalvageGeneratedOnDemoteEnabled(): boolean {
+  const raw = process.env.SALVAGE_GENERATED_ON_DEMOTE_ENABLED?.trim().toLowerCase();
+  return !(raw === 'false' || raw === '0' || raw === 'no' || raw === 'off');
+}
+
+export type GeneratedDemoteRow = {
+  id: string;
+  questionText: string;
+  answer: string;
+  explanation: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+};
+
+export type GeneratedSalvageAction = 'salvaged' | 'suppressed';
+export type GeneratedSalvageResult = { action: GeneratedSalvageAction; note: string };
+
+/**
+ * Pure decision: given the proposer's output and the re-verify outcome of the
+ * PROPOSED text, apply the fix or suppress. Exported for unit tests. Apply ONLY
+ * when a concrete edit exists AND it re-verified `ok`; everything else suppresses.
+ */
+export function decideGeneratedSalvage(
+  proposal: SalvageProposal,
+  reverifyOutcome: 'ok' | 'demoted' | 'unverifiable' | null,
+): { apply: false } | { apply: true; proposedStem: string | null; proposedExplanation: string | null } {
+  if (proposal.kind === 'unsalvageable') return { apply: false };
+  if (!proposal.proposedStem && !proposal.proposedExplanation) return { apply: false };
+  if (reverifyOutcome !== 'ok') return { apply: false };
+  return {
+    apply: true,
+    proposedStem: proposal.proposedStem,
+    proposedExplanation: proposal.proposedExplanation,
+  };
+}
+
+/**
+ * Salvage-or-suppress one demoted generated row. `persist=false` runs the full
+ * propose→re-verify pipeline and reports the action WITHOUT writing (dry-run).
+ * When persisting: a salvaged row is edited in place, stamped verified `ok`, and
+ * LEFT SERVING (is_duplicate stays false); a suppressed row gets the standard
+ * demote patch (is_duplicate=true, verdict='demoted').
+ */
+export async function salvageOrSuppressGeneratedDemote(
+  row: GeneratedDemoteRow,
+  verifierReason: string,
+  now: Date,
+  opts: { persist: boolean } = { persist: true },
+): Promise<GeneratedSalvageResult> {
+  const suppress = async (note: string): Promise<GeneratedSalvageResult> => {
+    if (opts.persist) {
+      await db
+        .update(generatedQuestions)
+        .set(verdictToGeneratedPatch('demoted', now, verifierReason))
+        .where(eq(generatedQuestions.id, row.id));
+    }
+    return { action: 'suppressed', note };
+  };
+
+  const proposal = await proposeSalvage({
+    questionText: row.questionText,
+    answer: row.answer,
+    explanation: row.explanation,
+    verificationReason: verifierReason,
+    canonicalSubcategory: row.canonicalSubcategory,
+    broadCategory: row.broadCategory,
+  });
+
+  if (proposal.kind === 'unsalvageable') return suppress(`unsalvageable: ${proposal.note}`);
+
+  // Re-verify the PROPOSED version against the UNCHANGED answer, same dimensions
+  // the salvage sweep uses. Fall back to the original for the field left untouched.
+  const reverify = await verifyQuestion({
+    questionText: proposal.proposedStem ?? row.questionText,
+    answer: row.answer,
+    explanation: proposal.proposedExplanation ?? row.explanation ?? undefined,
+    canonicalSubcategory: row.canonicalSubcategory ?? undefined,
+    broadCategory: row.broadCategory ?? undefined,
+    dimensions: ['false_premise', 'extra_fact'],
+  });
+
+  const decision = decideGeneratedSalvage(proposal, reverify?.outcome ?? null);
+  if (!decision.apply) {
+    return suppress(`reverify=${reverify?.outcome ?? 'none'}: ${proposal.note}`);
+  }
+
+  if (opts.persist) {
+    await db
+      .update(generatedQuestions)
+      .set({
+        ...(decision.proposedStem ? { questionText: decision.proposedStem } : {}),
+        ...(decision.proposedExplanation ? { explainer: decision.proposedExplanation } : {}),
+        // The proposed text passed the verifier — stamp it clean and keep it
+        // serving. Answer is never touched by salvage.
+        verificationVerdict: 'ok',
+        verifiedAt: now,
+        verificationReason: `salvaged: ${proposal.note}`.slice(0, 500),
+      })
+      .where(eq(generatedQuestions.id, row.id));
+  }
+  return { action: 'salvaged', note: `${proposal.kind}: ${proposal.note}` };
+}


### PR DESCRIPTION
Replaces #1528 (auto-closed when its base branch — the now-merged #1527 — was deleted). Same code, retargeted to `main`. Follow-up to #1527.

## Problem

The batch-verify sweep hard-suppresses a demoted row (`is_duplicate=true`). Authored `Question` demotions get chased by the salvage sweep, but **generated-bank demotions are excluded from the review queue** — so a demoted generated row goes dark with **no salvage and no human review**. All 476 uncovered fat-domain rows are generated, so a blind verify pass would silently suppress each demotion, false positives included.

## Dry-run evidence (read-only, 84 rows across two runs)

16 would-demote → ~10 clearly correct / 5 borderline / **1 clear false-positive** (DFW "still a student" — he *was* an MFA student). ≈6% clear-FP of demotes. Crucially, most demotes — including the false positive and every pedantic one — are the **salvageable** class (answer correct, one wrong adjacent fact).

## Fix

Generated rows are **machine-authored**, so this **auto-applies a re-verified minimal fix** instead of parking a proposal nobody approves:

```
demoted generated row
  → proposeSalvage (minimal edit, never touches the answer)
  → re-verify the PROPOSED text
     • re-verifies ok  → apply edit, stamp verified ok, KEEP SERVING
     • unsalvageable / still fails → suppress (is_duplicate=true), as before
```

The proposed text must itself re-verify `ok` before applying; any fault → suppress (never a silent serve-through). Wired into both sync and async cron paths; new `salvaged` tally counter. Flag `SALVAGE_GENERATED_ON_DEMOTE_ENABLED`, **default ON**, `=false` reverts. `Question` behavior unchanged.

## Also in this PR

- **Dropped the `expires_at > now` gate** in the sweep's generated selector. The pool is durable — `pickBankSource` serves past-expiry rows, but the sweep skipped them, stranding ~65 serving-but-expired rows permanently unverified. Verification eligibility now mirrors serving eligibility.
- **`scripts/backfill-verify-generated.ts`** — paced, dry-run-by-default one-time pass over every uncovered generated row (ignoring expiry) via the same prefilter → verify → salvage-or-suppress path, to clear the ~476 backlog in one run. `--apply` to write.

## Safety

Pure decision logic + flag unit-tested (7 tests). Typecheck + lint clean. Default-ON on merge (surfaced here). The backlog script is separate and does nothing until run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bc3ejDjRNFR8QMk1RN5cLm
