### PR TITLE
Add-a-topic: genuinely rotating suggestions from a wider catalog

### DIFF
--- a/src/app/api/interests/suggestions/route.ts
+++ b/src/app/api/interests/suggestions/route.ts
@@ -3,14 +3,20 @@ import { NextResponse } from 'next/server';
 import { getSession } from '@/server/auth/session';
 import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
+import { getCatalogSuggestions } from '@/server/db/queries/suggestion-catalog';
 import { buildSuggestionPool } from '@/lib/knowledge/suggestion-pool';
+import { domainKey } from '@/lib/knowledge/domain-key';
 
 export const dynamic = 'force-dynamic';
 
 // Suggestion pool for the "Add a topic" surfaces. Fetched client-side after
 // mount (like /api/daily/status) so it never sits on the home critical path.
-// Returns the related-but-specific topics the player doesn't already hold; the
-// client shuffles and shows a few, with add / "not for me" per circle.
+// Two sources, merged: the knowledge tree's direct unheld siblings (fast,
+// hand-authored graph — buildSuggestionPool), and the real question catalog
+// under the player's own broad categories (getCatalogSuggestions) — a much
+// larger space than the graph alone, so suggestions don't dry up to the same
+// small set once the tree-adjacent candidates are exhausted. The client
+// shuffles/rotates and shows a few at a time, with add / undo per circle.
 export async function GET() {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
@@ -24,6 +30,21 @@ export async function GET() {
     ...ownedDomains.map((domain) => domain.displayName || domain.domain),
     ...declared.map((interest) => interest.domain),
   ];
+  const ownedKeys = new Set(ownedNames.map(domainKey));
+  const broadCategories = [
+    ...new Set(
+      [...ownedDomains, ...declared]
+        .map((entry) => entry.broadCategory?.trim())
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ];
 
-  return NextResponse.json({ suggestions: buildSuggestionPool(tree, ownedNames) });
+  const treeSuggestions = buildSuggestionPool(tree, ownedNames);
+  const merged = new Map(treeSuggestions.map((suggestion) => [domainKey(suggestion.domain), suggestion]));
+  const catalogSuggestions = await getCatalogSuggestions(broadCategories, new Set([...ownedKeys, ...merged.keys()]));
+  for (const suggestion of catalogSuggestions) {
+    merged.set(domainKey(suggestion.domain), { ...suggestion, reason: 'From your categories' });
+  }
+
+  return NextResponse.json({ suggestions: [...merged.values()] });
 }

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -442,8 +442,11 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
     return () => window.cancelAnimationFrame(frame);
   }, []);
   // Shared builder (also used by the home suggestions endpoint) so both add
