### PR TITLE
Add-a-topic: drop the 'Add' caption; copy about topics, not seeding

### DIFF
--- a/src/components/home/AddTopicHomeCard.tsx
+++ b/src/components/home/AddTopicHomeCard.tsx
@@ -33,15 +33,16 @@ function AddYourOwnTile() {
 }
 
 // Homepage "Add a topic" module (Josh, 2026-07-17): suggestion circles only —
-// a lightweight, low-clutter way to seed a Daily Five topic from Home by tapping
-// a related-but-specific suggestion, paged through TopicSuggestionCarousel (swipe
-// for more — no per-circle dismiss). The carousel's last page is always the
-// "Add your own" tile above, linking to the full manage surface (/daily/setup)
-// where the create-your-own text field lives — kept off Home to stay
-// uncluttered, and off this card's footer since it's now reachable by
-// swiping to the end. Suggestions are fetched client-side after mount (like
-// TodaysFiveCard's status fetch) so they never touch the home critical path;
-// the card hides itself until there's something to show.
+// a lightweight, low-clutter way to add a topic to your interests from Home
+// by tapping a related-but-specific suggestion, paged through
+// TopicSuggestionCarousel (swipe for more — no per-circle dismiss). The
+// carousel's last page is always the "Add your own" tile above, linking to
+// the full manage surface (/daily/setup) where the create-your-own text
+// field lives — kept off Home to stay uncluttered, and off this card's
+// footer since it's now reachable by swiping to the end. Suggestions are
+// fetched client-side after mount (like TodaysFiveCard's status fetch) so
+// they never touch the home critical path; the card hides itself until
+// there's something to show.
 export function AddTopicHomeCard() {
   const [added, setAdded] = useState<string | null>(null);
   const [addedKeys, setAddedKeys] = useState<ReadonlySet<string>>(new Set());
@@ -145,8 +146,8 @@ export function AddTopicHomeCard() {
         className="mt-1 mb-3 text-sm leading-6 text-[var(--text-muted-warm)]"
         style={{ fontFamily: 'var(--font-serif), Georgia, serif' }}
       >
-        A few you might like, based on your interests — swipe for more, or tap one to seed your
-        Daily Five.
+        A few you might like, based on your interests — swipe for more, or tap one to add it to
+        your topics.
       </p>
       {pool.length > 0 ? (
         <TopicSuggestionCarousel

--- a/src/components/knowledge/GhostTerritoryCircle.tsx
+++ b/src/components/knowledge/GhostTerritoryCircle.tsx
@@ -6,8 +6,9 @@ import { Check, Plus } from 'lucide-react';
 import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
 import type { NearbyTerritory } from '@/lib/daily/territory-model';
 
-// The small caption under the circle — "Add" or "Added". One definition so
-// the tiny type size lives in a single literal.
+// The small "Added" caption shown once a circle is settled — the plus icon
+// and dashed circle already read as "tap to add" on their own, so there's no
+// caption for the resting state.
 const CAPTION_CLASS = 'text-[10px] tracking-[0.14em] uppercase';
 
 // A suggested ("nearby") territory the player hasn't adopted yet: a dashed
@@ -66,7 +67,7 @@ export function GhostTerritoryCircle({
       <span className="max-w-full px-1 font-serif text-quiet leading-tight break-words text-[var(--territory-text)]">
         {territory.domain}
       </span>
-      <span className={`${CAPTION_CLASS} text-[var(--territory-text)]`}>{added ? 'Added' : 'Add'}</span>
+      {added ? <span className={`${CAPTION_CLASS} text-[var(--territory-text)]`}>Added</span> : null}
     </button>
   );
 }


### PR DESCRIPTION
Two small copy/UI cleanups on the "Add a topic" surfaces (manage page, `/knowledge` block, homepage card).

## Take out the "Add" caption

`GhostTerritoryCircle`'s resting state no longer shows an "Add" caption under the circle — the dashed circle + plus icon already read as tap-to-add, so the label was redundant. "Added" still shows once a circle is settled, since that's a status worth calling out (matches the pattern already used elsewhere: only label the notable state).

## Copy isn't about "seeding" anymore

The homepage card said "tap one to seed your Daily Five" — reframed to "tap one to add it to your topics," matching how the rest of the surface already talks about this (adding topics/categories you're interested in), not the mechanics of how the daily round gets built from them.

## Verification

Real toolchain (this environment has `node_modules`):
- `npx next build` — succeeded.
- `npx tsc -p tsconfig.typecheck.json` — clean, 0 errors.
- `npx eslint` on changed files — clean.
- All six CI ratchets — pass, no new occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwoHebwKcgAkoe7JBYATdH