### PR TITLE
Add-a-topic: home suggestion circles + dim/confirmation/dismiss polish

### DIFF
--- a/src/app/api/interests/suggestions/route.ts
+++ b/src/app/api/interests/suggestions/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
+import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
+import { buildSuggestionPool } from '@/lib/knowledge/suggestion-pool';
+
+export const dynamic = 'force-dynamic';
+
+// Suggestion pool for the "Add a topic" surfaces. Fetched client-side after
+// mount (like /api/daily/status) so it never sits on the home critical path.
+// Returns the related-but-specific topics the player doesn't already hold; the
+// client shuffles and shows a few, with add / "not for me" per circle.
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const [{ tree, ownedDomains }, declared] = await Promise.all([
+    getKnowledgeMapData(session.userId),
+    getActiveDeclaredInterests(session.userId),
+  ]);
+
+  const ownedNames = [
+    ...ownedDomains.map((domain) => domain.displayName || domain.domain),
+    ...declared.map((interest) => interest.domain),
+  ];
+
+  return NextResponse.json({ suggestions: buildSuggestionPool(tree, ownedNames) });
+}

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -22,10 +22,10 @@ import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
 import { domainKey } from '@/lib/knowledge/domain-key';
 import {
   TERRITORY_FREQUENCY_LABEL,
-  getNearbyTerritories,
   type DomainPreferenceFrequency,
   type NearbyTerritory,
 } from '@/lib/daily/territory-model';
+import { buildSuggestionPool } from '@/lib/knowledge/suggestion-pool';
 import { GhostTerritoryCircle } from '@/components/knowledge/GhostTerritoryCircle';
 import { AddTopicField } from '@/components/interests/AddTopicField';
 import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
@@ -414,33 +414,16 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
     );
     return () => window.cancelAnimationFrame(frame);
   }, []);
-  const suggestionPool = useMemo<NearbyTerritory[]>(() => {
-    const owned = new Set<string>();
-    for (const domain of sortedDomains) owned.add(domainKey(domain.displayName));
-    for (const label of data?.pageData.declaredInterests ?? []) owned.add(domainKey(label));
-    const pool = new Map<string, NearbyTerritory>();
-    // Tree ghost leaves — specific adjacent topics the player doesn't hold yet.
-    // broadCategory is taken from the depth-1 ancestor (the broad-category node)
-    // so the ghost circle keeps its category tint.
-    const walk = (node: KnowledgeTreeNode, depth: number, category: string | null) => {
-      const cat = depth === 1 ? node.name : category;
-      const children = node.children ?? [];
-      if (node.ghost && children.length === 0) {
-        const key = domainKey(node.name);
-        if (!pool.has(key) && !owned.has(key)) {
-          pool.set(key, { domain: node.name, broadCategory: cat, reason: 'Related to your map' });
-        }
-      }
-      for (const child of children) walk(child, depth + 1, cat);
-    };
-    walk(detailTree, 0, null);
-    // Supplement with the hard-coded adjacency rules.
-    for (const territory of getNearbyTerritories(sortedDomains.map((domain) => domain.displayName))) {
-      const key = domainKey(territory.domain);
-      if (!pool.has(key) && !owned.has(key)) pool.set(key, territory);
-    }
-    return [...pool.values()];
-  }, [detailTree, sortedDomains, data]);
+  // Shared builder (also used by the home suggestions endpoint) so both add
+  // surfaces draw the identical related-but-specific pool.
+  const suggestionPool = useMemo<NearbyTerritory[]>(
+    () =>
+      buildSuggestionPool(detailTree, [
+        ...sortedDomains.map((domain) => domain.displayName),
+        ...(data?.pageData.declaredInterests ?? []),
+      ]),
+    [detailTree, sortedDomains, data],
+  );
   // Stable per-visit order: seeded Fisher–Yates (small LCG) keyed on the offset.
   // Kept separate from the visible slice so dismissing one entry doesn't
   // reshuffle the rest — the next pool item just slides up into the freed slot.

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { Combine, Plus, Trash2, X } from 'lucide-react';
+import { Check, Combine, Plus, Trash2, X } from 'lucide-react';
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
 import { Skeleton } from '@/components/ui/Skeleton';
 
@@ -838,7 +838,7 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
                 <GhostTerritoryCircle
                   key={territory.domain}
                   territory={territory}
