### PR TITLE
Header wordmark caps + Add-a-topic Undo and contrast fix

### DIFF
--- a/src/app/api/declared-interests/route.ts
+++ b/src/app/api/declared-interests/route.ts
@@ -9,6 +9,7 @@ import {
   DeclaredInterestLimitError,
   type DeclaredInterestInput,
   MAX_ACTIVE_DECLARED_INTERESTS,
+  removeDeclaredInterest,
   saveDeclaredInterests,
 } from '@/server/db/queries/users';
 import { TooBroadInterestError } from '@/lib/knowledge/interest-specificity';
@@ -17,6 +18,10 @@ import { UnanswerableInterestError } from '@/server/llm/interests';
 const addInterestSchema = z.object({
   label: z.string().trim().min(1).max(80),
   broadCategory: z.string().trim().max(80).optional(),
+});
+
+const removeInterestSchema = z.object({
+  domain: z.string().trim().min(1).max(80),
 });
 
 type DeclaredInterestsBody = {
@@ -162,4 +167,25 @@ export async function PATCH(request: Request) {
     const message = error instanceof Error ? error.message : 'Unable to save interests.';
     return NextResponse.json({ error: 'save_failed', message }, { status: 400 });
   }
+}
+
+// Undo for a single incremental add (POST above) — the "Undo" link on the
+// just-added confirmation banner. Deactivates one domain by name rather than
+// replacing the whole list (PATCH), so it can't clobber an interest declared
+// elsewhere in the meantime. Idempotent: undoing twice, or a domain that was
+// never active, is a harmless no-op.
+export async function DELETE(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = removeInterestSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_request', message: 'Send the domain to remove.' },
+      { status: 400 },
+    );
+  }
+
+  const removed = await removeDeclaredInterest(session.userId, parsed.data.domain);
+  return NextResponse.json({ removed });
 }

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -397,13 +397,44 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
   // interested" gesture — there's no per-circle dismiss.
   const [suggestionOffset, setSuggestionOffset] = useState(0);
   const [suggestError, setSuggestError] = useState<string | null>(null);
-  // Brief "Added …" confirmation shown under the add block after a topic lands.
+  // Brief "Added …" confirmation shown under the add block after a topic
+  // lands, with an Undo. addedKeys is the circles' source of truth for the
+  // checked "Added" state (TopicSuggestionCarousel doesn't track it itself,
+  // so Undo can flip a circle back here). Cleared per-domain by undoAddedTopic;
+  // otherwise only grows for the session, since an add that's still standing
+  // should keep reading as added even after a later add replaces the banner.
   const [addedTopic, setAddedTopic] = useState<string | null>(null);
+  const [addedKeys, setAddedKeys] = useState<ReadonlySet<string>>(new Set());
+  const [undoing, setUndoing] = useState(false);
   useEffect(() => {
     if (!addedTopic) return;
     const timer = window.setTimeout(() => setAddedTopic(null), 4500);
     return () => window.clearTimeout(timer);
   }, [addedTopic]);
+  const undoAddedTopic = async () => {
+    if (!addedTopic || undoing) return;
+    setUndoing(true);
+    try {
+      const response = await fetch('/api/declared-interests', {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ domain: addedTopic }),
+      });
+      if (!response.ok) throw new Error('undo failed');
+      setAddedKeys((prev) => {
+        const next = new Set(prev);
+        next.delete(domainKey(addedTopic));
+        return next;
+      });
+      setAddedTopic(null);
+      await loadKnowledge();
+    } catch {
+      setSuggestError('Could not undo that add. Remove it from Your topics instead.');
+    } finally {
+      setUndoing(false);
+    }
+  };
   useEffect(() => {
     const frame = window.requestAnimationFrame(() =>
       setSuggestionOffset(Math.floor(Math.random() * 1_000_000)),
@@ -452,6 +483,7 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
         throw new Error(body?.message ?? 'Could not add that territory.');
       }
       setAddedTopic(territory.domain);
+      setAddedKeys((prev) => new Set(prev).add(domainKey(territory.domain)));
       await loadKnowledge();
       return true;
     } catch (caught) {
@@ -475,6 +507,7 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
       throw new Error(body?.message ?? 'Could not add that topic.');
     }
     setAddedTopic(label);
+    setAddedKeys((prev) => new Set(prev).add(domainKey(label)));
     await loadKnowledge();
   };
 
