### PR TITLE
Read the answer after the question on a settled streak card

### DIFF
--- a/src/components/feed/FromFriendsStreak.tsx
+++ b/src/components/feed/FromFriendsStreak.tsx
@@ -451,14 +451,6 @@ function StreakQuestionCard({
               </FeedActionLink>
             }
           />
-        ) : revealed ? (
-          // A "View Answer" peek settles in the SAME leading slot as the graded
-          // verdict (request 2026-07-12): right, wrong, or gave-up, the result
-          // always sits above the question so a column of settled cards scans
-          // uniformly.
-          <div style={{ marginBottom: 10 }}>
-            <RevealedAnswer state={revealed} />
-          </div>
         ) : null}
 
         <p
@@ -468,13 +460,29 @@ function StreakQuestionCard({
             lineHeight: 1.28,
             fontWeight: 500,
             color: INK,
-            // Spent cards close on the question (verdict already led above), so
-            // drop the trailing margin that separated it from the bottom row.
-            margin: spent ? 0 : '0 0 14px',
+            // The question no longer closes a spent card — the answer read-back
+            // follows it (2026-08-06) — so it keeps a trailing margin only when
+            // an actions row follows. The answer blocks own their top spacing.
+            margin: spent || revealed ? 0 : '0 0 14px',
           }}
         >
           &ldquo;{question.text}&rdquo;
         </p>
+
+        {/* Answer AFTER the question, both for the settled read-back and for the
+            live "View Answer" peek — reversing the 2026-07-12 layout in which
+            the answer preceded the question it answered. */}
+        {spent ? (
+          <SettledAnswers
+            resolution={resolution}
+            correctAnswer={question.correctAnswer}
+            isCorrect={resolution ? resolution.isCorrect : question.priorResult !== 'incorrect'}
+          />
+        ) : revealed ? (
+          <div style={{ marginTop: 12 }}>
+            <RevealedAnswer state={revealed} />
+          </div>
+        ) : null}
 
         {spent ? null : (
           <>
@@ -587,8 +595,68 @@ function SpentResult({
         color: isCorrect ? 'var(--game-correct)' : 'var(--game-wrong)',
       }}
     >
-      {isCorrect ? '✓ Correct' : 'Not this time'}
-      {resolution ? ` · ${resolution.submitted}` : ''}
+      {isCorrect ? 'Answered correctly' : 'Not this time'}
     </div>
+  );
+}
+
+// The settled card's answer read-back, sitting UNDER the question (2026-08-06
+// request, reversing the 2026-07-12 "verdict always leads" layout): the verdict
+// keeps its slot above and states only the outcome, while the answers read in
+// question-then-answer order below it.
+//
+// Both lines are independently optional and the asymmetry is a DATA fact, not a
+// style choice: `submitted` exists only for a question answered in THIS session
+// (it lives in the in-memory StreakResolution), because MASTERY_EVENTS has no
+// submitted-answer column — a card restored from priorResult can never show
+// what the viewer typed, and no query can recover it. `correctAnswer` arrives
+// on the stream payload for settled questions only. So a same-session card
+// shows both lines and a prior-session card shows just the answer.
+function SettledAnswers({
+  resolution,
+  correctAnswer,
+  isCorrect,
+}: {
+  resolution: StreakResolution | null;
+  correctAnswer: string | null | undefined;
+  isCorrect: boolean;
+}) {
+  // Don't restate the answer twice on a correct card — the submitted string IS
+  // the answer there, so the "You said" line alone carries it.
+  const showCorrect = Boolean(correctAnswer) && !(isCorrect && resolution);
+  if (!resolution && !showCorrect) return null;
+  return (
+    <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {resolution ? (
+        <AnswerLine
+          label="You said"
+          value={resolution.submitted}
+          color={isCorrect ? 'var(--game-correct)' : 'var(--game-wrong)'}
+        />
+      ) : null}
+      {showCorrect ? <AnswerLine label="Answer" value={correctAnswer!} color={INK2} /> : null}
+    </div>
+  );
+}
+
+function AnswerLine({ label, value, color }: { label: string; value: string; color: string }) {
+  return (
+    <p style={{ margin: 0 }}>
+      <span
+        style={{
+          display: 'block',
+          fontFamily: FM,
+          fontSize: 10,
+          letterSpacing: '0.11em',
+          textTransform: 'uppercase',
+          fontWeight: 600,
+          color: INK3,
+          marginBottom: 3,
+        }}
+      >
+        {label}
+      </span>
+      <span style={{ fontFamily: FS, fontSize: 17, lineHeight: 1.3, color }}>{value}</span>
+    </p>
   );
 }

