### PR TITLE
fix(quality): mirror question edits across GeneratedQuestion↔Question twins

### DIFF
--- a/scripts/ops/reconcile-twin-drift.mjs
+++ b/scripts/ops/reconcile-twin-drift.mjs
@@ -1,0 +1,191 @@
+/**
+ * reconcile-twin-drift.mjs — Question ⇄ GeneratedQuestion content-drift reconciler.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Every daily-generated question exists as TWO rows: the original
+ * `GeneratedQuestion` and a `Question` "twin" linked by `generated_question_id`.
+ * The daily/bonus/catch-up serving path reads the stem/answer/explainer LIVE from
+ * the GeneratedQuestion (src/server/db/queries/daily.ts:833). But the quality/edit
+ * pipeline writes content to only ONE store at a time:
+ *   - approveEditedQuestion  (machine-demotions.ts:212) — XOR write, keyed on target.table
+ *   - adminEditQuestion      (admin-questions.ts:153)    — writes `questions` only
+ * So a correction applied to the twin never reaches the copy players are served
+ * (and vice-versa). The two texts drift. This script surfaces every drifted pair
+ * and (with --apply) converges each pair onto its canonical copy.
+ *
+ * CANONICAL DIRECTION (per row, NOT a blanket direction — drift goes both ways)
+ * ----------------------------------------------------------------------------
+ * The canonical copy is the one most recently blessed:
+ *   twinStamp = max(Question.verified_at, Question.updated_at)
+ *   genStamp  = GeneratedQuestion.verified_at
+ * Whichever is later wins. Tie / both-null → the twin wins (it's the store the
+ * human/quality pipeline corrects, and it carries trust_tier=human_validated).
+ * Convergence copies the winner's question_text / answer / explainer onto the loser.
+ *
+ * EMBEDDINGS: the two rows already share one (stale) embedding vector copied at
+ * twin-creation; whichever text we converge to, the embedding was ALREADY stale
+ * relative to at least one edited stem. This script does NOT re-embed — a separate
+ * re-embed pass (dedup relies on embeddings) is the right follow-up. It only reports
+ * the count of rows whose embedding should be recomputed after convergence.
+ *
+ * USAGE
+ * -----
+ *   node scripts/ops/reconcile-twin-drift.mjs            # DRY RUN (default) — no writes
+ *   node scripts/ops/reconcile-twin-drift.mjs --apply    # WRITES TO PROD (DATABASE_URL is prod)
+ *   node scripts/ops/reconcile-twin-drift.mjs --only-answers   # restrict to answer drift
+ *
+ * DATABASE_URL is read from .env — in this repo that IS prod. --apply performs
+ * prod DML; clear it with Josh before running.
+ */
+
+import pg from 'pg';
+import 'dotenv/config';
+
+const APPLY = process.argv.includes('--apply');
+const ONLY_ANSWERS = process.argv.includes('--only-answers');
+
+const { Client } = pg;
+const client = new Client({ connectionString: process.env.DATABASE_URL });
+
+function trunc(s, n = 90) {
+  if (s == null) return '∅';
+  const one = String(s).replace(/\s+/g, ' ').trim();
+  return one.length > n ? one.slice(0, n - 1) + '…' : one;
+}
+
+/** max of a set of timestamps, ignoring null/undefined; null if all empty. */
+function maxStamp(...vals) {
+  const ts = vals.filter(Boolean).map((v) => new Date(v).getTime());
+  return ts.length ? Math.max(...ts) : null;
+}
+
+async function main() {
+  await client.connect();
+
+  // Pull every live twin whose content diverges from its GeneratedQuestion source.
+  const { rows } = await client.query(`
+    select
+      q.id                     as q_id,
+      q.question_text          as q_text,
+      q.answer_text            as q_answer,
+      q.factual_explanation    as q_expl,
+      q.verified_at            as q_verified_at,
+      q.updated_at             as q_updated_at,
+      q.trust_tier             as q_trust,
+      g.id                     as g_id,
+      g.question_text          as g_text,
+      g.answer                 as g_answer,
+      g.explainer              as g_expl,
+      g.verified_at            as g_verified_at,
+      (q.question_text is distinct from g.question_text)       as text_drift,
+      (q.answer_text  is distinct from g.answer)               as answer_drift,
+      (coalesce(q.factual_explanation,'') is distinct from coalesce(g.explainer,'')) as expl_drift
+    from "Question" q
+    join "GeneratedQuestion" g on g.id = q.generated_question_id
+    where q.generated_question_id is not null
+      and q.deleted_at is null
+      and (
+        q.question_text is distinct from g.question_text
+        or q.answer_text is distinct from g.answer
+        or coalesce(q.factual_explanation,'') is distinct from coalesce(g.explainer,'')
+      )
+    order by q.updated_at desc nulls last
+  `);
+
+  const targets = ONLY_ANSWERS ? rows.filter((r) => r.answer_drift) : rows;
+
+  console.log(`\n${APPLY ? '🛠  APPLY MODE (writing to prod)' : '🔎 DRY RUN (no writes)'}`);
+  console.log(`Drifted twin pairs: ${targets.length}${ONLY_ANSWERS ? ' (answer drift only)' : ''}`);
+  console.log('='.repeat(100));
+
+  let toGen = 0; // convergence direction: twin wins → write GeneratedQuestion
+  let toTwin = 0; // GeneratedQuestion wins → write Question twin
+  let answerFixes = 0;
+  const plan = [];
+
+  for (const r of targets) {
+    const twinStamp = maxStamp(r.q_verified_at, r.q_updated_at);
+    const genStamp = maxStamp(r.g_verified_at);
+    // Later stamp wins; tie / both-null → twin (the corrected store).
+    const winner = genStamp != null && twinStamp != null && genStamp > twinStamp ? 'gen' : 'twin';
+
+    const canonical =
+      winner === 'twin'
+        ? { text: r.q_text, answer: r.q_answer, expl: r.q_expl }
+        : { text: r.g_text, answer: r.g_answer, expl: r.g_expl };
+
+    if (winner === 'twin') toGen++;
+    else toTwin++;
+    if (r.answer_drift) answerFixes++;
+
+    plan.push({ r, winner, canonical });
+
+    const flags = [r.text_drift && 'TEXT', r.answer_drift && 'ANSWER', r.expl_drift && 'EXPL']
+      .filter(Boolean)
+      .join('+');
+    console.log(`\n• ${flags}  canonical=${winner.toUpperCase()}  q=${r.q_id}  g=${r.g_id}`);
+    console.log(`    twinStamp=${twinStamp ? new Date(twinStamp).toISOString() : '∅'}  genStamp=${genStamp ? new Date(genStamp).toISOString() : '∅'}  trust=${r.q_trust}`);
+    if (r.text_drift) {
+      console.log(`    twin text: ${trunc(r.q_text)}`);
+      console.log(`    gen  text: ${trunc(r.g_text)}`);
+    }
+    if (r.answer_drift) {
+      console.log(`    twin ans : ${trunc(r.q_answer, 60)}`);
+      console.log(`    gen  ans : ${trunc(r.g_answer, 60)}`);
+    }
+    console.log(`    ⇒ converge both to ${winner.toUpperCase()}: ${trunc(canonical.text)}`);
+  }
+
+  console.log('\n' + '='.repeat(100));
+  console.log(`Summary: ${targets.length} drifted pairs`);
+  console.log(`  • twin is canonical → will overwrite GeneratedQuestion: ${toGen}`);
+  console.log(`  • gen  is canonical → will overwrite Question twin:      ${toTwin}`);
+  console.log(`  • pairs with an ANSWER drift (higher risk):             ${answerFixes}`);
+  console.log(`  • embeddings needing recompute after convergence:       ${targets.length} (out of scope — follow-up re-embed pass)`);
+
+  if (!APPLY) {
+    console.log('\nDRY RUN — no rows written. Re-run with --apply to converge (prod DML).');
+    await client.end();
+    return;
+  }
+
+  // --apply: converge each pair to its canonical copy in a single transaction.
+  await client.query('BEGIN');
+  try {
+    const now = new Date();
+    for (const { r, winner, canonical } of plan) {
+      if (winner === 'twin') {
+        // Push twin content onto the served GeneratedQuestion.
+        await client.query(
+          `update "GeneratedQuestion"
+             set question_text = $1, answer = $2, explainer = $3
+           where id = $4`,
+          [canonical.text, canonical.answer, canonical.expl ?? null, r.g_id],
+        );
+      } else {
+        // Push GeneratedQuestion content onto the twin (keeps admin view in sync).
+        await client.query(
+          `update "Question"
+             set question_text = $1, answer_text = $2, factual_explanation = $3, updated_at = $4
+           where id = $5`,
+          [canonical.text, canonical.answer, canonical.expl ?? null, now, r.q_id],
+        );
+      }
+    }
+    await client.query('COMMIT');
+    console.log(`\n✅ Applied. Converged ${plan.length} pairs.`);
+    console.log('   NOTE: embeddings NOT recomputed — run a re-embed pass before relying on dedup.');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('\n❌ Rolled back — no changes written.', err);
+    process.exitCode = 1;
+  }
+
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/server/db/queries/admin-questions.ts
+++ b/src/server/db/queries/admin-questions.ts
@@ -1,6 +1,6 @@
 import { and, asc, desc, eq, ilike, inArray, isNotNull, isNull, or, sql, type SQL } from 'drizzle-orm';
 
-import { db, questions, users } from '@/server/db';
+import { db, generatedQuestions, questions, users } from '@/server/db';
 import { resolveAuthorDisplay, parseQuestionSource } from '@/lib/questions-types';
 import { resolveFinestNode } from '@/server/knowledge/graph';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
@@ -207,7 +207,7 @@ export async function adminEditQuestion(
 
   // Only edit rows that still exist (deleted rows are restored first, not edited).
   const [existing] = await db
-    .select({ publicStatus: questions.publicStatus })
+    .select({ publicStatus: questions.publicStatus, generatedQuestionId: questions.generatedQuestionId })
     .from(questions)
     .where(and(eq(questions.id, id), isNull(questions.deletedAt)))
     .limit(1);
@@ -225,6 +225,27 @@ export async function adminEditQuestion(
   values.updatedAt = new Date();
 
   await db.update(questions).set(values).where(eq(questions.id, id));
+
+  // Mirror grading-adjacent content onto the linked GeneratedQuestion twin.
+  // Daily/bonus/catch-up serving reads the stem/answer/explainer LIVE from the
+  // GeneratedQuestion (daily.ts:833), so an admin edit that stops at the Question
+  // row never reaches the copy players are served (B-TWIN-DRIFT-01). Only the
+  // three served fields are mirrored, and only when they actually changed; the
+  // GeneratedQuestion's verification stamp is left to the batch-verify sweep.
+  if (contentChanged && existing.generatedQuestionId) {
+    const genValues: Partial<typeof generatedQuestions.$inferInsert> = {};
+    if (input.questionText !== undefined) genValues.questionText = input.questionText;
+    if (input.answerText !== undefined) genValues.answer = input.answerText;
+    // explainer is non-null in the generated store; only overwrite when a
+    // non-empty one is supplied (a cleared explainer is not mirrored across).
+    if (input.factualExplanation) genValues.explainer = input.factualExplanation;
+    if (Object.keys(genValues).length > 0) {
+      await db
+        .update(generatedQuestions)
+        .set(genValues)
+        .where(eq(generatedQuestions.id, existing.generatedQuestionId));
+    }
+  }
   return { ok: true };
 }
 

--- a/src/server/db/queries/machine-demotions.ts
+++ b/src/server/db/queries/machine-demotions.ts
@@ -209,6 +209,40 @@ export type ApproveResult =
 // checked the reworked question (the route requires the reviewer to have seen a
 // verdict). Works on BOTH stores. Any active incorrect reports on the target
 // are resolved as admin_edited.
+type ApprovedContent = { questionText: string; answerText: string; explanation?: string | null };
+
+// Push approved content from a Question twin onto its served GeneratedQuestion
+// (B-TWIN-DRIFT-01). Content-only: the stem/answer/explainer that serving reads
+// live. The GeneratedQuestion's verification stamp is intentionally untouched —
+// the batch-verify sweep re-fact-checks it on its own cadence.
+async function mirrorContentToGenerated(generatedQuestionId: string, input: ApprovedContent): Promise<void> {
+  await db
+    .update(generatedQuestions)
+    .set({
+      questionText: input.questionText,
+      answer: input.answerText,
+      // explainer is non-null in the generated store; only overwrite when the
+      // edit supplies one (matches the approve-generated branch's convention).
+      ...(input.explanation ? { explainer: input.explanation } : {}),
+    })
+    .where(eq(generatedQuestions.id, generatedQuestionId));
+}
+
+// Inverse mirror: push approved content from a GeneratedQuestion onto every live
+// Question twin linked to it, keeping the admin/grading copy in lockstep. Bumps
+// updatedAt (the twin's own edit marker); leaves the verification stamp to the sweep.
+async function mirrorContentToTwins(generatedQuestionId: string, input: ApprovedContent, now: Date): Promise<void> {
+  await db
+    .update(questions)
+    .set({
+      questionText: input.questionText,
+      answerText: input.answerText,
+      ...(input.explanation !== undefined ? { factualExplanation: input.explanation ?? null } : {}),
+      updatedAt: now,
+    })
+    .where(and(eq(questions.generatedQuestionId, generatedQuestionId), isNull(questions.deletedAt)));
+}
+
 export async function approveEditedQuestion(
   target: ReviewTarget,
   input: { questionText: string; answerText: string; explanation?: string | null },
@@ -231,8 +265,16 @@ export async function approveEditedQuestion(
         updatedAt: now,
       })
       .where(and(eq(questions.id, target.id), isNull(questions.deletedAt)))
-      .returning({ id: questions.id });
+      .returning({ id: questions.id, generatedQuestionId: questions.generatedQuestionId });
     if (updated.length === 0) return { ok: false, reason: 'not_found' };
+    // Mirror the edit onto the linked GeneratedQuestion twin. Daily/bonus/catch-up
+    // serving reads the stem/answer/explainer LIVE from the GeneratedQuestion
+    // (daily.ts:833), so an edit that stops at the Question row never reaches the
+    // copy players are served (B-TWIN-DRIFT-01). Mirror content only — the twin's
+    // own verification stamp is left to the batch-verify sweep.
+    if (updated[0]?.generatedQuestionId) {
+      await mirrorContentToGenerated(updated[0].generatedQuestionId, input);
+    }
     const resolvedReports = await resolveActiveIncorrectReportsForQuestion(target.id, 'admin_edited');
     return { ok: true, resolvedReports };
   }
@@ -253,6 +295,10 @@ export async function approveEditedQuestion(
     .where(eq(generatedQuestions.id, target.id))
     .returning({ id: generatedQuestions.id });
   if (updated.length === 0) return { ok: false, reason: 'not_found' };
+  // Mirror onto any live Question twins linked to this GeneratedQuestion, so the
+  // admin surface + grading path stay in lockstep with the served copy (see the
+  // twin-branch note above). Content only; each twin's stamp is the sweep's job.
+  await mirrorContentToTwins(target.id, input, now);
   const resolvedReports = await resolveActiveIncorrectReportsForGenerated(target.id);
   return { ok: true, resolvedReports };
 }


### PR DESCRIPTION
## Problem

A bonus item shown in-game didn't match its admin **Question detail** — same answer and inside-joke, different question stem. Root cause: every daily-generated question exists as **two rows** — the served `GeneratedQuestion` and a `Question` "twin" (linked by `generated_question_id`), each with its own editable `question_text` / `answer` / `explainer`.

Daily/bonus/catch-up serving reads content **live from the `GeneratedQuestion`** (`daily.ts:833`), but the edit pipeline wrote to only one store:

- **`approveEditedQuestion`** (`machine-demotions.ts`) — an **XOR write** keyed on `target.table`; never touches the linked counterpart.
- **`adminEditQuestion`** (`admin-questions.ts`, the admin Edit button) — writes the `Question` twin **only**.

So corrections (self-containment healing, factual fixes, false-premise demotions, admin edits, re-verify) never reached the copy players are served, and the two texts drifted apart.

## Blast radius (measured in prod)

653 twins → **84 drifted pairs** (45 stem-text, 5 answer, rest explainer). Notable: a **live-wrong served answer** (Hamlet served "Hamlet"; correct answer "Laertes") and a served Mozart-symphony misstatement.

## The fix

Both write paths now **mirror content** (`question_text` / `answer` / `explainer`) to the linked counterpart whenever a `generated_question_id` link exists. Content only — each store's verification stamp is still left to the batch-verify sweep. Carries a `B-TWIN-DRIFT-01` comment pointing at `daily.ts:833`.

## Auditor script

`scripts/ops/reconcile-twin-drift.mjs` — read-only by default, surfaces every drifted pair with a per-row canonical recommendation (`--apply` to converge). Used to reconcile the historical backlog: **83 rows converged in prod** (answer drifts + reviewed text/explainer drifts). One row (Nellie Bly, broken premise both sides) intentionally left for rework.

## Verification

- `npx tsc -p tsconfig.typecheck.json` — clean
- `eslint` on both files — clean
- 57 tests across `admin/questions`, `admin/content-reports`, `recovered-questions`, `salvage-sweep` — pass

## Follow-ups (not in this PR)

- Re-embed the touched rows — convergence changed served text but not the shared (stale) embedding vector; dedup relies on it.
- The healing/re-verify sweeps are introducing factual errors on some twins (DS9 "Sisko", Carroll Wright "1880s", Masaccio "27") — a separate quality signal worth investigating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bc3ejDjRNFR8QMk1RN5cLm