### PR TITLE
Add per-user daily rate limits to on-demand LLM endpoints

### DIFF
--- a/drizzle/0126_llm_usage_daily.sql
+++ b/drizzle/0126_llm_usage_daily.sql
@@ -1,0 +1,53 @@
+-- 0126: generalize CritiqueUsageDaily into an action-keyed LlmUsageDaily table.
+--
+-- B-LLM-RATE-LIMIT-01: as the app opens up to more users, several on-demand
+-- LLM endpoints (answer suggestion, verify-answer, crafter drafting, question
+-- creation) need the same per-user daily cap that /api/questions/critique
+-- already had via CritiqueUsageDaily. Rather than adding a near-identical
+-- single-purpose table per endpoint, this migration widens that table with an
+-- `action` column (one row per user/day/action) and renames it to
+-- LlmUsageDaily; every rate-limited call site shares the one table, keyed by
+-- its own action string ('critique', 'suggest-answer', 'verify-answer',
+-- 'craft-draft', 'create-question', ...).
+--
+-- Existing CritiqueUsageDaily rows are copied forward tagged action='critique'
+-- before the old table is dropped, so today's in-flight daily counts survive
+-- the cutover. IF NOT EXISTS / ON CONFLICT DO NOTHING / IF EXISTS throughout
+-- make this safe to re-run (boot guard chain, re-applied migration).
+--
+-- Rollback:
+--   CREATE TABLE "CritiqueUsageDaily" (id uuid primary key default gen_random_uuid(),
+--     user_id text not null references "User"(id) on delete cascade,
+--     usage_date date not null, critique_count integer not null default 0,
+--     updated_at timestamptz not null default now(),
+--     unique (user_id, usage_date));
+--   INSERT INTO "CritiqueUsageDaily" (user_id, usage_date, critique_count, updated_at)
+--     SELECT user_id, usage_date, count, updated_at FROM "LlmUsageDaily" WHERE action = 'critique';
+--   DROP TABLE "LlmUsageDaily";
+
+CREATE TABLE IF NOT EXISTS "LlmUsageDaily" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "usage_date" date NOT NULL,
+  "action" text NOT NULL,
+  "count" integer NOT NULL DEFAULT 0,
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "LlmUsageDaily_user_id_usage_date_action_key" UNIQUE ("user_id", "usage_date", "action")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "LlmUsageDaily_user_id_usage_date_action_idx"
+  ON "LlmUsageDaily" ("user_id", "usage_date", "action");
+--> statement-breakpoint
+ALTER TABLE "LlmUsageDaily" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('"CritiqueUsageDaily"') IS NOT NULL THEN
+    INSERT INTO "LlmUsageDaily" ("user_id", "usage_date", "action", "count", "updated_at")
+      SELECT "user_id", "usage_date", 'critique', "critique_count", "updated_at"
+      FROM "CritiqueUsageDaily"
+      ON CONFLICT ("user_id", "usage_date", "action") DO NOTHING;
+  END IF;
+END $$;
+--> statement-breakpoint
+DROP TABLE IF EXISTS "CritiqueUsageDaily";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,888 +1,895 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1777585453077,
-			"tag": "0000_material_lyja",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1777630800000,
-			"tag": "0001_add_ceremony_ready_sms_type",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1777654136670,
-			"tag": "0002_add_joshing_game_sms_types",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1777654800000,
-			"tag": "0003_question_rating",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1777662000000,
-			"tag": "0004_daily_preference_configuration",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1777671600000,
-			"tag": "0005_profile_domain_visibility_three_state",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1777737600000,
-			"tag": "0006_question_reactions_contexts",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1777780800000,
-			"tag": "0007_send_to_friend_note",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1777784400000,
-			"tag": "0008_add_to_bank_provenance",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1777771056661,
-			"tag": "0009_domain_merge_events",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1777771056661,
-			"tag": "0010_feed_submitted_answer",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1777771056661,
-			"tag": "0011_preview_schema_hotfix",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1777839477000,
-			"tag": "0012_feed_friend_answered",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1777840000000,
-			"tag": "0013_onboarding_demographics",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1777840100000,
-			"tag": "0014_territory_type",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1777840200000,
-			"tag": "0015_declared_promoted_event_type",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1777840300000,
-			"tag": "0016_quip_columns",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1777840400000,
-			"tag": "0017_creator_notes",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "7",
-			"when": 1777840500000,
-			"tag": "0018_daily_generated_and_player_mastery_territory",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "7",
-			"when": 1778508000000,
-			"tag": "0019_feed_item_nullable_columns_hotfix",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "7",
-			"when": 1778510000000,
-			"tag": "0020_question_critique_verification",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "7",
-			"when": 1778521283376,
-			"tag": "0021_feed_dismissed_domains_active_unique",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "7",
-			"when": 1778538800000,
-			"tag": "0022_player_mastery_territory_type_hotfix",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "7",
-			"when": 1778540000000,
-			"tag": "0023_profile_domain_visibility_runtime_hotfix",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "7",
-			"when": 1778616500000,
-			"tag": "0024_question_surface_priority_runtime_hotfix",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "7",
-			"when": 1778616600000,
-			"tag": "0025_grade_dispute_recheck_details",
-			"breakpoints": true
-		},
-		{
-			"idx": 26,
-			"version": "7",
-			"when": 1778616700000,
-			"tag": "0026_friend_invitation_pre_profile",
-			"breakpoints": true
-		},
-		{
-			"idx": 27,
-			"version": "7",
-			"when": 1778616800000,
-			"tag": "0027_friendship_request_context",
-			"breakpoints": true
-		},
-		{
-			"idx": 28,
-			"version": "7",
-			"when": 1778616900000,
-			"tag": "0028_remove_other_question_category",
-			"breakpoints": true
-		},
-		{
-			"idx": 29,
-			"version": "7",
-			"when": 1778714100000,
-			"tag": "0029_correct_answer_social_feed",
-			"breakpoints": true
-		},
-		{
-			"idx": 30,
-			"version": "7",
-			"when": 1778714200000,
-			"tag": "0030_apply_general_knowledge_category",
-			"breakpoints": true
-		},
-		{
-			"idx": 31,
-			"version": "7",
-			"when": 1778806800000,
-			"tag": "0031_feed_answered_card_data",
-			"breakpoints": true
-		},
-		{
-			"idx": 32,
-			"version": "7",
-			"when": 1778888376122,
-			"tag": "0032_biweekly_ceremony_unique_cycle",
-			"breakpoints": true
-		},
-		{
-			"idx": 33,
-			"version": "7",
-			"when": 1778910000000,
-			"tag": "0033_feed_item_source_result_check",
-			"breakpoints": true
-		},
-		{
-			"idx": 34,
-			"version": "7",
-			"when": 1778952386715,
-			"tag": "0034_territory_type_enum",
-			"breakpoints": true
-		},
-		{
-			"idx": 35,
-			"version": "7",
-			"when": 1779580800000,
-			"tag": "0035_mastery_events_viewer_status_idx",
-			"breakpoints": true
-		},
-		{
-			"idx": 36,
-			"version": "7",
-			"when": 1779667200000,
-			"tag": "0036_domain_exclusion_scope",
-			"breakpoints": true
-		},
-		{
-			"idx": 37,
-			"version": "7",
-			"when": 1779753600000,
-			"tag": "0037_round_reminder_optin",
-			"breakpoints": true
-		},
-		{
-			"idx": 38,
-			"version": "7",
-			"when": 1779840000000,
-			"tag": "0038_feed_item_catchup_resolved",
-			"breakpoints": true
-		},
-		{
-			"idx": 39,
-			"version": "7",
-			"when": 1779926400000,
-			"tag": "0039_repair_short_canonical_subcategory",
-			"breakpoints": true
-		},
-		{
-			"idx": 40,
-			"version": "7",
-			"when": 1780012800000,
-			"tag": "0040_question_reaction_include_submitted_answer",
-			"breakpoints": true
-		},
-		{
-			"idx": 41,
-			"version": "7",
-			"when": 1780099200000,
-			"tag": "0041_question_inside_joke",
-			"breakpoints": true
-		},
-		{
-			"idx": 42,
-			"version": "7",
-			"when": 1780185600000,
-			"tag": "0042_seed_player_mastery_for_declared_interests",
-			"breakpoints": true
-		},
-		{
-			"idx": 43,
-			"version": "7",
-			"when": 1780272000000,
-			"tag": "0043_rename_season_points_to_lifetime_baseline",
-			"breakpoints": true
-		},
-		{
-			"idx": 44,
-			"version": "7",
-			"when": 1780358400000,
-			"tag": "0044_user_last_activity_bell_opened_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 45,
-			"version": "7",
-			"when": 1780444800000,
-			"tag": "0045_user_handle",
-			"breakpoints": true
-		},
-		{
-			"idx": 46,
-			"version": "7",
-			"when": 1780531200000,
-			"tag": "0046_user_avatar_color",
-			"breakpoints": true
-		},
-		{
-			"idx": 47,
-			"version": "7",
-			"when": 1780617600000,
-			"tag": "0047_user_profile_fields",
-			"breakpoints": true
-		},
-		{
-			"idx": 48,
-			"version": "7",
-			"when": 1780704000000,
-			"tag": "0048_friends_privacy_foundation",
-			"breakpoints": true
-		},
-		{
-			"idx": 49,
-			"version": "7",
-			"when": 1780790400000,
-			"tag": "0049_user_invite_token",
-			"breakpoints": true
-		},
-		{
-			"idx": 50,
-			"version": "7",
-			"when": 1780876800000,
-			"tag": "0050_user_phone_hash_discovery",
-			"breakpoints": true
-		},
-		{
-			"idx": 51,
-			"version": "7",
-			"when": 1780963200000,
-			"tag": "0051_generated_question_fact_key",
-			"breakpoints": true
-		},
-		{
-			"idx": 52,
-			"version": "7",
-			"when": 1781049600000,
-			"tag": "0052_profile_section_visibility",
-			"breakpoints": true
-		},
-		{
-			"idx": 53,
-			"version": "7",
-			"when": 1781136000000,
-			"tag": "0053_drop_legacy_profile_visibility",
-			"breakpoints": true
-		},
-		{
-			"idx": 54,
-			"version": "7",
-			"when": 1781222400000,
-			"tag": "0054_redesign_profile",
-			"breakpoints": true
-		},
-		{
-			"idx": 55,
-			"version": "7",
-			"when": 1781308800000,
-			"tag": "0055_question_sub_angles",
-			"breakpoints": true
-		},
-		{
-			"idx": 56,
-			"version": "7",
-			"when": 1781395200000,
-			"tag": "0056_area_top_up_prompt",
-			"breakpoints": true
-		},
-		{
-			"idx": 57,
-			"version": "7",
-			"when": 1781481600000,
-			"tag": "0057_retire_creator_notes_and_quips",
-			"breakpoints": true
-		},
-		{
-			"idx": 58,
-			"version": "7",
-			"when": 1781568000000,
-			"tag": "0058_follow_model",
-			"breakpoints": true
-		},
-		{
-			"idx": 59,
-			"version": "7",
-			"when": 1781654400000,
-			"tag": "0059_niche_match_discoverability",
-			"breakpoints": true
-		},
-		{
-			"idx": 60,
-			"version": "7",
-			"when": 1781740800000,
-			"tag": "0060_generated_question_inside_joke",
-			"breakpoints": true
-		},
-		{
-			"idx": 61,
-			"version": "7",
-			"when": 1781827200000,
-			"tag": "0061_email_verification_token",
-			"breakpoints": true
-		},
-		{
-			"idx": 62,
-			"version": "7",
-			"when": 1781913600000,
-			"tag": "0062_pool_substrate_trust_scope",
-			"breakpoints": true
-		},
-		{
-			"idx": 63,
-			"version": "7",
-			"when": 1782000000000,
-			"tag": "0063_pool_embeddings",
-			"breakpoints": true
-		},
-		{
-			"idx": 64,
-			"version": "7",
-			"when": 1782086400000,
-			"tag": "0064_domain_difficulty_freeze",
-			"breakpoints": true
-		},
-		{
-			"idx": 65,
-			"version": "7",
-			"when": 1782172800000,
-			"tag": "0065_daily_refine_decision",
-			"breakpoints": true
-		},
-		{
-			"idx": 66,
-			"version": "7",
-			"when": 1782259200000,
-			"tag": "0066_ask_to_answer_verified",
-			"breakpoints": true
-		},
-		{
-			"idx": 67,
-			"version": "7",
-			"when": 1782345600000,
-			"tag": "0067_human_validated_backfill",
-			"breakpoints": true
-		},
-		{
-			"idx": 68,
-			"version": "7",
-			"when": 1782432000000,
-			"tag": "0068_acceptable_variants",
-			"breakpoints": true
-		},
-		{
-			"idx": 69,
-			"version": "7",
-			"when": 1782518400000,
-			"tag": "0069_question_visibility_blocked",
-			"breakpoints": true
-		},
-		{
-			"idx": 70,
-			"version": "7",
-			"when": 1782604800000,
-			"tag": "0070_daily_domain_preference_frequency",
-			"breakpoints": true
-		},
-		{
-			"idx": 71,
-			"version": "7",
-			"when": 1782691200000,
-			"tag": "0071_pg_trgm_convergence",
-			"breakpoints": true
-		},
-		{
-			"idx": 72,
-			"version": "7",
-			"when": 1782777600000,
-			"tag": "0072_first_session_recap_seen",
-			"breakpoints": true
-		},
-		{
-			"idx": 73,
-			"version": "7",
-			"when": 1782864000000,
-			"tag": "0073_content_report",
-			"breakpoints": true
-		},
-		{
-			"idx": 74,
-			"version": "7",
-			"when": 1782950400000,
-			"tag": "0074_generated_question_domain_key",
-			"breakpoints": true
-		},
-		{
-			"idx": 75,
-			"version": "7",
-			"when": 1783036800000,
-			"tag": "0075_daily_queue_email_reminder",
-			"breakpoints": true
-		},
-		{
-			"idx": 76,
-			"version": "7",
-			"when": 1783123200000,
-			"tag": "0076_first_game_recap_seen",
-			"breakpoints": true
-		},
-		{
-			"idx": 77,
-			"version": "7",
-			"when": 1783209600000,
-			"tag": "0077_email_verification_opt_in_intent",
-			"breakpoints": true
-		},
-		{
-			"idx": 78,
-			"version": "7",
-			"when": 1783296000000,
-			"tag": "0078_perf_lookup_indexes",
-			"breakpoints": true
-		},
-		{
-			"idx": 79,
-			"version": "7",
-			"when": 1783382400000,
-			"tag": "0079_perf_fk_covering_indexes",
-			"breakpoints": true
-		},
-		{
-			"idx": 80,
-			"version": "7",
-			"when": 1783468800000,
-			"tag": "0080_question_author_deleted",
-			"breakpoints": true
-		},
-		{
-			"idx": 81,
-			"version": "7",
-			"when": 1783555200000,
-			"tag": "0081_enable_rls_public_tables",
-			"breakpoints": true
-		},
-		{
-			"idx": 82,
-			"version": "7",
-			"when": 1783641600000,
-			"tag": "0082_question_bank_added_at_idx",
-			"breakpoints": true
-		},
-		{
-			"idx": 83,
-			"version": "7",
-			"when": 1783728000000,
-			"tag": "0083_fk_covering_indexes",
-			"breakpoints": true
-		},
-		{
-			"idx": 84,
-			"version": "7",
-			"when": 1783814400000,
-			"tag": "0084_via_attribution",
-			"breakpoints": true
-		},
-		{
-			"idx": 85,
-			"version": "7",
-			"when": 1783900800000,
-			"tag": "0085_feed_item_answered_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 86,
-			"version": "7",
-			"when": 1783987200000,
-			"tag": "0086_subject_entity",
-			"breakpoints": true
-		},
-		{
-			"idx": 87,
-			"version": "7",
-			"when": 1784073600000,
-			"tag": "0087_app_settings",
-			"breakpoints": true
-		},
-		{
-			"idx": 88,
-			"version": "7",
-			"when": 1784160000000,
-			"tag": "0088_provider_provenance",
-			"breakpoints": true
-		},
-		{
-			"idx": 89,
-			"version": "7",
-			"when": 1784246400000,
-			"tag": "0089_domain_expansion_offer",
-			"breakpoints": true
-		},
-		{
-			"idx": 90,
-			"version": "7",
-			"when": 1784332800000,
-			"tag": "0090_llm_provider_change_log",
-			"breakpoints": true
-		},
-		{
-			"idx": 91,
-			"version": "7",
-			"when": 1784419200000,
-			"tag": "0091_llm_usage_event",
-			"breakpoints": true
-		},
-		{
-			"idx": 92,
-			"version": "7",
-			"when": 1784505600000,
-			"tag": "0092_llm_cost_report",
-			"breakpoints": true
-		},
-		{
-			"idx": 93,
-			"version": "7",
-			"when": 1784592000000,
-			"tag": "0093_recovered_set_aside",
-			"breakpoints": true
-		},
-		{
-			"idx": 94,
-			"version": "7",
-			"when": 1784678400000,
-			"tag": "0094_expansion_mastery_event_type",
-			"breakpoints": true
-		},
-		{
-			"idx": 95,
-			"version": "7",
-			"when": 1784764800000,
-			"tag": "0095_player_mastery_rotation_eligible",
-			"breakpoints": true
-		},
-		{
-			"idx": 96,
-			"version": "7",
-			"when": 1784851200000,
-			"tag": "0096_question_verification",
-			"breakpoints": true
-		},
-		{
-			"idx": 97,
-			"version": "7",
-			"when": 1784937600000,
-			"tag": "0097_quality_report",
-			"breakpoints": true
-		},
-		{
-			"idx": 98,
-			"version": "7",
-			"when": 1785024000000,
-			"tag": "0098_retrieval_domain_health",
-			"breakpoints": true
-		},
-		{
-			"idx": 99,
-			"version": "7",
-			"when": 1785110400000,
-			"tag": "0099_domain_relation",
-			"breakpoints": true
-		},
-		{
-			"idx": 100,
-			"version": "7",
-			"when": 1785196800000,
-			"tag": "0100_verification_reason",
-			"breakpoints": true
-		},
-		{
-			"idx": 101,
-			"version": "7",
-			"when": 1785283200000,
-			"tag": "0101_author_invitation",
-			"breakpoints": true
-		},
-		{
-			"idx": 102,
-			"version": "7",
-			"when": 1785369600000,
-			"tag": "0102_knowledge_graph",
-			"breakpoints": true
-		},
-		{
-			"idx": 103,
-			"version": "7",
-			"when": 1785456000000,
-			"tag": "0103_crafter_draft_decision",
-			"breakpoints": true
-		},
-		{
-			"idx": 104,
-			"version": "7",
-			"when": 1785542400000,
-			"tag": "0104_knowledge_parent_mastery",
-			"breakpoints": true
-		},
-		{
-			"idx": 105,
-			"version": "7",
-			"when": 1785628800000,
-			"tag": "0105_llm_usage_web_search",
-			"breakpoints": true
-		},
-		{
-			"idx": 106,
-			"version": "7",
-			"when": 1785715200000,
-			"tag": "0106_verify_batch_run",
-			"breakpoints": true
-		},
-		{
-			"idx": 107,
-			"version": "7",
-			"when": 1785801600000,
-			"tag": "0107_knowledge_node_wikidata_qid",
-			"breakpoints": true
-		},
-		{
-			"idx": 108,
-			"version": "7",
-			"when": 1785888000000,
-			"tag": "0108_domain_reference_passage",
-			"breakpoints": true
-		},
-		{
-			"idx": 109,
-			"version": "7",
-			"when": 1785974400000,
-			"tag": "0109_knowledge_node_weight",
-			"breakpoints": true
-		},
-		{
-			"idx": 110,
-			"version": "7",
-			"when": 1786060800000,
-			"tag": "0110_drop_knowledge_edge_type",
-			"breakpoints": true
-		},
-		{
-			"idx": 111,
-			"version": "7",
-			"when": 1786147200000,
-			"tag": "0111_knowledge_leaf_mastery",
-			"breakpoints": true
-		},
-		{
-			"idx": 112,
-			"version": "7",
-			"when": 1786233600000,
-			"tag": "0112_drop_node_weight",
-			"breakpoints": true
-		},
-		{
-			"idx": 113,
-			"version": "7",
-			"when": 1786320000000,
-			"tag": "0113_milestone_dismissed",
-			"breakpoints": true
-		},
-		{
-			"idx": 114,
-			"version": "7",
-			"when": 1786406400000,
-			"tag": "0114_set_completion",
-			"breakpoints": true
-		},
-		{
-			"idx": 115,
-			"version": "7",
-			"when": 1786492800000,
-			"tag": "0115_question_salvage_proposal",
-			"breakpoints": true
-		},
-		{
-			"idx": 116,
-			"version": "7",
-			"when": 1786579200000,
-			"tag": "0116_domain_depth_estimate",
-			"breakpoints": true
-		},
-		{
-			"idx": 117,
-			"version": "7",
-			"when": 1786665600000,
-			"tag": "0117_domain_size_estimate",
-			"breakpoints": true
-		},
-		{
-			"idx": 118,
-			"version": "7",
-			"when": 1786752000000,
-			"tag": "0118_supply_dry_tracking",
-			"breakpoints": true
-		},
-		{
-			"idx": 119,
-			"version": "7",
-			"when": 1786838400000,
-			"tag": "0119_supply_manual_override_calibration",
-			"breakpoints": true
-		},
-		{
-			"idx": 120,
-			"version": "7",
-			"when": 1786924800000,
-			"tag": "0120_gate_drop_stat",
-			"breakpoints": true
-		},
-		{
-			"idx": 121,
-			"version": "7",
-			"when": 1787011200000,
-			"tag": "0121_domain_generation_cap",
-			"breakpoints": true
-		},
-		{
-			"idx": 122,
-			"version": "7",
-			"when": 1787097600000,
-			"tag": "0122_reviewed_domain_pair",
-			"breakpoints": true
-		},
-		{
-			"idx": 123,
-			"version": "7",
-			"when": 1787184000000,
-			"tag": "0123_mastery_calibration_snapshot",
-			"breakpoints": true
-		},
-		{
-			"idx": 124,
-			"version": "7",
-			"when": 1787270400000,
-			"tag": "0124_domain_rest_until",
-			"breakpoints": true
-		},
-		{
-			"idx": 125,
-			"version": "7",
-			"when": 1787356800000,
-			"tag": "0125_reminder_interstitial_seen_at",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1777585453077,
+      "tag": "0000_material_lyja",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777630800000,
+      "tag": "0001_add_ceremony_ready_sms_type",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777654136670,
+      "tag": "0002_add_joshing_game_sms_types",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777654800000,
+      "tag": "0003_question_rating",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1777662000000,
+      "tag": "0004_daily_preference_configuration",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777671600000,
+      "tag": "0005_profile_domain_visibility_three_state",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1777737600000,
+      "tag": "0006_question_reactions_contexts",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1777780800000,
+      "tag": "0007_send_to_friend_note",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1777784400000,
+      "tag": "0008_add_to_bank_provenance",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777771056661,
+      "tag": "0009_domain_merge_events",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777771056661,
+      "tag": "0010_feed_submitted_answer",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777771056661,
+      "tag": "0011_preview_schema_hotfix",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1777839477000,
+      "tag": "0012_feed_friend_answered",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1777840000000,
+      "tag": "0013_onboarding_demographics",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1777840100000,
+      "tag": "0014_territory_type",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1777840200000,
+      "tag": "0015_declared_promoted_event_type",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1777840300000,
+      "tag": "0016_quip_columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1777840400000,
+      "tag": "0017_creator_notes",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1777840500000,
+      "tag": "0018_daily_generated_and_player_mastery_territory",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1778508000000,
+      "tag": "0019_feed_item_nullable_columns_hotfix",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1778510000000,
+      "tag": "0020_question_critique_verification",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1778521283376,
+      "tag": "0021_feed_dismissed_domains_active_unique",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1778538800000,
+      "tag": "0022_player_mastery_territory_type_hotfix",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1778540000000,
+      "tag": "0023_profile_domain_visibility_runtime_hotfix",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1778616500000,
+      "tag": "0024_question_surface_priority_runtime_hotfix",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1778616600000,
+      "tag": "0025_grade_dispute_recheck_details",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1778616700000,
+      "tag": "0026_friend_invitation_pre_profile",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1778616800000,
+      "tag": "0027_friendship_request_context",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1778616900000,
+      "tag": "0028_remove_other_question_category",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1778714100000,
+      "tag": "0029_correct_answer_social_feed",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1778714200000,
+      "tag": "0030_apply_general_knowledge_category",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1778806800000,
+      "tag": "0031_feed_answered_card_data",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1778888376122,
+      "tag": "0032_biweekly_ceremony_unique_cycle",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1778910000000,
+      "tag": "0033_feed_item_source_result_check",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1778952386715,
+      "tag": "0034_territory_type_enum",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1779580800000,
+      "tag": "0035_mastery_events_viewer_status_idx",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1779667200000,
+      "tag": "0036_domain_exclusion_scope",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1779753600000,
+      "tag": "0037_round_reminder_optin",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1779840000000,
+      "tag": "0038_feed_item_catchup_resolved",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1779926400000,
+      "tag": "0039_repair_short_canonical_subcategory",
+      "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1780012800000,
+      "tag": "0040_question_reaction_include_submitted_answer",
+      "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1780099200000,
+      "tag": "0041_question_inside_joke",
+      "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1780185600000,
+      "tag": "0042_seed_player_mastery_for_declared_interests",
+      "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1780272000000,
+      "tag": "0043_rename_season_points_to_lifetime_baseline",
+      "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1780358400000,
+      "tag": "0044_user_last_activity_bell_opened_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1780444800000,
+      "tag": "0045_user_handle",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1780531200000,
+      "tag": "0046_user_avatar_color",
+      "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1780617600000,
+      "tag": "0047_user_profile_fields",
+      "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1780704000000,
+      "tag": "0048_friends_privacy_foundation",
+      "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1780790400000,
+      "tag": "0049_user_invite_token",
+      "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1780876800000,
+      "tag": "0050_user_phone_hash_discovery",
+      "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1780963200000,
+      "tag": "0051_generated_question_fact_key",
+      "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1781049600000,
+      "tag": "0052_profile_section_visibility",
+      "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1781136000000,
+      "tag": "0053_drop_legacy_profile_visibility",
+      "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1781222400000,
+      "tag": "0054_redesign_profile",
+      "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1781308800000,
+      "tag": "0055_question_sub_angles",
+      "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1781395200000,
+      "tag": "0056_area_top_up_prompt",
+      "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1781481600000,
+      "tag": "0057_retire_creator_notes_and_quips",
+      "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1781568000000,
+      "tag": "0058_follow_model",
+      "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1781654400000,
+      "tag": "0059_niche_match_discoverability",
+      "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1781740800000,
+      "tag": "0060_generated_question_inside_joke",
+      "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1781827200000,
+      "tag": "0061_email_verification_token",
+      "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1781913600000,
+      "tag": "0062_pool_substrate_trust_scope",
+      "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1782000000000,
+      "tag": "0063_pool_embeddings",
+      "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1782086400000,
+      "tag": "0064_domain_difficulty_freeze",
+      "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1782172800000,
+      "tag": "0065_daily_refine_decision",
+      "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1782259200000,
+      "tag": "0066_ask_to_answer_verified",
+      "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1782345600000,
+      "tag": "0067_human_validated_backfill",
+      "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1782432000000,
+      "tag": "0068_acceptable_variants",
+      "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1782518400000,
+      "tag": "0069_question_visibility_blocked",
+      "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1782604800000,
+      "tag": "0070_daily_domain_preference_frequency",
+      "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1782691200000,
+      "tag": "0071_pg_trgm_convergence",
+      "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1782777600000,
+      "tag": "0072_first_session_recap_seen",
+      "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1782864000000,
+      "tag": "0073_content_report",
+      "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1782950400000,
+      "tag": "0074_generated_question_domain_key",
+      "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1783036800000,
+      "tag": "0075_daily_queue_email_reminder",
+      "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1783123200000,
+      "tag": "0076_first_game_recap_seen",
+      "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1783209600000,
+      "tag": "0077_email_verification_opt_in_intent",
+      "breakpoints": true
+    },
+    {
+      "idx": 78,
+      "version": "7",
+      "when": 1783296000000,
+      "tag": "0078_perf_lookup_indexes",
+      "breakpoints": true
+    },
+    {
+      "idx": 79,
+      "version": "7",
+      "when": 1783382400000,
+      "tag": "0079_perf_fk_covering_indexes",
+      "breakpoints": true
+    },
+    {
+      "idx": 80,
+      "version": "7",
+      "when": 1783468800000,
+      "tag": "0080_question_author_deleted",
+      "breakpoints": true
+    },
+    {
+      "idx": 81,
+      "version": "7",
+      "when": 1783555200000,
+      "tag": "0081_enable_rls_public_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1783641600000,
+      "tag": "0082_question_bank_added_at_idx",
+      "breakpoints": true
+    },
+    {
+      "idx": 83,
+      "version": "7",
+      "when": 1783728000000,
+      "tag": "0083_fk_covering_indexes",
+      "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1783814400000,
+      "tag": "0084_via_attribution",
+      "breakpoints": true
+    },
+    {
+      "idx": 85,
+      "version": "7",
+      "when": 1783900800000,
+      "tag": "0085_feed_item_answered_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "7",
+      "when": 1783987200000,
+      "tag": "0086_subject_entity",
+      "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1784073600000,
+      "tag": "0087_app_settings",
+      "breakpoints": true
+    },
+    {
+      "idx": 88,
+      "version": "7",
+      "when": 1784160000000,
+      "tag": "0088_provider_provenance",
+      "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "7",
+      "when": 1784246400000,
+      "tag": "0089_domain_expansion_offer",
+      "breakpoints": true
+    },
+    {
+      "idx": 90,
+      "version": "7",
+      "when": 1784332800000,
+      "tag": "0090_llm_provider_change_log",
+      "breakpoints": true
+    },
+    {
+      "idx": 91,
+      "version": "7",
+      "when": 1784419200000,
+      "tag": "0091_llm_usage_event",
+      "breakpoints": true
+    },
+    {
+      "idx": 92,
+      "version": "7",
+      "when": 1784505600000,
+      "tag": "0092_llm_cost_report",
+      "breakpoints": true
+    },
+    {
+      "idx": 93,
+      "version": "7",
+      "when": 1784592000000,
+      "tag": "0093_recovered_set_aside",
+      "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "7",
+      "when": 1784678400000,
+      "tag": "0094_expansion_mastery_event_type",
+      "breakpoints": true
+    },
+    {
+      "idx": 95,
+      "version": "7",
+      "when": 1784764800000,
+      "tag": "0095_player_mastery_rotation_eligible",
+      "breakpoints": true
+    },
+    {
+      "idx": 96,
+      "version": "7",
+      "when": 1784851200000,
+      "tag": "0096_question_verification",
+      "breakpoints": true
+    },
+    {
+      "idx": 97,
+      "version": "7",
+      "when": 1784937600000,
+      "tag": "0097_quality_report",
+      "breakpoints": true
+    },
+    {
+      "idx": 98,
+      "version": "7",
+      "when": 1785024000000,
+      "tag": "0098_retrieval_domain_health",
+      "breakpoints": true
+    },
+    {
+      "idx": 99,
+      "version": "7",
+      "when": 1785110400000,
+      "tag": "0099_domain_relation",
+      "breakpoints": true
+    },
+    {
+      "idx": 100,
+      "version": "7",
+      "when": 1785196800000,
+      "tag": "0100_verification_reason",
+      "breakpoints": true
+    },
+    {
+      "idx": 101,
+      "version": "7",
+      "when": 1785283200000,
+      "tag": "0101_author_invitation",
+      "breakpoints": true
+    },
+    {
+      "idx": 102,
+      "version": "7",
+      "when": 1785369600000,
+      "tag": "0102_knowledge_graph",
+      "breakpoints": true
+    },
+    {
+      "idx": 103,
+      "version": "7",
+      "when": 1785456000000,
+      "tag": "0103_crafter_draft_decision",
+      "breakpoints": true
+    },
+    {
+      "idx": 104,
+      "version": "7",
+      "when": 1785542400000,
+      "tag": "0104_knowledge_parent_mastery",
+      "breakpoints": true
+    },
+    {
+      "idx": 105,
+      "version": "7",
+      "when": 1785628800000,
+      "tag": "0105_llm_usage_web_search",
+      "breakpoints": true
+    },
+    {
+      "idx": 106,
+      "version": "7",
+      "when": 1785715200000,
+      "tag": "0106_verify_batch_run",
+      "breakpoints": true
+    },
+    {
+      "idx": 107,
+      "version": "7",
+      "when": 1785801600000,
+      "tag": "0107_knowledge_node_wikidata_qid",
+      "breakpoints": true
+    },
+    {
+      "idx": 108,
+      "version": "7",
+      "when": 1785888000000,
+      "tag": "0108_domain_reference_passage",
+      "breakpoints": true
+    },
+    {
+      "idx": 109,
+      "version": "7",
+      "when": 1785974400000,
+      "tag": "0109_knowledge_node_weight",
+      "breakpoints": true
+    },
+    {
+      "idx": 110,
+      "version": "7",
+      "when": 1786060800000,
+      "tag": "0110_drop_knowledge_edge_type",
+      "breakpoints": true
+    },
+    {
+      "idx": 111,
+      "version": "7",
+      "when": 1786147200000,
+      "tag": "0111_knowledge_leaf_mastery",
+      "breakpoints": true
+    },
+    {
+      "idx": 112,
+      "version": "7",
+      "when": 1786233600000,
+      "tag": "0112_drop_node_weight",
+      "breakpoints": true
+    },
+    {
+      "idx": 113,
+      "version": "7",
+      "when": 1786320000000,
+      "tag": "0113_milestone_dismissed",
+      "breakpoints": true
+    },
+    {
+      "idx": 114,
+      "version": "7",
+      "when": 1786406400000,
+      "tag": "0114_set_completion",
+      "breakpoints": true
+    },
+    {
+      "idx": 115,
+      "version": "7",
+      "when": 1786492800000,
+      "tag": "0115_question_salvage_proposal",
+      "breakpoints": true
+    },
+    {
+      "idx": 116,
+      "version": "7",
+      "when": 1786579200000,
+      "tag": "0116_domain_depth_estimate",
+      "breakpoints": true
+    },
+    {
+      "idx": 117,
+      "version": "7",
+      "when": 1786665600000,
+      "tag": "0117_domain_size_estimate",
+      "breakpoints": true
+    },
+    {
+      "idx": 118,
+      "version": "7",
+      "when": 1786752000000,
+      "tag": "0118_supply_dry_tracking",
+      "breakpoints": true
+    },
+    {
+      "idx": 119,
+      "version": "7",
+      "when": 1786838400000,
+      "tag": "0119_supply_manual_override_calibration",
+      "breakpoints": true
+    },
+    {
+      "idx": 120,
+      "version": "7",
+      "when": 1786924800000,
+      "tag": "0120_gate_drop_stat",
+      "breakpoints": true
+    },
+    {
+      "idx": 121,
+      "version": "7",
+      "when": 1787011200000,
+      "tag": "0121_domain_generation_cap",
+      "breakpoints": true
+    },
+    {
+      "idx": 122,
+      "version": "7",
+      "when": 1787097600000,
+      "tag": "0122_reviewed_domain_pair",
+      "breakpoints": true
+    },
+    {
+      "idx": 123,
+      "version": "7",
+      "when": 1787184000000,
+      "tag": "0123_mastery_calibration_snapshot",
+      "breakpoints": true
+    },
+    {
+      "idx": 124,
+      "version": "7",
+      "when": 1787270400000,
+      "tag": "0124_domain_rest_until",
+      "breakpoints": true
+    },
+    {
+      "idx": 125,
+      "version": "7",
+      "when": 1787356800000,
+      "tag": "0125_reminder_interstitial_seen_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 126,
+      "version": "7",
+      "when": 1787443200000,
+      "tag": "0126_llm_usage_daily",
+      "breakpoints": true
+    }
+  ]
 }