--- a/src/components/feed/__tests__/FromFriendsStreak.test.tsx
+++ b/src/components/feed/__tests__/FromFriendsStreak.test.tsx
@@ -110,14 +110,14 @@ describe('FromFriendsStreak — headerless (streak page) mode', () => {
 });
 
 describe('FromFriendsStreak — answered questions resolve in place (Phase 2)', () => {
-  it('keeps a correctly-answered question as a spent "✓ Correct" card with a Send-onward affordance', () => {
+  it('keeps a correctly-answered question as a spent "Answered correctly" card with a Send-onward affordance', () => {
     const html = renderToStaticMarkup(
       <FromFriendsStreak item={streakItem([q('done', { priorResult: 'correct' }), q('fresh')])} />,
     );
     // The answered-correct question stays visible as a settled card (it is no
     // longer answerable but it IS forwardable), only the fresh one is playable.
     expect(html).toContain('Question done');
-    expect(html).toContain('✓ Correct');
+    expect(html).toContain('Answered correctly');
     expect(html).toContain('Send onward');
     expect(html).toContain('Question fresh');
     expect(answerCardCount(html)).toBe(1);
@@ -147,7 +147,7 @@ describe('FromFriendsStreak — answered questions resolve in place (Phase 2)', 
     expect(html).not.toBe('');
     expect(html).toContain('Question a');
     expect(html).toContain('Question b');
-    expect(html).toContain('✓ Correct');
+    expect(html).toContain('Answered correctly');
     expect(html).toContain('Send onward');
     // None are answerable any more.
     expect(answerCardCount(html)).toBe(0);
@@ -193,6 +193,71 @@ describe('FromFriendsStreak — View Answer peek', () => {
     // A card the viewer already answered is not answerable and offers no peek.
     expect(html).not.toContain('View Answer');
     expect(answerCardCount(html)).toBe(0);
+  });
+});
+
+describe('FromFriendsStreak — settled answer reads BELOW the question (2026-08-06)', () => {
+  // Reverses the 2026-07-12 "verdict always leads" layout. The verdict keeps the
+  // slot above the question and now carries the OUTCOME ONLY; the answer strings
+  // move underneath, so the card reads question-then-answer.
+  it('puts the answer after the question, not before it', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak
+        item={streakItem([q('done', { priorResult: 'incorrect', correctAnswer: 'Red' })])}
+      />,
+    );
+    expect(html).toContain('Question done');
+    expect(html).toContain('Red');
+    // Reading order is the whole point of the change: the question's index in
+    // the markup must precede the answer's.
+    expect(html.indexOf('Question done')).toBeLessThan(html.indexOf('Red'));
+  });
+
+  it('keeps the verdict line free of the answer', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak
+        item={streakItem([q('done', { priorResult: 'incorrect', correctAnswer: 'Red' })])}
+      />,
+    );
+    // The old copy interpolated the answer into the verdict ("Not this time · Blue").
+    expect(html).toContain('Not this time');
+    expect(html).not.toContain('Not this time ·');
+  });
+
+  it('labels the answer on a prior-session card', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak
+        item={streakItem([q('done', { priorResult: 'incorrect', correctAnswer: 'Red' })])}
+      />,
+    );
+    // No submitted string survives a prior session (MASTERY_EVENTS never stored
+    // one), so such a card shows the answer alone — never a blank "You said".
+    expect(html).toContain('Answer');
+    expect(html).not.toContain('You said');
+  });
+
+  it('shows no answer line when the payload carries none', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak item={streakItem([q('done', { priorResult: 'correct' })])} />,
+    );
+    // A settled card whose answer didn't come through still renders cleanly —
+    // verdict and question only, no empty label.
+    expect(html).toContain('Answered correctly');
+    expect(html).not.toContain('You said');
+    expect(html).not.toContain('>Answer<');
+  });
+
+  it('never renders an answer on a still-answerable card', () => {
+    // The leak guard, restated at the component boundary: build-stream only
+    // populates correctAnswer for settled questions, but if an answerable one
+    // ever arrived carrying it, the card must not print it.
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak
+        item={streakItem([q('fresh', { priorResult: null, correctAnswer: 'LEAKED' })])}
+      />,
+    );
+    expect(html).not.toContain('LEAKED');
+    expect(answerCardCount(html)).toBe(1);
   });
 });
 

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -52,6 +52,13 @@ export type StreamQuestion = {
   // the feed — and drives the ANSWERED history's "Correct" / "Not this time"
   // copy plus the bundle progress mark.
   priorResult: 'correct' | 'incorrect' | null;
+  // The canonical answer, for read-back UNDER the question on a settled card.
+  // Set ONLY when the viewer has already settled this question (priorResult is
+  // non-null) — build-stream narrows before looking it up, because a From
+  // Friends bundle carries settled and still-answerable questions together and
+  // populating this for the latter would hand over answers the viewer is about
+  // to play for. Absent on every answerable card, by construction.
+  correctAnswer?: string | null;
   // The viewer has DISMISSED this milestone question (dismiss-as-answered). Like
   // `priorResult`, it CONSUMES the question — it counts toward the bundle's
   // played progress and a bundle whose questions are all answered-or-dismissed

--- a/src/server/activity/__tests__/build-stream-exhaust.test.ts
+++ b/src/server/activity/__tests__/build-stream-exhaust.test.ts
@@ -47,6 +47,8 @@ vi.mock('@/server/db/queries/lately', () => ({
     new Map(ids.map((id) => [id, { questionId: id, text: `text ${id}`, domain: 'history' }])),
   ),
   getViewerPriorAnswerResults: getViewerPriorAnswerResultsMock,
+  // Settled-card answer read-back; irrelevant to these cases, so a bare empty map.
+  getCorrectAnswersForSettledQuestions: async () => new Map<string, string>(),
   getViewerDismissedMilestoneIds: getViewerDismissedMilestoneIdsMock,
 }));
 