-                  disabled={addingSuggestion !== null}
+                  disabled={addingSuggestion === territory.domain}
                   onAdd={() => void addSuggestion(territory)}
                   onDismiss={() => dismissSuggestion(territory.domain)}
                 />
@@ -846,9 +846,16 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
             </div>
           ) : null}
           {addedTopic ? (
-            <p className="mt-3 text-quiet text-[var(--ink)]" role="status" aria-live="polite">
-              Added &ldquo;{addedTopic}&rdquo; — it&rsquo;ll show up in an upcoming round.
-            </p>
+            <div
+              className="mt-4 flex items-start gap-2 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--cream-warm)] px-3 py-2"
+              role="status"
+              aria-live="polite"
+            >
+              <Check className="mt-0.5 size-4 shrink-0 text-[var(--accent-gold-ink)]" aria-hidden="true" />
+              <p className="m-0 text-quiet text-[var(--ink)]">
+                Added &ldquo;{addedTopic}&rdquo; — it&rsquo;ll show up in an upcoming round.
+              </p>
+            </div>
           ) : null}
           {suggestError ? (
             <p className="mt-2 text-xs" style={{ color: 'var(--game-wrong-strong)' }}>{suggestError}</p>
@@ -923,7 +930,7 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
                     <GhostTerritoryCircle
                       key={territory.domain}
                       territory={territory}
-                      disabled={addingSuggestion !== null}
+                      disabled={addingSuggestion === territory.domain}
                       onAdd={() => void addSuggestion(territory)}
                       onDismiss={() => dismissSuggestion(territory.domain)}
                     />
@@ -931,9 +938,16 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
                 </div>
               ) : null}
               {addedTopic ? (
-                <p className="mt-3 text-quiet text-[var(--ink)]" role="status" aria-live="polite">
-                  Added &ldquo;{addedTopic}&rdquo; — it&rsquo;ll show up in an upcoming round.
-                </p>
+                <div
+                  className="mt-4 flex items-start gap-2 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--cream-warm)] px-3 py-2"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <Check className="mt-0.5 size-4 shrink-0 text-[var(--accent-gold-ink)]" aria-hidden="true" />
+                  <p className="m-0 text-quiet text-[var(--ink)]">
+                    Added &ldquo;{addedTopic}&rdquo; — it&rsquo;ll show up in an upcoming round.
+                  </p>
+                </div>
               ) : null}
               {suggestError ? (
                 <p className="mt-2 text-[0.78rem]" style={{ color: 'var(--game-wrong-strong)' }}>{suggestError}</p>

--- a/src/components/home/AddTopicHomeCard.tsx
+++ b/src/components/home/AddTopicHomeCard.tsx
@@ -1,17 +1,26 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 
 import { AddTopicField } from '@/components/interests/AddTopicField';
+import { GhostTerritoryCircle } from '@/components/knowledge/GhostTerritoryCircle';
+import { domainKey } from '@/lib/knowledge/domain-key';
+import type { NearbyTerritory } from '@/lib/daily/territory-model';
 
 // Homepage "Add a topic" module (Josh, 2026-07-17): a lightweight entry point
-// to seed a Daily Five topic without leaving Home. Mirrors the /daily/setup
-// inline field, but input-only (no suggestion circles) so it adds no data cost
-// to the perf-sensitive home hot path; "Manage topics →" links to the full
-// surface. Card + eyebrow styling matches the other home feature modules.
+// to seed a Daily Five topic without leaving Home. Mirrors the /daily/setup add
+// block — the create-your-own field plus related-but-specific suggestion
+// circles — but the suggestions are fetched client-side after mount (like
+// TodaysFiveCard's status fetch) so they never touch the home critical path.
+// "Manage topics →" links to the full surface. Card + eyebrow styling matches
+// the other home feature modules.
 export function AddTopicHomeCard() {
   const [added, setAdded] = useState<string | null>(null);
+  const [pool, setPool] = useState<NearbyTerritory[]>([]);
+  const [dismissed, setDismissed] = useState<ReadonlySet<string>>(new Set());
+  const [addedKeys, setAddedKeys] = useState<ReadonlySet<string>>(new Set());
+  const [addingKey, setAddingKey] = useState<string | null>(null);
 
   // Auto-dismiss the confirmation so the card returns to its resting state.
   useEffect(() => {
@@ -19,6 +28,71 @@ export function AddTopicHomeCard() {
     const timer = window.setTimeout(() => setAdded(null), 4500);
     return () => window.clearTimeout(timer);
   }, [added]);
+
+  // Fetch + shuffle the suggestion pool once, client-side (off the home hot
+  // path). Shuffle here (client-only, post-mount) so there's no SSR mismatch.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch('/api/interests/suggestions', { credentials: 'include' });
+        if (!response.ok) return;
+        const body = (await response.json().catch(() => null)) as
+          | { suggestions?: NearbyTerritory[] }
+          | null;
+        if (cancelled) return;
+        const list = Array.isArray(body?.suggestions) ? body.suggestions : [];
+        for (let i = list.length - 1; i > 0; i -= 1) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [list[i], list[j]] = [list[j], list[i]];
+        }
+        setPool(list);
+      } catch {
+        // Suggestions are a nicety — the create-your-own field still works.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const visible = useMemo(
+    () =>
+      pool
+        .filter((territory) => {
+          const key = domainKey(territory.domain);
+          return !dismissed.has(key) && !addedKeys.has(key);
+        })
+        .slice(0, 3),
+    [pool, dismissed, addedKeys],
+  );
+
+  const postInterest = async (label: string, broadCategory?: string | null) => {
+    const response = await fetch('/api/declared-interests', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label, ...(broadCategory ? { broadCategory } : {}) }),
+    });
+    if (!response.ok) {
+      const body = (await response.json().catch(() => null)) as { message?: string } | null;
+      throw new Error(body?.message ?? 'Could not add that topic.');
+    }
+  };
+
+  const addSuggestion = async (territory: NearbyTerritory) => {
+    if (addingKey) return;
+    setAddingKey(domainKey(territory.domain));
+    try {
+      await postInterest(territory.domain, territory.broadCategory);
+      setAddedKeys((prev) => new Set(prev).add(domainKey(territory.domain)));
+      setAdded(territory.domain);
+    } catch {
+      // Leave the circle in place so the player can retry.
+    } finally {
+      setAddingKey(null);
+    }
+  };
 
   return (
     <section className="card px-5 py-4" aria-label="Add a topic">
@@ -37,7 +111,9 @@ export function AddTopicHomeCard() {
         className="mt-1 mb-3 text-sm leading-6 text-[var(--text-muted-warm)]"
         style={{ fontFamily: 'var(--font-serif), Georgia, serif' }}
       >
-        Something you&rsquo;d love to be asked about? Add it and it&rsquo;ll seed your Daily Five.
+        {visible.length > 0
+          ? 'Pick a suggestion below, or add something you’d love to be asked about.'
+          : 'Something you’d love to be asked about? Add it and it’ll seed your Daily Five.'}
       </p>
       <AddTopicField
         convergeBeforeAdd
@@ -45,24 +121,25 @@ export function AddTopicHomeCard() {
         // not the pill default.
         inputClassName="min-h-12 flex-1 rounded-[var(--radius-xs)] border border-[var(--accent-gold)] bg-[var(--brand-field)] px-4 text-sm text-[var(--ink)] placeholder:text-[var(--text-muted-warm)]/60 focus:border-[var(--brand-navy)] focus-visible:outline-none disabled:opacity-60"
         onAdd={async (topic) => {
-          const response = await fetch('/api/declared-interests', {
-            method: 'POST',
-            credentials: 'include',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({
-              label: topic.label,
-              ...(topic.broadCategory ? { broadCategory: topic.broadCategory } : {}),
-            }),
-          });
-          if (!response.ok) {
-            const body = (await response.json().catch(() => null)) as { message?: string } | null;
-            throw new Error(body?.message ?? 'Could not add that topic.');
-          }
+          await postInterest(topic.label, topic.broadCategory ?? null);
           setAdded(topic.label);
         }}
       />
+      {visible.length > 0 ? (
+        <div className="mt-4 grid grid-cols-3 gap-3">
+          {visible.map((territory) => (
+            <GhostTerritoryCircle
+              key={territory.domain}
+              territory={territory}
+              disabled={addingKey !== null}
+              onAdd={() => void addSuggestion(territory)}
+              onDismiss={() => setDismissed((prev) => new Set(prev).add(domainKey(territory.domain)))}
+            />
+          ))}
+        </div>
+      ) : null}
       {added ? (
-        <p className="mt-2 text-sm text-[var(--brand-ink)]" role="status" aria-live="polite">
+        <p className="mt-3 text-sm text-[var(--brand-ink)]" role="status" aria-live="polite">
           Added &ldquo;{added}&rdquo; — it&rsquo;ll show up in an upcoming round.
         </p>
       ) : null}

--- a/src/components/home/AddTopicHomeCard.tsx
+++ b/src/components/home/AddTopicHomeCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
 import { Check } from 'lucide-react';
 
 import { AddTopicField } from '@/components/interests/AddTopicField';
@@ -14,8 +13,8 @@ import type { NearbyTerritory } from '@/lib/daily/territory-model';
 // block — the create-your-own field plus related-but-specific suggestion
 // circles — but the suggestions are fetched client-side after mount (like
 // TodaysFiveCard's status fetch) so they never touch the home critical path.
-// "Manage topics →" links to the full surface. Card + eyebrow styling matches
-// the other home feature modules.
+// Card + eyebrow styling matches the other home feature modules. (The full
+// manage surface is reachable from the Today's Five "Customize" pill.)
 export function AddTopicHomeCard() {
   const [added, setAdded] = useState<string | null>(null);
   const [pool, setPool] = useState<NearbyTerritory[]>([]);
@@ -97,17 +96,9 @@ export function AddTopicHomeCard() {
 
   return (
     <section className="card px-5 py-4" aria-label="Add a topic">
-      <div className="flex items-baseline justify-between gap-3">
-        <p className="text-quiet font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
-          Add a topic
-        </p>
-        <Link
-          href="/daily/setup"
-          className="text-xs font-medium tracking-[0.08em] text-[var(--brand-link)] uppercase hover:opacity-70"
-        >
-          Manage topics →
-        </Link>
-      </div>
+      <p className="text-quiet font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
+        Add a topic
+      </p>
       <p
         className="mt-1 mb-3 text-sm leading-6 text-[var(--text-muted-warm)]"
         style={{ fontFamily: 'var(--font-serif), Georgia, serif' }}

--- a/src/components/home/AddTopicHomeCard.tsx
+++ b/src/components/home/AddTopicHomeCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { Check } from 'lucide-react';
 
 import { AddTopicField } from '@/components/interests/AddTopicField';
 import { GhostTerritoryCircle } from '@/components/knowledge/GhostTerritoryCircle';
@@ -131,7 +132,7 @@ export function AddTopicHomeCard() {
             <GhostTerritoryCircle
               key={territory.domain}
               territory={territory}
-              disabled={addingKey !== null}
+              disabled={addingKey === domainKey(territory.domain)}
               onAdd={() => void addSuggestion(territory)}
               onDismiss={() => setDismissed((prev) => new Set(prev).add(domainKey(territory.domain)))}
             />
@@ -139,9 +140,16 @@ export function AddTopicHomeCard() {
         </div>
       ) : null}
       {added ? (
-        <p className="mt-3 text-sm text-[var(--brand-ink)]" role="status" aria-live="polite">
-          Added &ldquo;{added}&rdquo; — it&rsquo;ll show up in an upcoming round.
-        </p>
+        <div
+          className="mt-4 flex items-start gap-2 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--cream-warm)] px-3 py-2"
+          role="status"
+          aria-live="polite"
+        >
+          <Check className="mt-0.5 size-4 shrink-0 text-[var(--accent-gold-ink)]" aria-hidden="true" />
+          <p className="m-0 text-quiet text-[var(--ink)]">
+            Added &ldquo;{added}&rdquo; — it&rsquo;ll show up in an upcoming round.
+          </p>
+        </div>
       ) : null}
     </section>
   );

--- a/src/components/knowledge/GhostTerritoryCircle.tsx
+++ b/src/components/knowledge/GhostTerritoryCircle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { CSSProperties } from 'react';
-import { Plus } from 'lucide-react';
+import { Plus, X } from 'lucide-react';
 
 import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
 import type { NearbyTerritory } from '@/lib/daily/territory-model';
@@ -58,12 +58,12 @@ export function GhostTerritoryCircle({
         <button
           type="button"
           aria-label={`Not interested in ${territory.domain} — show another`}
-          title="Show another suggestion"
-          className={`${CAPTION_CLASS} transition hover:text-[var(--ink)] disabled:opacity-40`}
+          title="Not for me — show another"
+          className="grid size-7 place-items-center rounded-full text-[var(--text-muted-warm)] transition hover:bg-[var(--cream-warm)] hover:text-[var(--ink)] disabled:opacity-40"
           disabled={disabled}
           onClick={onDismiss}
         >
-          Not for me
+          <X className="size-4" aria-hidden="true" />
         </button>
       ) : (
         <span className={CAPTION_CLASS}>Add</span>

--- a/src/lib/knowledge/suggestion-pool.ts
+++ b/src/lib/knowledge/suggestion-pool.ts
@@ -1,0 +1,43 @@
+import { getNearbyTerritories, type NearbyTerritory } from '@/lib/daily/territory-model';
+import { domainKey } from '@/lib/knowledge/domain-key';
+import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
+
+// The "Add a topic" suggestion pool: related-but-specific topics the player
+// doesn't hold yet. Primary source is the knowledge tree's unheld "ghost"
+// leaves — leaf-level adjacent topics (e.g. Bach → Baroque Music, never a broad
+// bucket like "Music") — supplemented by the hard-coded adjacency rules over
+// the owned domains. `ownedNames` (owned + declared) are excluded.
+//
+// Pure and shared so the manage page (client, from its live tree) and the home
+// suggestions endpoint (server) build the identical pool. Importing the tree
+// type here is `import type` only — no server runtime is pulled into clients.
+export function buildSuggestionPool(
+  tree: KnowledgeTreeNode,
+  ownedNames: readonly string[],
+): NearbyTerritory[] {
+  const owned = new Set(ownedNames.map(domainKey));
+  const pool = new Map<string, NearbyTerritory>();
+
+  // Tree ghost leaves — specific adjacent topics. broadCategory comes from the
+  // depth-1 ancestor (the broad-category node) so the circle keeps its tint.
+  const walk = (node: KnowledgeTreeNode, depth: number, category: string | null) => {
+    const cat = depth === 1 ? node.name : category;
+    const children = node.children ?? [];
+    if (node.ghost && children.length === 0) {
+      const key = domainKey(node.name);
+      if (!pool.has(key) && !owned.has(key)) {
+        pool.set(key, { domain: node.name, broadCategory: cat, reason: 'Related to your map' });
+      }
+    }
+    for (const child of children) walk(child, depth + 1, cat);
+  };
+  walk(tree, 0, null);
+
+  // Supplement with the hard-coded adjacency rules over the owned domains.
+  for (const territory of getNearbyTerritories([...ownedNames])) {
+    const key = domainKey(territory.domain);
+    if (!pool.has(key) && !owned.has(key)) pool.set(key, territory);
+  }
+
+  return [...pool.values()];
+}


### PR DESCRIPTION
Follow-up to the merged #1538 (which landed the home "Add a topic" module input-only). These are the commits that came after that merge, restarted on top of the latest `main`.

## Homepage suggestion circles

The home "Add a topic" module now shows the suggestion **circles**, not just the input. Suggestions are fetched **client-side after mount** (like `TodaysFiveCard`'s status fetch) so they never touch the home critical path — loading them asynchronously is fine per Josh.

- New shared helper `buildSuggestionPool` (pure) + `GET /api/interests/suggestions` endpoint; the manage page (`/daily/setup`) refactored onto the same helper so both surfaces build the identical related-but-specific pool (tree ghost leaves + adjacency rules).
- Removed the "Manage topics →" link from the home module — the Today's Five **Customize** pill already reaches the full surface.

## Polish (both surfaces)

- **Only the circle being added dims** now — the `disabled` state was keyed to "any add in flight," which greyed out all three. It's now keyed to the specific circle's domain.
- **Confirmation restyled** as a bordered cream banner with a check icon and proper separation, instead of plain text crowding the circle captions.
- **Dismiss is a small ✕** under the circle (was "NOT FOR ME"), with a "Not for me — show another" tooltip.

## Notes

- Verified by `tsc` parse (0 syntax errors in changed files) + all six CI ratchets. No `next build` in the container — the Vercel build on this PR is the first real compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwoHebwKcgAkoe7JBYATdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwoHebwKcgAkoe7JBYATdH)_