### PR TITLE
Stop paying for web search the verify prompt forbids, and fix the cost digest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ dev-stderr.txt
 audits/
 supabase/
 _scratch/
+
+# MCP config (contains Supabase access token)
+.mcp.json

--- a/scripts/measure-verify-dimension-mix.ts
+++ b/scripts/measure-verify-dimension-mix.ts
@@ -1,0 +1,175 @@
+/**
+ * Dimension-level attribution for batch-verify's web-search cost.
+ *
+ * WHY THIS EXISTS. Two existing harnesses each answer half the question and
+ * neither answers this one:
+ *   - measure-verify-web-search-rate.ts reads the LlmUsageEvent ledger and gives
+ *     the per-call search rate, but the ledger records no dimensions, so it
+ *     cannot say WHICH dimension mix is doing the searching.
+ *   - measure-prefilter-skip-rate.ts replays the pure pre-filter, but it never
+ *     selects canonical_subcategory, so `ambiguous_source` is INERT there (see
+ *     verification-prefilter.ts: "When omitted the ambiguous_source route is
+ *     inert") and it only tallies false_premise / extra_fact — never the
+ *     combinations.
+ *
+ * This script closes that gap: it selects canonical_subcategory so all three
+ * dimensions route for real, then reports the dimension-COMBINATION mix. The
+ * combination is the point — a row routed on `ambiguous_source` ALONE has
+ * nothing to fact-check (the verify system prompt says that dimension "needs NO
+ * web search" and to "never search for it"), so attaching the web_search tool to
+ * that call can only cost money. buildVerifyRequestParams now omits the tool for
+ * those calls; this measures how many calls that actually reaches.
+ *
+ * Read-only. Zero LLM spend. Nothing is written.
+ *
+ *   npx tsx scripts/measure-verify-dimension-mix.ts        # 300 rows/store
+ *   npx tsx scripts/measure-verify-dimension-mix.ts 600    # custom sample size
+ *
+ * Context for reading the output (measured 2026-08-03, trailing 7d):
+ *   - a searching batch-verify call costs ~24x a knowledge-only one
+ *     ($0.0615 vs $0.0026) — search results are re-processed across tool turns,
+ *     adding ~21.6k cache tokens per call
+ *   - ~27-31% of calls search at all
+ *   - the 2026-07-17 knowledge-first prompt tightening moved that rate only
+ *     36.2% -> 31.5%, so prompt-side is a weak lever; structural routing (not
+ *     asking the model to restrain itself) is where the remaining win is
+ */
+import 'dotenv/config';
+
+import { desc } from 'drizzle-orm';
+
+import { db, generatedQuestions, pool, questions } from '../src/server/db';
+import {
+  prefilterForVerification,
+  type PrefilterInput,
+  type VerificationDimension,
+} from '../src/server/quality/verification-prefilter';
+
+type SampleRow = PrefilterInput & { store: 'Question' | 'GeneratedQuestion'; id: string };
+
+// Measured 2026-08-03 over the trailing 7d of scope='batch-verify' ledger rows,
+// split on whether the call invoked web_search. Used only to turn the routed-row
+// counts below into a rough dollar reach — not a billing figure.
+const USD_SEARCHING_CALL = 0.0615;
+const USD_KNOWLEDGE_ONLY_CALL = 0.0026;
+// Share of tool-bearing calls that actually invoke search (trailing 7d: 88/323).
+const OBSERVED_SEARCH_RATE = 0.27;
+
+/** Stable label for a dimension set, e.g. "ambiguous_source only". */
+function comboLabel(dimensions: VerificationDimension[]): string {
+  const sorted = [...dimensions].sort();
+  return sorted.length === 1 ? `${sorted[0]} only` : sorted.join(' + ');
+}
+
+function pct(part: number, whole: number): string {
+  return whole === 0 ? '—' : `${((part / whole) * 100).toFixed(1)}%`;
+}
+
+async function main() {
+  const perStore = Math.max(1, Number(process.argv[2] ?? 300));
+
+  // canonical_subcategory is the column measure-prefilter-skip-rate.ts omits;
+  // without it isAmbiguousSourceCandidate() returns false for every row and the
+  // whole dimension silently disappears from the mix.
+  const [questionRows, generatedRows] = await Promise.all([
+    db
+      .select({
+        id: questions.id,
+        questionText: questions.questionText,
+        answer: questions.answerText,
+        explanation: questions.factualExplanation,
+        canonicalSubcategory: questions.canonicalSubcategory,
+      })
+      .from(questions)
+      .orderBy(desc(questions.createdAt))
+      .limit(perStore),
+    db
+      .select({
+        id: generatedQuestions.id,
+        questionText: generatedQuestions.questionText,
+        answer: generatedQuestions.answer,
+        explanation: generatedQuestions.explainer,
+        canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+      })
+      .from(generatedQuestions)
+      .orderBy(desc(generatedQuestions.createdAt))
+      .limit(perStore),
+  ]);
+
+  const sample: SampleRow[] = [
+    ...questionRows.map((r) => ({ ...r, store: 'Question' as const })),
+    ...generatedRows.map((r) => ({ ...r, store: 'GeneratedQuestion' as const })),
+  ];
+
+  let skipped = 0;
+  let routed = 0;
+  let ambiguousOnly = 0;
+  const byCombo = new Map<string, number>();
+  const ambiguousOnlyExamples: SampleRow[] = [];
+
+  for (const row of sample) {
+    const decision = prefilterForVerification(row, {});
+    if (!decision.needsVerification) {
+      skipped += 1;
+      continue;
+    }
+    routed += 1;
+    const label = comboLabel(decision.dimensions);
+    byCombo.set(label, (byCombo.get(label) ?? 0) + 1);
+    if (decision.dimensions.length === 1 && decision.dimensions[0] === 'ambiguous_source') {
+      ambiguousOnly += 1;
+      if (ambiguousOnlyExamples.length < 10) ambiguousOnlyExamples.push(row);
+    }
+  }
+
+  const n = sample.length;
+  console.log(
+    `\nSample: ${n} rows (${questionRows.length} Question + ${generatedRows.length} GeneratedQuestion, most recent)`,
+  );
+  console.log(`Routed to verification: ${routed} (${pct(routed, n)})   Skipped: ${skipped} (${pct(skipped, n)})\n`);
+
+  console.log('dimension combination                     rows    % of routed');
+  for (const [label, count] of [...byCombo.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`${label.padEnd(40)}  ${String(count).padStart(4)}    ${pct(count, routed).padStart(6)}`);
+  }
+
+  // The headline: how far the no-tool-on-ambiguous_source-only change reaches.
+  console.log(`\n=== reach of the ambiguous_source-only tool suppression ===`);
+  console.log(`ambiguous_source-only calls: ${ambiguousOnly} of ${routed} routed (${pct(ambiguousOnly, routed)})`);
+
+  if (ambiguousOnly === 0) {
+    console.log(
+      '\nZero rows route on ambiguous_source alone in this sample. The change is still\n' +
+        'correct (it can only ever remove a tool the prompt forbids using), but it is\n' +
+        'NOT a cost lever at this sample size — do not bank savings on it. The search\n' +
+        'spend lives in the factual dimensions; look there instead.',
+    );
+  } else {
+    // Rough: only the searching share of those calls was actually costing the
+    // premium, so credit the delta on that share alone.
+    const wouldHaveSearched = ambiguousOnly * OBSERVED_SEARCH_RATE;
+    const saved = wouldHaveSearched * (USD_SEARCHING_CALL - USD_KNOWLEDGE_ONLY_CALL);
+    console.log(
+      `~${wouldHaveSearched.toFixed(1)} of them would have searched at the observed ${(OBSERVED_SEARCH_RATE * 100).toFixed(0)}% rate,\n` +
+        `so the change is worth roughly $${saved.toFixed(3)} per ${routed} routed calls.`,
+    );
+    console.log('\nExamples (ambiguous_source only — these no longer carry the search tool):');
+    for (const row of ambiguousOnlyExamples) {
+      console.log(`  [${row.store}] ${row.questionText.slice(0, 100)}`);
+      console.log(`      subject: ${row.canonicalSubcategory ?? '(none)'}`);
+    }
+  }
+
+  console.log(
+    '\nNote: this sizes ONE structural change. The dominant search cost sits in the\n' +
+      'factual dimensions, which genuinely need the tool — reducing that is a quality\n' +
+      'tradeoff, not a free win, and wants its own measured experiment.',
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => void pool.end());

--- a/src/server/db/queries/llm-cost-report.ts
+++ b/src/server/db/queries/llm-cost-report.ts
@@ -500,10 +500,17 @@ export function renderCostLatencyReportMarkdown(r: CostLatencyReport): string {
   lines.push('');
   if (r.costPerQuestionUsd != null) {
     lines.push(
-      `- Cost per question generated: **${usd(r.costPerQuestionUsd)}** (${r.questionsGenerated.toLocaleString('en-US')} generated)`,
+      `- Cost to *write* a question: **${usd(r.costPerQuestionUsd)}** (${r.questionsGenerated.toLocaleString('en-US')} generated)`,
+    );
+    // Honesty guard: this is the 'generate' bucket alone. Gating and the
+    // post-hoc verification sweep are the majority of spend and are NOT in
+    // this number, so reading it as all-in cost-per-question understates the
+    // true figure by roughly an order of magnitude.
+    lines.push(
+      '  - Generation only — excludes quality gating and fact-checking, which are most of the spend. Not the all-in cost of a question.',
     );
   } else {
-    lines.push('- Cost per question generated: no questions generated this week.');
+    lines.push('- Cost to write a question: no questions generated this week.');
   }
   if (r.costPerAnswerGradedUsd != null) {
     lines.push(
@@ -520,7 +527,7 @@ export function renderCostLatencyReportMarkdown(r: CostLatencyReport): string {
   if (r.slowestPlayerFacing) {
     const s = r.slowestPlayerFacing;
     lines.push(
-      `Players wait longest on **${s.label.toLowerCase()}**: ~${ms(s.avgMs)} average, ~${ms(s.p95Ms)} at worst.`,
+      `Of the surfaces a player waits on live, the worst tail is **${s.label.toLowerCase()}**: ~${ms(s.p95Ms)} at p95 (~${ms(s.avgMs)} average).`,
     );
   } else {
     lines.push('No timed player-facing calls this week.');
@@ -528,10 +535,15 @@ export function renderCostLatencyReportMarkdown(r: CostLatencyReport): string {
   lines.push('');
   const timed = r.latency.filter((l) => l.calls > 0);
   if (timed.length > 0) {
-    lines.push('| Surface | Avg | Worst (p95) |');
-    lines.push('| --- | --- | --- |');
+    // The "Waits" column is the whole point of this table: most of these
+    // surfaces are background crons, so an unlabelled 12.5s generation row
+    // reads as "players wait 12.5s" when nobody is waiting on it at all.
+    lines.push('| Surface | Player waits? | Avg | Worst (p95) |');
+    lines.push('| --- | --- | --- | --- |');
     for (const l of timed) {
-      lines.push(`| ${l.label} | ${ms(l.avgMs)} | ${ms(l.p95Ms)} |`);
+      lines.push(
+        `| ${l.label} | ${l.playerFacing ? 'yes' : 'no — background'} | ${ms(l.avgMs)} | ${ms(l.p95Ms)} |`,
+      );
     }
     lines.push('');
   }

--- a/src/server/email/templates/llm-cost-report.ts
+++ b/src/server/email/templates/llm-cost-report.ts
@@ -188,14 +188,25 @@ export function buildCostReportEmailTemplate(params: {
 
   // Latency rows (only timed surfaces).
   const timed = r.latency.filter((l) => l.calls > 0);
+  // The "Waits" column is the whole point of this table: most of these
+  // surfaces are background crons, so an unlabelled 12.5s generation row reads
+  // as "players wait 12.5s" when nobody is waiting on it at all.
   const latencyRows = timed
-    .map((l) => `<tr>${td(escapeHtml(l.label), 'left')}${td(ms(l.avgMs), 'right')}${td(ms(l.p95Ms), 'right')}</tr>`)
+    .map(
+      (l) =>
+        `<tr>${td(escapeHtml(l.label), 'left')}${td(
+          l.playerFacing ? 'yes' : 'no — background',
+          'left',
+        )}${td(ms(l.avgMs), 'right')}${td(ms(l.p95Ms), 'right')}</tr>`,
+    )
     .join('');
 
   const slowest = r.slowestPlayerFacing
-    ? `Players wait longest on <strong>${escapeHtml(r.slowestPlayerFacing.label.toLowerCase())}</strong>: ~${ms(
+    ? `Of the surfaces a player waits on live, the worst tail is <strong>${escapeHtml(
+        r.slowestPlayerFacing.label.toLowerCase(),
+      )}</strong>: ~${ms(r.slowestPlayerFacing.p95Ms)} at p95 (~${ms(
         r.slowestPlayerFacing.avgMs,
-      )} average, ~${ms(r.slowestPlayerFacing.p95Ms)} at worst.`
+      )} average).`
     : 'No timed player-facing calls this week.';
 
   const perQuestion =
@@ -239,7 +250,8 @@ export function buildCostReportEmailTemplate(params: {
               </td></tr>
 
               ${eyebrow('Cost per unit')}
-              <tr><td style="font-family:${SERIF};font-size:15px;color:${INK};padding:2px 0;">Per question generated — ${perQuestion}</td></tr>
+              <tr><td style="font-family:${SERIF};font-size:15px;color:${INK};padding:2px 0;">Cost to write a question — ${perQuestion}</td></tr>
+              <tr><td style="font-family:${SANS};font-size:12px;line-height:1.5;color:${INK_FAINT};padding:0 0 6px 0;">Generation only — excludes quality gating and fact-checking, which are most of the spend. Not the all-in cost of a question.</td></tr>
               <tr><td style="font-family:${SERIF};font-size:15px;color:${INK};padding:2px 0;">Per answer graded — ${perGrade}</td></tr>
 
               ${eyebrow('How long players wait')}
@@ -248,7 +260,7 @@ export function buildCostReportEmailTemplate(params: {
                 timed.length > 0
                   ? `<tr><td>
                 <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
-                  <tr>${th('Surface', 'left')}${th('Avg', 'right')}${th('Worst (p95)', 'right')}</tr>
+                  <tr>${th('Surface', 'left')}${th('Player waits?', 'left')}${th('Avg', 'right')}${th('Worst (p95)', 'right')}</tr>
                   ${latencyRows}
                 </table>
               </td></tr>`

--- a/src/server/quality/verify-question.ts
+++ b/src/server/quality/verify-question.ts
@@ -142,14 +142,25 @@ function buildUserMessage(input: VerifyInput): string {
  */
 export function buildVerifyRequestParams(input: VerifyInput): Anthropic.MessageCreateParamsNonStreaming {
   const allowedDomains = verifyAllowedDomains();
-  const tools: Anthropic.MessageCreateParamsNonStreaming['tools'] = isWebSearchEnabled()
-    ? [{
-        type: 'web_search_20250305',
-        name: 'web_search',
-        max_uses: WEB_SEARCH_MAX_USES,
-        ...(allowedDomains ? { allowed_domains: allowedDomains } : {}),
-      }]
-    : undefined;
+  // ambiguous_source is a judgment about the question TEXT — the system prompt
+  // already says it "needs NO web search" and to "never search for it". When
+  // it is the ONLY routed dimension there is nothing to fact-check, so don't
+  // attach the tool at all rather than relying on the model to decline it.
+  //
+  // This is a cost lever, not a quality one: a searching call costs ~24x a
+  // knowledge-only one (measured 2026-08-03 — search results are re-processed
+  // across tool turns, ~21.6k extra cache tokens per call), and a search here
+  // buys nothing the dimension can use. Factual dimensions are unaffected.
+  const needsFactCheck = input.dimensions.some((d) => d !== 'ambiguous_source');
+  const tools: Anthropic.MessageCreateParamsNonStreaming['tools'] =
+    isWebSearchEnabled() && needsFactCheck
+      ? [{
+          type: 'web_search_20250305',
+          name: 'web_search',
+          max_uses: WEB_SEARCH_MAX_USES,
+          ...(allowedDomains ? { allowed_domains: allowedDomains } : {}),
+        }]
+      : undefined;
   return {
     model: ANTHROPIC_MODEL,
     max_tokens: 1024,


### PR DESCRIPTION
Started from the weekly digest: **$9.79 last week, with "Fact-checking questions" at $7.29 (74%)**. Tracing it turned up two separate problems — the digest was describing the spend inaccurately, and the verifier was attaching a tool to calls that are forbidden from using it.

## Where the money actually goes

`batch-verify` splits cleanly in two (trailing 7d, `LlmUsageEvent`):

| | Calls | Avg cache-write tokens | $/call |
|---|---|---|---|
| Resolved from knowledge | 235 (73%) | 363 | $0.0026 |
| **Reached for web_search** | **88 (27%)** | **21,588** | **$0.0615** |

**A searching call costs 24× a knowledge-only one, and 27% of calls drive 83% of the bucket.** The premium isn't mainly the $10/1k search meter (~$1.26) — it's that search results get re-processed across tool turns.

## Two levers considered and dropped on measurement

Recording these so they don't get re-litigated from the same surface reading:

- **Suppressing the cache write on tool turns.** *Retracted.* At measured volumes, caching those tokens costs **$0.0391/call vs $0.0439 uncached** — it's saving 11%, not wasting it. The line is large because search volume is large.
- **Swapping the verifier to Haiku.** Models ~$3.89/wk, but tier and search rate are **coupled** — a model less sure of its own knowledge searches *more*, inflating the exact cache-write line that dominates the bill. `D-LLM-PROVIDER-AB-AND-GATE-TIER-01` already measured Haiku mis-calibrated on this task. Wants an A/B, not a flip.

## What changed in the verifier

`ambiguous_source` is a judgment about the question text — the system prompt already says it "needs NO web search" and to "never search for it." But the pre-filter routes it *independently* of the factual dimensions, so a call can route on it **alone** and still be handed the tool.

Now the tool is omitted when no factual dimension is present. Search buys that dimension nothing, so this is a cost change with no quality surface.

## What was misleading in the digest

- **"How long players wait" listed background crons unlabelled** — a 12.5s generation cron read as a 12.5s player wait. Rows now say whether anyone is actually waiting.
- **The slowest-surface line picked by p95 but led with the average** — naming grading (1.1s avg) while the table beside it showed a 1.8s avg row. It now states the basis.
- **"Per question generated — $0.012" counted the `generate` bucket alone**, omitting gating and fact-checking (most of the spend) while reading as all-in. Relabelled with the exclusion stated.

## The harness

`scripts/measure-verify-dimension-mix.ts` (read-only, zero LLM spend) fills the gap between the two existing scripts: the ledger one knows the search rate but records no dimensions; the pre-filter one never selects `canonical_subcategory`, which silently made `ambiguous_source` **inert** and left it tallying two dimensions of three.

Over 600 recent rows (81.5% route to verification):

| Dimension combination | % of routed |
|---|---|
| extra_fact only | 21.1% |
| ambiguous_source + extra_fact | 18.8% |
| false_premise only | 15.7% |
| extra_fact + false_premise | 13.7% |
| **ambiguous_source only** | **12.3%** ← reached by this change |
| ambiguous_source + false_premise | 10.0% |
| all three | 8.4% |

I'd predicted this fix would be a rounding error; it's 12.3%. Measuring beat guessing.

**It also bounds the remaining win:** `ambiguous_source` appears in 49.5% of routed calls but is bundled with a factual dimension in most, so the rest of the search spend is load-bearing. Cutting it trades quality — and the 2026-07-17 knowledge-first prompt tightening already showed prompt-side yields only **36.2% → 31.5%**. That needs its own experiment.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` clean
- [x] `npm run lint` — 0 errors (4 pre-existing warnings in `friends/`, untouched)
- [x] 300 tests pass across `src/server/quality` + `src/server/db/queries`
- [x] Harness run against prod (read-only)
- [ ] **Render the digest email before the next Monday 09:00 UTC cron.** The latency table went from 3 columns to 4 and email clients are unforgiving about table layout — this is the one thing here not verified against a real render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsnxcCmnb1J8Hxx3K7sKSP
