### PR TITLE
fix(knowledge-admin): hold un-mined rich leaves out of the exhausted decision queue

### DIFF
--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -70,6 +70,12 @@ export type SupplyReadout = {
    * generator failure (author/ground it), not a too-granular leaf (merge it up). */
   corpusEstimatedQuestions: number | null;
   fandomHost: string | null;
+  /** Refill-observation signals (0118): whether the finite-set generation loop has
+   * ever actually worked this domain — `hasEverYielded` = it once produced a
+   * surviving fact, `consecutiveDryRounds` > 0 = it was offered and came back dry.
+   * A RICH leaf with neither is UN-MINED, not exhausted (see the worklist filter). */
+  hasEverYielded: boolean;
+  consecutiveDryRounds: number;
 };
 
 // Same plain-speech vocabulary as the Supply view's STATE_LABEL — the two
@@ -421,13 +427,38 @@ function KnowledgeTreeEditor({
       if (threshold == null) return true; // no target set — deciding one is the work
       return (pointsByKey[k] ?? 0) < threshold; // still short of masterable
     };
+    // A RICH leaf (fandom-backed / deep corpus) that the finite-set refill has
+    // NEVER actually worked — never yielded a surviving fact AND never come back
+    // dry — is UN-MINED, not exhausted. Its high dup rate is a shallow-sample
+    // artifact: a fandom-backed topic estimated in the hundreds does not run dry
+    // in ~15 tries, and most of those "failures" are self-containment formatting
+    // demotions, not the topic running out. The fix is mechanical — set a target
+    // and let refill mine the wiki — not a human shrink/merge/hand-author call, so
+    // it does not belong in the decision queue. Gated on "never observed by refill"
+    // rather than a gen-count so a rich topic the machine HAS hammered and still
+    // can't yield (real generator failure) stays flagged as a genuine decision.
+    const unminedRichLeaf = (k: string) => {
+      const supply = supplyByKey[k];
+      return (
+        supply != null &&
+        isRichTopic(supply) &&
+        !supply.hasEverYielded &&
+        supply.consecutiveDryRounds === 0
+      );
+    };
     return Object.keys(exhaustedByKey)
-      .filter((k) => exhaustedByKey[k]?.self && nodeByKey.has(k) && needsDecision(k))
+      .filter(
+        (k) =>
+          exhaustedByKey[k]?.self &&
+          nodeByKey.has(k) &&
+          needsDecision(k) &&
+          !unminedRichLeaf(k),
+      )
       .sort(
         (a, b) =>
           parentLabelOf(a).localeCompare(parentLabelOf(b)) || labelOf(a).localeCompare(labelOf(b)),
       );
-  }, [exhaustedByKey, nodeByKey, parentsByChild, pointsByKey]);
+  }, [exhaustedByKey, nodeByKey, parentsByChild, pointsByKey, supplyByKey]);
 
   // "Show all the places and I can go to any of them" — jump to a specific
   // instance of a multi-parent node: expand every ancestor path of the target
@@ -1241,7 +1272,9 @@ function ExhaustedWorklist({
             stand alone, or <strong>hand-author / ground</strong> more if it&apos;s a rich
             topic the machine just failed. The <em>best guess</em> on each row is a
             heuristic, not a verdict — all three levers stay open. Leaves already holding
-            enough to master are hidden — nothing to decide there.
+            enough to master are hidden — nothing to decide there. Rich topics the
+            refill has never actually mined are hidden too — they need a generation
+            run, not a decision.
           </p>
           <ul className="space-y-1 px-2 pb-2">
           {leaves.map((key) => {

--- a/src/app/admin/knowledge/page.tsx
+++ b/src/app/admin/knowledge/page.tsx
@@ -164,6 +164,8 @@ export default async function AdminKnowledgePage() {
       capped: entry.generationCapped,
       corpusEstimatedQuestions: entry.corpusEstimatedQuestions,
       fandomHost: entry.fandomHost,
+      hasEverYielded: entry.lastYieldAt != null,
+      consecutiveDryRounds: entry.consecutiveDryRounds,
     };
   }
 


### PR DESCRIPTION
## Problem

The **Exhausted — needs a decision** worklist (`/admin/knowledge`) was surfacing false positives: richly-grounded topics that had barely been generated. The classifier (`isExhaustedLeaf`) reads only *gen-total / distinct-facts / dup-rate* and **never consults corpus richness**, so a fandom-backed topic that got ~15 shallow generation attempts reads identically to a genuinely dry one.

Two live examples flagged on the dashboard:

| Domain | Wiki | Est. Qs | Gen attempts | Dup | Demotions | Real state |
|---|---|---|---|---|---|---|
| Avatar TV Show | 14,473-article `avatar.fandom.com` | 1,200 | 19 | 68% | 13 — **11 are self-containment formatting** | un-mined |
| The Golden Girls | 827-article `goldengirls.fandom.com` | 1,200 | 13 | 54% | 7 — **all 7 formatting** | un-mined |

Neither is exhausted — the refill loop has never actually mined them (`last_yield_at` null, `consecutive_dry_rounds` 0). The high dup rate is a shallow-sample artifact, and the bulk of the "failures" are formatting demotions the codebase already excludes elsewhere (`crafter-demand.ts:96`).

## Fix

Exclude a leaf from the decision queue when it is **rich** (`isRichTopic` — fandom-backed / deep corpus) **AND** the finite-set refill has never worked it — `!hasEverYielded && consecutiveDryRounds === 0`. Gated on *"never observed by refill"* rather than a gen-count, so a rich topic the machine **has** hammered and still can't yield stays flagged as a genuine decision.

- `SupplyReadout` gains `hasEverYielded` + `consecutiveDryRounds`, threaded from `DomainDepthEstimate` (migration 0118 signals) through `page.tsx`.
- `exhaustedLeaves` filter adds the `unminedRichLeaf` hold-out; worklist blurb states the rule.
- The panel only renders when non-empty, so these drop off cleanly.

## Scope / notes

- Per-parent `⛔ N exhausted` **badges are intentionally unchanged** — they remain the raw "generation is walled here" signal; the worklist is the actionable subset (same pattern as the existing "already masterable" hold-out).
- Companion data change (already applied to prod, not in this diff): set `Avatar TV Show` `mastery_threshold` = 2,500 (was null → resolving to the 1,000 default).

## Verification

- `npx tsc -p tsconfig.typecheck.json` — clean
- `npx eslint` on both changed files — clean
- No tests construct `SupplyReadout`; new fields are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bc3ejDjRNFR8QMk1RN5cLm