### PR TITLE
Audit fixes: undo gating, twMerge text-quiet, stale test mocks, scanner literals

### DIFF
--- a/.github/workflows/zindex-ratchet.yml
+++ b/.github/workflows/zindex-ratchet.yml
@@ -2,8 +2,10 @@
 # z-[N] arbitraries, inline zIndex >= 30) in src/ rise above the recorded
 # ceiling. The ceiling and the exemption list live in
 # scripts/check-zindex-ratchet.mjs. Independent of the color/font/spacing/
-# radius ratchets by design. Consumers of the z-scale tokens (the
-# z-[var(--z-*)] arbitrary form) are on-system and not counted.
+# radius ratchets by design. Consumers of the z-scale tokens (the z arbitrary
+# form with a var(--z-*) value; spelled apart here because Tailwind v4 scans
+# comments and a * inside a var() arbitrary compiles into invalid CSS) are
+# on-system and not counted.
 name: Z-index ratchet
 
 on:

--- a/scripts/check-zindex-ratchet.mjs
+++ b/scripts/check-zindex-ratchet.mjs
@@ -12,7 +12,9 @@
 // var(--z-*) consumers never match — they're the point. Standard Tailwind
 // utilities (z-10..z-50) are not counted: they're on Tailwind's own scale and
 // the overlay surfaces have all been swept onto the tokens; new overlay work
-// should use z-[var(--z-*)].
+// should use the z arbitrary form with a var(--z-*) value. (Spelled apart
+// here because Tailwind v4 scans comments and a * inside a var() arbitrary
+// compiles into invalid CSS.)
 //
 // To LOWER the ceiling after a cleanup: run the script, take the count, update
 // CEILING. To raise it: don't — use the --z-* scale instead.

--- a/src/app/api/daily/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/answer/__tests__/route.test.ts
@@ -157,7 +157,10 @@ vi.mock('@/server/answers/canonical-answer', () => ({
   normalizeCanonicalAnswerLabel: (s: string) => s,
 }))
 
-vi.mock('@/lib/llm', () => ({
+// Keep the real module (constants like ANTHROPIC_MODEL are read at import
+// time by the route's dependency graph) and stub only the LLM call itself.
+vi.mock('@/lib/llm', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/llm')>()),
   suggestAnswer: suggestAnswerMock,
 }))
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -405,8 +405,12 @@
     --scrim-soft: color-mix(in srgb, var(--brand-ink) 20%, transparent);
     --scrim: color-mix(in srgb, var(--brand-ink) 40%, transparent);
     --scrim-heavy: color-mix(in srgb, var(--brand-ink) 60%, transparent);
-    /* Z-scale — the ONLY sanctioned layers above page content. Use
-       z-[var(--z-*)] (or inline zIndex: 'var(--z-*)'); never a raw number.
+    /* Z-scale — the ONLY sanctioned layers above page content. Use the z
+       arbitrary with a var(--z-…) token, e.g. z-[ var(--z-modal) ] without the
+       spaces (spelled apart here because Tailwind v4 scans comments too, and a
+       literal with * inside var() compiles into invalid CSS — same trap as the
+       rounded-[…] note in CLAUDE.md), or inline zIndex: 'var(--z-…)'; never a
+       raw number.
        nav(40) chrome < sheet(50) drawers/bottom-sheets/anchored menus <
        modal(60) dialogs (may open above a sheet) < toast(70) notices (never
        hidden) < takeover(80) full-screen moments (tour, mastery, loading). */

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -403,7 +403,10 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
   // so Undo can flip a circle back here). Cleared per-domain by undoAddedTopic;
   // otherwise only grows for the session, since an add that's still standing
   // should keep reading as added even after a later add replaces the banner.
-  const [addedTopic, setAddedTopic] = useState<string | null>(null);
+  // `created` comes from the POST response: an idempotent re-add of an
+  // already-active topic returns created:false, and Undo must not render
+  // there — it would deactivate the pre-existing interest.
+  const [addedTopic, setAddedTopic] = useState<{ domain: string; created: boolean } | null>(null);
   const [addedKeys, setAddedKeys] = useState<ReadonlySet<string>>(new Set());
   const [undoing, setUndoing] = useState(false);
   useEffect(() => {
@@ -412,19 +415,19 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
     return () => window.clearTimeout(timer);
   }, [addedTopic]);
   const undoAddedTopic = async () => {
-    if (!addedTopic || undoing) return;
+    if (!addedTopic?.created || undoing) return;
     setUndoing(true);
     try {
       const response = await fetch('/api/declared-interests', {
         method: 'DELETE',
         credentials: 'include',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ domain: addedTopic }),
+        body: JSON.stringify({ domain: addedTopic.domain }),
       });
       if (!response.ok) throw new Error('undo failed');
       setAddedKeys((prev) => {
         const next = new Set(prev);
-        next.delete(domainKey(addedTopic));
+        next.delete(domainKey(addedTopic.domain));
         return next;
       });
       setAddedTopic(null);
@@ -513,12 +516,16 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
           ...(territory.broadCategory ? { broadCategory: territory.broadCategory } : {}),
         }),
       });
