### PR TITLE
Soften add-topic confirmation copy: may show up in an upcoming round

### DIFF
--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -914,7 +914,7 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
               <div className="flex-1">
                 <p className="m-0 text-quiet text-[var(--ink)]">
                   {addedTopic.created ? (
-                    <>Added &ldquo;{addedTopic.domain}&rdquo; — it&rsquo;ll show up in an upcoming round.</>
+                    <>Added &ldquo;{addedTopic.domain}&rdquo; — it may show up in an upcoming round.</>
                   ) : (
                     <>&ldquo;{addedTopic.domain}&rdquo; is already in your topics.</>
                   )}
@@ -1014,7 +1014,7 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
                   <div className="flex-1">
                     <p className="m-0 text-quiet text-[var(--ink)]">
                       {addedTopic.created ? (
-                        <>Added &ldquo;{addedTopic.domain}&rdquo; — it&rsquo;ll show up in an upcoming round.</>
+                        <>Added &ldquo;{addedTopic.domain}&rdquo; — it may show up in an upcoming round.</>
                       ) : (
                         <>&ldquo;{addedTopic.domain}&rdquo; is already in your topics.</>
                       )}

--- a/src/components/home/AddTopicHomeCard.tsx
+++ b/src/components/home/AddTopicHomeCard.tsx
@@ -175,7 +175,7 @@ export function AddTopicHomeCard() {
           <div className="flex-1">
             <p className="m-0 text-quiet text-[var(--ink)]">
               {added.created ? (
-                <>Added &ldquo;{added.domain}&rdquo; — it&rsquo;ll show up in an upcoming round.</>
+                <>Added &ldquo;{added.domain}&rdquo; — it may show up in an upcoming round.</>
               ) : (
                 <>&ldquo;{added.domain}&rdquo; is already in your topics.</>
               )}


### PR DESCRIPTION
The old wording ('it'll show up in an upcoming round') promised the
newly added topic would appear next, but it may not be included in the
next game. Changed to 'it may show up' to set accurate expectations.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LFj7BD31Z8B7uX7nHJQqsY