### PR TITLE
Recent activity: bundle answers leave a trace (played_along moments)

### DIFF
--- a/src/components/activity/PersonActivityCard.tsx
+++ b/src/components/activity/PersonActivityCard.tsx
@@ -92,12 +92,17 @@ export function PersonActivityCard({
   const saved = rows.filter((r) => r.relationship === 'saved');
   const reacted = rows.filter((r) => r.relationship === 'reacted');
   const convergence = rows.find((r) => r.relationship === 'convergence') ?? null;
+  // Bundle answers (LLM questions from the friend's From Friends bundle). Kept
+  // apart from you_got so the roll-up never reads "got {Name}" for a question
+  // the friend didn't write.
+  const playedAlong = rows.filter((r) => r.relationship === 'played_along');
   // Anything without a relationship kind (mastery, opened a domain, follows…)
   // keeps its own quiet one-liner as a fallback.
   const others = rows.filter((r) => !r.relationship);
 
   const youGotTopics = topicsOf(youGot);
   const gotYouTopics = topicsOf(gotYou);
+  const playedAlongTopics = topicsOf(playedAlong);
   const seed = rows[0]?.id ?? 'person';
 
   return (
@@ -148,6 +153,12 @@ export function PersonActivityCard({
           </SubLine>
         ) : null}
         {reacted.length ? <SubLine>{name} reacted to your question</SubLine> : null}
+        {playedAlong.length ? (
+          <SubLine>
+            played along with {name}
+            {playedAlongTopics.length ? ` — ${playedAlongTopics.join(', ')}` : ''}
+          </SubLine>
+        ) : null}
         {convergence ? <SubLine>{convergencePredicate(convergence)}</SubLine> : null}
         {others.map((row) => (
           <SubLine key={row.id}>

--- a/src/lib/__tests__/activity-stream-bundle-answer.test.ts
+++ b/src/lib/__tests__/activity-stream-bundle-answer.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { bundleAnswerToStreamItem } from '@/lib/activity-stream';
+import { LATELY_TIER } from '@/lib/lately';
+import type { BundleAnswerMoment } from '@/server/db/queries/lately';
+
+// A bundle answer is the viewer answering a creator-less (LLM) question met
+// through a friend's From Friends bundle. It must surface as a quiet Recent
+// activity one-liner (previously it left no trace at all once the bundle was
+// exhausted) — WITHOUT ever claiming the friend authored the question.
+
+function moment(over: Partial<BundleAnswerMoment> = {}): BundleAnswerMoment {
+  return {
+    momentId: 'me-1',
+    friendId: 'f-david',
+    friendName: 'David',
+    friendFirstName: 'David',
+    questionId: 'q-1',
+    questionText:
+      'In Rosencrantz and Guildenstern Are Dead, which classic Shakespeare play does the action take place within and around?',
+    category: 'Tom Stoppard Plays',
+    answeredAt: new Date('2026-07-17T23:15:05Z'),
+    ...over,
+  };
+}
+
+function lineText(parts: { v?: string; name?: string }[]): string {
+  return parts.map((p) => p.v ?? p.name ?? '').join('');
+}
+
+describe('bundleAnswerToStreamItem', () => {
+  it('names the friend and the topic in the shared-territory voice', () => {
+    const item = bundleAnswerToStreamItem(moment());
+    const text = lineText(item.line);
+    expect(text).toContain('David');
+    expect(text).toContain('Tom Stoppard Plays');
+    // Never an authorship claim: these lines describe shared territory, not
+    // "{friend}'s question".
+    expect(text).not.toMatch(/David's/);
+  });
+
+  it('links the friend as an actor part and the topic as a serif category part', () => {
+    const item = bundleAnswerToStreamItem(moment());
+    expect(item.line).toContainEqual({ t: 'actor', name: 'David', userId: 'f-david' });
+    expect(item.line).toContainEqual({ t: 'category', v: 'Tom Stoppard Plays' });
+  });
+
+  it('is quiet texture: OTHER tier, not home-headline-eligible, diamond mark', () => {
+    const item = bundleAnswerToStreamItem(moment());
+    expect(item.tier).toBe(LATELY_TIER.OTHER);
+    expect(item.homeEligible).toBe(false);
+    expect(item.icon).toBe('diamond');
+    expect(item.sortAt).toEqual(new Date('2026-07-17T23:15:05Z'));
+  });
+
+  it('carries the played_along relationship (never you_got) for person-card roll-ups', () => {
+    const item = bundleAnswerToStreamItem(moment());
+    expect(item.relationship).toBe('played_along');
+    expect(item.friendId).toBe('f-david');
+    expect(item.topic).toBe('Tom Stoppard Plays');
+  });
+
+  it('expands to a send-onward reveal with honest LLM attribution', () => {
+    const item = bundleAnswerToStreamItem(moment());
+    expect(item.expand).toEqual({
+      kind: 'your_question',
+      question: {
+        questionId: 'q-1',
+        text: moment().questionText,
+        domain: 'Tom Stoppard Plays',
+        priorResult: 'correct',
+        // null (not undefined): the reveal must render the LLM attribution
+        // label, never imply the friend wrote it.
+        authorName: null,
+      },
+    });
+  });
+
+  it('prefixes the stream id so it can never collide with a moment on the same event', () => {
+    const item = bundleAnswerToStreamItem(moment());
+    expect(item.id).toBe('bundle-answer-me-1');
+  });
+
+  it('varies the line by event id but stays deterministic per event', () => {
+    const a1 = lineText(bundleAnswerToStreamItem(moment({ momentId: 'a' })).line);
+    const a2 = lineText(bundleAnswerToStreamItem(moment({ momentId: 'a' })).line);
+    expect(a1).toBe(a2);
+  });
+});

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -21,7 +21,7 @@
 import { HOME_TOP3_ELIGIBLE_TYPES } from '@/lib/activity-types';
 import type { ActivityItemView } from '@/server/db/queries/activity';
 import type { MasteryTier } from '@/types/db';
-import type { LatelyMoment } from '@/server/db/queries/lately';
+import type { BundleAnswerMoment, LatelyMoment } from '@/server/db/queries/lately';
 import { LATELY_TIER, latelyTierForMomentDir, djb2 } from '@/lib/lately';
 import type { LatelyMilestone } from '@/lib/lately-milestones';
 import type { FriendActivityCard } from '@/lib/friend-activity';
@@ -249,13 +249,17 @@ export type StreamItem = {
   friendId?: string | null;
   // How this row reads inside a per-person relationship cluster, so the cluster
   // can roll events up by direction without re-parsing copy (D-FEED-TIER v2 §3):
-  //   you_got     — you answered THEIR question right ("got {Name} — topics")
-  //   got_you     — they answered YOUR question ("{Name} got yours — topics")
-  //   convergence — you both knew the same shared questions (folded, one line)
-  //   saved       — they saved your question
-  //   reacted     — they reacted to your question
+  //   you_got      — you answered THEIR question right ("got {Name} — topics")
+  //   got_you      — they answered YOUR question ("{Name} got yours — topics")
+  //   convergence  — you both knew the same shared questions (folded, one line)
+  //   saved        — they saved your question
+  //   reacted      — they reacted to your question
+  //   played_along — you answered a creator-less (LLM) question from their
+  //                  From Friends bundle. Distinct from you_got on purpose: the
+  //                  friend PLAYED the question, they didn't write it, so the
+  //                  rolled-up copy must never read as "got {Name}".
   // Undefined = not a per-person relationship event (renders as a plain line).
-  relationship?: 'you_got' | 'got_you' | 'convergence' | 'saved' | 'reacted';
+  relationship?: 'you_got' | 'got_you' | 'convergence' | 'saved' | 'reacted' | 'played_along';
   // The topic/category this event is about, for the cluster's rolled-up lists.
   topic?: string | null;
   // Whether this item is eligible for the homepage's curated head.
@@ -802,6 +806,64 @@ export function momentToStreamItem(moment: LatelyMoment): StreamItem {
         text: moment.questionText,
         domain: moment.category,
         priorResult: 'correct',
+      },
+    },
+  };
+}
+
+// --- Bundle answers ----------------------------------------------------------
+
+// Pool — bundle answers: YOU answered a creator-less (LLM) question from a
+// friend's From Friends bundle. The friend played the question, they didn't
+// write it, so every line stays in the shared-territory register and never
+// claims authorship ("{friend}'s question" is reserved for questions a person
+// actually wrote). Hash-selected per event id like the other pools.
+const BUNDLE_ANSWER_LINES = [
+  'You followed {friend} into {topic}',
+  'You played along with {friend} on {topic}',
+  'You kept {friend} company in {topic}',
+] as const;
+const BUNDLE_ANSWER_NO_TOPIC = 'You played a question from {friend}';
+
+// A bundle answer, as a quiet you-did-this one-liner. Same prominence tier as a
+// you_got_them moment (the viewer's own action — texture, not headline). The
+// question is creator-less by query construction, so the expanded reveal
+// carries the honest LLM attribution (authorName: null — see StreamQuestion)
+// instead of implying the friend wrote it; the forward action is send-onward,
+// exactly like a moment reveal (already answered, so answering isn't offered).
+export function bundleAnswerToStreamItem(moment: BundleAnswerMoment): StreamItem {
+  const topic = moment.category;
+  const friend = { name: moment.friendName, userId: moment.friendId };
+  const line = renderTemplate(
+    pickLine(BUNDLE_ANSWER_LINES, BUNDLE_ANSWER_NO_TOPIC, moment.momentId, topic),
+    friend,
+    topic,
+  );
+  return {
+    // Prefixed so the id can never collide with the same mastery event read as
+    // a moment (disjoint by creatorId today, but cheap insurance).
+    id: `bundle-answer-${moment.momentId}`,
+    sortAt: moment.answeredAt,
+    tier: LATELY_TIER.OTHER,
+    homeEligible: false,
+    friendId: moment.friendId,
+    relationship: 'played_along',
+    topic,
+    line,
+    secondLine: null,
+    anchorId: null,
+    action: null,
+    icon: 'diamond',
+    expand: {
+      kind: 'your_question',
+      question: {
+        questionId: moment.questionId,
+        text: moment.questionText,
+        domain: moment.category,
+        priorResult: 'correct',
+        // Creator-less by query construction → the LLM attribution marker
+        // (null ≠ undefined here; see StreamQuestion.authorName).
+        authorName: null,
       },
     },
   };

--- a/src/server/activity/__tests__/build-stream-exhaust.test.ts
+++ b/src/server/activity/__tests__/build-stream-exhaust.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/app/activities/filter-utility-activities', () => ({
 vi.mock('@/lib/activity-stream', () => ({
   activityToStreamItem: (x: unknown) => x,
   momentToStreamItem: (x: unknown) => x,
+  bundleAnswerToStreamItem: (x: unknown) => x,
   convergenceToStreamItem: (_c: unknown, questions: unknown) => ({ kind: 'convergence', questions }),
   friendActivityToStreamItem: (card: { id: string }, questions: unknown) => ({
     kind: 'milestone',
@@ -39,6 +40,7 @@ vi.mock('@/server/db/queries/content-reports', () => ({
 }));
 vi.mock('@/server/db/queries/lately', () => ({
   getLatelyMoments: vi.fn(async () => []),
+  getBundleAnswerMoments: vi.fn(async () => []),
   getLatelyConvergences: vi.fn(async () => []),
   getFriendActivity: getFriendActivityMock,
   getMilestoneQuestionText: vi.fn(async (ids: string[]) =>

--- a/src/server/activity/__tests__/build-stream-hollow-degraded.test.ts
+++ b/src/server/activity/__tests__/build-stream-hollow-degraded.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/app/activities/filter-utility-activities', () => ({
 vi.mock('@/lib/activity-stream', () => ({
   activityToStreamItem: (x: { id: string }) => x,
   momentToStreamItem: (x: unknown) => x,
+  bundleAnswerToStreamItem: (x: unknown) => x,
   convergenceToStreamItem: (_c: unknown, questions: unknown) => ({ kind: 'convergence', questions }),
   friendActivityToStreamItem: (card: { id: string }, questions: unknown) => ({ kind: 'milestone', id: card.id, questions }),
 }));
@@ -31,6 +32,7 @@ vi.mock('@/server/db/queries/content-reports', () => ({
 }));
 vi.mock('@/server/db/queries/lately', () => ({
   getLatelyMoments: vi.fn(async () => []),
+  getBundleAnswerMoments: vi.fn(async () => []),
   getLatelyConvergences: vi.fn(async () => []),
   getFriendActivity: vi.fn(async () => []),
   getMilestoneQuestionText: vi.fn(async () => new Map()),

--- a/src/server/activity/__tests__/build-stream-self-hide.test.ts
+++ b/src/server/activity/__tests__/build-stream-self-hide.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/app/activities/filter-utility-activities', () => ({
 vi.mock('@/lib/activity-stream', () => ({
   activityToStreamItem: (x: unknown) => x,
   momentToStreamItem: (x: unknown) => x,
+  bundleAnswerToStreamItem: (x: unknown) => x,
   convergenceToStreamItem: (_c: unknown, questions: unknown) => ({ kind: 'convergence', questions }),
   friendActivityToStreamItem: (card: { id: string }, questions: unknown) => ({ kind: 'milestone', id: card.id, questions }),
 }));
@@ -31,6 +32,7 @@ vi.mock('@/server/db/queries/content-reports', () => ({
 }));
 vi.mock('@/server/db/queries/lately', () => ({
   getLatelyMoments: vi.fn(async () => []),
+  getBundleAnswerMoments: vi.fn(async () => []),
   getLatelyConvergences: vi.fn(async () => []),
   getFriendActivity: vi.fn(async () => [{ id: 'm1', questionIds: ['q-keep', 'q-hidden'] }]),
   getMilestoneQuestionText: vi.fn(async (ids: string[]) =>

--- a/src/server/activity/__tests__/build-stream-stale-follow-request.test.ts
+++ b/src/server/activity/__tests__/build-stream-stale-follow-request.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/app/activities/filter-utility-activities', () => ({
 vi.mock('@/lib/activity-stream', () => ({
   activityToStreamItem: (x: { id: string }) => x,
   momentToStreamItem: (x: unknown) => x,
+  bundleAnswerToStreamItem: (x: unknown) => x,
   convergenceToStreamItem: (_c: unknown, questions: unknown) => ({ kind: 'convergence', questions }),
   friendActivityToStreamItem: (card: { id: string }, questions: unknown) => ({ kind: 'milestone', id: card.id, questions }),
 }));
@@ -33,6 +34,7 @@ vi.mock('@/server/db/queries/content-reports', () => ({
 }));
 vi.mock('@/server/db/queries/lately', () => ({
   getLatelyMoments: vi.fn(async () => []),
+  getBundleAnswerMoments: vi.fn(async () => []),
   getLatelyConvergences: vi.fn(async () => []),
   getFriendActivity: vi.fn(async () => []),
   getMilestoneQuestionText: vi.fn(async () => new Map()),

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -13,6 +13,7 @@
 import { filterUtilityActivities } from '@/app/activities/filter-utility-activities';
 import {
   activityToStreamItem,
+  bundleAnswerToStreamItem,
   convergenceToStreamItem,
   friendActivityToStreamItem,
   momentToStreamItem,
@@ -24,6 +25,7 @@ import { MILESTONE_CARD_QUESTION_CAP } from '@/lib/lately-milestones';
 import { getActivitiesForUser } from '@/server/db/queries/activity';
 import { getViewerHiddenQuestionIds } from '@/server/db/queries/content-reports';
 import {
+  getBundleAnswerMoments,
   getFriendActivity,
   getLatelyConvergences,
   getLatelyMoments,
@@ -56,6 +58,10 @@ export async function buildActivityStream(
   // overlapping rather than adding to it.
   const itemsPromise = getActivitiesForUser(userId, windowDays);
   const momentsPromise = getLatelyMoments(userId, windowDays);
+  // The complement of moments: creator-less (LLM) questions the viewer answered
+  // out of a friend's From Friends bundle — without this the answer leaves no
+  // trace anywhere on Home once the bundle is exhausted.
+  const bundleAnswersPromise = getBundleAnswerMoments(userId, windowDays);
   const [friendCards, convergences] = await Promise.all([
     getFriendActivity(userId, windowDays),
     getLatelyConvergences(userId, windowDays),
@@ -76,9 +82,10 @@ export async function buildActivityStream(
       ...convergences.flatMap((c) => c.questionIds),
     ]),
   ];
-  const [items, moments, textById, priorById, hiddenIds, dismissedIds] = await Promise.all([
+  const [items, moments, bundleAnswers, textById, priorById, hiddenIds, dismissedIds] = await Promise.all([
     itemsPromise,
     momentsPromise,
+    bundleAnswersPromise,
     getMilestoneQuestionText(allQuestionIds),
     getViewerPriorAnswerResults(userId, allQuestionIds),
     // B-Report-3: durable self-hide — a question the viewer reported as
@@ -128,6 +135,7 @@ export async function buildActivityStream(
     })
     .map(activityToStreamItem);
   const momentItems = moments.map(momentToStreamItem);
+  const bundleAnswerItems = bundleAnswers.map(bundleAnswerToStreamItem);
   const friendActivityItems = friendCards
     .map((card, i) => {
       const questions: StreamQuestion[] = cappedIdsByCard[i].ids
@@ -192,6 +200,7 @@ export async function buildActivityStream(
 
   return sortByProminence([
     ...momentItems,
+    ...bundleAnswerItems,
     ...friendActivityItems,
     ...convergenceItems,
     ...utilityItems,

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, isNotNull, isNull, ne, notExists, or, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNotNull, isNull, like, ne, notExists, or, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 
 import {
@@ -26,8 +26,8 @@ import {
 } from '@/server/daily/verification-gating';
 import { db, feedItems, follows, masteryEvents, milestoneDismissed, questions, users } from '@/server/db';
 import { pgErrorCode } from '@/server/db/pg-error';
-import { approvedFollowExists } from '@/server/db/queries/follow-visibility';
-import { ALWAYS_VISIBLE_MAIN_FEED_SOURCE_TYPES, SOCIAL_FEED_SOURCE_TYPE, notBlockedForViewer } from '@/server/feed/visibility';
+import { approvedFollowExists, mutualFollowApproved } from '@/server/db/queries/follow-visibility';
+import { ALWAYS_VISIBLE_MAIN_FEED_SOURCE_TYPES, SOCIAL_FEED_SOURCE_TYPE, notBlocked, notBlockedForViewer } from '@/server/feed/visibility';
 
 export type LatelyDirection = 'they_got_you' | 'you_got_them';
 
@@ -159,6 +159,108 @@ export async function getLatelyMoments(
       // Footnote brand label. v2 spec example uses ASTERISK; not worth
       // per-surface disambiguation until the user asks for it.
       gameTitle: 'asterisk',
+      answeredAt: row.answeredAt,
+    });
+  }
+  return moments;
+}
+
+// A bundle answer: the viewer answered a question they met through a friend's
+// From Friends bundle (via /api/lately/milestone/answer). The friend PLAYED the
+// question — their correct `friend_answered` feed row is what put it in the
+// bundle — but nobody-the-viewer-knows WROTE it: these are the creator-less LLM
+// questions `getLatelyMoments` excludes by construction. Without this read the
+// answer leaves no activity trace at all (the exhausted bundle also disappears
+// from From Friends), so "the last thing I did" is invisible on Home.
+// Human-authored bundle questions are deliberately NOT read here — they already
+// surface as you_got_them moments, and reading them again would double the row.
+export type BundleAnswerMoment = {
+  momentId: string;
+  friendId: string;
+  friendName: string;
+  friendFirstName: string;
+  questionId: string;
+  questionText: string;
+  category: string;
+  answeredAt: Date;
+};
+
+export async function getBundleAnswerMoments(
+  userId: string,
+  windowDays = MOMENTS_WINDOW_DAYS,
+): Promise<BundleAnswerMoment[]> {
+  const windowStart = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+
+  const rows = await db
+    .select({
+      momentId: masteryEvents.id,
+      friendId: feedItems.sourceUserId,
+      friendDisplayName: users.displayName,
+      questionId: questions.id,
+      questionText: questions.questionText,
+      canonicalSubcategory: questions.canonicalSubcategory,
+      category: questions.category,
+      answeredAt: masteryEvents.createdAt,
+      playedAt: feedItems.sourceEventAt,
+    })
+    .from(masteryEvents)
+    .innerJoin(questions, eq(questions.id, masteryEvents.questionId))
+    // The friend whose bundle carried this question: the same correct
+    // `friend_answered` row getFriendActivity builds the bundle from. Two
+    // friends can both have played it — the JS pass below keeps the most
+    // recent play per mastery event.
+    .innerJoin(
+      feedItems,
+      and(
+        eq(feedItems.questionId, masteryEvents.questionId),
+        eq(feedItems.recipientUserId, userId),
+        eq(feedItems.sourceType, SOCIAL_FEED_SOURCE_TYPE),
+        eq(feedItems.sourceResult, 'correct'),
+      ),
+    )
+    .innerJoin(users, eq(users.id, feedItems.sourceUserId))
+    .where(
+      and(
+        eq(masteryEvents.userId, userId),
+        // The milestone answer route's deterministic answer id is the marker
+        // that this event came from a bundle answer: write-mastery-event
+        // composes `${sourceType}:${sourceId}:…` and that route passes
+        // sourceType 'feed' with sourceId `milestone:{questionId}`.
+        like(masteryEvents.answerId, 'feed:milestone:%'),
+        inArray(masteryEvents.answerState, CORRECT_ANSWER_STATES),
+        gte(masteryEvents.createdAt, windowStart),
+        // Creator-less (LLM) questions only — human-authored bundle answers
+        // already read as you_got_them moments in getLatelyMoments; this query
+        // is the complement, never an overlap.
+        isNull(questions.creatorId),
+        // Safety hard-block (no owner exception possible on a creator-less
+        // question, so the plain form suffices).
+        notBlocked(),
+        // Bundle membership is friends-only (mutual), same gate as the bundle
+        // reads in getFriendActivity/getLatelyMilestones.
+        mutualFollowApproved(userId, feedItems.sourceUserId, 'bundle_answer'),
+      ),
+    )
+    .orderBy(desc(masteryEvents.createdAt), desc(feedItems.sourceEventAt))
+    .limit(200);
+
+  const seen = new Set<string>();
+  const moments: BundleAnswerMoment[] = [];
+  for (const row of rows) {
+    if (!row.answeredAt || !row.friendId) continue;
+    // Rows arrive newest-play-first within each event; keep the first (most
+    // recent) friend per mastery event.
+    if (seen.has(row.momentId)) continue;
+    seen.add(row.momentId);
+    const friendName = row.friendDisplayName?.trim() || 'A friend';
+    moments.push({
+      momentId: row.momentId,
+      friendId: row.friendId,
+      friendName,
+      friendFirstName: firstName(row.friendDisplayName, friendName),
+      questionId: row.questionId,
+      questionText: row.questionText,
+      category: prettifyCategory(row.canonicalSubcategory, row.category),
       answeredAt: row.answeredAt,
     });
   }


### PR DESCRIPTION
## Problem

Answering an LLM-generated question from a friend's **From Friends** bundle left **no trace anywhere on Home** (Josh's report, 2026-07-17: answered David's Tom Stoppard question, nothing in Recent activity):

- `getLatelyMoments` only produces "You understood {friend}'s question" rows for **human-authored** questions (`questions.creator_id` = a friend). Bundle questions are mostly creator-less `daily_generated` rows the friend merely *played*, so no moment is ever written.
- On top of that, answering the last question **exhausts the bundle**, which disappears from From Friends (D-HOME-DASHBOARD-MODEL-01 point 3) — so the answer's only surface vanished too.

Verified against prod: the answer was recorded fine (`first_correct`, `answer_id feed:milestone:…`); the row was simply never readable by any activity query.

## Change

**`getBundleAnswerMoments`** (new, `src/server/db/queries/lately.ts`) — the complement of the moments query: the viewer's correct answers whose `answer_id` carries the milestone route's `feed:milestone:` marker, restricted to **creator-less questions** (human-authored ones already surface as `you_got_them` moments — no overlap, no double rows). The friend is resolved from the same correct `friend_answered` feed row the bundle was built from (most recent play wins when two friends played it), with the same mutual-follow and blocked-question gates as the other bundle reads.

**`bundleAnswerToStreamItem`** (new, `src/lib/activity-stream.ts`) — a quiet one-liner in the shared-territory register: *"You followed {friend} into {topic}"* / *"You played along with {friend} on {topic}"* / *"You kept {friend} company in {topic}"* (hash-varied per event, like the other pools). The copy deliberately **never claims authorship** — "{friend}'s question" stays reserved for questions a person actually wrote. The expanded reveal carries the honest LLM attribution (`authorName: null`) and the send-onward action, exactly like a moment reveal. `OTHER` tier, diamond mark, not home-headline-eligible — parity with `you_got_them` moments.

**`relationship: 'played_along'`** (new kind) + a `PersonActivityCard` roll-up branch ("played along with {name} — topics") — kept apart from `you_got` so a grouped card never reads "got {Name}" for a question the friend didn't write (and so the rows don't silently vanish from the card, which is what an unknown relationship kind would do).

**`build-stream.ts`** — the new query runs in parallel with the moments query (no added critical-path latency) and its items merge into the same prominence sort.

## Tests

- New `activity-stream-bundle-answer.test.ts` (7 cases), including the no-authorship-claim guarantee and the honest-LLM-attribution expand.
- The four `build-stream-*` test files' module mocks updated for the new function.
- `npx tsc -p tsconfig.typecheck.json` clean; full vitest run shows no new failures (the 6 files still failing — FriendsHubPage, FeedCards, daily answer route, and three `src/server/daily` queue suites — fail identically with this change stashed; pre-existing on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnYgjN1pFdSZVqRf1d9mwd
