### PR TITLE
Add-a-topic: swipeable carousel replaces per-circle dismiss

### DIFF
--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -26,7 +26,7 @@ import {
   type NearbyTerritory,
 } from '@/lib/daily/territory-model';
 import { buildSuggestionPool } from '@/lib/knowledge/suggestion-pool';
-import { GhostTerritoryCircle } from '@/components/knowledge/GhostTerritoryCircle';
+import { TopicSuggestionCarousel } from '@/components/knowledge/TopicSuggestionCarousel';
 import { AddTopicField } from '@/components/interests/AddTopicField';
 import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
 import type { MasteryTier } from '@/types/db';
@@ -392,15 +392,11 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
   // adjacent topics — e.g. Bach → Baroque Music, never a broad bucket like
   // "Music"), supplemented by the hard-coded adjacency rules. A per-visit
   // random offset (set in a deferred, client-only frame so SSR markup never
-  // disagrees) seeds a shuffle so the block isn't the same three every time.
+  // disagrees) seeds a shuffle so the carousel isn't in the same order every
+  // time. Paging through them (TopicSuggestionCarousel) is the "not
+  // interested" gesture — there's no per-circle dismiss.
   const [suggestionOffset, setSuggestionOffset] = useState(0);
-  const [addingSuggestion, setAddingSuggestion] = useState<string | null>(null);
   const [suggestError, setSuggestError] = useState<string | null>(null);
-  // Suggestions the player waved away ("Not for me") — filtered out so the next
-  // pool item slides into the freed slot.
-  const [dismissedSuggestions, setDismissedSuggestions] = useState<ReadonlySet<string>>(new Set());
-  const dismissSuggestion = (domain: string) =>
-    setDismissedSuggestions((prev) => new Set(prev).add(domainKey(domain)));
   // Brief "Added …" confirmation shown under the add block after a topic lands.
   const [addedTopic, setAddedTopic] = useState<string | null>(null);
   useEffect(() => {
@@ -425,8 +421,6 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
     [detailTree, sortedDomains, data],
   );
   // Stable per-visit order: seeded Fisher–Yates (small LCG) keyed on the offset.
-  // Kept separate from the visible slice so dismissing one entry doesn't
-  // reshuffle the rest — the next pool item just slides up into the freed slot.
   const shuffledPool = useMemo(() => {
     const shuffled = [...suggestionPool];
     let seed = (suggestionOffset % 2_147_483_646) + 1;
@@ -440,17 +434,8 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
     }
     return shuffled;
   }, [suggestionPool, suggestionOffset]);
-  const visibleNearby = useMemo(
-    () =>
-      shuffledPool
-        .filter((territory) => !dismissedSuggestions.has(domainKey(territory.domain)))
-        .slice(0, 3),
-    [shuffledPool, dismissedSuggestions],
-  );
 
