### PR TITLE
Suggestion circles: bigger + icon, in the forest green accent

### DIFF
--- a/src/components/knowledge/GhostTerritoryCircle.tsx
+++ b/src/components/knowledge/GhostTerritoryCircle.tsx
@@ -62,7 +62,14 @@ export function GhostTerritoryCircle({
         }`}
         style={{ background: 'color-mix(in srgb, var(--brand-card) 55%, transparent)' }}
       >
-        {added ? <Check className="size-5" aria-hidden="true" /> : <Plus className="size-5" aria-hidden="true" />}
+        {added ? (
+          <Check className="size-7" aria-hidden="true" />
+        ) : (
+          // Forest green (--game-correct) — the same "Play Missed Questions"
+          // accent, not the category tint, so the tap target itself pops
+          // rather than blending into the dashed outline.
+          <Plus className="size-7 text-[var(--game-correct)]" aria-hidden="true" />
+        )}
       </div>
       <span className="max-w-full px-1 font-serif text-quiet leading-tight break-words text-[var(--territory-text)]">
         {territory.domain}


### PR DESCRIPTION
## What changed

- Both the **Plus** (not-added) and **Check** (added) icons in `GhostTerritoryCircle` go from `size-5` to `size-7` — bigger, reads more clearly inside the `size-16` circle.
- The Plus icon now uses `--game-correct` (forest green, `#366045`) — the **same green already used elsewhere** (it's the accent on the "Play Missed Questions" button text on Home), not a new color. The Check icon keeps the category's own tint so "this topic is now yours" still reads distinctly from the plain "tap to add" invitation.

## Verification

Real toolchain (this environment has `node_modules`):
- `npx next build` — succeeded.
- `npx tsc -p tsconfig.typecheck.json` — clean, 0 errors.
- `npx eslint` — clean.
- All six CI ratchets — pass, no new occurrences (the color is a `var()` reference to an existing token, not a new literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwoHebwKcgAkoe7JBYATdH