--- a/src/server/activity/__tests__/build-stream-hollow-degraded.test.ts
+++ b/src/server/activity/__tests__/build-stream-hollow-degraded.test.ts
@@ -37,6 +37,8 @@ vi.mock('@/server/db/queries/lately', () => ({
   getFriendActivity: vi.fn(async () => []),
   getMilestoneQuestionText: vi.fn(async () => new Map()),
   getViewerPriorAnswerResults: vi.fn(async () => new Map()),
+  // Settled-card answer read-back; irrelevant to these cases, so a bare empty map.
+  getCorrectAnswersForSettledQuestions: vi.fn(async () => new Map()),
   getViewerDismissedMilestoneIds: vi.fn(async () => new Set()),
 }));
 

--- a/src/server/activity/__tests__/build-stream-self-hide.test.ts
+++ b/src/server/activity/__tests__/build-stream-self-hide.test.ts
@@ -39,6 +39,8 @@ vi.mock('@/server/db/queries/lately', () => ({
     new Map(ids.map((id) => [id, { questionId: id, text: `text ${id}`, domain: 'history' }])),
   ),
   getViewerPriorAnswerResults: getViewerPriorAnswerResultsMock,
+  // Settled-card answer read-back; irrelevant to these cases, so a bare empty map.
+  getCorrectAnswersForSettledQuestions: async () => new Map<string, string>(),
   getViewerDismissedMilestoneIds: vi.fn(async () => new Set()),
 }));
 

