### PR TITLE
fix(composer): remove Followers visibility option

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -13,8 +13,8 @@ type SortMode = 'newest' | 'most_answered' | 'hardest' | 'easiest';
 type OrderMode = 'category' | 'recency';
 type Tab = 'authored' | 'answered';
 // Capability 8 (B-4 Stage A): the CreateChooser passes a three-way intent that
-// pre-selects the composer's destinations. 'followers' maps to D-1 Stage 4's
-// 'friends' visibility (followers-only) — not a hardcoded 'public'.
+// pre-selects the composer's destinations. 'followers' is a legacy intent name
+// (friend = mutual follow now); it pre-checks "share with all friends".
 type CreateIntent = 'bank' | 'followers' | 'specific';
 type DrawerState =
   | { mode: 'closed' }
@@ -42,7 +42,10 @@ function createFormProps(intent: CreateIntent | null): {
 } {
   switch (intent) {
     case 'followers':
-      return { initialValues: { shareToFeed: true, visibility: 'friends' } };
+      // Followers are gone as a concept (friend = mutual follow); the picker
+      // no longer offers 'friends' visibility, so this intent now means
+      // "share with all friends" on the default (public) visibility.
+      return { initialValues: { shareToFeed: true } };
     case 'specific':
       return { initialSpecificMode: true };
     case 'bank':

--- a/src/components/CreateChooser.tsx
+++ b/src/components/CreateChooser.tsx
@@ -5,11 +5,11 @@ import { useRouter } from 'next/navigation';
 import { Gamepad2, Pencil, Send, Users } from 'lucide-react';
 
 // Capability 8: creating a question is a three-way choice surfaced up front —
-// bank it only, send to your followers, or send to specific people. Sending
+// bank it only, send to your friends, or send to specific people. Sending
 // always banks it too; these intents pre-select the matching destinations in
-// the composer (the form still lets you adjust before saving). The
-// 'send-to-followers' intent maps to the D-1 Stage 4 'friends' visibility
-// (followers-only), not a hardcoded 'public'.
+// the composer (the form still lets you adjust before saving). 'followers' is
+// a legacy intent name (friend = mutual follow now); it pre-checks the
+// composer's "share with all friends" destination.
 type CreateIntent = 'bank' | 'followers' | 'specific';
 
 const QUESTION_OPTIONS: ReadonlyArray<{
@@ -27,8 +27,8 @@ const QUESTION_OPTIONS: ReadonlyArray<{
   {
     intent: 'followers',
     icon: Users,
-    title: 'Send to followers',
-    description: 'Share it with everyone who follows you (also banked).',
+    title: 'Send to friends',
+    description: 'Share it with all your friends (also banked).',
   },
   {
     intent: 'specific',

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -406,8 +406,10 @@ export function scopeSignpost(visibility: 'public' | 'friends' | 'private'): str
   switch (visibility) {
     case 'public':
       return 'Others can play this. Your friends will see it’s from you.';
+    // Legacy value: the picker no longer offers it (followers are gone —
+    // friend = mutual), but existing rows / callers may still carry it.
     case 'friends':
-      return 'Kept to friends only — only people who follow you will see it.';
+      return 'Kept to friends only — only your friends will see it.';
     case 'private':
       return 'Only you can see this — it won’t be shared.';
   }
@@ -986,7 +988,6 @@ export function QuestionForm({
                 <div className="inline-flex rounded-md border bg-background p-0.5" role="group" aria-label="Question visibility">
                   {([
                     { value: 'public', label: 'Public' },
-                    { value: 'friends', label: 'Followers' },
                     { value: 'private', label: 'Private' },
                   ] as const).map((option) => (
                     <button


### PR DESCRIPTION
## Summary

Followers are no longer a product concept (friend = mutual follow), but the composer's "Who can see this" picker still offered **Public / Followers / Private**. This removes the straggler and the two places that fed it:

- **`QuestionForm.tsx`** — the visibility picker is now **Public / Private**. The `friends` visibility value stays in the type, API, and `scopeSignpost` (existing rows still carry it and the pool layer reads it as `friends_only` scope), but its signpost copy no longer says "people who follow you".
- **`questions/page.tsx`** — the `?intent=followers` create-intent used to seed `visibility: 'friends'`, which would have opened the form with no picker button selected. It now just pre-checks "Share with all friends" on the default public visibility. The internal `followers` intent value is unchanged so no URLs or types churn.
- **`CreateChooser.tsx`** — "Send to followers / Share it with everyone who follows you" → "Send to friends / Share it with all your friends (also banked)", matching the friends-hub scrub (its test already asserts "Followers" never renders).

## Testing

- `npx tsc -p tsconfig.typecheck.json` — clean
- ESLint on all three files — clean
- `QuestionForm.test.tsx` — all pass
- `FriendsHubPage.test.tsx` has one failing test ("Who shares your world?" copy) that fails on the untouched tree too — pre-existing copy drift, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eXr91vo42m1WY9PX9JVdH