-  // surfaces draw the identical related-but-specific pool.
-  const suggestionPool = useMemo<NearbyTerritory[]>(
+  // surfaces draw the identical related-but-specific pool. Instant/local —
+  // no fetch — but bounded to the knowledge tree's direct unheld siblings
+  // plus a handful of hard-coded adjacency rules, which for a modest map is
+  // often a small, quickly-exhausted set.
+  const treeSuggestionPool = useMemo<NearbyTerritory[]>(
     () =>
       buildSuggestionPool(detailTree, [
         ...sortedDomains.map((domain) => domain.displayName),
@@ -451,6 +454,38 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
       ]),
     [detailTree, sortedDomains, data],
   );
+  // Supplements the tree pool with the real question catalog under the
+  // player's own broad categories (/api/interests/suggestions — same
+  // endpoint the home card uses) so suggestions aren't capped to the
+  // hand-authored graph. Fetched once; the tree pool renders immediately and
+  // this widens it once it arrives, rather than blocking on it.
+  const [catalogSuggestions, setCatalogSuggestions] = useState<NearbyTerritory[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch('/api/interests/suggestions', { credentials: 'include' });
+        if (!response.ok) return;
+        const body = (await response.json().catch(() => null)) as
+          | { suggestions?: NearbyTerritory[] }
+          | null;
+        if (!cancelled && Array.isArray(body?.suggestions)) setCatalogSuggestions(body.suggestions);
+      } catch {
+        // The tree pool alone is still a usable fallback.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const suggestionPool = useMemo<NearbyTerritory[]>(() => {
+    const merged = new Map(treeSuggestionPool.map((territory) => [domainKey(territory.domain), territory]));
+    for (const territory of catalogSuggestions) {
+      const key = domainKey(territory.domain);
+      if (!merged.has(key)) merged.set(key, territory);
+    }
+    return [...merged.values()];
+  }, [treeSuggestionPool, catalogSuggestions]);
   // Stable per-visit order: seeded Fisher–Yates (small LCG) keyed on the offset.
   const shuffledPool = useMemo(() => {
     const shuffled = [...suggestionPool];

--- a/src/components/knowledge/TopicSuggestionCarousel.tsx
+++ b/src/components/knowledge/TopicSuggestionCarousel.tsx
@@ -1,15 +1,24 @@
 'use client';
 
-import { useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 
 import { EditorialCarousel } from '@/components/feed/EditorialCarousel';
 import { GhostTerritoryCircle } from '@/components/knowledge/GhostTerritoryCircle';
 import { domainKey } from '@/lib/knowledge/domain-key';
+import {
+  pickRotatedSuggestions,
+  readRecentlyShownSuggestions,
+  rememberShownSuggestions,
+} from '@/lib/knowledge/suggestion-rotation';
 import type { NearbyTerritory } from '@/lib/daily/territory-model';
 
 const PAGE_SIZE = 3;
-// Defensive cap so a very large tree doesn't turn this into an endless swipe.
-const MAX_SUGGESTIONS = 15;
+// Visible cap per visit. Lower than the full candidate pool for most maps
+// (the pool is direct unheld siblings of what you own, plus a handful of
+// adjacency rules — often modest), so there's usually room for
+// pickRotatedSuggestions to swap in genuinely different topics each visit
+// instead of just reordering the same ones.
+const MAX_SUGGESTIONS = 9;
 
 function chunk<T>(items: readonly T[], size: number): T[][] {
   const pages: T[][] = [];
@@ -31,6 +40,13 @@ function chunk<T>(items: readonly T[], size: number): T[][] {
  * to flip a circle back when the player taps "Undo" on the confirmation
  * banner, so the single source of truth for "is this domain added" lives
  * wherever the undo/remove call does.
+ *
+ * The caller re-shuffles `suggestions` once per visit, but for a modest map
+ * that alone doesn't help — if the whole candidate pool fits under
+ * MAX_SUGGESTIONS, a reshuffle just reorders the exact same set. Genuine
+ * per-visit variety comes from pickRotatedSuggestions (see
+ * suggestion-rotation.ts), which remembers what was shown last time and
+ * prefers fresh candidates.
  */
 export function TopicSuggestionCarousel({
   suggestions,
@@ -55,10 +71,24 @@ export function TopicSuggestionCarousel({
   // caller's `addedKeys` truth.
   const [addingKey, setAddingKey] = useState<string | null>(null);
 
-  const pages = useMemo(
-    () => chunk(suggestions.slice(0, MAX_SUGGESTIONS), PAGE_SIZE),
+  // The rotated, capped subset actually shown this visit. The pick itself is
+  // pure (a plain useMemo, reading the previous "recently shown" snapshot);
+  // persisting the new snapshot is the actual side effect, fired from an
+  // effect that only writes — never calls setState — so it can't cascade
+  // renders. Runs once per fresh `suggestions` array (i.e. once per pool
+  // fetch/shuffle), not on every re-render.
+  const visible = useMemo(
+    () =>
+      suggestions.length > 0
+        ? pickRotatedSuggestions(suggestions, MAX_SUGGESTIONS, readRecentlyShownSuggestions())
+        : [],
     [suggestions],
   );
+  useEffect(() => {
+    if (visible.length > 0) rememberShownSuggestions(visible.map((territory) => domainKey(territory.domain)));
+  }, [visible]);
+
+  const pages = useMemo(() => chunk(visible, PAGE_SIZE), [visible]);
 
   const handleAdd = async (territory: NearbyTerritory) => {
     if (addingKey) return;

--- a/src/lib/knowledge/suggestion-rotation.ts
+++ b/src/lib/knowledge/suggestion-rotation.ts
@@ -1,0 +1,58 @@
+import { domainKey } from '@/lib/knowledge/domain-key';
+import type { NearbyTerritory } from '@/lib/daily/territory-model';
+
+// Shared across every "Add a topic" surface (Home, the manage page, the
+// /knowledge block) — one localStorage key, so rotation feels continuous
+// across the whole app in a session, not siloed per surface.
+const STORAGE_KEY = 'topic_suggestions_recently_shown';
+
+// Read-only — safe to call during render (a stable snapshot, same shape on
+// server (always empty, guarded below) and on first client render, so no
+// hydration mismatch). The actual persistence is a separate write call the
+// caller fires from an effect; keeping read and write apart means the
+// picking logic below has no side effect of its own and can live in a
+// plain useMemo.
+export function readRecentlyShownSuggestions(): ReadonlySet<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((value): value is string => typeof value === 'string'));
+  } catch {
+    // localStorage can be unavailable (private mode) — rotation just resets
+    // every visit rather than persisting, which is a harmless degrade.
+    return new Set();
+  }
+}
+
+export function rememberShownSuggestions(keys: readonly string[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(keys));
+  } catch {
+    // Same graceful degrade as above.
+  }
+}
+
+/**
+ * Pick up to `limit` suggestions from `pool` (already shuffled by the
+ * caller), preferring ones NOT in `recentlyShown` — so a reload doesn't
+ * surface the identical set, even when the underlying candidate pool (the
+ * knowledge tree's direct unheld siblings, plus a handful of hard-coded
+ * adjacency rules) is small enough that everything would otherwise always
+ * be visible regardless of shuffle order. Falls back to the recently-shown
+ * items only if there aren't enough fresh ones to fill `limit`. Pure — no
+ * localStorage access itself; the caller persists the result (via
+ * rememberShownSuggestions) as the new "recently shown" set for next time.
+ */
+export function pickRotatedSuggestions(
+  pool: readonly NearbyTerritory[],
+  limit: number,
+  recentlyShown: ReadonlySet<string>,
+): NearbyTerritory[] {
+  const fresh = pool.filter((territory) => !recentlyShown.has(domainKey(territory.domain)));
+  const stale = pool.filter((territory) => recentlyShown.has(domainKey(territory.domain)));
+  return [...fresh, ...stale].slice(0, limit);
+}

--- a/src/server/db/queries/suggestion-catalog.ts
+++ b/src/server/db/queries/suggestion-catalog.ts
@@ -1,0 +1,58 @@
+import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm';
+
+import { db, generatedQuestions } from '@/server/db';
+import { domainKey } from '@/lib/knowledge/domain-key';
+
+export type CatalogSuggestion = { domain: string; broadCategory: string | null };
+
+// "Add a topic" suggestions were previously bounded to the knowledge tree's
+// DIRECT unheld siblings of what the player already owns, plus ~9 hard-coded
+// adjacency rules — a small, often-exhausted set (Josh, 2026-07-17: "It seems
+// to only suggest what is there now as well. Could it look beyond that?").
+// This looks beyond the authored graph into the REAL catalog: any topic with
+// actual verified question supply under a broad category the player already
+// has some presence in — same relevance test ("related to your interests"),
+// far larger candidate space, since it's not limited to hand-authored graph
+// edges. Verified-only + a minimum row count is a light quality bar so a
+// single stray/low-confidence question doesn't surface as a suggestion.
+const MIN_VERIFIED_QUESTIONS = 3;
+
+export async function getCatalogSuggestions(
+  broadCategories: readonly string[],
+  excludeDomainKeys: ReadonlySet<string>,
+  limit = 40,
+): Promise<CatalogSuggestion[]> {
+  if (broadCategories.length === 0) return [];
+
+  const rows = await db
+    .select({
+      label: generatedQuestions.canonicalSubcategory,
+      broadCategory: generatedQuestions.broadCategory,
+    })
+    .from(generatedQuestions)
+    .where(
+      and(
+        inArray(generatedQuestions.broadCategory, [...broadCategories]),
+        isNotNull(generatedQuestions.verifiedAt),
+        eq(generatedQuestions.isDuplicate, false),
+      ),
+    )
+    .groupBy(generatedQuestions.canonicalSubcategory, generatedQuestions.broadCategory)
+    .having(sql`count(*) >= ${MIN_VERIFIED_QUESTIONS}`)
+    // Over-fetch: some rows will fold onto an already-excluded/duplicate key
+    // once normalized below, so ask for more than `limit` up front.
+    .limit(limit * 3);
+
+  const seen = new Set<string>();
+  const result: CatalogSuggestion[] = [];
+  for (const row of rows) {
+    const label = row.label?.trim();
+    if (!label) continue;
+    const key = domainKey(label);
+    if (excludeDomainKeys.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    result.push({ domain: label, broadCategory: row.broadCategory });
+    if (result.length >= limit) break;
+  }
+  return result;
+}


### PR DESCRIPTION
Two compounding fixes for "I keep seeing the same suggestions, even reshuffled."

## 1. Rotation (client-side)

The candidate pool was reshuffled each visit, but for a modest map the whole pool often fits under the visible cap — so a reshuffle just reorders the same set. New `pickRotatedSuggestions` (`suggestion-rotation.ts`) remembers what was shown last visit (one shared `localStorage` key across every Add-a-topic surface) and prefers fresh candidates, falling back to repeats only if there aren't enough. Also lowered the visible cap 15 → 9 so a larger pool has more room to actually rotate.

Split the pure pick (`useMemo`) from the `localStorage` write (a plain `useEffect`, no `setState`) to satisfy `react-hooks/set-state-in-effect` — caught by this repo's lint config.

## 2. Wider source (server-side)

Per Josh: "It seems to only suggest what is there now as well. Could it look beyond that?" — the pool itself was bounded to the knowledge tree's **direct** unheld siblings of what you own, plus ~9 hard-coded adjacency rules — a small, often-exhausted set.

New `getCatalogSuggestions` (`suggestion-catalog.ts`) draws from the real question catalog: any topic with verified, non-duplicate question supply (≥3 rows) under a broad category the player already has some presence in — same relevance test ("related to your interests"), far larger candidate space since it's not limited to hand-authored graph edges.

`/api/interests/suggestions` now merges both sources (tree ghosts + catalog). The manage page, which previously computed its pool purely client-side from the tree, now also fetches this endpoint and merges it in, so both surfaces (Home + manage page + `/knowledge` block) draw from the same widened pool.

## Verification

Real toolchain (this environment has `node_modules`):
- `npx next build` — succeeded.
- `npx tsc -p tsconfig.typecheck.json` — clean, 0 errors.
- `npx eslint` on all changed files — clean (including the set-state-in-effect fix).
- All six CI ratchets — pass, no new occurrences.
- The new SQL (`.groupBy()` + `.having()` over `generatedQuestions`) follows the exact pattern already used in `retrieval-demand.ts`, including the same `isDuplicate = false` quality filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwoHebwKcgAkoe7JBYATdH