--- a/src/app/api/craft/route.ts
+++ b/src/app/api/craft/route.ts
@@ -6,9 +6,16 @@ import { draftCandidatesForDomain, flagDraftCandidates } from '@/server/crafter/
 import { keepCandidate } from '@/server/crafter/keep-candidate';
 import { hasActiveInvitation } from '@/server/db/queries/author-invitations';
 import { recordDraftDecision } from '@/server/db/queries/crafter-decisions';
+import { getDailyLlmUsageCount, incrementDailyLlmUsage } from '@/server/llm/rate-limit';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 120;
+
+// Drafting is a full generation-model call per request; cap by candidates
+// requested (not requests) since `count` varies 1-6 per call — ~5 rounds of
+// 4 candidates a day is generous for a real crafting session.
+const DRAFT_DAILY_LIMIT = 20;
+const DRAFT_ACTION = 'craft-draft';
 
 // B-CRAFTER-LIFECYCLE-01 Phase 3 — the PLAYER creation surface's API. Same two
 // verbs as the admin route (/api/admin/craft), same shared rails
@@ -90,6 +97,11 @@ export async function POST(request: NextRequest) {
   }
 
   if (data.action === 'draft') {
+    const usageCount = await getDailyLlmUsageCount(session.userId, DRAFT_ACTION);
+    if (usageCount + data.count > DRAFT_DAILY_LIMIT) {
+      return NextResponse.json({ error: 'rate_limited' }, { status: 429 });
+    }
+
     const result = await draftCandidatesForDomain({
       domain: data.domain,
       tier: data.tier,
@@ -98,6 +110,7 @@ export async function POST(request: NextRequest) {
     if (!result.ok) {
       return NextResponse.json({ error: result.reason }, { status: 503 });
     }
+    await incrementDailyLlmUsage(session.userId, DRAFT_ACTION, DRAFT_DAILY_LIMIT, data.count);
     return NextResponse.json({ candidates: result.candidates });
   }
 

--- a/src/app/api/questions/critique/route.ts
+++ b/src/app/api/questions/critique/route.ts
@@ -1,14 +1,14 @@
-import { and, eq, sql } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
-import { db, critiqueUsageDaily } from '@/server/db';
 import { critiqueQuestion } from '@/server/llm/critique';
+import { getDailyLlmUsageCount, incrementDailyLlmUsage } from '@/server/llm/rate-limit';
 
 export const dynamic = 'force-dynamic';
 
 const DAILY_LIMIT = 5;
+const ACTION = 'critique';
 
 const bodySchema = z.object({ questionText: z.string().optional().catch(undefined) });
 
@@ -19,10 +19,6 @@ type CritiqueResponse = {
   limitReached: boolean;
   remaining: number | null;
 };
-
-function utcDateString(date = new Date()): string {
-  return date.toISOString().slice(0, 10);
-}
 
 function passResponse(extra: Partial<CritiqueResponse> = {}): CritiqueResponse {
   return { ok: true, limitReached: false, remaining: null, ...extra };
@@ -39,38 +35,22 @@ export async function POST(request: NextRequest) {
       : '';
     if (!questionText) return NextResponse.json(passResponse({ remaining: null }));
 
-    const usageDate = utcDateString();
-    const [usage] = await db
-      .select({ critiqueCount: critiqueUsageDaily.critiqueCount })
-      .from(critiqueUsageDaily)
-      .where(and(eq(critiqueUsageDaily.userId, session.userId), eq(critiqueUsageDaily.usageDate, usageDate)))
-      .limit(1);
-
-    if ((usage?.critiqueCount ?? 0) >= DAILY_LIMIT) {
+    const usageCount = await getDailyLlmUsageCount(session.userId, ACTION);
+    if (usageCount >= DAILY_LIMIT) {
       return NextResponse.json(passResponse({ limitReached: true, remaining: 0 }));
     }
 
     const critiqueResult = await critiqueQuestion({ questionText });
 
-    const rows = await db.execute<{ critique_count: number }>(sql`
-      INSERT INTO "CritiqueUsageDaily" ("user_id", "usage_date", "critique_count", "updated_at")
-      VALUES (${session.userId}, ${usageDate}::date, 1, now())
-      ON CONFLICT ("user_id", "usage_date") DO UPDATE
-      SET "critique_count" = "CritiqueUsageDaily"."critique_count" + 1,
-          "updated_at" = now()
-      WHERE "CritiqueUsageDaily"."critique_count" < ${DAILY_LIMIT}
-      RETURNING "critique_count"
-    `);
-    const incremented = Array.isArray(rows) ? rows[0] : rows.rows?.[0];
-    if (!incremented) {
+    const { ok, count } = await incrementDailyLlmUsage(session.userId, ACTION, DAILY_LIMIT);
+    if (!ok) {
       return NextResponse.json(passResponse({ limitReached: true, remaining: 0 }));
     }
 
-    const newCount = Number(incremented.critique_count ?? DAILY_LIMIT);
     return NextResponse.json({
       ...critiqueResult,
       limitReached: false,
-      remaining: Math.max(DAILY_LIMIT - newCount, 0),
+      remaining: Math.max(DAILY_LIMIT - count, 0),
     } satisfies CritiqueResponse);
   } catch (error) {
     console.warn('[api/questions/critique] fail_open', error);

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -29,8 +29,15 @@ import { textContainsAnswer } from '@/server/questions/self-answering';
 import { assessQuestionDifficulty, fallbackQuestionDifficulty } from '@/server/questions/llm-difficulty';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { isReconcileAuthoredDomainsEnabled, reconcileAuthoredDomain } from '@/server/questions/reconcile-authored-domain';
+import { getDailyLlmUsageCount, incrementDailyLlmUsage } from '@/server/llm/rate-limit';
 
 export const dynamic = 'force-dynamic';
+
+// Every creation attempt spends 3 LLM calls (categorize, vet, difficulty).
+// Reserved up front, before those calls run, so a scripted create-loop can't
+// outrun the counter across the several early-return branches below.
+const CREATE_DAILY_LIMIT = 25;
+const CREATE_ACTION = 'create-question';
 
 function shouldIncludeShareRecipientDiagnostics() {
   return process.env.NODE_ENV !== 'production' || process.env.SHARE_TO_FEED_DEBUG_RECIPIENT_IDS === 'true';
@@ -89,6 +96,12 @@ export async function POST(request: NextRequest) {
     }
     return NextResponse.json({ error: 'validation', fields: errors }, { status: 400 });
   }
+
+  const usageCount = await getDailyLlmUsageCount(session.userId, CREATE_ACTION);
+  if (usageCount >= CREATE_DAILY_LIMIT) {
+    return NextResponse.json({ error: 'rate_limited' }, { status: 429 });
+  }
+  await incrementDailyLlmUsage(session.userId, CREATE_ACTION, CREATE_DAILY_LIMIT);
 
   const { sendToFriendIds, shareToFeed, ...rawQuestionFields } = value;
 

--- a/src/app/api/questions/suggest/route.ts
+++ b/src/app/api/questions/suggest/route.ts
@@ -3,8 +3,15 @@ import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { suggestQuestionAnswer } from '@/server/llm/suggest-question';
+import { getDailyLlmUsageCount, incrementDailyLlmUsage } from '@/server/llm/rate-limit';
 
 const bodySchema = z.object({ questionText: z.string() });
+
+// Generate (+ verify, + possible regenerate) an answer for a question the
+// user is composing. The most expensive call in the create-a-question flow,
+// so it gets the same daily-cap treatment as /api/questions/critique.
+const DAILY_LIMIT = 15;
+const ACTION = 'suggest-answer';
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
@@ -14,8 +21,14 @@ export async function POST(request: NextRequest) {
   const questionText = parsed.success ? parsed.data.questionText.trim() : '';
   if (!questionText) return NextResponse.json({ error: 'questionText is required' }, { status: 400 });
 
+  const usageCount = await getDailyLlmUsageCount(session.userId, ACTION);
+  if (usageCount >= DAILY_LIMIT) {
+    return NextResponse.json({ error: 'rate_limited' }, { status: 429 });
+  }
+
   try {
     const suggestion = await suggestQuestionAnswer(questionText);
+    await incrementDailyLlmUsage(session.userId, ACTION, DAILY_LIMIT);
     return NextResponse.json(suggestion);
   } catch {
     return NextResponse.json({ error: 'Suggestion unavailable.' }, { status: 500 });

--- a/src/app/api/questions/verify-answer/route.ts
+++ b/src/app/api/questions/verify-answer/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { verifyAnswer } from '@/server/llm/suggest-question';
+import { getDailyLlmUsageCount, incrementDailyLlmUsage } from '@/server/llm/rate-limit';
 
 // On-demand answer fact-check. Surfaces where a human edits a proposed answer
 // (e.g. the crafter keep/kill cards) call this to confirm the edited answer is
@@ -13,6 +14,11 @@ const bodySchema = z.object({
   answer: z.string().trim().min(1).max(400),
 });
 
+// Same compose-time bucket cost class as /api/questions/suggest, one LLM
+// call instead of two-to-three, so it shares the cap.
+const DAILY_LIMIT = 15;
+const ACTION = 'verify-answer';
+
 export async function POST(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
@@ -22,8 +28,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'questionText and answer are required' }, { status: 400 });
   }
 
+  const usageCount = await getDailyLlmUsageCount(session.userId, ACTION);
+  if (usageCount >= DAILY_LIMIT) {
+    return NextResponse.json({ error: 'rate_limited' }, { status: 429 });
+  }
+
   try {
     const verdict = await verifyAnswer(parsed.data.questionText, parsed.data.answer);
+    await incrementDailyLlmUsage(session.userId, ACTION, DAILY_LIMIT);
     return NextResponse.json({ verdict: verdict.verdict, correctedAnswer: verdict.correctedAnswer });
   } catch {
     return NextResponse.json({ error: 'Verification unavailable.' }, { status: 500 });

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -632,7 +632,7 @@ export async function deleteUserAccount(userId: string): Promise<void> {
     await tx.execute(sql`delete from "GeneratedQuestion" where "user_id" = ${userId}`);
 
     await tx.execute(sql`delete from "PLAYER_MASTERY" where "user_id" = ${userId}`);
-    await tx.execute(sql`delete from "CritiqueUsageDaily" where "user_id" = ${userId}`);
+    await tx.execute(sql`delete from "LlmUsageDaily" where "user_id" = ${userId}`);
     await tx.execute(sql`delete from "USER_DOMAIN_DIFFICULTY" where "user_id" = ${userId}`);
     await tx.execute(sql`delete from "USER_DOMAIN_EXCLUSIONS" where "user_id" = ${userId}`);
     await tx.execute(sql`delete from "PROFILE_DOMAIN_VISIBILITY" where "user_id" = ${userId}`);

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -517,18 +517,25 @@ export const playerMastery = pgTable(
 );
 
 
-export const critiqueUsageDaily = pgTable(
-  'CritiqueUsageDaily',
+// Generic per-user-per-day usage counter for rate-limited, on-demand LLM
+// endpoints (answer suggestion, verify-answer, crafter drafting, critique,
+// question creation, ...). One row per (user, day, action); `action` is a
+// free-form key each call site owns (e.g. 'critique', 'suggest-answer').
+// Superseded the critique-only `CritiqueUsageDaily` table (see migration
+// 0126) once a second caller needed the same pattern.
+export const llmUsageDaily = pgTable(
+  'LlmUsageDaily',
   {
     id: uuid('id').primaryKey().defaultRandom(),
     userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
     usageDate: date('usage_date').notNull(),
-    critiqueCount: integer('critique_count').notNull().default(0),
+    action: text('action').notNull(),
+    count: integer('count').notNull().default(0),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    unique('CritiqueUsageDaily_user_id_usage_date_key').on(table.userId, table.usageDate),
-    index('CritiqueUsageDaily_user_id_usage_date_idx').on(table.userId, table.usageDate),
+    unique('LlmUsageDaily_user_id_usage_date_action_key').on(table.userId, table.usageDate, table.action),
+    index('LlmUsageDaily_user_id_usage_date_action_idx').on(table.userId, table.usageDate, table.action),
   ],
 );
 

--- a/src/server/llm/rate-limit.ts
+++ b/src/server/llm/rate-limit.ts
@@ -1,0 +1,78 @@
+/**
+ * B-LLM-RATE-LIMIT-01 — shared per-user daily cap for on-demand LLM endpoints
+ * (answer suggestion, verify-answer, crafter drafting, question creation,
+ * critique, ...). Backed by LlmUsageDaily (one row per user/day/action).
+ *
+ * Call getDailyLlmUsageCount BEFORE the LLM call to short-circuit over-quota
+ * requests without spending tokens, then incrementDailyLlmUsage AFTER a
+ * successful call. Both fail open on any DB error — a rate-limit outage must
+ * never block the underlying feature (same posture as the critique route's
+ * existing fail_open catch).
+ */
+import { and, eq, sql } from 'drizzle-orm';
+
+import { db, llmUsageDaily } from '@/server/db';
+
+export function utcDateString(date = new Date()): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export async function getDailyLlmUsageCount(
+  userId: string,
+  action: string,
+  usageDate: string = utcDateString(),
+): Promise<number> {
+  try {
+    const [usage] = await db
+      .select({ count: llmUsageDaily.count })
+      .from(llmUsageDaily)
+      .where(
+        and(
+          eq(llmUsageDaily.userId, userId),
+          eq(llmUsageDaily.usageDate, usageDate),
+          eq(llmUsageDaily.action, action),
+        ),
+      )
+      .limit(1);
+    return usage?.count ?? 0;
+  } catch (error) {
+    console.warn('[rate-limit] getDailyLlmUsageCount fail_open', action, error);
+    return 0;
+  }
+}
+
+/**
+ * Atomically adds `amount` to today's counter for (userId, action), but only
+ * if the result stays within `limit` — mirrors the critique route's
+ * INSERT ... ON CONFLICT DO UPDATE ... WHERE guard, generalized to a
+ * variable increment (crafter drafting consumes one unit per candidate
+ * requested, not one per call).
+ */
+export async function incrementDailyLlmUsage(
+  userId: string,
+  action: string,
+  limit: number,
+  amount = 1,
+): Promise<{ ok: boolean; count: number }> {
+  const usageDate = utcDateString();
+  try {
+    const rows = await db.execute<{ count: number }>(sql`
+      INSERT INTO "LlmUsageDaily" ("user_id", "usage_date", "action", "count", "updated_at")
+      VALUES (${userId}, ${usageDate}::date, ${action}, ${amount}, now())
+      ON CONFLICT ("user_id", "usage_date", "action") DO UPDATE
+      SET "count" = "LlmUsageDaily"."count" + ${amount},
+          "updated_at" = now()
+      WHERE "LlmUsageDaily"."count" + ${amount} <= ${limit}
+      RETURNING "count"
+    `);
+    const incremented = Array.isArray(rows) ? rows[0] : rows.rows?.[0];
+    if (!incremented) {
+      const current = await getDailyLlmUsageCount(userId, action, usageDate);
+      return { ok: false, count: current };
+    }
+    return { ok: true, count: Number(incremented.count) };
+  } catch (error) {
+    console.warn('[rate-limit] incrementDailyLlmUsage fail_open', action, error);
+    return { ok: true, count: 0 };
+  }
+}


### PR DESCRIPTION
## Summary
- As the app opens up to more users, several on-demand LLM endpoints had no per-user cap — a single account could loop `/api/questions/suggest` (generate+verify+regenerate, 2-3 LLM calls) or `POST /api/questions` (categorize+vet+difficulty, 3 LLM calls) indefinitely.
- Generalizes the critique route's existing daily-cap pattern (`CritiqueUsageDaily`, a single-purpose table) into an action-keyed `LlmUsageDaily` table (migration `0126`) shared by all five rate-limited endpoints, plus `src/server/llm/rate-limit.ts` (`getDailyLlmUsageCount` / `incrementDailyLlmUsage`) as the common helper.
- Caps applied: `critique` 5/day (unchanged), `suggest-answer` 15/day, `verify-answer` 15/day, `craft-draft` 20 candidates/day (crafter mode, gated separately by author invitation), `create-question` 25/day.
- Fails open on any DB error, matching the critique route's existing posture — a rate-limit outage should never block gameplay.
- Migration 0126 has already been run against the database (table created, `CritiqueUsageDaily` rows copied forward as `action='critique'` and the old table dropped) — this PR is code-only from a deploy perspective.

## Test plan
- [x] `npx tsc -p tsconfig.typecheck.json` — clean
- [x] `npm run lint` — clean (4 pre-existing warnings, unrelated)
- [x] `npx vitest run src/app/api/craft src/app/api/questions` — 43/43 passing
- [x] Migration applied to the live DB; verified `LlmUsageDaily` exists, `CritiqueUsageDaily` is gone, migration recorded correctly in `__drizzle_migrations`
- [ ] Manual: hit `/api/questions/suggest` (or another capped endpoint) >limit times in one day and confirm a 429 with `{ error: 'rate_limited' }`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Qud6NBqzFvPAZuLQq5RrBw