### PR TITLE
Disable iOS autocorrect on shared-game answer input

### DIFF
--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -365,7 +365,9 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
               placeholder="Your answer..."
               aria-label="Your answer"
               autoComplete="off"
-              autoCapitalize="sentences"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
               enterKeyHint="send"
               className="min-h-11 flex-1 rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-4 text-base outline-none focus:border-[var(--brand-navy)]"
             />


### PR DESCRIPTION
## Summary
- The shared/generated-game answer input (`src/app/games/[id]/play-client.tsx`) only set `autoCapitalize="sentences"`, unlike the daily-play `AnswerInputBar.tsx` which already disables autoCorrect/autoCapitalize/spellCheck.
- On iOS this let Safari silently autocorrect submitted words before grading ever saw them (observed case: "affordances" → "avoidances", which the grader then correctly scored wrong since it's a real word with the opposite meaning).
- Brings this input in line with the daily-play answer bar: `autoCorrect="off"`, `autoCapitalize="off"`, `spellCheck={false}`.

## Test plan
- [ ] Load a shared game on iOS Safari and confirm typed answers (e.g. words not in the iOS dictionary) submit unmodified
- [ ] Confirm existing answer submission/grading flow still works on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qud6NBqzFvPAZuLQq5RrBw