+      const body = (await response.json().catch(() => null)) as
+        | { domain?: string; created?: boolean; message?: string }
+        | null;
       if (!response.ok) {
-        const body = (await response.json().catch(() => null)) as { message?: string } | null;
         throw new Error(body?.message ?? 'Could not add that territory.');
       }
-      setAddedTopic(territory.domain);
-      setAddedKeys((prev) => new Set(prev).add(domainKey(territory.domain)));
+      // Prefer the canonical domain the server persisted over our local label.
+      const domain = typeof body?.domain === 'string' && body.domain ? body.domain : territory.domain;
+      setAddedTopic({ domain, created: body?.created === true });
+      setAddedKeys((prev) => new Set(prev).add(domainKey(domain)));
       await loadKnowledge();
       return true;
     } catch (caught) {
@@ -537,12 +544,16 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ label, ...(broadCategory ? { broadCategory } : {}) }),
     });
+    const body = (await response.json().catch(() => null)) as
+      | { domain?: string; created?: boolean; message?: string }
+      | null;
     if (!response.ok) {
-      const body = (await response.json().catch(() => null)) as { message?: string } | null;
       throw new Error(body?.message ?? 'Could not add that topic.');
     }
-    setAddedTopic(label);
-    setAddedKeys((prev) => new Set(prev).add(domainKey(label)));
+    // Prefer the canonical domain the server persisted over our local label.
+    const domain = typeof body?.domain === 'string' && body.domain ? body.domain : label;
+    setAddedTopic({ domain, created: body?.created === true });
+    setAddedKeys((prev) => new Set(prev).add(domainKey(domain)));
     await loadKnowledge();
   };
 
@@ -902,16 +913,22 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
               <Check className="mt-0.5 size-4 shrink-0 text-[var(--accent-gold-ink)]" aria-hidden="true" />
               <div className="flex-1">
                 <p className="m-0 text-quiet text-[var(--ink)]">
-                  Added &ldquo;{addedTopic}&rdquo; — it&rsquo;ll show up in an upcoming round.
+                  {addedTopic.created ? (
+                    <>Added &ldquo;{addedTopic.domain}&rdquo; — it&rsquo;ll show up in an upcoming round.</>
+                  ) : (
+                    <>&ldquo;{addedTopic.domain}&rdquo; is already in your topics.</>
+                  )}
                 </p>
-                <button
-                  type="button"
-                  className="mt-1 text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70 disabled:opacity-50"
-                  onClick={() => void undoAddedTopic()}
-                  disabled={undoing}
-                >
-                  {undoing ? 'Undoing…' : 'Undo'}
-                </button>
+                {addedTopic.created ? (
+                  <button
+                    type="button"
+                    className="mt-1 text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70 disabled:opacity-50"
+                    onClick={() => void undoAddedTopic()}
+                    disabled={undoing}
+                  >
+                    {undoing ? 'Undoing…' : 'Undo'}
+                  </button>
+                ) : null}
               </div>
             </div>
           ) : null}
@@ -996,16 +1013,22 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
                   <Check className="mt-0.5 size-4 shrink-0 text-[var(--accent-gold-ink)]" aria-hidden="true" />
                   <div className="flex-1">
                     <p className="m-0 text-quiet text-[var(--ink)]">