-  const addSuggestion = async (territory: NearbyTerritory) => {
-    if (addingSuggestion) return;
-    setAddingSuggestion(territory.domain);
+  const addSuggestion = async (territory: NearbyTerritory): Promise<boolean> => {
     setSuggestError(null);
     try {
       const response = await fetch('/api/declared-interests', {
@@ -468,10 +453,10 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
       }
       setAddedTopic(territory.domain);
       await loadKnowledge();
+      return true;
     } catch (caught) {
       setSuggestError(caught instanceof Error ? caught.message : 'Could not add that territory.');
-    } finally {
-      setAddingSuggestion(null);
+      return false;
     }
   };
 
@@ -821,8 +806,8 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
         <section className="bg-[var(--brand-card)] border border-[var(--border-warm)] p-4" aria-label="Add topics">
           <h2 className="m-0 text-lg font-semibold text-[var(--ink)] font-[var(--font-serif)]">Add a topic</h2>
           <p className="mt-1 mb-3 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
-            {visibleNearby.length > 0
-              ? 'Suggestions based on the shape of your map — or create your own.'
+            {shuffledPool.length > 0
+              ? 'Suggestions based on the shape of your map — swipe for more, or create your own.'
               : 'Create your own, and more suggestions will appear as your map grows.'}
           </p>
           <AddTopicField
@@ -835,17 +820,9 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
               await adoptTopic(topic.label, topic.broadCategory ?? null);
             }}
           />
-          {visibleNearby.length > 0 ? (
-            <div className="mt-4 grid grid-cols-3 gap-3">
-              {visibleNearby.map((territory) => (
-                <GhostTerritoryCircle
-                  key={territory.domain}
-                  territory={territory}
-                  disabled={addingSuggestion === territory.domain}
-                  onAdd={() => void addSuggestion(territory)}
-                  onDismiss={() => dismissSuggestion(territory.domain)}
-                />
-              ))}
+          {shuffledPool.length > 0 ? (
+            <div className="mt-4">
+              <TopicSuggestionCarousel suggestions={shuffledPool} onAdd={addSuggestion} />
             </div>
           ) : null}
           {addedTopic ? (
@@ -920,24 +897,16 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
             <div className="mt-6 border-t border-[var(--border-warm)] pt-4">
               <h3 className="m-0 text-lg font-semibold text-[var(--ink)] font-[var(--font-serif)]">Add a territory</h3>
               <p className="mt-1 mb-3 text-[0.82rem] leading-[1.5] text-[var(--text-muted-warm)]">
-                {visibleNearby.length > 0
-                  ? 'Suggestions based on the shape of your map — or create your own.'
+                {shuffledPool.length > 0
+                  ? 'Suggestions based on the shape of your map — swipe for more, or create your own.'
                   : 'Create your own, and more suggestions will appear as your map grows.'}
               </p>
               <Link href="/daily/setup" className="btn-ghost gap-1.5">
                 <Plus className="size-4" aria-hidden /> Create your own
               </Link>
-              {visibleNearby.length > 0 ? (
-                <div className="mt-4 grid grid-cols-3 gap-3">
-                  {visibleNearby.map((territory) => (
-                    <GhostTerritoryCircle
-                      key={territory.domain}
-                      territory={territory}
-                      disabled={addingSuggestion === territory.domain}
-                      onAdd={() => void addSuggestion(territory)}
-                      onDismiss={() => dismissSuggestion(territory.domain)}
-                    />
-                  ))}
+              {shuffledPool.length > 0 ? (
+                <div className="mt-4">
+                  <TopicSuggestionCarousel suggestions={shuffledPool} onAdd={addSuggestion} />
                 </div>
               ) : null}
               {addedTopic ? (

--- a/src/components/home/AddTopicHomeCard.tsx
+++ b/src/components/home/AddTopicHomeCard.tsx
@@ -1,25 +1,25 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { Check } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Check, Plus } from 'lucide-react';
 
-import { GhostTerritoryCircle } from '@/components/knowledge/GhostTerritoryCircle';
-import { domainKey } from '@/lib/knowledge/domain-key';
+import { TopicSuggestionCarousel } from '@/components/knowledge/TopicSuggestionCarousel';
 import type { NearbyTerritory } from '@/lib/daily/territory-model';
 
 // Homepage "Add a topic" module (Josh, 2026-07-17): suggestion circles only —
 // a lightweight, low-clutter way to seed a Daily Five topic from Home by tapping
-// a related-but-specific suggestion. The create-your-own text field lives on the
-// full manage surface (/daily/setup, reachable from the Today's Five Customize
-// pill) to keep Home uncluttered. Suggestions are fetched client-side after
-// mount (like TodaysFiveCard's status fetch) so they never touch the home
-// critical path; the card hides itself until there's something to show.
+// a related-but-specific suggestion, paged through TopicSuggestionCarousel (swipe
+// for more — no per-circle dismiss). The create-your-own text field lives on the
+// full manage surface (/daily/setup, reachable from the "+ Add your own" link
+// below or the Today's Five Customize pill) to keep Home uncluttered.
+// Suggestions are fetched client-side after mount (like TodaysFiveCard's status
+// fetch) so they never touch the home critical path; the card hides itself
+// until there's something to show.
 export function AddTopicHomeCard() {
   const [added, setAdded] = useState<string | null>(null);
   const [pool, setPool] = useState<NearbyTerritory[]>([]);
-  const [dismissed, setDismissed] = useState<ReadonlySet<string>>(new Set());
-  const [addedKeys, setAddedKeys] = useState<ReadonlySet<string>>(new Set());
-  const [addingKey, setAddingKey] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
 
   // Auto-dismiss the confirmation so the card returns to its resting state.
   useEffect(() => {
@@ -48,6 +48,8 @@ export function AddTopicHomeCard() {
         setPool(list);
       } catch {
         // Suggestions are a nicety; failing quietly just hides the module.
+      } finally {
+        if (!cancelled) setLoaded(true);
       }
     })();
     return () => {
@@ -55,20 +57,7 @@ export function AddTopicHomeCard() {
     };
   }, []);
 
-  const visible = useMemo(
-    () =>
-      pool
-        .filter((territory) => {
-          const key = domainKey(territory.domain);
-          return !dismissed.has(key) && !addedKeys.has(key);
-        })
-        .slice(0, 3),
-    [pool, dismissed, addedKeys],
-  );
-
-  const addSuggestion = async (territory: NearbyTerritory) => {
-    if (addingKey) return;
-    setAddingKey(domainKey(territory.domain));
+  const addSuggestion = async (territory: NearbyTerritory): Promise<boolean> => {
     try {
       const response = await fetch('/api/declared-interests', {
         method: 'POST',
@@ -80,18 +69,17 @@ export function AddTopicHomeCard() {
         }),
       });
       if (!response.ok) throw new Error('add failed');
-      setAddedKeys((prev) => new Set(prev).add(domainKey(territory.domain)));
       setAdded(territory.domain);
+      return true;
     } catch {
       // Leave the circle in place so the player can retry.
-    } finally {
-      setAddingKey(null);
+      return false;
     }
   };
 
-  // Nothing to show until suggestions arrive (or a confirmation is up) — keeps
-  // Home from carrying an empty card.
-  if (visible.length === 0 && !added) return null;
+  // Nothing to show until suggestions arrive — keeps Home from carrying an
+  // empty card while the fetch is in flight.
+  if (!loaded || (pool.length === 0 && !added)) return null;
 
   return (
     <section className="card px-5 py-4" aria-label="Suggested topics">
@@ -102,21 +90,10 @@ export function AddTopicHomeCard() {
         className="mt-1 mb-3 text-sm leading-6 text-[var(--text-muted-warm)]"
         style={{ fontFamily: 'var(--font-serif), Georgia, serif' }}
       >
-        A few you might like, based on your interests — tap one to seed your Daily Five.
+        A few you might like, based on your interests — swipe for more, or tap one to seed your
+        Daily Five.
       </p>
-      {visible.length > 0 ? (
-        <div className="grid grid-cols-3 gap-3">
-          {visible.map((territory) => (
-            <GhostTerritoryCircle
-              key={territory.domain}
-              territory={territory}
-              disabled={addingKey === domainKey(territory.domain)}
-              onAdd={() => void addSuggestion(territory)}
-              onDismiss={() => setDismissed((prev) => new Set(prev).add(domainKey(territory.domain)))}
-            />
-          ))}
-        </div>
-      ) : null}
+      {pool.length > 0 ? <TopicSuggestionCarousel suggestions={pool} onAdd={addSuggestion} /> : null}
       {added ? (
         <div
           className="mt-4 flex items-start gap-2 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--cream-warm)] px-3 py-2"
@@ -129,6 +106,12 @@ export function AddTopicHomeCard() {
           </p>
         </div>
       ) : null}
+      <Link
+        href="/daily/setup"
+        className="mt-4 inline-flex items-center gap-1 text-quiet font-medium tracking-[0.08em] text-[var(--brand-link)] uppercase hover:opacity-70"
+      >
+        <Plus className="size-3.5" aria-hidden="true" /> Add your own
+      </Link>
     </section>
   );
 }

--- a/src/components/knowledge/GhostTerritoryCircle.tsx
+++ b/src/components/knowledge/GhostTerritoryCircle.tsx
@@ -1,73 +1,68 @@
 'use client';
 
 import type { CSSProperties } from 'react';
-import { Plus, X } from 'lucide-react';
+import { Check, Plus } from 'lucide-react';
 
 import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
 import type { NearbyTerritory } from '@/lib/daily/territory-model';
 
-// The small caption under the circle — "Add" (static) or "Not for me"
-// (interactive dismiss). One definition so the tiny type size lives in a single
-// literal.
-const CAPTION_CLASS = 'text-[10px] tracking-[0.14em] text-[var(--text-muted-warm)] uppercase';
+// The small caption under the circle — "Add" or "Added". One definition so
+// the tiny type size lives in a single literal.
+const CAPTION_CLASS = 'text-[10px] tracking-[0.14em] uppercase';
 
 // A suggested ("nearby") territory the player hasn't adopted yet: a dashed
 // category-tinted circle with an Add affordance. Originally the Configure
-// page's suggestion cell; shared here so the Knowledge page's "Add a topic"
-// block draws the identical invitation. When `onDismiss` is supplied, the line
-// under the circle becomes a "Not for me" control (in place of the "Add"
-// label) that waves this suggestion away so another takes its place — the
-// circle itself stays the Add target, so nothing floats over the circle.
+// page's suggestion cell; shared by every "Add a topic" surface, each of
+// which pages sets of these through TopicSuggestionCarousel — swiping to
+// another page IS the "not interested" gesture, so there's no per-circle
+// dismiss here. Once added, the circle flips in place to a solid, checked
+// "Added" state rather than being removed, so a page never reflows mid-swipe.
 export function GhostTerritoryCircle({
   territory,
   disabled,
+  added = false,
   onAdd,
-  onDismiss,
 }: {
   territory: NearbyTerritory;
+  /** In flight — this add is being persisted. */
   disabled: boolean;
+  /** Settled — already added; the circle shows the confirmed state and stops responding to taps. */
+  added?: boolean;
   onAdd: () => void;
-  onDismiss?: () => void;
 }) {
   const color = getPortraitDomainColor(territory.broadCategory ?? 'General Knowledge');
   const style = {
     '--territory-border': `color-mix(in srgb, ${color.primary} 40%, transparent)`,
     '--territory-text': color.text,
   } as CSSProperties;
+  const busy = disabled && !added;
 
   return (
-    <div className="flex w-full flex-col items-center gap-2 text-center" style={style}>
-      <button
-        type="button"
-        aria-label={`Add ${territory.domain}`}
-        className="flex w-full flex-col items-center gap-2 rounded-[var(--radius-3xl)] p-1 opacity-70 transition hover:opacity-100 disabled:opacity-40"
-        disabled={disabled}
-        onClick={onAdd}
+    <button
+      type="button"
+      aria-label={added ? `${territory.domain} — added` : `Add ${territory.domain}`}
+      aria-pressed={added}
+      className={`flex w-full flex-col items-center gap-2 rounded-[var(--radius-3xl)] p-1 text-center transition ${
+        added ? 'opacity-100' : busy ? 'opacity-40' : 'opacity-70 hover:opacity-100'
+      }`}
+      style={style}
+      disabled={disabled || added}
+      onClick={onAdd}
+    >
+      <div
+        className={`grid size-16 place-items-center rounded-full border text-[var(--territory-text)] ${
+          added ? 'border-solid border-[var(--territory-text)]' : 'border-dashed border-[var(--territory-border)]'
+        }`}
+        style={{ background: 'color-mix(in srgb, var(--brand-card) 55%, transparent)' }}
       >
-        <div
-          className="grid size-16 place-items-center rounded-full border border-dashed border-[var(--territory-border)] text-[var(--territory-text)]"
-          style={{ background: 'color-mix(in srgb, var(--brand-card) 55%, transparent)' }}
-        >
-          <Plus className="size-5" aria-hidden="true" />
-        </div>
-        <span className="max-w-full px-1 font-serif text-quiet leading-tight break-words text-[var(--territory-text)]">
-          {territory.domain}
-        </span>
-      </button>
-      {onDismiss ? (
-        <button
-          type="button"
-          aria-label={`Not interested in ${territory.domain} — show another`}
-          title="Not for me — show another"
-          className="grid size-7 place-items-center rounded-full text-[var(--text-muted-warm)] transition hover:bg-[var(--cream-warm)] hover:text-[var(--ink)] disabled:opacity-40"
-          disabled={disabled}
-          onClick={onDismiss}
-        >
-          <X className="size-4" aria-hidden="true" />
-        </button>
-      ) : (
-        <span className={CAPTION_CLASS}>Add</span>
-      )}
-    </div>
+        {added ? <Check className="size-5" aria-hidden="true" /> : <Plus className="size-5" aria-hidden="true" />}
+      </div>
+      <span className="max-w-full px-1 font-serif text-quiet leading-tight break-words text-[var(--territory-text)]">
+        {territory.domain}
+      </span>
+      <span className={`${CAPTION_CLASS} ${added ? 'text-[var(--territory-text)]' : 'text-[var(--text-muted-warm)]'}`}>
+        {added ? 'Added' : 'Add'}
+      </span>
+    </button>
   );
 }

--- a/src/components/knowledge/TopicSuggestionCarousel.tsx
+++ b/src/components/knowledge/TopicSuggestionCarousel.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { EditorialCarousel } from '@/components/feed/EditorialCarousel';
+import { GhostTerritoryCircle } from '@/components/knowledge/GhostTerritoryCircle';
+import { domainKey } from '@/lib/knowledge/domain-key';
+import type { NearbyTerritory } from '@/lib/daily/territory-model';
+
+const PAGE_SIZE = 3;
+// Defensive cap so a very large tree doesn't turn this into an endless swipe.
+const MAX_SUGGESTIONS = 15;
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const pages: T[][] = [];
+  for (let i = 0; i < items.length; i += size) pages.push(items.slice(i, i + size));
+  return pages;
+}
+
+/**
+ * The "Add a topic" suggestions, paginated three-at-a-time behind a swipeable
+ * carousel — built on the shared EditorialCarousel scroll-snap primitive
+ * (same one the feed's artwork slides use), so paging shares its dot
+ * indicator, reduced-motion handling, and touch/scroll behavior. Swiping to
+ * another page IS the "not interested" gesture, replacing a per-circle
+ * dismiss control. Adding a topic flips its circle in place to a checkmark +
+ * "Added" state (GhostTerritoryCircle's `added`) rather than removing it, so
+ * a page never reflows mid-swipe.
+ */
+export function TopicSuggestionCarousel({
+  suggestions,
+  onAdd,
+}: {
+  suggestions: NearbyTerritory[];
+  /** Persist the add; resolve true on success so the circle can flip to added. */
+  onAdd: (territory: NearbyTerritory) => Promise<boolean>;
+}) {
+  const [addedKeys, setAddedKeys] = useState<ReadonlySet<string>>(new Set());
+  const [addingKey, setAddingKey] = useState<string | null>(null);
+
+  const pages = useMemo(
+    () => chunk(suggestions.slice(0, MAX_SUGGESTIONS), PAGE_SIZE),
+    [suggestions],
+  );
+
+  const handleAdd = async (territory: NearbyTerritory) => {
+    if (addingKey) return;
+    const key = domainKey(territory.domain);
+    setAddingKey(key);
+    try {
+      const ok = await onAdd(territory);
+      if (ok) setAddedKeys((prev) => new Set(prev).add(key));
+    } finally {
+      setAddingKey(null);
+    }
+  };
+
+  if (pages.length === 0) return null;
+
+  return (
+    <EditorialCarousel
+      ariaLabel="Suggested topics"
+      slides={pages.map((page, pageIndex) => (
+        <div key={pageIndex} className="grid w-full grid-cols-3 gap-3">
+          {page.map((territory) => {
+            const key = domainKey(territory.domain);
+            return (
+              <GhostTerritoryCircle
+                key={territory.domain}
+                territory={territory}
+                added={addedKeys.has(key)}
+                disabled={addingKey === key}
+                onAdd={() => void handleAdd(territory)}
+              />
+            );
+          })}
+        </div>
+      ))}
+    />
+  );
+}


### PR DESCRIPTION
Per Josh: the row of X's under each suggestion circle looked sloppy. Replace it with a swipeable carousel that pages three suggestions at a time — swiping to another page IS the "not interested" gesture, so there's no more per-circle dismiss control.

## What changed

- **New `TopicSuggestionCarousel`**, built on the existing `EditorialCarousel` scroll-snap primitive (the same one the feed's artwork slides use) — paging shares its dot indicator, reduced-motion handling, and touch/scroll behavior instead of reinventing it.
- **`GhostTerritoryCircle`** drops `onDismiss` and gains an `added` state: adding a topic flips its circle in place to a checkmark + solid "Added" state rather than removing it, so a page never reflows mid-swipe. Simplified back to a single button (no more separate dismiss button underneath).
- Wired into all three add surfaces: the manage page (`/daily/setup`), the `/knowledge` portrait's "Add a territory" block, and the homepage module.
- Homepage module also gets a **"+ Add your own"** link at the bottom, linking to `/daily/setup` for the full create-your-own field (kept off Home to stay uncluttered).

## Verification

This environment has `node_modules`, so unlike prior rounds I could run the real toolchain instead of just static checks:
- `npx next build` — **succeeded**, all routes compiled including `/daily/setup` and `/knowledge`.
- `npx tsc -p tsconfig.typecheck.json` — clean, 0 errors.
- `npx eslint` on all changed files — clean.
- All six CI ratchets (colors/fonts/spacing/radius/z-index/type-size) — pass, no new occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwoHebwKcgAkoe7JBYATdH