--- a/src/server/activity/__tests__/build-stream-settled-answers.test.ts
+++ b/src/server/activity/__tests__/build-stream-settled-answers.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The settled-card answer read-back (2026-08-06). A From Friends bundle carries
+// SETTLED and STILL-ANSWERABLE questions in one payload, so the guard that
+// matters is which of them get a `correctAnswer` attached: shipping one for a
+// question the viewer still has a swing at would hand over the answer before
+// they play it. build-stream narrows to `priorResult !== null` before the
+// lookup; these tests pin that narrowing at the boundary, and assert the
+// lookup is never even ASKED about an answerable id.
+
+const {
+  getViewerPriorAnswerResultsMock,
+  getCorrectAnswersForSettledQuestionsMock,
+  getFriendActivityMock,
+} = vi.hoisted(() => ({
+  getViewerPriorAnswerResultsMock: vi.fn(async () => new Map<string, 'correct' | 'incorrect'>()),
+  getCorrectAnswersForSettledQuestionsMock: vi.fn(async (_ids: string[]) => new Map<string, string>()),
+  getFriendActivityMock: vi.fn(async () => [{ id: 'm1', questionIds: ['settled', 'fresh'] }]),
+}));
+
+vi.mock('@/app/activities/filter-utility-activities', () => ({
+  filterUtilityActivities: () => [],
+}));
+vi.mock('@/lib/activity-stream', () => ({
+  activityToStreamItem: (x: unknown) => x,
+  momentToStreamItem: (x: unknown) => x,
+  bundleAnswerToStreamItem: (x: unknown) => x,
+  convergenceToStreamItem: (_c: unknown, questions: unknown) => ({ kind: 'convergence', questions }),
+  friendActivityToStreamItem: (card: { id: string }, questions: unknown) => ({
+    kind: 'milestone',
+    id: card.id,
+    questions,
+  }),
+}));
+vi.mock('@/lib/lately', () => ({
+  sortByProminence: (items: unknown[]) => items,
+  convergenceCaptionTemplate: () => '',
+}));
+vi.mock('@/lib/lately-milestones', () => ({ MILESTONE_CARD_QUESTION_CAP: 5 }));
+vi.mock('@/server/db/queries/activity', () => ({ getActivitiesForUser: vi.fn(async () => []) }));
+vi.mock('@/server/db/queries/content-reports', () => ({
+  getViewerHiddenQuestionIds: vi.fn(async () => new Set<string>()),
+}));
+vi.mock('@/server/db/queries/lately', () => ({
+  getLatelyMoments: vi.fn(async () => []),
+  getBundleAnswerMoments: vi.fn(async () => []),
+  getLatelyConvergences: vi.fn(async () => []),
+  getFriendActivity: getFriendActivityMock,
+  getMilestoneQuestionText: vi.fn(async (ids: string[]) =>
+    new Map(ids.map((id) => [id, { questionId: id, text: `text ${id}`, domain: 'history' }])),
+  ),
+  getViewerPriorAnswerResults: getViewerPriorAnswerResultsMock,
+  getCorrectAnswersForSettledQuestions: getCorrectAnswersForSettledQuestionsMock,
+  getViewerDismissedMilestoneIds: vi.fn(async () => new Set<string>()),
+}));
+
+import { buildActivityStream } from '@/server/activity/build-stream';
+
+type MilestoneItem = {
+  kind: string;
+  id: string;
+  questions: Array<{ questionId: string; priorResult: string | null; correctAnswer?: string | null }>;
+};
+
+async function questions(): Promise<MilestoneItem['questions']> {
+  const stream = (await buildActivityStream('viewer-1')) as unknown as MilestoneItem[];
+  const milestone = stream.find((i) => i.kind === 'milestone');
+  return milestone?.questions ?? [];
+}
+
+beforeEach(() => {
+  getCorrectAnswersForSettledQuestionsMock.mockClear();
+  getCorrectAnswersForSettledQuestionsMock.mockResolvedValue(new Map());
+  // One played question, one still answerable — the mixed bundle the guard exists for.
+  getViewerPriorAnswerResultsMock.mockResolvedValue(new Map([['settled', 'incorrect']]));
+});
+
+describe('build-stream — settled-answer read-back', () => {
+  it('asks for the answer to the settled question only', async () => {
+    await questions();
+    const askedFor = getCorrectAnswersForSettledQuestionsMock.mock.calls[0]?.[0] ?? [];
+    expect(askedFor).toContain('settled');
+    // The narrowing happens BEFORE the query, so an answerable id is never even
+    // sent — the answer to it is not fetched, let alone serialized.
+    expect(askedFor).not.toContain('fresh');
+  });
+
+  it('attaches the answer to the settled question', async () => {
+    getCorrectAnswersForSettledQuestionsMock.mockResolvedValue(new Map([['settled', 'Red']]));
+    const qs = await questions();
+    expect(qs.find((q) => q.questionId === 'settled')?.correctAnswer).toBe('Red');
+  });
+
+  it('leaves an answerable question with no answer even if the lookup returns one', async () => {
+    // Defence in depth: if the map ever came back wider than the ids we asked
+    // about, the still-answerable card must still not carry an answer.
+    getCorrectAnswersForSettledQuestionsMock.mockResolvedValue(
+      new Map([
+        ['settled', 'Red'],
+        ['fresh', 'LEAKED'],
+      ]),
+    );
+    const qs = await questions();
+    const fresh = qs.find((q) => q.questionId === 'fresh');
+    expect(fresh?.priorResult).toBeNull();
+    expect(fresh?.correctAnswer).not.toBe('LEAKED');
+  });
+
+  it('nulls the answer when the question has none on file', async () => {
+    const qs = await questions();
+    expect(qs.find((q) => q.questionId === 'settled')?.correctAnswer).toBeNull();
+  });
+});