-                      Added &ldquo;{addedTopic}&rdquo; — it&rsquo;ll show up in an upcoming round.
+                      {addedTopic.created ? (
+                        <>Added &ldquo;{addedTopic.domain}&rdquo; — it&rsquo;ll show up in an upcoming round.</>
+                      ) : (
+                        <>&ldquo;{addedTopic.domain}&rdquo; is already in your topics.</>
+                      )}
                     </p>
-                    <button
-                      type="button"
-                      className="mt-1 text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70 disabled:opacity-50"
-                      onClick={() => void undoAddedTopic()}
-                      disabled={undoing}
-                    >
-                      {undoing ? 'Undoing…' : 'Undo'}
-                    </button>
+                    {addedTopic.created ? (
+                      <button
+                        type="button"
+                        className="mt-1 text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70 disabled:opacity-50"
+                        onClick={() => void undoAddedTopic()}
+                        disabled={undoing}
+                      >
+                        {undoing ? 'Undoing…' : 'Undo'}
+                      </button>
+                    ) : null}
                   </div>
                 </div>
               ) : null}

--- a/src/components/__tests__/FriendsHubPage.test.tsx
+++ b/src/components/__tests__/FriendsHubPage.test.tsx
@@ -20,13 +20,15 @@ const forbiddenRelationshipCopy =
   /Following|Followers|Who can follow you|Make public|Follow requests|Mutual|Follows you/i;
 
 describe('Friends page QA surface', () => {
-  it('centers the page on inviting someone without leaderboard/ranking mechanics', () => {
+  it('centers the page on adding a friend without leaderboard/ranking mechanics', () => {
     const html = renderToStaticMarkup(<FriendsHubPage />);
 
     expect(html).toContain('Friends');
-    expect(html).toContain('Who shares your world?');
-    expect(html).toContain('Invite Someone');
-    expect(html).not.toContain('Add friend');
+    // The single lookup-field entry point ("Add a friend" / "Add someone")
+    // replaced the standalone "Invite Someone" block — see the comment in
+    // FriendsHubPage.tsx; inviting is reachable from the field's no-match state.
+    expect(html).toContain('Add a friend');
+    expect(html).toContain('Add someone');
     expect(html).not.toMatch(forbiddenGamificationCopy);
     expect(html).not.toMatch(forbiddenRelationshipCopy);
   });

--- a/src/components/feed/FeedActionLink.tsx
+++ b/src/components/feed/FeedActionLink.tsx
@@ -29,7 +29,10 @@ export function FeedActionLink({ className, type, size = 'lg', ...props }: FeedA
     <button
       type={type ?? 'button'}
       className={cn(
-        'inline-flex min-h-11 items-center text-[var(--brand-link)] underline underline-offset-4 transition',
+        // The `color:` hint is load-bearing: without it tailwind-merge can't
+        // tell the arbitrary var() value is a color, classifies it against the
+        // size utility below, and drops it in 'sm' mode (text-quiet won).
+        'inline-flex min-h-11 items-center text-[color:var(--brand-link)] underline underline-offset-4 transition',
         size === 'lg'
           ? 'text-sm font-medium'
           : 'text-quiet font-medium tracking-[0.04em]',

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -385,7 +385,7 @@ describe('Feed answered states', () => {
     )
     expect(rendered).toContain('Recheck →')
     // Brand action-link treatment (matches "Answer →"): sans, slate, underlined — no offset-shadow box.
-    expect(rendered).toContain('text-[var(--brand-link)]')
+    expect(rendered).toContain('text-[color:var(--brand-link)]')
     expect(rendered).not.toContain('3px 3px 0 var(--ink)')
   })
 })
@@ -413,7 +413,7 @@ describe('Answer feedback sheet recheck affordance', () => {
     )
     expect(rendered).toContain('Recheck →')
     // Reuses the shared sans slate action link, not a hand-rolled button.
-    expect(rendered).toContain('text-[var(--brand-link)]')
+    expect(rendered).toContain('text-[color:var(--brand-link)]')
   })
 
   it('hides the recheck link when no onRecheck handler is supplied', () => {

--- a/src/components/home/AddTopicHomeCard.tsx
+++ b/src/components/home/AddTopicHomeCard.tsx
@@ -44,7 +44,10 @@ function AddYourOwnTile() {
 // they never touch the home critical path; the card hides itself until
 // there's something to show.
 export function AddTopicHomeCard() {
-  const [added, setAdded] = useState<string | null>(null);
+  // `created` comes from the POST response: an idempotent re-add of an
+  // already-active topic returns created:false, and Undo must not render
+  // there — it would deactivate the pre-existing interest.
+  const [added, setAdded] = useState<{ domain: string; created: boolean } | null>(null);
   const [addedKeys, setAddedKeys] = useState<ReadonlySet<string>>(new Set());
   const [undoing, setUndoing] = useState(false);
   const [pool, setPool] = useState<NearbyTerritory[]>([]);
@@ -98,8 +101,13 @@ export function AddTopicHomeCard() {
         }),
       });
       if (!response.ok) throw new Error('add failed');
-      setAdded(territory.domain);
-      setAddedKeys((prev) => new Set(prev).add(domainKey(territory.domain)));
+      const body = (await response.json().catch(() => null)) as
+        | { domain?: string; created?: boolean }
+        | null;
+      // Prefer the canonical domain the server persisted over our local label.
+      const domain = typeof body?.domain === 'string' && body.domain ? body.domain : territory.domain;
+      setAdded({ domain, created: body?.created === true });
+      setAddedKeys((prev) => new Set(prev).add(domainKey(domain)));
       return true;
     } catch {
       // Leave the circle in place so the player can retry.
@@ -110,19 +118,19 @@ export function AddTopicHomeCard() {
   // Undo the most recent add — deactivates that one domain (not a full
   // replace), so it can't clobber an interest declared elsewhere meanwhile.
   const undoAdded = async () => {
-    if (!added || undoing) return;
+    if (!added?.created || undoing) return;
     setUndoing(true);
     try {
       const response = await fetch('/api/declared-interests', {
         method: 'DELETE',
         credentials: 'include',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ domain: added }),
+        body: JSON.stringify({ domain: added.domain }),
       });
       if (!response.ok) throw new Error('undo failed');
       setAddedKeys((prev) => {
         const next = new Set(prev);
-        next.delete(domainKey(added));
+        next.delete(domainKey(added.domain));
         return next;
       });
       setAdded(null);
@@ -166,16 +174,22 @@ export function AddTopicHomeCard() {
           <Check className="mt-0.5 size-4 shrink-0 text-[var(--accent-gold-ink)]" aria-hidden="true" />
           <div className="flex-1">
             <p className="m-0 text-quiet text-[var(--ink)]">
-              Added &ldquo;{added}&rdquo; — it&rsquo;ll show up in an upcoming round.
+              {added.created ? (
+                <>Added &ldquo;{added.domain}&rdquo; — it&rsquo;ll show up in an upcoming round.</>
+              ) : (
+                <>&ldquo;{added.domain}&rdquo; is already in your topics.</>
+              )}
             </p>
-            <button
-              type="button"
-              className="mt-1 text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70 disabled:opacity-50"
-              onClick={() => void undoAdded()}
-              disabled={undoing}
-            >
-              {undoing ? 'Undoing…' : 'Undo'}
-            </button>
+            {added.created ? (
+              <button
+                type="button"
+                className="mt-1 text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70 disabled:opacity-50"
+                onClick={() => void undoAdded()}
+                disabled={undoing}
+              >
+                {undoing ? 'Undoing…' : 'Undo'}
+              </button>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,17 @@
 import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { extendTailwindMerge } from "tailwind-merge"
+
+// `text-quiet` is the theme's 13px font-size register (--text-quiet in
+// globals.css). tailwind-merge can't see the Tailwind v4 theme, so without
+// this it classifies text-quiet as a text-COLOR and silently drops any real
+// color class (e.g. text-[color:var(--brand-link)]) merged alongside it.
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": ["text-quiet"],
+    },
+  },
+})
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))

--- a/src/server/daily/__tests__/diversity-cap.test.ts
+++ b/src/server/daily/__tests__/diversity-cap.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   clearStaleShortTodayQueue: vi.fn(),
   countDailyQueues: vi.fn(),
   getKnowledgeBase: vi.fn(),
+  getExcludedKnowledgeDomains: vi.fn(),
   pickEligibleAuthoredQuestions: vi.fn(),
   pickHouseQuestions: vi.fn(),
   persistDailyQueue: vi.fn(),
@@ -33,6 +34,7 @@ vi.mock('@/server/db/queries/daily', () => ({
   clearStaleShortTodayQueue: mocks.clearStaleShortTodayQueue,
   countDailyQueues: mocks.countDailyQueues,
   getKnowledgeBase: mocks.getKnowledgeBase,
+  getExcludedKnowledgeDomains: mocks.getExcludedKnowledgeDomains,
   pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
   pickHouseQuestions: mocks.pickHouseQuestions,
   getRecentAnsweredAnswerKeys: vi.fn(async () => new Set<string>()),
@@ -71,6 +73,12 @@ vi.mock('@/server/daily/generate-questions', () => ({
 
 vi.mock('@/server/questions/canonical-subcategory', () => ({
   isGenericSubcategory: mocks.isGenericSubcategory,
+}));
+
+// Unmocked, commitPendingRefineDecisions reaches the real @/server/db pool and
+// these tests fail with ECONNREFUSED instead of exercising the cap.
+vi.mock('@/server/refine/commit', () => ({
+  commitPendingRefineDecisions: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
@@ -120,6 +128,13 @@ beforeEach(() => {
   mocks.carryForwardUntouchedDailyQueue.mockResolvedValue(false);
   mocks.clearStaleShortTodayQueue.mockResolvedValue(false);
   mocks.countDailyQueues.mockResolvedValue(3);
+
+  // No Rested/Muted domains — the resting allow-set is resting-domains.test.ts's
+  // concern, not this suite's.
+  mocks.getExcludedKnowledgeDomains.mockResolvedValue({
+    subcategories: new Set<string>(),
+    broadCategories: new Set<string>(),
+  });
 
   // A broad knowledge base (≥3 domains) so the effective cap stays at the base
   // DAILY_QUEUE_MAX_PER_SUBCATEGORY rather than scaling up for a thin KB.

--- a/src/server/daily/__tests__/queue-build-race.test.ts
+++ b/src/server/daily/__tests__/queue-build-race.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   clearStaleShortTodayQueue: vi.fn(),
   countDailyQueues: vi.fn(),
   getKnowledgeBase: vi.fn(),
+  getExcludedKnowledgeDomains: vi.fn(),
   pickEligibleAuthoredQuestions: vi.fn(),
   pickHouseQuestions: vi.fn(),
   persistDailyQueue: vi.fn(),
@@ -41,6 +42,7 @@ vi.mock('@/server/db/queries/daily', () => ({
   clearStaleShortTodayQueue: mocks.clearStaleShortTodayQueue,
   countDailyQueues: mocks.countDailyQueues,
   getKnowledgeBase: mocks.getKnowledgeBase,
+  getExcludedKnowledgeDomains: mocks.getExcludedKnowledgeDomains,
   pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
   pickHouseQuestions: mocks.pickHouseQuestions,
   getRecentAnsweredAnswerKeys: vi.fn(async () => new Set<string>()),
@@ -126,6 +128,10 @@ beforeEach(() => {
   mocks.clearStaleShortTodayQueue.mockResolvedValue(false);
   mocks.countDailyQueues.mockResolvedValue(3);
   mocks.getKnowledgeBase.mockResolvedValue([{ domain: 'Jazz' }]);
+  mocks.getExcludedKnowledgeDomains.mockResolvedValue({
+    subcategories: new Set<string>(),
+    broadCategories: new Set<string>(),
+  });
   mocks.getDailyPreferences.mockResolvedValue({
     difficulty: 'adaptive',
     domainMode: 'random',

--- a/src/server/daily/__tests__/queue-floor.test.ts
+++ b/src/server/daily/__tests__/queue-floor.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   clearStaleShortTodayQueue: vi.fn(),
   countDailyQueues: vi.fn(),
   getKnowledgeBase: vi.fn(),
+  getExcludedKnowledgeDomains: vi.fn(),
   pickEligibleAuthoredQuestions: vi.fn(),
   pickHouseQuestions: vi.fn(),
   persistDailyQueue: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock('@/server/db/queries/daily', () => ({
   clearStaleShortTodayQueue: mocks.clearStaleShortTodayQueue,
   countDailyQueues: mocks.countDailyQueues,
   getKnowledgeBase: mocks.getKnowledgeBase,
+  getExcludedKnowledgeDomains: mocks.getExcludedKnowledgeDomains,
   pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
   pickHouseQuestions: mocks.pickHouseQuestions,
   getRecentAnsweredAnswerKeys: vi.fn(async () => new Set<string>()),
@@ -74,6 +76,12 @@ vi.mock('@/server/questions/canonical-subcategory', () => ({
   isGenericSubcategory: mocks.isGenericSubcategory,
 }));
 
+// Unmocked, commitPendingRefineDecisions reaches the real @/server/db pool and
+// these tests fail with ECONNREFUSED instead of exercising the floor.
+vi.mock('@/server/refine/commit', () => ({
+  commitPendingRefineDecisions: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
 
 const USER = 'user-1';
@@ -100,6 +108,12 @@ beforeEach(() => {
   // the queue is built purely from generated questions (the path that yields
   // the single-question regression when generation under-yields).
   mocks.getKnowledgeBase.mockResolvedValue([{ domain: 'Jazz' }]);
+  // No Rested/Muted domains — the resting allow-set is resting-domains.test.ts's
+  // concern, not this suite's.
+  mocks.getExcludedKnowledgeDomains.mockResolvedValue({
+    subcategories: new Set<string>(),
+    broadCategories: new Set<string>(),
+  });
   mocks.getDailyPreferences.mockResolvedValue({
     difficulty: 'adaptive',
     domainMode: 'random',


### PR DESCRIPTION
Five fixes from the 2026-07-18 post-merge audit. Full suite goes **23 failing → 0** (2283 passed), and `next build` goes from 2 invalid-CSS warnings to **0**.

## Real regressions fixed

**tailwind-merge dropped text colors merged with `text-quiet`** — twMerge can't see the Tailwind v4 theme, so it classified the custom 13px `text-quiet` utility as a text-*color*; any real color class merged alongside it via `cn()` silently lost. Visible symptom: FeedActionLink's `sm` mode (Recheck → / View N more) rendered without its brand-link color, which the existing FeedCards test correctly caught. Fixed globally in `src/lib/utils.ts` by registering `text-quiet` in the font-size group via `extendTailwindMerge`, plus an explicit `color:` hint on FeedActionLink's arbitrary value.

**Add-a-topic Undo could deactivate a pre-existing interest** — POST `/api/declared-interests` returns `created: false` on an idempotent re-add, but both clients ignored the response body and always offered Undo, which would then deactivate the interest the user already had (reachable via the knowledge page's free-text add, or a second tab). `AddTopicHomeCard` and `KnowledgeFlatClient` now parse the body, prefer the server's canonical `domain`, and only render Undo when `created === true`; a re-add shows a "…is already in your topics" notice instead.

## Test-suite hygiene (21 of the 23 failures)

- **Daily queue mocks lagged the resting-domains work**: added `getExcludedKnowledgeDomains` to the `@/server/db/queries/daily` mocks in `queue-build-race`, `diversity-cap`, and `queue-floor` (mirroring `resting-domains.test.ts`), and added the missing `@/server/refine/commit` mock to the latter two — unmocked, `commitPendingRefineDecisions` reached the real pool (`ECONNREFUSED 127.0.0.1:5432`).
- **Answer-route test**: its `@/lib/llm` mock replaced the whole module but only stubbed `suggestAnswer`, so the route graph's import of `ANTHROPIC_MODEL` exploded at collection. Now spreads `importOriginal` and stubs only the LLM call.
- **FriendsHubPage test**: expected the removed "Who shares your world?" / standalone "Invite Someone" surface; now asserts the current single lookup-field entry point ("Add a friend" / "Add someone"), keeping the forbidden-copy regex guards.

## Build warnings

Defused the contiguous `z-[var(--z-…)]`-with-`*` comment literals in `globals.css`, `scripts/check-zindex-ratchet.mjs`, and `.github/workflows/zindex-ratchet.yml` — Tailwind v4 scans comments repo-wide and the `*` compiles into invalid CSS (same trap CLAUDE.md documents for `rounded-[…]`).

## Verification

- `npm test`: 297 files / 2283 tests passed, 0 failed
- `npx tsc -p tsconfig.typecheck.json`: clean
- `npm run lint`: same 4 pre-existing warnings only
- All six design ratchets at ceiling (fonts, colors, spacing, radius, z-index, type-size)
- `npm run build`: compiles with zero CSS warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnYgjN1pFdSZVqRf1d9mwd
