### PR TITLE
fix(catchup): exclude rested domains from missed questions

### DIFF
--- a/src/server/db/queries/__tests__/catchup-resting-domain.test.ts
+++ b/src/server/db/queries/__tests__/catchup-resting-domain.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression: a domain the player has RESTED must not replay its missed
+// questions in "Catch up". The "This is {Name}'s bag but not mine" opt-out on a
+// +2 bonus rests the whole domain, and every other daily-selection surface
+// already excludes rested domains — catch-up was the one that still nagged.
+// getDailyCatchupItems now drops candidate slots whose domain is rested.
+
+const { TABLES, rowsByTable } = vi.hoisted(() => ({
+  TABLES: {
+    dailyQueues: { id: 'dq.id', userId: 'dq.userId', queueDate: 'dq.queueDate' },
+    questions: { id: 'q.id', visibility: 'visibility', creatorId: 'creatorId', deletedAt: 'deletedAt' },
+    generatedQuestions: { id: 'gq.id', userId: 'gq.userId' },
+    feedItems: { id: 'fi.id' },
+    contentReports: { questionId: 'cr.q', generatedQuestionId: 'cr.gq' },
+    users: { id: 'u.id', displayName: 'u.name' },
+  },
+  rowsByTable: new Map<unknown, unknown[]>(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
+  or: vi.fn((...parts) => ({ op: 'or', parts })),
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  asc: vi.fn((column) => ({ op: 'asc', column })),
+  desc: vi.fn((column) => ({ op: 'desc', column })),
+  gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+  lte: vi.fn((column, value) => ({ op: 'lte', column, value })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+  isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+  isNull: vi.fn((column) => ({ op: 'isNull', column })),
+  notExists: vi.fn((query) => ({ op: 'notExists', query })),
+  sql: vi.fn(() => ({ op: 'sql', as: vi.fn(() => ({ op: 'sqlAs' })) })),
+}));
+
+vi.mock('@/server/db', () => {
+  const rowsFor = (table: unknown) => (rowsByTable.get(table) ?? []) as unknown[];
+  const makeChain = () => {
+    let fromTable: unknown = null;
+    const chain: Record<string, unknown> = {
+      select: vi.fn(() => chain),
+      from: vi.fn((t: unknown) => {
+        fromTable = t;
+        return chain;
+      }),
+      innerJoin: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve(rowsFor(fromTable))),
+      where: vi.fn(() => chain),
+      then: (resolve: (r: unknown[]) => unknown) => resolve(rowsFor(fromTable)),
+    };
+    return chain;
+  };
+  return {
+    db: { select: vi.fn(() => makeChain()) },
+    dailyQueues: TABLES.dailyQueues,
+    questions: TABLES.questions,
+    generatedQuestions: TABLES.generatedQuestions,
+    feedItems: TABLES.feedItems,
+    contentReports: TABLES.contentReports,
+    users: TABLES.users,
+    dailyPreferences: {}, declaredInterests: {}, masteryEvents: {}, playerMastery: {},
+    skippedDailyQuestions: {}, userDomainExclusions: {},
+  };
+});
+
+vi.mock('@/lib/games/timezone', () => ({
+  getDailyAssignmentBounds: () => ({ assignmentDateStr: '2026-06-16', assignmentDate: new Date('2026-06-16T00:00:00Z') }),
+}));
+vi.mock('@/server/play/catch-up-eligibility', () => ({
+  isCatchUpQueueDateEligible: () => true,
+  isCatchUpSlotEligible: () => true,
+  catchUpExpiresAt: () => '2026-07-01',
+  expiresWithin24Hours: () => false,
+  queueAgeInDays: () => 0,
+}));
+vi.mock('@/server/daily/catchup', () => ({
+  CATCHUP_LOOKBACK_DAYS: 30,
+  asQueueSlots: (v: unknown) => (Array.isArray(v) ? v : []),
+  dailyQueueItemId: (queueId: string, slotIndex: number) => `${queueId}:${slotIndex}`,
+  feedCatchupItemId: () => 'feed-item-id',
+  minusUtcDays: () => new Date('2026-06-01T00:00:00Z'),
+  orderCatchUpItems: <T>(items: T[]) => items,
+  dedupeCatchUpItems: <T>(items: T[]) => items,
+}));
+
+// Preferences: "Jazz" is RESTED; "Opera" is actively played.
+const getDailyPreferencesMock = vi.fn();
+vi.mock('@/server/db/queries/daily-preferences', () => ({
+  getDailyPreferences: (...args: unknown[]) => getDailyPreferencesMock(...args),
+}));
+
+import { getCatchupQuestions } from '@/server/db/queries/daily';
+
+function genRow(id: string, subcategory: string) {
+  return {
+    id,
+    questionText: `Question ${id}`,
+    answer: `Answer ${id}`,
+    explainer: `Because ${id}`,
+    canonicalSubcategory: subcategory,
+    broadCategory: subcategory,
+    basePoints: 10,
+    difficultyEstimate: 'accessible',
+  };
+}
+
+beforeEach(() => {
+  rowsByTable.clear();
+  getDailyPreferencesMock.mockReset();
+  getDailyPreferencesMock.mockResolvedValue({
+    userId: 'viewer-1',
+    difficulty: 'adaptive',
+    domainMode: 'random',
+    selectedDomains: [],
+    domainPreferenceFrequency: { Jazz: 'resting', Opera: 'often' },
+    updatedAt: null,
+  });
+
+  // One queue: a missed Jazz slot (rested) and a missed Opera slot (active).
+  rowsByTable.set(TABLES.dailyQueues, [
+    {
+      id: 'queue-1',
+      queueDate: '2026-06-10',
+      slots: [
+        { slot_index: 0, generated_question_id: 'gq-jazz', domain: 'Jazz', answered: true, answer_state: 'incorrect' },
+        { slot_index: 1, generated_question_id: 'gq-opera', domain: 'Opera', answered: true, answer_state: 'incorrect' },
+      ],
+    },
+  ]);
+  rowsByTable.set(TABLES.generatedQuestions, [genRow('gq-jazz', 'Jazz'), genRow('gq-opera', 'Opera')]);
+  rowsByTable.set(TABLES.feedItems, []);
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('getCatchupQuestions excludes rested domains', () => {
+  it('drops a rested domain from catch-up and keeps active domains', async () => {
+    const items = await getCatchupQuestions('viewer-1');
+    const domains = items.map((item) => item.domain);
+    expect(domains).toContain('Opera');
+    expect(domains).not.toContain('Jazz');
+  });
+
+  it('keeps both when nothing is rested', async () => {
+    getDailyPreferencesMock.mockResolvedValue({
+      userId: 'viewer-1',
+      difficulty: 'adaptive',
+      domainMode: 'random',
+      selectedDomains: [],
+      domainPreferenceFrequency: { Opera: 'often' },
+      updatedAt: null,
+    });
+    const items = await getCatchupQuestions('viewer-1');
+    const domains = items.map((item) => item.domain);
+    expect(domains).toContain('Opera');
+    expect(domains).toContain('Jazz');
+  });
+});

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -711,18 +711,43 @@ async function getDailyCatchupItems(
   userId: string,
   assignmentDateStr: string,
 ): Promise<CatchupQuestion[]> {
-  const queues = await db
-    .select()
-    .from(dailyQueues)
-    .where(and(
-      eq(dailyQueues.userId, userId),
-      lte(dailyQueues.queueDate, assignmentDateStr),
-    ))
-    .orderBy(asc(dailyQueues.queueDate));
+  const [queues, preferences] = await Promise.all([
+    db
+      .select()
+      .from(dailyQueues)
+      .where(and(
+        eq(dailyQueues.userId, userId),
+        lte(dailyQueues.queueDate, assignmentDateStr),
+      ))
+      .orderBy(asc(dailyQueues.queueDate)),
+    getDailyPreferences(userId),
+  ]);
+
+  // Resting is the strongest "not now / not mine" signal a player can set on a
+  // domain. The "This is {Name}'s bag but not mine" opt-out on a +2 bonus rests
+  // the whole domain (via the domain-frequency route), and every other daily-
+  // selection surface — rotation, authored picks, house picks — already excludes
+  // rested domains (see resting-domains.test.ts). Catch-up was the one daily
+  // surface still replaying them, so a rested domain's missed questions kept
+  // nagging in "Catch up" — the exact "someone else's bag shouldn't come back as
+  // a missed question for me" complaint. Drop rested domains here too, keyed on
+  // the same normalized domain the preference is stored under.
+  const restingKeys = new Set(
+    Object.entries(preferences.domainPreferenceFrequency)
+      .filter(([, frequency]) => frequency === 'resting')
+      .map(([domain]) => normalizeDomain(domain).toLowerCase())
+      .filter(Boolean),
+  );
+  const isRestingDomain = (domain: string | null | undefined): boolean =>
+    typeof domain === 'string' && restingKeys.has(normalizeDomain(domain).toLowerCase());
 
   const candidateSlots = queues.flatMap((queue) =>
     asQueueSlots(queue.slots)
-      .filter((slot) => isCatchUpQueueDateEligible(String(queue.queueDate), assignmentDateStr) && isCatchUpSlotEligible(slot))
+      .filter((slot) =>
+        isCatchUpQueueDateEligible(String(queue.queueDate), assignmentDateStr) &&
+        isCatchUpSlotEligible(slot) &&
+        !isRestingDomain(slot.domain),
+      )
       .map((slot) => ({ queue, slot }))
   );
 


### PR DESCRIPTION
## Problem

On a +2 bonus question, the **"This is {Name}'s bag but not mine"** opt-out (`muteBonusDomain` in `src/app/daily/page.tsx`) rests the domain *and* closes the slot through the plain `/api/daily/skip` path. But a skipped slot is catch-up-eligible — `isCatchUpSlotEligible` returns `true` for anything skipped with no `dismissed_at`. So the exact bonus question you'd just declared *not yours* came straight back as a **missed question** in Catch up.

## Fix

`getDailyCatchupItems` (`src/server/db/queries/daily.ts`) now drops any catch-up candidate whose domain is currently **`resting`** in `domainPreferenceFrequency`, keyed on the same normalized+lowercased domain the preference is stored under.

- **Whole-domain scope** (the product call): not just the flagged card — the entire rested domain stays out of missed questions.
- **Consistency:** every other daily-selection surface (rotation, authored picks, house picks — see `resting-domains.test.ts`) already fully excludes rested domains. Catch-up was the lone daily surface still replaying them; this brings it in line.

## Behavioral notes

- Keyed on the **live** resting preference, so un-resting a domain (undo) makes its missed questions reappear — matches "I changed my mind, I do want this."
- **Daily** catch-up only; the friend-**feed** catch-up surface is untouched (bonus lives on the daily surface).

## Tests

- New: `src/server/db/queries/__tests__/catchup-resting-domain.test.ts` — rested domain dropped, active domain kept; both-kept when nothing rested.
- Existing `catchup-blocked`, `catchup-report-target`, `resting-domains` still pass; changed file typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZwN82TS8N8Gjgn9qnkjJ4