--- a/src/server/activity/__tests__/build-stream-stale-follow-request.test.ts
+++ b/src/server/activity/__tests__/build-stream-stale-follow-request.test.ts
@@ -39,6 +39,8 @@ vi.mock('@/server/db/queries/lately', () => ({
   getFriendActivity: vi.fn(async () => []),
   getMilestoneQuestionText: vi.fn(async () => new Map()),
   getViewerPriorAnswerResults: vi.fn(async () => new Map()),
+  // Settled-card answer read-back; irrelevant to these cases, so a bare empty map.
+  getCorrectAnswersForSettledQuestions: vi.fn(async () => new Map()),
   getViewerDismissedMilestoneIds: vi.fn(async () => new Set()),
 }));
 

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -31,6 +31,7 @@ import {
   getLatelyMoments,
   getMilestoneQuestionText,
   getViewerDismissedMilestoneIds,
+  getCorrectAnswersForSettledQuestions,
   getViewerPriorAnswerResults,
 } from '@/server/db/queries/lately';
 
@@ -98,6 +99,15 @@ export async function buildActivityStream(
     getViewerDismissedMilestoneIds(userId, allQuestionIds),
   ]);
 
+  // Canonical answers for read-back on settled cards only. The narrowing here is
+  // the guard, not an optimisation: `allQuestionIds` mixes questions the viewer
+  // has played with ones they still have a swing at (a partially-played bundle
+  // carries both), so looking up the whole set would attach answers to cards
+  // that are still answerable. Keyed off priorById — the same per-viewer settle
+  // signal that locks the question — so the two can never disagree.
+  const settledQuestionIds = allQuestionIds.filter((id) => priorById.has(id));
+  const correctAnswerById = await getCorrectAnswersForSettledQuestions(settledQuestionIds);
+
   const utilityItems = filterUtilityActivities(items, moments)
     // Drop dead-end degraded rows. An "{actor} answered your question" card whose
     // actor is unknown (the friend/stranger deleted their account, so actorUserId
