### PR TITLE
Make a catch-up dismiss stick to the question, not the day

### DIFF
--- a/drizzle/0127_missed_return_dismissed.sql
+++ b/drizzle/0127_missed_return_dismissed.sql
@@ -1,0 +1,39 @@
+-- 0127: MissedReturnDismissed — per-(user, question) "don't ask me this again"
+-- for the missed-question return system (D-MISSED-RETURN-01 §3.3, Phase 1 of
+-- B-MISSED-RETURN-01).
+--
+-- Catch-up's existing dismiss is SLOT-scoped: it stamps `dismissed_at` into
+-- that day's "DailyQueue".slots JSONB blob, or "FeedItem"."catchupResolvedAt".
+-- A returning question is by definition a NEW slot in a DIFFERENT queue, so
+-- that slot-level state is invisible to it — a question the player explicitly
+-- waved off would resurface days later. This table holds the dismiss at the
+-- (userId, questionId) level so it survives across queue instances. The
+-- catch-up dismiss/undismiss routes dual-write here; the old slot-level write
+-- is retained because other code still reads it.
+--
+-- Shape mirrors "RecoveredSetAside"/"MilestoneDismissed" exactly (migrations
+-- 0093 and 0113): dismissedAt + nullable reinstatedAt, with a partial unique
+-- index keeping at most one ACTIVE row per (userId, questionId). It is a
+-- distinct table from "RecoveredSetAside" on purpose — same shape, opposite
+-- meaning ("a question I now know" vs "a question I don't know and don't want
+-- back"), and the rows must never be conflated.
+--
+-- Purely additive; RLS enabled per B-SECURITY-RLS-01 (no policies — the app
+-- connects as the owner role, which bypasses RLS).
+--
+-- Rollback: DROP TABLE IF EXISTS "MissedReturnDismissed";
+CREATE TABLE IF NOT EXISTS "MissedReturnDismissed" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "questionId" text NOT NULL REFERENCES "Question"("id") ON DELETE CASCADE,
+  "dismissedAt" timestamp with time zone NOT NULL DEFAULT now(),
+  "reinstatedAt" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "MissedReturnDismissed_userId_idx" ON "MissedReturnDismissed" ("userId");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_active_unique"
+  ON "MissedReturnDismissed" ("userId", "questionId")
+  WHERE "reinstatedAt" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "MissedReturnDismissed" ENABLE ROW LEVEL SECURITY;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -890,6 +890,13 @@
       "when": 1787443200000,
       "tag": "0126_llm_usage_daily",
       "breakpoints": true
+    },
+    {
+      "idx": 127,
+      "version": "7",
+      "when": 1787529600000,
+      "tag": "0127_missed_return_dismissed",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-missed-return-dismissed.ts
+++ b/scripts/backfill-missed-return-dismissed.ts
@@ -1,0 +1,162 @@
+/**
+ * D-MISSED-RETURN-01 §7-G — one-time backfill of existing slot-level catch-up
+ * dismisses into `MissedReturnDismissed`.
+ *
+ * Before this table existed, a catch-up dismiss was recorded SLOT-scoped:
+ *   - `DailyQueue.slots[]` entries with `dismissed_at IS NOT NULL`
+ *   - `FeedItem.catchupResolvedAt IS NOT NULL`
+ *
+ * A return slot is a new slot in a different queue and cannot see either. This
+ * script promotes those historical dismisses to (userId, questionId) rows so no
+ * previously-waved-off question can resurface when the return feature ships.
+ *
+ * SCOPE — canonical questions only. A daily slot carrying `generated_question_id`
+ * is LLM-origin, has no `Question` row to key on, and is skipped: it is out of
+ * this feature's scope by construction (MASTERY_EVENTS.question_id is null for
+ * generated questions too, so the Recovered pool excludes them as well).
+ *
+ * !! THE FEED SOURCE IS NOT A DISMISS MARKER — measured 2026-08-09 !!
+ * D-MISSED-RETURN-01 §7-G names `FeedItem.catchupResolvedAt` as a dismiss
+ * source. It is not: `catchup/answer/route.ts` stamps the SAME column when the
+ * player ANSWERS a feed catch-up item. On live data all 49 resolved feed rows
+ * were answers (state='answered', answerResult set on every one — 36 correct,
+ * 13 incorrect) and ZERO were clean dismisses. Backfilling that column blind
+ * would have permanently suppressed 13 wrong-answered questions — precisely the
+ * inventory this feature exists to return — with no player-facing way to undo.
+ *
+ * So the feed collector below filters to rows bearing NO answer evidence at all.
+ * That yields 0 rows today and is the semantically correct rule going forward.
+ * Erring toward UNDER-suppression is deliberate: a missed dismiss means a
+ * question returns once and can be dismissed again (and now it sticks), while an
+ * over-suppression silently kills eligibility forever.
+ *
+ * DRY RUN BY DEFAULT. Pass --apply to write.
+ *
+ *   npx tsx scripts/backfill-missed-return-dismissed.ts
+ *   npx tsx scripts/backfill-missed-return-dismissed.ts --apply
+ */
+import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+
+import { db, dailyQueues, feedItems, missedReturnDismissed, questions } from '../src/server/db';
+
+const APPLY = process.argv.includes('--apply');
+
+type Pair = { userId: string; questionId: string; source: 'daily' | 'feed' };
+
+function keyOf(p: Pair): string {
+  return `${p.userId}::${p.questionId}`;
+}
+
+async function collectDailyPairs(): Promise<Pair[]> {
+  // Unnest the slots JSONB and keep dismissed, canonical-question slots.
+  const rows = await db.execute<{ userId: string; questionId: string }>(sql`
+    SELECT DISTINCT q.user_id AS "userId", slot->>'question_id' AS "questionId"
+    FROM "DailyQueue" q,
+         LATERAL jsonb_array_elements(q.slots) AS slot
+    WHERE slot->>'dismissed_at' IS NOT NULL
+      AND slot->>'question_id' IS NOT NULL
+      AND slot->>'generated_question_id' IS NULL
+  `);
+  return (rows as unknown as { userId: string; questionId: string }[]).map((r) => ({
+    userId: r.userId,
+    questionId: r.questionId,
+    source: 'daily' as const,
+  }));
+}
+
+async function collectFeedPairs(): Promise<Pair[]> {
+  // Resolved AND carrying no answer evidence — see the header. `catchupResolvedAt`
+  // alone is stamped by the answer path too, so it cannot stand on its own.
+  const rows = await db
+    .select({ userId: feedItems.recipientUserId, questionId: feedItems.questionId })
+    .from(feedItems)
+    .where(
+      and(
+        isNotNull(feedItems.catchupResolvedAt),
+        isNotNull(feedItems.questionId),
+        isNull(feedItems.answerResult),
+        isNull(feedItems.answeredAt),
+        isNull(feedItems.submittedAnswer),
+      ),
+    );
+  return rows
+    .filter((r): r is { userId: string; questionId: string } => Boolean(r.userId && r.questionId))
+    .map((r) => ({ userId: r.userId, questionId: r.questionId, source: 'feed' as const }));
+}
+
+async function main() {
+  const [dailyPairs, feedPairs] = await Promise.all([collectDailyPairs(), collectFeedPairs()]);
+
+  // Dedupe across both sources.
+  const byKey = new Map<string, Pair>();
+  for (const p of [...dailyPairs, ...feedPairs]) {
+    if (!byKey.has(keyOf(p))) byKey.set(keyOf(p), p);
+  }
+
+  // Drop pairs whose question no longer exists (the FK would reject them).
+  const allQuestionIds = [...new Set([...byKey.values()].map((p) => p.questionId))];
+  const liveQuestionIds = new Set<string>();
+  const CHUNK = 500;
+  for (let i = 0; i < allQuestionIds.length; i += CHUNK) {
+    const chunk = allQuestionIds.slice(i, i + CHUNK);
+    const rows = await db
+      .select({ id: questions.id })
+      .from(questions)
+      .where(sql`${questions.id} = ANY(${chunk})`);
+    for (const r of rows) liveQuestionIds.add(r.id);
+  }
+
+  // Skip pairs that already have an active row.
+  const existing = await db
+    .select({ userId: missedReturnDismissed.userId, questionId: missedReturnDismissed.questionId })
+    .from(missedReturnDismissed)
+    .where(isNull(missedReturnDismissed.reinstatedAt));
+  const existingKeys = new Set(existing.map((r) => `${r.userId}::${r.questionId}`));
+
+  const toInsert = [...byKey.values()].filter(
+    (p) => liveQuestionIds.has(p.questionId) && !existingKeys.has(keyOf(p)),
+  );
+
+  const orphaned = [...byKey.values()].filter((p) => !liveQuestionIds.has(p.questionId));
+
+  console.log('--- MissedReturnDismissed backfill ---');
+  console.log(`Daily slot-level dismisses (canonical only): ${dailyPairs.length}`);
+  console.log(`Feed dismisses (resolved, no answer):        ${feedPairs.length}`);
+  console.log(`Distinct (user, question) pairs:             ${byKey.size}`);
+  console.log(`  already present (active row):              ${byKey.size - toInsert.length - orphaned.length}`);
+  console.log(`  skipped, question row is gone:             ${orphaned.length}`);
+  console.log(`  TO INSERT:                                 ${toInsert.length}`);
+  console.log(`Distinct users affected:                     ${new Set(toInsert.map((p) => p.userId)).size}`);
+  console.log('');
+  console.log(
+    'NOTE: feed rows are filtered to those with NO answer evidence. FeedItem.catchupResolvedAt',
+  );
+  console.log(
+    'is also stamped by the catch-up ANSWER path, so it is not a dismiss marker on its own',
+  );
+  console.log('(see the header). A count above 0 here is unusual — inspect before applying.');
+
+  if (!APPLY) {
+    console.log('\nDRY RUN — pass --apply to write these rows.');
+    return;
+  }
+
+  let inserted = 0;
+  for (let i = 0; i < toInsert.length; i += CHUNK) {
+    const chunk = toInsert.slice(i, i + CHUNK);
+    await db
+      .insert(missedReturnDismissed)
+      .values(chunk.map((p) => ({ userId: p.userId, questionId: p.questionId })))
+      .onConflictDoNothing();
+    inserted += chunk.length;
+    console.log(`  inserted ${inserted}/${toInsert.length}`);
+  }
+  console.log(`\n✓ Backfill complete — ${inserted} rows written.`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/app/api/daily/catchup/dismiss/route.ts
+++ b/src/app/api/daily/catchup/dismiss/route.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { getSession } from '@/server/auth/session';
 import { dailyQueues, db, feedItems } from '@/server/db';
 import { getCatchupQuestions } from '@/server/db/queries/daily';
+import { dismissMissedReturn } from '@/server/db/queries/missed-return-dismissed';
 import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
 import { catchUpErrorResponse } from '@/server/play/catch-up-submit-error';
@@ -39,6 +40,19 @@ export async function POST(request: NextRequest) {
     .find((item) => item.dailyQueueItemId === parsed.dailyQueueItemId);
   if (!catchupItem) return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found');
 
+  // D-MISSED-RETURN-01 §3.3 — dual-write the dismiss at (userId, questionId) so
+  // it survives across queue instances. The slot-level writes below are
+  // SLOT-scoped and invisible to a future return slot, which is by definition a
+  // new slot in a different queue; without this row a waved-off question would
+  // resurface days later. The old writes are retained — other code reads them.
+  //
+  // Resolved from `reportTarget`, NOT the flat `catchupItem.questionId`: that
+  // field holds either a `questions.id` OR a `generatedQuestions.id` and cannot
+  // disambiguate the two FK targets. LLM-origin daily questions have no
+  // canonical row to key on and are out of this feature's scope (they are
+  // likewise absent from the Recovered pool).
+  const canonicalQuestionId = catchupItem.reportTarget.questionId;
+
   if (catchupItem.surface === 'feed') {
     if (!catchupItem.feedItemId) {
       return catchUpErrorResponse(500, 'invalid_state', 'Feed catch-up item missing feed reference');
@@ -59,6 +73,10 @@ export async function POST(request: NextRequest) {
       .update(feedItems)
       .set({ catchupResolvedAt: new Date() })
       .where(eq(feedItems.id, feedItem.id));
+
+    if (canonicalQuestionId) {
+      await dismissMissedReturn(session.userId, canonicalQuestionId);
+    }
 
     return Response.json({ dismissed: true });
   }
@@ -100,6 +118,10 @@ export async function POST(request: NextRequest) {
     .update(dailyQueues)
     .set({ slots: nextSlots })
     .where(eq(dailyQueues.id, catchupItem.queueId));
+
+  if (canonicalQuestionId) {
+    await dismissMissedReturn(session.userId, canonicalQuestionId);
+  }
 
   return Response.json({ dismissed: true });
 }

--- a/src/app/api/daily/catchup/undismiss/route.ts
+++ b/src/app/api/daily/catchup/undismiss/route.ts
@@ -10,6 +10,7 @@ import {
   replaceQueueSlot,
 } from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
+import { reinstateMissedReturn } from '@/server/db/queries/missed-return-dismissed';
 import { catchUpErrorResponse } from '@/server/play/catch-up-submit-error';
 
 export const dynamic = 'force-dynamic';
@@ -53,6 +54,15 @@ export async function POST(request: NextRequest) {
       .set({ catchupResolvedAt: null })
       .where(eq(feedItems.id, feedItem.id));
 
+    // D-MISSED-RETURN-01 §3.3 — mirror of the dismiss route's dual-write. This
+    // reversal is NOT optional: without it, un-dismissing in catch-up would
+    // leave the (userId, questionId) row active and suppress the question from
+    // returning forever, which is the exact bug the dual-write exists to
+    // prevent, inverted. feedItems.questionId is always canonical.
+    if (feedItem.questionId) {
+      await reinstateMissedReturn(session.userId, feedItem.questionId);
+    }
+
     return Response.json({ restored: true });
   }
 
@@ -83,6 +93,13 @@ export async function POST(request: NextRequest) {
   );
 
   await db.update(dailyQueues).set({ slots: nextSlots }).where(eq(dailyQueues.id, target.queueId));
+
+  // Mirror of the dismiss route's dual-write — see the feed branch above.
+  // `question_id` is the canonical FK; a slot carrying `generated_question_id`
+  // instead is LLM-origin and has no canonical row to reinstate.
+  if (slot.question_id && !slot.generated_question_id) {
+    await reinstateMissedReturn(session.userId, slot.question_id);
+  }
 
   return Response.json({ restored: true });
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2259,6 +2259,32 @@ export async function register() {
       // Fresh databases may not have User/Question yet — migrate() creates all
       // three in normal migration order.
     }
+    // Migration 0127 (D-MISSED-RETURN-01 §3.3) adds the per-(user, question)
+    // dismiss table for the missed-question return system. The catch-up
+    // dismiss/undismiss routes dual-write it on every call and would 42P01 if
+    // the migration recorded without the table present.
+    // Self-contained; precedent: 0113's MilestoneDismissed guard above.
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "MissedReturnDismissed" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+          "questionId" text NOT NULL REFERENCES "Question"("id") ON DELETE CASCADE,
+          "dismissedAt" timestamp with time zone NOT NULL DEFAULT now(),
+          "reinstatedAt" timestamp with time zone
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "MissedReturnDismissed" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "MissedReturnDismissed_userId_idx" ON "MissedReturnDismissed" ("userId")`);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_active_unique"
+        ON "MissedReturnDismissed" ("userId", "questionId")
+        WHERE "reinstatedAt" IS NULL
+      `);
+    } catch {
+      // Fresh databases may not have User/Question yet — migrate() creates all
+      // three in normal migration order.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/server/db/queries/missed-return-dismissed.ts
+++ b/src/server/db/queries/missed-return-dismissed.ts
@@ -1,0 +1,143 @@
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+
+import { db, missedReturnDismissed } from '@/server/db';
+import { pgErrorCode } from '@/server/db/pg-error';
+
+/**
+ * D-MISSED-RETURN-01 §3.3 — the per-(user, question) dismiss for the
+ * missed-question return system.
+ *
+ * Catch-up's own dismiss is SLOT-scoped (it stamps `dismissed_at` into that
+ * day's DailyQueue.slots blob, or feedItems.catchupResolvedAt). A return is by
+ * definition a new slot in a different queue, so slot-level state cannot answer
+ * "has this player waved this question off for good?". These helpers own that
+ * question.
+ *
+ * A dismiss here is NEUTRAL — it writes only this row and touches no
+ * mastery/points state, so it never reads as a wrong answer (§5).
+ *
+ * SCOPE: `questionId` is a `questions.id` (canonical questions only). LLM-origin
+ * daily questions live in `generatedQuestions` and carry no `questions.id`; they
+ * are out of this feature's scope by construction, exactly as they are out of
+ * the Recovered pool's (MASTERY_EVENTS.question_id is null for them). Callers
+ * holding a catch-up item must resolve the canonical id via `reportTarget`
+ * rather than the flat `questionId` field, which can hold either FK target.
+ *
+ * Every read is resilient to the table not existing yet: a pre-migration
+ * database returns "nothing dismissed" rather than failing the calling surface
+ * (mirrors getSetAsideQuestionIds / getDismissedDomains' 42P01 handling).
+ */
+
+/** True when the viewer has an ACTIVE dismiss on this question. */
+export async function isReturnDismissed(userId: string, questionId: string): Promise<boolean> {
+  try {
+    const [row] = await db
+      .select({ id: missedReturnDismissed.id })
+      .from(missedReturnDismissed)
+      .where(
+        and(
+          eq(missedReturnDismissed.userId, userId),
+          eq(missedReturnDismissed.questionId, questionId),
+          isNull(missedReturnDismissed.reinstatedAt),
+        ),
+      )
+      .limit(1);
+    return Boolean(row);
+  } catch (error) {
+    if (pgErrorCode(error) === '42P01') return false; // table not yet migrated
+    throw error;
+  }
+}
+
+/**
+ * The viewer's actively-dismissed question ids. The batched form the eligibility
+ * query wants — one round trip instead of one per candidate.
+ *
+ * Pass `questionIds` to bound the scan to a candidate set; omit it for the whole
+ * set (what the Customize list needs).
+ */
+export async function getReturnDismissedQuestionIds(
+  userId: string,
+  questionIds?: readonly string[],
+): Promise<Set<string>> {
+  if (questionIds && questionIds.length === 0) return new Set();
+  try {
+    const rows = await db
+      .select({ questionId: missedReturnDismissed.questionId })
+      .from(missedReturnDismissed)
+      .where(
+        and(
+          eq(missedReturnDismissed.userId, userId),
+          isNull(missedReturnDismissed.reinstatedAt),
+          ...(questionIds ? [inArray(missedReturnDismissed.questionId, [...questionIds])] : []),
+        ),
+      );
+    return new Set(rows.map((r) => r.questionId));
+  } catch (error) {
+    if (pgErrorCode(error) === '42P01') return new Set(); // table not yet migrated
+    throw error;
+  }
+}
+
+/**
+ * Record a dismiss. A no-op if one is already active — the partial unique index
+ * guarantees at most one active row per (user, question). Mirrors
+ * setAsideRecoveredQuestion.
+ *
+ * Deliberately swallows 42P01 (table not yet migrated) and 23503 (the question
+ * is not a canonical `questions.id`): this is a dual-write riding along on the
+ * existing catch-up dismiss route, and it must never be able to fail a dismiss
+ * the player already performed successfully at the slot level.
+ */
+export async function dismissMissedReturn(userId: string, questionId: string): Promise<void> {
+  try {
+    const [existing] = await db
+      .select({ id: missedReturnDismissed.id })
+      .from(missedReturnDismissed)
+      .where(
+        and(
+          eq(missedReturnDismissed.userId, userId),
+          eq(missedReturnDismissed.questionId, questionId),
+          isNull(missedReturnDismissed.reinstatedAt),
+        ),
+      )
+      .limit(1);
+
+    if (existing) return;
+
+    await db.insert(missedReturnDismissed).values({ userId, questionId });
+  } catch (error) {
+    const code = pgErrorCode(error);
+    // 23505: a concurrent dismiss won the race — the state we wanted is the
+    // state we have. 23503: not a canonical question (see SCOPE above).
+    if (code === '42P01' || code === '23503' || code === '23505') return;
+    throw error;
+  }
+}
+
+/**
+ * Reverse a dismiss, putting the question back in return rotation. A no-op if
+ * none was active. Mirrors restoreRecoveredQuestion.
+ *
+ * This backs BOTH reversal paths: the catch-up undismiss route (reversible
+ * forever, already shipped) and Phase 3's immediate toast-undo window. Same
+ * mechanism, different window — per D-doc §7-C the return surface simply never
+ * builds a browsable archive on top of it.
+ */
+export async function reinstateMissedReturn(userId: string, questionId: string): Promise<void> {
+  try {
+    await db
+      .update(missedReturnDismissed)
+      .set({ reinstatedAt: new Date() })
+      .where(
+        and(
+          eq(missedReturnDismissed.userId, userId),
+          eq(missedReturnDismissed.questionId, questionId),
+          isNull(missedReturnDismissed.reinstatedAt),
+        ),
+      );
+  } catch (error) {
+    if (pgErrorCode(error) === '42P01') return; // table not yet migrated
+    throw error;
+  }
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1617,6 +1617,51 @@ export const milestoneDismissed = pgTable(
   ],
 );
 
+// Per-user "don't ask me this again" for the missed-question return system
+// (D-MISSED-RETURN-01 §3.3). A reversible soft-dismiss at the QUESTION level:
+// an active row (reinstatedAt IS NULL) makes the question permanently
+// ineligible to return to the Daily Five as a return slot.
+//
+// WHY THIS EXISTS SEPARATELY from the catch-up dismiss it dual-writes with:
+// catch-up's dismiss is SLOT-scoped — it stamps `dismissed_at` into that day's
+// DailyQueue.slots JSONB, or feedItems.catchupResolvedAt. A return is by
+// definition a NEW slot in a DIFFERENT queue, so a slot-level dismiss is
+// invisible to it and a waved-off question would resurface days later. This
+// table is the (userId, questionId) state that survives across queue instances.
+//
+// WHY IT IS NOT RecoveredSetAside: same shape, OPPOSITE meaning, and the rows
+// must never be conflated (D-MISSED-RETURN-01 §3.1). RecoveredSetAside means
+// "stop showing me this in the review deck" — a question I now KNOW. This means
+// "stop asking me this" — a question I do NOT know and don't want back.
+//
+// Like MilestoneDismissed, a dismiss here is deliberately NEUTRAL: it writes
+// ONLY this row and touches nothing in mastery/points, so it never reads as a
+// wrong answer (D-MISSED-RETURN-01 §5). Undo sets reinstatedAt = now();
+// dismissing again inserts a fresh active row. Mirrors RecoveredSetAside /
+// MilestoneDismissed exactly (the partial unique index keeps at most one active
+// row per (userId, questionId)).
+//
+// Note `questionId` FKs to Question — canonical questions only. LLM-origin
+// daily questions live in GeneratedQuestion and are out of this feature's scope
+// by construction (MASTERY_EVENTS.question_id is likewise null for them, so the
+// Recovered pool excludes them too).
+export const missedReturnDismissed = pgTable(
+  'MissedReturnDismissed',
+  {
+    id: id(),
+    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    dismissedAt: timestamp('dismissedAt', { withTimezone: true }).notNull().defaultNow(),
+    reinstatedAt: timestamp('reinstatedAt', { withTimezone: true }),
+  },
+  (table) => [
+    index('MissedReturnDismissed_userId_idx').on(table.userId),
+    uniqueIndex('missed_return_dismissed_active_unique')
+      .on(table.userId, table.questionId)
+      .where(sql`${table.reinstatedAt} IS NULL`),
+  ],
+);
+
 export const friendInvitations = pgTable(
   'FriendInvitation',
   {


### PR DESCRIPTION
**Phase 1 of `B-MISSED-RETURN-01`**, authorized by `D-MISSED-RETURN-01` §3.3 / §7-G. Corrects an existing weakness in catch-up dismiss and stands alone — nothing reads the new table yet (Phase 2's job).

## What was wrong

Catch-up dismiss is **slot-scoped**. It stamps `dismissed_at` into that day's `DailyQueue.slots` JSONB, or `FeedItem.catchupResolvedAt`. A returning question is by definition a new slot in a different queue, so a dismiss recorded against the old slot is invisible to it — a question the player explicitly waved off would reappear days later.

## What this adds

- **`MissedReturnDismissed`** keyed `(userId, questionId)`, on the `RecoveredSetAside` / `MilestoneDismissed` shape verbatim: `dismissedAt` + nullable `reinstatedAt`, partial unique index on `(userId, questionId) WHERE reinstatedAt IS NULL`. Migration `0127`, journaled, with an idempotent boot guard (precedent: 0113).
- **Dual-write from both catch-up routes**, retaining the existing slot-level writes.
- **Read helper** `src/server/db/queries/missed-return-dismissed.ts` — single + batched, 42P01-tolerant like its siblings.
- **Backfill script**, dry-run by default.

## Three judgment calls, per the slate

**1. Kept `reinstatedAt` (the slate left this open).** The shipped `undismiss` route is reversible-forever and needs a reversal mechanism, so a straight delete-on-confirm doesn't fit. Phase 3's toast-undo is the same mechanism on a shorter window; no archive UI is built on top, per §7-C.

**2. `undismiss` dual-writes too — the slate only specified `dismiss`.** Without the reversal, un-dismissing in catch-up would leave the row active and suppress the question forever: the same bug this PR fixes, inverted.

**3. The canonical id comes from `reportTarget`, not the flat `questionId`.** That field holds *either* a `questions.id` *or* a `generatedQuestions.id` and cannot disambiguate the two FK targets — dual-writing it blind would 23503 and break dismiss for LLM-origin questions.

## ⚠️ The backfill finding — §7-G's premise is wrong on live data

The D-doc names `FeedItem.catchupResolvedAt` as a dismiss source. **It is not one.** `catchup/answer/route.ts:519` stamps that same column when the player *answers*. Measured on prod:

| source | rows | verdict |
|---|---|---|
| `DailyQueue.slots[].dismissed_at`, canonical | **4** | genuine dismisses (all `not_interested`; 3 answered-incorrect-then-dismissed) |
| `DailyQueue.slots[].dismissed_at`, generated | 56 | out of scope — no `Question` row to key on |
| `FeedItem.catchupResolvedAt` | 49 | **all answers**, zero dismisses (`state='answered'`, `answerResult` set on all 49 — 36 correct, 13 incorrect) |

Backfilling the feed column blind would have permanently suppressed **13 wrong-answered questions** — precisely the inventory this feature exists to return — with no player-facing undo. The collector now filters feed rows to those carrying no answer evidence (0 today, correct going forward), erring toward under-suppression: a missed dismiss returns once and can be re-dismissed (and now it sticks), while an over-suppression is silent and unrecoverable.

**Real backfill: 4 rows across 3 users.** Not yet run — DML on prod, awaiting Josh.

## Scope note for Phase 2

`MASTERY_EVENTS.question_id` FKs to `Question` and is **null for LLM-origin generated questions**, so the Recovered pool already excludes them — and this feature line inherits that. The return system covers canonical (friend-authored/curated) questions only. Worth confirming against §8.3's audit criterion ("a real account with known misses must actually receive a return slot") before Phase 4 flips the flag.

## Verification

- `npx tsc -p tsconfig.typecheck.json` — 0 errors
- `npm run lint` — 0 errors (4 pre-existing warnings, untouched files)
- `npx vitest run src/app/api/daily/catchup` — 16/16 pass, **unmodified**
- Migration not manually applied; it is journaled and auto-applies via `migrate()` on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsnxcCmnb1J8Hxx3K7sKSP