@@ -822,7 +855,7 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
           />
           {shuffledPool.length > 0 ? (
             <div className="mt-4">
-              <TopicSuggestionCarousel suggestions={shuffledPool} onAdd={addSuggestion} />
+              <TopicSuggestionCarousel suggestions={shuffledPool} addedKeys={addedKeys} onAdd={addSuggestion} />
             </div>
           ) : null}
           {addedTopic ? (
@@ -832,9 +865,19 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
               aria-live="polite"
             >
               <Check className="mt-0.5 size-4 shrink-0 text-[var(--accent-gold-ink)]" aria-hidden="true" />
-              <p className="m-0 text-quiet text-[var(--ink)]">
-                Added &ldquo;{addedTopic}&rdquo; — it&rsquo;ll show up in an upcoming round.
-              </p>
+              <div className="flex-1">
+                <p className="m-0 text-quiet text-[var(--ink)]">
+                  Added &ldquo;{addedTopic}&rdquo; — it&rsquo;ll show up in an upcoming round.
+                </p>
+                <button
+                  type="button"
+                  className="mt-1 text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70 disabled:opacity-50"
+                  onClick={() => void undoAddedTopic()}
+                  disabled={undoing}
+                >
+                  {undoing ? 'Undoing…' : 'Undo'}
+                </button>
+              </div>
             </div>
           ) : null}
           {suggestError ? (
@@ -906,7 +949,7 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
               </Link>
               {shuffledPool.length > 0 ? (
                 <div className="mt-4">
-                  <TopicSuggestionCarousel suggestions={shuffledPool} onAdd={addSuggestion} />
+                  <TopicSuggestionCarousel suggestions={shuffledPool} addedKeys={addedKeys} onAdd={addSuggestion} />
                 </div>
               ) : null}
               {addedTopic ? (
@@ -916,9 +959,19 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
                   aria-live="polite"
                 >
                   <Check className="mt-0.5 size-4 shrink-0 text-[var(--accent-gold-ink)]" aria-hidden="true" />
-                  <p className="m-0 text-quiet text-[var(--ink)]">
-                    Added &ldquo;{addedTopic}&rdquo; — it&rsquo;ll show up in an upcoming round.
-                  </p>
+                  <div className="flex-1">
+                    <p className="m-0 text-quiet text-[var(--ink)]">
+                      Added &ldquo;{addedTopic}&rdquo; — it&rsquo;ll show up in an upcoming round.
+                    </p>
+                    <button
+                      type="button"
+                      className="mt-1 text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70 disabled:opacity-50"
+                      onClick={() => void undoAddedTopic()}
+                      disabled={undoing}
+                    >
+                      {undoing ? 'Undoing…' : 'Undo'}
+                    </button>
+                  </div>
                 </div>
               ) : null}
               {suggestError ? (

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -188,7 +188,7 @@ export function Nav({
         <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-3">
           <Link
             href="/"
-            className="font-wordmark text-[22px] font-semibold leading-none tracking-[0.05em] text-foreground"
+            className="font-wordmark text-[22px] font-semibold uppercase leading-none tracking-[0.05em] text-foreground"
           >
             Joshing
           </Link>

--- a/src/components/home/AddTopicHomeCard.tsx
+++ b/src/components/home/AddTopicHomeCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Check, Plus } from 'lucide-react';
 
 import { TopicSuggestionCarousel } from '@/components/knowledge/TopicSuggestionCarousel';
+import { domainKey } from '@/lib/knowledge/domain-key';
 import type { NearbyTerritory } from '@/lib/daily/territory-model';
 
 // The final carousel page, in place of a separate "+ Add your own" link
@@ -43,6 +44,8 @@ function AddYourOwnTile() {
 // the card hides itself until there's something to show.
 export function AddTopicHomeCard() {
   const [added, setAdded] = useState<string | null>(null);
+  const [addedKeys, setAddedKeys] = useState<ReadonlySet<string>>(new Set());
+  const [undoing, setUndoing] = useState(false);
   const [pool, setPool] = useState<NearbyTerritory[]>([]);
   const [loaded, setLoaded] = useState(false);
 
@@ -95,10 +98,37 @@ export function AddTopicHomeCard() {
       });
       if (!response.ok) throw new Error('add failed');
       setAdded(territory.domain);
+      setAddedKeys((prev) => new Set(prev).add(domainKey(territory.domain)));
       return true;
     } catch {
       // Leave the circle in place so the player can retry.
       return false;
+    }
+  };
+
+  // Undo the most recent add — deactivates that one domain (not a full
+  // replace), so it can't clobber an interest declared elsewhere meanwhile.
+  const undoAdded = async () => {
+    if (!added || undoing) return;
+    setUndoing(true);
+    try {
+      const response = await fetch('/api/declared-interests', {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ domain: added }),
+      });
+      if (!response.ok) throw new Error('undo failed');
+      setAddedKeys((prev) => {
+        const next = new Set(prev);
+        next.delete(domainKey(added));
+        return next;
+      });
+      setAdded(null);
+    } catch {
+      // Leave the confirmation up — the circle is still genuinely added.
+    } finally {
+      setUndoing(false);
     }
   };
 
@@ -121,6 +151,7 @@ export function AddTopicHomeCard() {
       {pool.length > 0 ? (
         <TopicSuggestionCarousel
           suggestions={pool}
+          addedKeys={addedKeys}
           onAdd={addSuggestion}
           trailingSlide={<AddYourOwnTile />}
         />
@@ -132,9 +163,19 @@ export function AddTopicHomeCard() {
           aria-live="polite"
         >
           <Check className="mt-0.5 size-4 shrink-0 text-[var(--accent-gold-ink)]" aria-hidden="true" />
-          <p className="m-0 text-quiet text-[var(--ink)]">
-            Added &ldquo;{added}&rdquo; — it&rsquo;ll show up in an upcoming round.
-          </p>
+          <div className="flex-1">
+            <p className="m-0 text-quiet text-[var(--ink)]">
+              Added &ldquo;{added}&rdquo; — it&rsquo;ll show up in an upcoming round.
+            </p>
+            <button
+              type="button"
+              className="mt-1 text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70 disabled:opacity-50"
+              onClick={() => void undoAdded()}
+              disabled={undoing}
+            >
+              {undoing ? 'Undoing…' : 'Undo'}
+            </button>
+          </div>
         </div>
       ) : null}
     </section>

--- a/src/components/knowledge/GhostTerritoryCircle.tsx
+++ b/src/components/knowledge/GhostTerritoryCircle.tsx
@@ -31,8 +31,14 @@ export function GhostTerritoryCircle({
   onAdd: () => void;
 }) {
   const color = getPortraitDomainColor(territory.broadCategory ?? 'General Knowledge');
+  // The "not added" state now borrows the same visual weight as "added"
+  // (solid territory-text caption, near-full opacity) rather than a separate,
+  // washed-out treatment — only the border stays dashed vs. solid, since
+  // that's the one distinction that actually needs to read at a glance.
+  // Bumped from a 40% color mix to 65% so the dashed border itself doesn't
+  // disappear against the card.
   const style = {
-    '--territory-border': `color-mix(in srgb, ${color.primary} 40%, transparent)`,
+    '--territory-border': `color-mix(in srgb, ${color.primary} 65%, transparent)`,
     '--territory-text': color.text,
   } as CSSProperties;
   const busy = disabled && !added;
@@ -43,7 +49,7 @@ export function GhostTerritoryCircle({
       aria-label={added ? `${territory.domain} — added` : `Add ${territory.domain}`}
       aria-pressed={added}
       className={`flex w-full flex-col items-center gap-2 rounded-[var(--radius-3xl)] p-1 text-center transition ${
-        added ? 'opacity-100' : busy ? 'opacity-40' : 'opacity-70 hover:opacity-100'
+        busy ? 'opacity-40' : 'opacity-100'
       }`}
       style={style}
       disabled={disabled || added}
@@ -60,9 +66,7 @@ export function GhostTerritoryCircle({
       <span className="max-w-full px-1 font-serif text-quiet leading-tight break-words text-[var(--territory-text)]">
         {territory.domain}
       </span>
-      <span className={`${CAPTION_CLASS} ${added ? 'text-[var(--territory-text)]' : 'text-[var(--text-muted-warm)]'}`}>
-        {added ? 'Added' : 'Add'}
-      </span>
+      <span className={`${CAPTION_CLASS} text-[var(--territory-text)]`}>{added ? 'Added' : 'Add'}</span>
     </button>
   );
 }

--- a/src/components/knowledge/TopicSuggestionCarousel.tsx
+++ b/src/components/knowledge/TopicSuggestionCarousel.tsx
@@ -26,14 +26,22 @@ function chunk<T>(items: readonly T[], size: number): T[][] {
  * dismiss control. Adding a topic flips its circle in place to a checkmark +
  * "Added" state (GhostTerritoryCircle's `added`) rather than removing it, so
  * a page never reflows mid-swipe.
+ *
+ * `addedKeys` is caller-owned (not internal state): the parent also needs it
+ * to flip a circle back when the player taps "Undo" on the confirmation
+ * banner, so the single source of truth for "is this domain added" lives
+ * wherever the undo/remove call does.
  */
 export function TopicSuggestionCarousel({
   suggestions,
+  addedKeys,
   onAdd,
   trailingSlide,
 }: {
   suggestions: NearbyTerritory[];
-  /** Persist the add; resolve true on success so the circle can flip to added. */
+  /** Domain keys (domainKey-normalized) already added — rendered as the checked "Added" state. */
+  addedKeys: ReadonlySet<string>;
+  /** Persist the add; resolve true on success so the caller can add the key to `addedKeys`. */
   onAdd: (territory: NearbyTerritory) => Promise<boolean>;
   /**
    * An extra page appended after the suggestion pages — e.g. an "Add your
@@ -43,7 +51,8 @@ export function TopicSuggestionCarousel({
    */
   trailingSlide?: ReactNode;
 }) {
-  const [addedKeys, setAddedKeys] = useState<ReadonlySet<string>>(new Set());
+  // Purely transient UI state — which circle is mid-request. Not part of the
+  // caller's `addedKeys` truth.
   const [addingKey, setAddingKey] = useState<string | null>(null);
 
   const pages = useMemo(
@@ -56,8 +65,7 @@ export function TopicSuggestionCarousel({
     const key = domainKey(territory.domain);
     setAddingKey(key);
     try {
-      const ok = await onAdd(territory);
-      if (ok) setAddedKeys((prev) => new Set(prev).add(key));
+      await onAdd(territory);
     } finally {
       setAddingKey(null);
     }

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -338,6 +338,27 @@ export async function addDeclaredInterest(
   return { created: true, domain: interest.label, broadCategory: interest.broadCategory ?? null };
 }
 
+// Undo for the incremental add path (addDeclaredInterest): deactivate one
+// domain by the same case-insensitive match addDeclaredInterest itself uses,
+// rather than a full-replace PATCH — so undoing a just-added topic can never
+// clobber some other interest declared concurrently (another tab, a second
+// carousel add). Idempotent: undoing an already-inactive/unknown domain is a
+// harmless no-op (returns false).
+export async function removeDeclaredInterest(userId: string, domain: string): Promise<boolean> {
+  const result = await db
+    .update(declaredInterests)
+    .set({ isActive: false })
+    .where(
+      and(
+        eq(declaredInterests.userId, userId),
+        eq(declaredInterests.isActive, true),
+        sql`lower(${declaredInterests.domain}) = ${domain.trim().toLowerCase()}`,
+      ),
+    )
+    .returning({ domain: declaredInterests.domain });
+  return result.length > 0;
+}
+
 export async function markOnboardingComplete(userId: string) {
   await db
     .update(users)


### PR DESCRIPTION
Three changes, landed on one branch since none of them merged in between.

## 1. Uppercase the header wordmark

The header logo (top-left, `Nav.tsx`) rendered "Joshing" in mixed case; Josh wants it all caps. Applied via CSS `uppercase` on the existing Link rather than hardcoding the text, so the DOM text content is unchanged.

## 2. Undo on the "Added" confirmation banner

Accidentally tapping a suggestion circle had no way back except finding it in "Your topics" and removing it there.

- New `removeDeclaredInterest(userId, domain)` query — deactivates one domain (`isActive = false`) by the same case-insensitive match `addDeclaredInterest` already uses, rather than a full-replace PATCH, so undoing a just-added topic can never clobber some other interest declared concurrently (another tab, a second carousel add).
- New `DELETE /api/declared-interests`, idempotent, backing it.
- The confirmation banner on all three add surfaces (manage page, `/knowledge` block, homepage card) now has an **Undo** action. `addedKeys` (which circle shows the checked "Added" state) is lifted out of `TopicSuggestionCarousel` into each caller, since Undo needs to flip a specific circle back to "Add".

## 3. Higher-contrast suggestion circles

Per Josh: the "Add a topic" card read as washed out. Rather than inventing a new visual treatment, reused the one already established for the "added" state (which is already legible — solid border, saturated category color, bold caption): the "not yet added" circle now sits at full opacity at rest (was 70%, dimming it), its caption uses the category's own color instead of flat gray, and the dashed border's color-mix goes from 40% to 65% so it doesn't disappear against the card. Only the dashed-vs-solid border still distinguishes "not added" from "added".

## Verification

Real toolchain (this environment has `node_modules`):
- `npx next build` — succeeded.
- `npx tsc -p tsconfig.typecheck.json` — clean, 0 errors.
- `npx eslint` on all changed files — clean.
- All six CI ratchets — pass, no new occurrences.
- Existing `add-declared-interest` / `save-declared-interests` query test suites — unchanged, all 12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwoHebwKcgAkoe7JBYATdH