@@ -146,19 +156,28 @@ export async function buildActivityStream(
         // the viewer already played — each carries its viewer-relative prior
         // result, so the played ones render as spent (hollow) triangles in the
         // expansion while the unplayed ones stay answerable.
-        .map((q) => ({
-          questionId: q.questionId,
-          text: q.text,
-          domain: q.domain,
-          priorResult: priorById.get(q.questionId) ?? null,
-          dismissed: dismissedIds.has(q.questionId),
-          authorName: q.authorName,
-          authorIsHouse: q.authorIsHouse,
-          // D-4 via-attribution: the relay source the friend got this question
-          // from ("via Josh"). Friend-and-question-specific, so it's read off the
-          // card (not the global textById map, which is keyed by questionId alone).
-          via: card.viaByQuestionId?.[q.questionId] ?? null,
-        }));
+        .map((q) => {
+          const prior = priorById.get(q.questionId) ?? null;
+          return {
+            questionId: q.questionId,
+            text: q.text,
+            domain: q.domain,
+            priorResult: prior,
+            // Gated on `prior` HERE, not merely on the narrowed lookup above.
+            // The narrowing decides what we ask the database for; this decides
+            // what leaves the server. Keeping both means a future change that
+            // widens the query — or a caller that passes the whole id set —
+            // still cannot put an answer on a card the viewer can still play.
+            correctAnswer: prior === null ? null : (correctAnswerById.get(q.questionId) ?? null),
+            dismissed: dismissedIds.has(q.questionId),
+            authorName: q.authorName,
+            authorIsHouse: q.authorIsHouse,
+            // D-4 via-attribution: the relay source the friend got this question
+            // from ("via Josh"). Friend-and-question-specific, so it's read off
+            // the card (not the global textById map, keyed by questionId alone).
+            via: card.viaByQuestionId?.[q.questionId] ?? null,
+          };
+        });
       // D-HOME-DASHBOARD-MODEL-01 point 3 — a From Friends bundle is a dashboard
       // item, not an archive entry. Once the viewer has played EVERY answerable
       // question in it (remaining === 0) it is exhausted and disappears; this also

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -713,6 +713,39 @@ export async function getMilestoneQuestionText(
   return out;
 }
 
+/**
+ * Canonical answers for the given questions, for read-back on cards the viewer
+ * has ALREADY settled.
+ *
+ * ⚠️ CALLER MUST PASS ONLY SETTLED QUESTION IDS. This returns the answer to
+ * anything you ask about — it does not and cannot know which questions the
+ * viewer still has a swing at. A From Friends bundle mixes settled and
+ * still-answerable questions in one payload, so handing it the whole bundle
+ * would ship the answers to questions the viewer is about to play. build-stream
+ * narrows to `priorResult !== null` before calling; keep any new caller doing
+ * the same.
+ *
+ * Read-only. Distinct from the /api/lately/milestone/answer route, which also
+ * returns an answer but PERSISTS a give-up miss (no points, no catch-up swing)
+ * — correct for a live "View Answer" peek, catastrophic for a card the viewer
+ * already answered correctly.
+ */
+export async function getCorrectAnswersForSettledQuestions(
+  settledIds: string[],
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (settledIds.length === 0) return out;
+  const rows = await db
+    .select({ id: questions.id, answerText: questions.answerText })
+    .from(questions)
+    .where(inArray(questions.id, settledIds));
+  for (const row of rows) {
+    const answer = row.answerText?.trim();
+    if (answer) out.set(row.id, answer);
+  }
+  return out;
+}
+
 // The viewer's own prior result on each of the given questions, if any. Drives
 // the milestone expansion's progress on first render AND the cross-session lock:
 // a single attempt (right OR wrong) settles the question, so it must report


### PR DESCRIPTION
The card put the answer **above** the question it answered. "View Answer" revealed the answer before you'd read what was asked, and a graded card led with `✓ Correct · Red` — a verdict and an answer welded into one line.

Now the verdict keeps that slot and states only the outcome; the answer reads underneath.

```
✓ Correct · Red     →     Answered correctly
                          "…What color is that girl's coat?"

                          YOU SAID
                          Red
```

**Visual spec, every state:** https://claude.ai/code/artifact/e20f28c9-fb3c-4de1-8c42-76c53f233dc6

## A wrong card gains what it never had

`Not this time · Blue` showed the answer you got **wrong** and never the right one — the card told you that you missed without telling you what you missed. It now carries both: your answer, then the canonical one.

## This reverses a deliberate decision

The 2026-07-12 request wanted a settled result always leading, so a column of spent cards scanned uniformly. This trades that for reading order. Worth a conscious ack — though the uniformity largely survives, since the verdict line still leads every settled card.

## Why this touched the server

Neither spent state had the answer to show. `StreakResolution` carries only what you submitted; `priorResult` is a three-value enum.

The one existing route to a canonical answer is `/api/lately/milestone/answer`, which **persists a give-up** — a miss with no points and no catch-up swing. Correct for a live "View Answer" peek; **data corruption** if fired on a card you already answered correctly.

So the stream now carries the answer for settled questions via a new read-only join that writes nothing: `getCorrectAnswersForSettledQuestions`.

## The guard

A From Friends bundle carries settled **and** still-answerable questions in one payload, so attaching answers indiscriminately would hand over answers to questions the viewer is about to play. Two independent gates:

1. `build-stream` narrows to `priorResult !== null` **before** the query runs — decides what we ask the database
2. Gates again on the same signal when attaching — decides what leaves the server

**A defence-in-depth test caught a real bug here.** My first version had only the narrowing; feeding a deliberately over-wide lookup result failed the test, proving an answerable card *would* have carried an answer if the query ever widened. Fixed the code, not the test.

## What cannot be built

A prior-session card shows `Answer` but never `You said`. Verified against the live database — the only `submitted_answer` columns belong to `FeedItem`, `GradeDispute` and `JoshingGameResponse`. **`MASTERY_EVENTS` never had one.** What you typed in an earlier session was never recorded, so no query recovers it and no migration backfills it.

That card is the same treatment minus a line the data never held. Flagging because it means State 6 can't fully match State 5, contrary to what I'd initially claimed.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` clean
- [x] `npm run lint` — 0 errors (4 pre-existing warnings in `friends/`, untouched)
- [x] Full suite: **2,292 passed / 300 files**
- [x] 5 new component tests — reading order, verdict free of the answer, prior-session label, empty-payload, and no answer on an answerable card
- [x] 4 new server tests — settled-only lookup, attachment, over-wide-map leak guard, null handling
- [ ] Eyeball on a real device: a live grade (`resolution` present) showing both lines, which the unit tests cover structurally but not visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsnxcCmnb1J8Hxx3K7sKSP
