### PR TITLE
Merge PR #1535 (dedicated /daily/setup manage-topics page) into main

### DIFF
--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -498,13 +498,15 @@ export function TerritorySetupClient({
         <header className="mb-8 flex items-start justify-between gap-4">
           <div>
             <p className="text-xs font-semibold tracking-[0.2em] text-[var(--text-muted-warm)] uppercase">
-              TODAY’S FIVE
+              YOUR TOPICS
             </p>
             <h1 className="mt-3 font-serif text-5xl leading-[0.95] font-semibold text-[var(--ink)]">
               Shape your next round
             </h1>
             <p className="mt-4 max-w-lg text-base leading-7 text-[var(--text-muted-warm)]">
-              Move territories around to decide what Joshing should ask you about next.
+              Add topics you’d love to be asked about — pick a suggestion or create your own. Then
+              tap any territory to bring up its options: change how often it comes up, or throw it
+              out.
             </p>
           </div>
           <Link

--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -498,15 +498,13 @@ export function TerritorySetupClient({
         <header className="mb-8 flex items-start justify-between gap-4">
           <div>
             <p className="text-xs font-semibold tracking-[0.2em] text-[var(--text-muted-warm)] uppercase">
-              YOUR TOPICS
+              TODAY’S FIVE
             </p>
             <h1 className="mt-3 font-serif text-5xl leading-[0.95] font-semibold text-[var(--ink)]">
               Shape your next round
             </h1>
             <p className="mt-4 max-w-lg text-base leading-7 text-[var(--text-muted-warm)]">
-              Add topics you’d love to be asked about — pick a suggestion or create your own. Then
-              tap any territory to bring up its options: change how often it comes up, or throw it
-              out.
+              Move territories around to decide what Joshing should ask you about next.
             </p>
           </div>
           <Link

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -1,12 +1,50 @@
 import { redirect } from 'next/navigation';
 
+import { getSession } from '@/server/auth/session';
+import { getKnowledgeBase } from '@/server/db/queries/daily';
+import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
+import { buildInitialFrequencyMap, type TerritoryDomain } from '@/lib/daily/territory-model';
+
+import { TerritorySetupClient } from './TerritorySetupClient';
+
 export const dynamic = 'force-dynamic';
 
-// The Configure page retired into the knowledge portrait (Josh, 2026-07-14):
-// rotation lives in the portrait's Frequency view + detail pop-up, adding in
-// the "Add a territory" block, and removal in the pop-up's remove link. This
-// stub keeps every old /daily/setup URL (emails, bookmarks, stale clients)
-// landing somewhere sensible. TerritorySetupClient stays on disk, unrouted.
-export default function DailySetupPage() {
-  redirect('/knowledge');
+// The dedicated "manage your topics" page (Josh, 2026-07-17): un-retired from
+// the /knowledge redirect stub. This is the separate surface for adding topics
+// (with nearby suggestions), setting how often each comes up, and throwing ones
+// out — deliberately NOT the /knowledge portrait, which stays the read-only
+// "your mind" view with the shareable modules. Existing links already point
+// here (the daily-reminder email's manage-interests URL, the refine flow's
+// ADD_TERRITORIES_HREF); they now land on the real page instead of redirecting.
+export default async function DailySetupPage() {
+  const session = await getSession();
+  if (!session) redirect('/login');
+
+  const [preferences, knowledgeBase] = await Promise.all([
+    getDailyPreferences(session.userId),
+    getKnowledgeBase(session.userId),
+  ]);
+
+  const availableDomains: TerritoryDomain[] = knowledgeBase.map((domain) => ({
+    domain: domain.domain,
+    broadCategory: domain.broadCategory ?? null,
+    totalPoints: domain.totalPoints,
+    tier: domain.tier,
+    correctAnswerCount: domain.correctAnswerCount,
+  }));
+
+  const initialFrequencyByDomain = buildInitialFrequencyMap({
+    domains: availableDomains,
+    savedFrequency: preferences.domainPreferenceFrequency ?? null,
+    selectedDomains: preferences.selectedDomains ?? [],
+    domainMode: preferences.domainMode ?? 'random',
+  });
+
+  return (
+    <TerritorySetupClient
+      initialDomains={availableDomains}
+      initialDifficulty={preferences.difficulty ?? 'adaptive'}
+      initialFrequencyByDomain={initialFrequencyByDomain}
+    />
+  );
 }

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -1,50 +1,36 @@
 import { redirect } from 'next/navigation';
 
+import { KnowledgeFlatClient } from '../../knowledge/KnowledgeFlatClient';
 import { getSession } from '@/server/auth/session';
-import { getKnowledgeBase } from '@/server/db/queries/daily';
+import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
+import { getFullyExploredDomains } from '@/server/knowledge/fully-explored';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
-import { buildInitialFrequencyMap, type TerritoryDomain } from '@/lib/daily/territory-model';
-
-import { TerritorySetupClient } from './TerritorySetupClient';
 
 export const dynamic = 'force-dynamic';
 
 // The dedicated "manage your topics" page (Josh, 2026-07-17): un-retired from
-// the /knowledge redirect stub. This is the separate surface for adding topics
-// (with nearby suggestions), setting how often each comes up, and throwing ones
-// out — deliberately NOT the /knowledge portrait, which stays the read-only
-// "your mind" view with the shareable modules. Existing links already point
-// here (the daily-reminder email's manage-interests URL, the refine flow's
-// ADD_TERRITORIES_HREF); they now land on the real page instead of redirecting.
+// the /knowledge redirect stub. It reuses the /knowledge portrait format (the
+// same Domain/Mastery/Frequency circles and the tap-a-circle detail pop-up that
+// changes frequency, adds a related topic, or removes it) via the `manage`
+// variant — no shareable modules, and the add-topics field lifted to the top.
+// Existing links already point here (the daily-reminder email's manage-interests
+// URL, the refine flow's ADD_TERRITORIES_HREF); they now land on the real page.
 export default async function DailySetupPage() {
   const session = await getSession();
   if (!session) redirect('/login');
 
-  const [preferences, knowledgeBase] = await Promise.all([
+  const [{ tree }, preferences, fullyExplored] = await Promise.all([
+    getKnowledgeMapData(session.userId),
     getDailyPreferences(session.userId),
-    getKnowledgeBase(session.userId),
+    getFullyExploredDomains(session.userId),
   ]);
 
-  const availableDomains: TerritoryDomain[] = knowledgeBase.map((domain) => ({
-    domain: domain.domain,
-    broadCategory: domain.broadCategory ?? null,
-    totalPoints: domain.totalPoints,
-    tier: domain.tier,
-    correctAnswerCount: domain.correctAnswerCount,
-  }));
-
-  const initialFrequencyByDomain = buildInitialFrequencyMap({
-    domains: availableDomains,
-    savedFrequency: preferences.domainPreferenceFrequency ?? null,
-    selectedDomains: preferences.selectedDomains ?? [],
-    domainMode: preferences.domainMode ?? 'random',
-  });
-
   return (
-    <TerritorySetupClient
-      initialDomains={availableDomains}
-      initialDifficulty={preferences.difficulty ?? 'adaptive'}
-      initialFrequencyByDomain={initialFrequencyByDomain}
+    <KnowledgeFlatClient
+      variant="manage"
+      tree={tree}
+      frequencyByDomain={preferences.domainPreferenceFrequency}
+      fullyExploredDomains={fullyExplored}
     />
   );
 }

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Suspense, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Combine, Plus, Trash2, X } from 'lucide-react';
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
@@ -780,13 +781,9 @@ function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }:
                 ? 'Suggestions based on the shape of your map — or create your own.'
                 : 'Create your own, and more suggestions will appear as your map grows.'}
             </p>
-            <button
-              type="button"
-              className="btn-ghost gap-1.5"
-              onClick={() => setActiveModal({ type: 'manage-interests' })}
-            >
+            <Link href="/daily/setup" className="btn-ghost gap-1.5">
               <Plus className="size-4" aria-hidden /> Create your own
-            </button>
+            </Link>
             {visibleNearby.length > 0 ? (
               <div className="mt-4 grid grid-cols-3 gap-3">
                 {visibleNearby.map((territory) => (
@@ -820,13 +817,9 @@ function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }:
             Add something you&rsquo;d be delighted to be asked about, and Joshing will start shaping
             around it.
           </p>
-          <button
-            type="button"
-            className="btn-primary mx-auto mt-4 gap-1.5"
-            onClick={() => setActiveModal({ type: 'manage-interests' })}
-          >
+          <Link href="/daily/setup" className="btn-primary mx-auto mt-4 gap-1.5">
             <Plus className="size-5" aria-hidden /> Create your own
-          </button>
+          </Link>
         </section>
       )}
 

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { Combine, Plus, Repeat2, Trash2, X } from 'lucide-react';
+import { Combine, Plus, Trash2, X } from 'lucide-react';
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
 import { Skeleton } from '@/components/ui/Skeleton';
 
@@ -1023,16 +1023,16 @@ function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }:
               </button>
             </div>
             <div className="grid grid-cols-[repeat(auto-fit,minmax(118px,1fr))] gap-2.5 mt-5">
-              {declaredSlots.map((slot, index) => (
+              {declaredSlots.map((slot) => (
                 <div key={slot.domain} className="min-h-[132px] border border-[var(--border-light)] rounded-lg p-3 flex flex-col justify-between bg-[var(--cream)]">
                   <div className="min-w-0">
                     <h3 className="m-0 text-[0.9rem] leading-[1.25] text-[var(--ink)]">{slot.displayName}</h3>
                     <p className="mt-1 text-[var(--text-muted-warm)] text-[0.72rem]">{slot.broadCategory ?? asTier(slot.tier)}</p>
                   </div>
                   <div className="flex gap-1.5 mt-2">
-                    <button type="button" className="flex-1 min-h-[34px] border border-[var(--border-warm)] bg-[var(--brand-card)] text-[var(--text-muted-warm)] inline-flex items-center justify-center gap-1.5 text-[0.68rem] uppercase tracking-[0.08em] cursor-pointer" onClick={() => openInterestModal(index, slot.domain)}>
-                      <Repeat2 className="size-3.5" />
-                      Swap
+                    <button type="button" className="flex-1 min-h-[34px] border border-[var(--border-warm)] bg-[var(--brand-card)] text-[var(--text-muted-warm)] inline-flex items-center justify-center gap-1.5 text-[0.68rem] uppercase tracking-[0.08em] cursor-pointer" onClick={() => openInterestModal(declaredSlots.length, null)}>
+                      <Plus className="size-3.5" />
+                      Add
                     </button>
                     <button type="button" className="min-h-[34px] w-[34px] border border-[var(--border-warm)] bg-[var(--brand-card)] text-[var(--text-muted-warm)] inline-flex items-center justify-center cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onClick={() => void removeDeclaredInterest(slot.domain)} disabled={savingInterests || declaredSlots.length <= 1} aria-label={`Remove ${slot.displayName}`} title={declaredSlots.length <= 1 ? 'Keep at least one interest' : `Remove ${slot.displayName}`}>
                       <Trash2 className="size-3.5" />

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -27,6 +27,7 @@ import {
   type NearbyTerritory,
 } from '@/lib/daily/territory-model';
 import { GhostTerritoryCircle } from '@/components/knowledge/GhostTerritoryCircle';
+import { AddTopicField } from '@/components/interests/AddTopicField';
 import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
 import type { MasteryTier } from '@/types/db';
 
@@ -147,6 +148,11 @@ function emptyDomain(domain: string): DomainMastery {
 // itself still loads from /api/knowledge client-side; these ride alongside so a
 // tapped circle can open the same PeakDetailCard the "peaks" view uses.
 type PeaksDetailData = {
+  // 'portrait' (default) is the read-only /knowledge view with the shareable
+  // modules. 'manage' is the dedicated /daily/setup topic-management page:
+  // same portrait format and tap-a-circle pop-up, but no shareable modules and
+  // the add-topics field lifted to the top.
+  variant?: 'portrait' | 'manage';
   tree: KnowledgeTreeNode;
   frequencyByDomain: DomainPreferenceFrequency;
   fullyExploredDomains: ReadonlySet<string>;
@@ -231,7 +237,8 @@ export function KnowledgeFlatClient(props: PeaksDetailData) {
   );
 }
 
-function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }: PeaksDetailData) {
+function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, fullyExploredDomains }: PeaksDetailData) {
+  const isManage = variant === 'manage';
   const searchParams = useSearchParams();
   const highlightedDomainSlug = searchParams.get('domain');
   const tierCrossed = searchParams.get('tier_crossed');
@@ -428,6 +435,23 @@ function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }:
     } finally {
       setAddingSuggestion(null);
     }
+  };
+
+  // Inline "create your own" on the manage page. AddTopicField owns the
+  // canonicalize/converge step and throws on a known persistence failure, so
+  // this just writes the declared interest and reloads the map.
+  const adoptTopic = async (label: string, broadCategory?: string | null) => {
+    const response = await fetch('/api/declared-interests', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label, ...(broadCategory ? { broadCategory } : {}) }),
+    });
+    if (!response.ok) {
+      const body = (await response.json().catch(() => null)) as { message?: string } | null;
+      throw new Error(body?.message ?? 'Could not add that topic.');
+    }
+    await loadKnowledge();
   };
 
   // A tapped circle (outside edit mode) opens the peaks detail pop-up. Prefer the
@@ -718,8 +742,15 @@ function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }:
   return (
     <main className="w-[min(672px,94vw)] mx-auto pt-5 pb-10 grid gap-3.5">
       <h1 className="m-0 px-1 font-serif text-[2rem] font-medium leading-tight text-[var(--brand-ink)]">
-        Knowledge
+        {isManage ? 'Manage your topics' : 'Knowledge'}
       </h1>
+
+      {isManage && (
+        <p className="px-1 text-[0.9rem] leading-[1.5] text-[var(--text-muted-warm)]">
+          Add topics you&rsquo;d love to be asked about. Tap any circle below to bring up its
+          options &mdash; change how often it comes up, add a related topic, or remove it.
+        </p>
+      )}
 
       {tierCrossed && highlightedDomainSlug && (
         <section className="bg-[var(--cream-accent)] text-[var(--ink)] px-4 py-3 text-base">
@@ -727,7 +758,42 @@ function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }:
         </section>
       )}
 
-      {topCardDomains.length > 0 && (
+      {/* Manage variant: the add-topics field + suggestions lead the page,
+          replacing the shareable portrait/expanding modules. */}
+      {isManage && (
+        <section className="bg-[var(--brand-card)] border border-[var(--border-warm)] p-4" aria-label="Add topics">
+          <h2 className="m-0 text-lg font-semibold text-[var(--ink)] font-[var(--font-serif)]">Add a topic</h2>
+          <p className="mt-1 mb-3 text-[0.82rem] leading-[1.5] text-[var(--text-muted-warm)]">
+            {visibleNearby.length > 0
+              ? 'Suggestions based on the shape of your map — or create your own.'
+              : 'Create your own, and more suggestions will appear as your map grows.'}
+          </p>
+          <AddTopicField
+            existingLabels={sortedDomains.map((domain) => domain.displayName)}
+            convergeBeforeAdd
+            onAdd={async (topic) => {
+              await adoptTopic(topic.label, topic.broadCategory ?? null);
+            }}
+          />
+          {visibleNearby.length > 0 ? (
+            <div className="mt-4 grid grid-cols-3 gap-3">
+              {visibleNearby.map((territory) => (
+                <GhostTerritoryCircle
+                  key={territory.domain}
+                  territory={territory}
+                  disabled={addingSuggestion !== null}
+                  onAdd={() => void addSuggestion(territory)}
+                />
+              ))}
+            </div>
+          ) : null}
+          {suggestError ? (
+            <p className="mt-2 text-[0.78rem]" style={{ color: 'var(--game-wrong-strong)' }}>{suggestError}</p>
+          ) : null}
+        </section>
+      )}
+
+      {!isManage && topCardDomains.length > 0 && (
         <KnowledgeCard
           playerDisplayName={displayName}
           portraitStatement={yourMind}
@@ -752,14 +818,16 @@ function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }:
         />
       )}
 
-      <RecentlyExpanding domains={expandingDomains} playerDisplayName={displayName} onNotice={showShareNotice} />
+      {!isManage && (
+        <RecentlyExpanding domains={expandingDomains} playerDisplayName={displayName} onNotice={showShareNotice} />
+      )}
 
       {hasAnything && (
         <section className="bg-[var(--brand-card)] border border-[var(--border-warm)] p-4" aria-label="Knowledge progression">
           <div className="mb-2">
-            <p className="m-0 text-[13px] [font-variant:small-caps] text-[var(--ink)] font-[var(--font-neutral)] tracking-[0.06em]">YOUR KNOWLEDGE</p>
+            <p className="m-0 text-[13px] [font-variant:small-caps] text-[var(--ink)] font-[var(--font-neutral)] tracking-[0.06em]">{isManage ? 'YOUR TOPICS' : 'YOUR KNOWLEDGE'}</p>
             <p className="mt-0.5 text-[10px] [font-variant:small-caps] text-[var(--text-muted-warm)] tracking-[0.06em] font-[var(--font-neutral)]">
-              SEE HOW YOUR KNOWLEDGE IS BUILDING -&gt;
+              {isManage ? 'TAP A TOPIC FOR OPTIONS ->' : 'SEE HOW YOUR KNOWLEDGE IS BUILDING ->'}
             </p>
           </div>
 
@@ -771,41 +839,45 @@ function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }:
             />
           </div>
 
-          {/* Add a Territory — ported from the retired Configure page: nearby
-              suggestions from the shape of the map plus the create-your-own
-              flow (the existing declared-interests modal). */}
-          <div className="mt-6 border-t border-[var(--border-warm)] pt-4">
-            <h3 className="m-0 text-lg font-semibold text-[var(--ink)] font-[var(--font-serif)]">Add a territory</h3>
-            <p className="mt-1 mb-3 text-[0.82rem] leading-[1.5] text-[var(--text-muted-warm)]">
-              {visibleNearby.length > 0
-                ? 'Suggestions based on the shape of your map — or create your own.'
-                : 'Create your own, and more suggestions will appear as your map grows.'}
-            </p>
-            <Link href="/daily/setup" className="btn-ghost gap-1.5">
-              <Plus className="size-4" aria-hidden /> Create your own
-            </Link>
-            {visibleNearby.length > 0 ? (
-              <div className="mt-4 grid grid-cols-3 gap-3">
-                {visibleNearby.map((territory) => (
-                  <GhostTerritoryCircle
-                    key={territory.domain}
-                    territory={territory}
-                    disabled={addingSuggestion !== null}
-                    onAdd={() => void addSuggestion(territory)}
-                  />
-                ))}
-              </div>
-            ) : null}
-            {suggestError ? (
-              <p className="mt-2 text-[0.78rem]" style={{ color: 'var(--game-wrong-strong)' }}>{suggestError}</p>
-            ) : null}
-          </div>
+          {/* Add a Territory — portrait variant only: a shortcut into the
+              dedicated manage page (/daily/setup), which owns the inline add.
+              The manage page lifts adding to the top instead. */}
+          {!isManage && (
+            <div className="mt-6 border-t border-[var(--border-warm)] pt-4">
+              <h3 className="m-0 text-lg font-semibold text-[var(--ink)] font-[var(--font-serif)]">Add a territory</h3>
+              <p className="mt-1 mb-3 text-[0.82rem] leading-[1.5] text-[var(--text-muted-warm)]">
+                {visibleNearby.length > 0
+                  ? 'Suggestions based on the shape of your map — or create your own.'
+                  : 'Create your own, and more suggestions will appear as your map grows.'}
+              </p>
+              <Link href="/daily/setup" className="btn-ghost gap-1.5">
+                <Plus className="size-4" aria-hidden /> Create your own
+              </Link>
+              {visibleNearby.length > 0 ? (
+                <div className="mt-4 grid grid-cols-3 gap-3">
+                  {visibleNearby.map((territory) => (
+                    <GhostTerritoryCircle
+                      key={territory.domain}
+                      territory={territory}
+                      disabled={addingSuggestion !== null}
+                      onAdd={() => void addSuggestion(territory)}
+                    />
+                  ))}
+                </div>
+              ) : null}
+              {suggestError ? (
+                <p className="mt-2 text-[0.78rem]" style={{ color: 'var(--game-wrong-strong)' }}>{suggestError}</p>
+              ) : null}
+            </div>
+          )}
         </section>
       )}
 
       {/* First-territory moment — the retired Configure page's empty state,
-          now living where the map does. */}
-      {!hasAnything && (
+          now living where the map does. Portrait only: on the manage page the
+          top add-topics section already covers the empty case (and this block's
+          CTA links to /daily/setup, which would be a self-link there). */}
+      {!isManage && !hasAnything && (
         <section
           className="bg-[var(--brand-card)] border border-dashed border-[var(--border-warm)] p-6 text-center"
           aria-label="Add your first territory"
@@ -848,8 +920,9 @@ function KnowledgePageContent({ tree, frequencyByDomain, fullyExploredDomains }:
       </section>
 
       {/* Off-screen portrait card, snapshotted in the background so the card's
-          Share button can fire the native share sheet without a preview step. */}
-      {topCardDomains.length > 0 ? (
+          Share button can fire the native share sheet without a preview step.
+          Portrait only — the manage page has no share affordance. */}
+      {!isManage && topCardDomains.length > 0 ? (
         <div aria-hidden="true" style={{ position: 'fixed', left: -10000, top: 0, pointerEvents: 'none' }}>
           <SharePortraitCard
             ref={portraitCardRef}

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -771,6 +771,9 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
           <AddTopicField
             existingLabels={sortedDomains.map((domain) => domain.displayName)}
             convergeBeforeAdd
+            // Standard field radius (--radius-xs, the login/field corner) rather
+            // than the pill default, per Josh's request for this surface.
+            inputClassName="min-h-12 flex-1 rounded-[var(--radius-xs)] border border-[var(--accent-gold)] bg-[var(--brand-field)] px-4 text-sm text-[var(--ink)] placeholder:text-[var(--text-muted-warm)]/60 focus:border-[var(--brand-navy)] focus-visible:outline-none disabled:opacity-60"
             onAdd={async (topic) => {
               await adoptTopic(topic.label, topic.broadCategory ?? null);
             }}

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -836,6 +836,7 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
               entries={portraitEntries}
               frequencyLabelFor={frequencyLabelFor}
               onSelectDomain={openDomainDetail}
+              defaultSortMode={isManage ? 'frequency' : 'domain'}
             />
           </div>
 

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -387,29 +387,65 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
     return true;
   };
 
-  // "Add a Territory" — ported from the retired Configure page. Suggestions
-  // come from the deterministic nearby-territory rules over the domains
-  // already held; the offset rotates the visible window per visit (set in a
-  // deferred frame, client-only, so SSR markup never disagrees).
+  // "Add a topic" suggestions — related but specific, and fresh each visit.
+  // The pool is the knowledge tree's unheld "ghost" siblings (leaf-level
+  // adjacent topics — e.g. Bach → Baroque Music, never a broad bucket like
+  // "Music"), supplemented by the hard-coded adjacency rules. A per-visit
+  // random offset (set in a deferred, client-only frame so SSR markup never
+  // disagrees) seeds a shuffle so the block isn't the same three every time.
   const [suggestionOffset, setSuggestionOffset] = useState(0);
   const [addingSuggestion, setAddingSuggestion] = useState<string | null>(null);
   const [suggestError, setSuggestError] = useState<string | null>(null);
   useEffect(() => {
     const frame = window.requestAnimationFrame(() =>
-      setSuggestionOffset(Math.floor(Math.random() * 1000)),
+      setSuggestionOffset(Math.floor(Math.random() * 1_000_000)),
     );
     return () => window.cancelAnimationFrame(frame);
   }, []);
-  const nearbySuggestions = useMemo(
-    () => getNearbyTerritories(sortedDomains.map((domain) => domain.displayName)),
-    [sortedDomains],
-  );
+  const suggestionPool = useMemo<NearbyTerritory[]>(() => {
+    const owned = new Set<string>();
+    for (const domain of sortedDomains) owned.add(domainKey(domain.displayName));
+    for (const label of data?.pageData.declaredInterests ?? []) owned.add(domainKey(label));
+    const pool = new Map<string, NearbyTerritory>();
+    // Tree ghost leaves — specific adjacent topics the player doesn't hold yet.
+    // broadCategory is taken from the depth-1 ancestor (the broad-category node)
+    // so the ghost circle keeps its category tint.
+    const walk = (node: KnowledgeTreeNode, depth: number, category: string | null) => {
+      const cat = depth === 1 ? node.name : category;
+      const children = node.children ?? [];
+      if (node.ghost && children.length === 0) {
+        const key = domainKey(node.name);
+        if (!pool.has(key) && !owned.has(key)) {
+          pool.set(key, { domain: node.name, broadCategory: cat, reason: 'Related to your map' });
+        }
+      }
+      for (const child of children) walk(child, depth + 1, cat);
+    };
+    walk(detailTree, 0, null);
+    // Supplement with the hard-coded adjacency rules.
+    for (const territory of getNearbyTerritories(sortedDomains.map((domain) => domain.displayName))) {
+      const key = domainKey(territory.domain);
+      if (!pool.has(key) && !owned.has(key)) pool.set(key, territory);
+    }
+    return [...pool.values()];
+  }, [detailTree, sortedDomains, data]);
   const visibleNearby = useMemo(() => {
     const SHOWN = 3;
-    if (nearbySuggestions.length <= SHOWN) return nearbySuggestions;
-    const start = suggestionOffset % nearbySuggestions.length;
-    return [...nearbySuggestions.slice(start), ...nearbySuggestions.slice(0, start)].slice(0, SHOWN);
-  }, [nearbySuggestions, suggestionOffset]);
+    if (suggestionPool.length <= SHOWN) return suggestionPool;
+    // Seeded Fisher–Yates (small LCG) keyed on the per-visit offset: stable
+    // within a render, re-rolled each visit.
+    const shuffled = [...suggestionPool];
+    let seed = (suggestionOffset % 2_147_483_646) + 1;
+    const next = () => {
+      seed = (seed * 48_271) % 2_147_483_647;
+      return seed / 2_147_483_647;
+    };
+    for (let i = shuffled.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(next() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled.slice(0, SHOWN);
+  }, [suggestionPool, suggestionOffset]);
 
   const addSuggestion = async (territory: NearbyTerritory) => {
     if (addingSuggestion) return;

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -777,9 +777,24 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
 
   return (
     <main className="w-[min(672px,94vw)] mx-auto pt-5 pb-10 grid gap-3.5">
-      <h1 className="m-0 px-1 font-serif text-[2rem] font-medium leading-tight text-[var(--brand-ink)]">
-        {isManage ? 'Manage your topics' : 'Knowledge'}
-      </h1>
+      {isManage ? (
+        <div className="flex items-start justify-between gap-4 px-1">
+          <h1 className="m-0 font-serif text-[2rem] font-medium leading-tight text-[var(--brand-ink)]">
+            Manage your topics
+          </h1>
+          <Link
+            href="/"
+            aria-label="Done — changes save automatically"
+            className="grid size-10 shrink-0 place-items-center rounded-full border border-[var(--border-warm)] bg-[var(--brand-card)] text-[var(--ink)] transition hover:bg-[var(--cream-warm)]"
+          >
+            <X className="size-5" aria-hidden="true" />
+          </Link>
+        </div>
+      ) : (
+        <h1 className="m-0 px-1 font-serif text-[2rem] font-medium leading-tight text-[var(--brand-ink)]">
+          Knowledge
+        </h1>
+      )}
 
       {isManage && (
         <p className="px-1 text-[0.9rem] leading-[1.5] text-[var(--text-muted-warm)]">
@@ -958,6 +973,15 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
           Tidy up my map
         </button>
       </section>
+
+      {/* Manage page has no bottom nav (hidden on /daily/*), so a clear exit
+          lives at the end of the page as well as the corner X. Changes save
+          as you go, so this just returns Home. */}
+      {isManage && (
+        <Link href="/" className="btn-primary mt-1 w-full">
+          Done
+        </Link>
+      )}
 
       {/* Off-screen portrait card, snapshotted in the background so the card's
           Share button can fire the native share sheet without a preview step.

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -281,12 +281,12 @@ export default function TodaysFiveCard({
             on a near-card cream fill + softened hairline border, no shadow so it
             reads as part of the header rather than a floating chip). The row is
             items-center so the pill sits on the "Today's Five" eyebrow baseline.
-            Destination is /knowledge — the Configure page retired into the
-            knowledge portrait's rotation module. The 44px min height keeps
-            the tap target accessible; `shrink-0` protects it from being squeezed
-            by the eyebrow on narrow widths. */}
+            Destination is /daily/setup — the dedicated manage-your-topics page
+            (adds at top, tap a circle for frequency/remove/related). The 44px
+            min height keeps the tap target accessible; `shrink-0` protects it
+            from being squeezed by the eyebrow on narrow widths. */}
         <Link
-          href="/knowledge"
+          href="/daily/setup"
           data-tour="customize"
           className={CUSTOMIZE_DAILY_LINK_CLASS}
           aria-label="Customize your Daily Five"

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -37,6 +37,12 @@ type PortraitCirclesProps = {
   frequencyLabelFor?: (canonicalSubcategory: string) => string | null
   /** Tap handler for a circle — opens the domain's detail pop-up. */
   onSelectDomain?: (canonicalSubcategory: string) => void
+  /**
+   * Initial sort tab. Defaults to 'domain'. 'frequency' only takes effect when
+   * `frequencyLabelFor` is provided (otherwise that tab isn't rendered), so it
+   * falls back to 'domain' when rotation data isn't threaded in.
+   */
+  defaultSortMode?: SortMode
 }
 
 const TIER_ORDER: PortraitTier[] = [
@@ -393,8 +399,13 @@ export function PortraitCircles({
   entries,
   frequencyLabelFor,
   onSelectDomain,
+  defaultSortMode = 'domain',
 }: PortraitCirclesProps) {
-  const [sortMode, setSortMode] = useState<SortMode>('domain')
+  // 'frequency' is only a valid tab when rotation data is threaded in; clamp to
+  // 'domain' otherwise so the initial mode always matches a rendered tab.
+  const [sortMode, setSortMode] = useState<SortMode>(
+    defaultSortMode === 'frequency' && !frequencyLabelFor ? 'domain' : defaultSortMode,
+  )
 
   const validEntries = useMemo(
     () =>

--- a/src/components/review/RefineYourGame.tsx
+++ b/src/components/review/RefineYourGame.tsx
@@ -41,7 +41,7 @@ export function RefineYourGame({ refine }: { refine: RefineSectionView }) {
       <div className="flex items-center justify-between gap-3">
         <h2 style={titleStyle}>Refine Your Game</h2>
         <Link
-          href="/knowledge"
+          href="/daily/setup"
           className={CUSTOMIZE_DAILY_LINK_CLASS}
           aria-label="Customize your Daily Five"
         >


### PR DESCRIPTION
Brings **PR #1535** (dedicated "Manage your topics" page at `/daily/setup`) into `main`, with the `main`↔PR conflict resolved. PR #1535 itself targets `dev2`; `main` has diverged from `dev2`, so this branch carries the conflict-resolved merge.

## Conflict resolved
`src/app/knowledge/KnowledgeFlatClient.tsx` — the portrait eyebrow line:
- `main` had migrated it to the `text-quiet` design-system token (static text `YOUR KNOWLEDGE`).
- PR #1535 kept `text-[13px]` but made the label conditional (`YOUR TOPICS` vs `YOUR KNOWLEDGE`) for the new `manage` variant.
- **Kept both** — the `text-quiet` token *and* the `isManage` conditional label.

## Type-size ratchet fix
PR #1535 was branched before `main`'s type-size ratchet (`scripts/check-typesize-ratchet.mjs`, commit `dac667d`) landed, so its new manage-variant paragraphs carried arbitrary `text-[Nrem]` sizes that pushed the repo count to 216 vs the 213 ceiling — a CI failure that never surfaces as a git conflict. Migrated the new lines to the nearest named register (sub-pixel deltas):
- `text-[0.9rem]` → `text-sm`
- `text-[0.82rem]` → `text-quiet`
- `text-[0.78rem]` → `text-xs`

Back at the 213 ceiling.

## Verification
- All six CI ratchets pass locally: typesize, font, color, spacing, radius, zindex.
- The other four files (`daily/setup/page.tsx`, `TodaysFiveCard.tsx`, `PortraitCircles.tsx`, `RefineYourGame.tsx`) auto-merged cleanly.
- `tsc`/`next build` could not run in the container (no `node_modules`) — the Vercel preview build here is the first real compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uiw28wGhUPRYP7UgN3iDZk)_