### PR TITLE
Bring a missed question back, once, as a sixth slot nobody paid for

### DIFF
--- a/drizzle/0128_missed_return_state.sql
+++ b/drizzle/0128_missed_return_state.sql
@@ -1,0 +1,46 @@
+-- 0128: MissedReturnState + the DailyPreference toggle — Phase 2 of
+-- B-MISSED-RETURN-01 (D-MISSED-RETURN-01 §4, §7-B1, §7-F1).
+--
+-- "MissedReturnState" holds the two per-(user, question) facts the return
+-- eligibility rule needs and cannot get cheaply from anywhere else:
+--   lastReturnedAt — the 7-day floor between sightings of the same question (R5)
+--   returnCount    — the lifetime cap of 3 returns per (player, question) (R7)
+-- One row per pair, updated in place: this is CURRENT STATE, not an event log.
+-- MASTERY_EVENTS already keeps the history, and re-deriving these two values
+-- from it would mean scanning the whole log per candidate on every queue build.
+--
+-- There is deliberately NO retiredAt column. R6 ("stop on first correct") is
+-- already queryable as "has a first_correct_after_wrong event" — the same
+-- predicate the shipped Recovered deck uses, which is exactly why a correct
+-- return lands the question in that deck with no new plumbing (§3.1).
+--
+-- "DailyPreference"."missed_return_enabled" is the single on/off toggle (§7-B1)
+-- governing both scopes together, defaulting TRUE for everyone (§7-F1). The
+-- default covers existing rows; users with NO DailyPreference row are treated as
+-- enabled in code, so "never opened Customize" never reads as "opted out".
+--
+-- Purely additive — the new column carries a DEFAULT so it is safe on the
+-- existing non-empty table. RLS enabled on the new table per B-SECURITY-RLS-01
+-- (no policies — the app connects as the owner role, which bypasses RLS).
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "MissedReturnState";
+--   ALTER TABLE "DailyPreference" DROP COLUMN IF EXISTS "missed_return_enabled";
+CREATE TABLE IF NOT EXISTS "MissedReturnState" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "questionId" text NOT NULL REFERENCES "Question"("id") ON DELETE CASCADE,
+  "lastReturnedAt" timestamp with time zone NOT NULL DEFAULT now(),
+  "returnCount" integer NOT NULL DEFAULT 0,
+  "createdAt" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "MissedReturnState_userId_idx" ON "MissedReturnState" ("userId");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_question_unique"
+  ON "MissedReturnState" ("userId", "questionId");
+--> statement-breakpoint
+ALTER TABLE "MissedReturnState" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "DailyPreference"
+  ADD COLUMN IF NOT EXISTS "missed_return_enabled" boolean NOT NULL DEFAULT true;

--- a/drizzle/0129_sms_missed_return_recovered.sql
+++ b/drizzle/0129_sms_missed_return_recovered.sql
@@ -1,0 +1,22 @@
+-- 0129: add 'missed_return_recovered' to the SmsMessageType enum
+-- (D-MISSED-RETURN-01 §7-A1).
+--
+-- The author push for the wrong→right moment: a question someone wrote comes
+-- back to a player who once missed it, and this time they get it. Nothing
+-- carried that signal back to the author before. Kept in its OWN migration
+-- (precedent: 0094's MasterySourceType addition) because ALTER TYPE ... ADD
+-- VALUE is a different class of change from the table work in 0128 and the new
+-- value cannot be used in the same transaction that adds it.
+--
+-- NOTE — pre-existing drift, NOT introduced here: five values already declared
+-- in schema.ts are absent from the production enum (ceremony_ready,
+-- joshing_game_received, joshing_game_progress, joshing_game_complete,
+-- friend_answered_question), so sends using them currently fail in prod. That is
+-- a separate bug with its own fix (standalone ALTER TYPE ADD VALUE per value)
+-- and is deliberately left alone here to keep this migration to its authorized
+-- scope. This migration adds only the one value this feature needs.
+--
+-- Rollback: enum values cannot be dropped in Postgres without recreating the
+-- type. This value is additive and unused until the return feature's flag is
+-- turned on, so the rollback is to leave it in place (a no-op) and stop writing it.
+ALTER TYPE "SmsMessageType" ADD VALUE IF NOT EXISTS 'missed_return_recovered';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -897,6 +897,20 @@
       "when": 1787529600000,
       "tag": "0127_missed_return_dismissed",
       "breakpoints": true
+    },
+    {
+      "idx": 128,
+      "version": "7",
+      "when": 1787616000000,
+      "tag": "0128_missed_return_state",
+      "breakpoints": true
+    },
+    {
+      "idx": 129,
+      "version": "7",
+      "when": 1787702400000,
+      "tag": "0129_sms_missed_return_recovered",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -14,7 +14,8 @@ import { deriveAnswerOutcome, recordAnswerSideEffects } from '@/server/answers/a
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
 import { isRoundComplete, type QueueSlot } from '@/server/daily/types';
 import { isDailyReplenishEnabled, replenishBankAfterPlay } from '@/server/daily/replenish-bank';
-import { isBonusSlot } from '@/server/daily/bonus';
+import { isBonusSlot, isReturnSlot } from '@/server/daily/bonus';
+import { notifyAuthorOfReturnRecovery } from '@/server/daily/missed-return-notify';
 import { asQueueSlots } from '@/server/daily/catchup';
 import { resolveDailyBasePoints } from '@/server/daily/types';
 import { resolveEffectiveDifficulty } from '@/server/daily/empirical-difficulty';
@@ -468,10 +469,24 @@ export async function POST(request: NextRequest) {
         // (D-RECOVERY-SCORING-UNIFY-01). question.difficulty reproduces
         // `basePoints` as the first-correct base; recovery earns
         // round(base × RECOVERY_STATE_WEIGHT). Live surface (catchUp omitted).
+        // D-MISSED-RETURN-01 §5 — a RETURN slot never earns live credit, in
+        // either scope. Without `catchUp`, an expired-scope return scores
+        // `first_correct` at LIVE_SURFACE_WEIGHT (100%) because the player has
+        // genuinely never answered it, which contradicts the §5 table's
+        // CATCHUP_SURFACE_WEIGHT (25%) and would make Daily Five scores
+        // incomparable across players (R4).
+        //
+        // Passing it for BOTH scopes is deliberate and safe: for the wrong scope
+        // the state is `first_correct_after_wrong`, and canonicalPointsForAnswer's
+        // MAX-not-compound rule (D-RECOVERY-SCORING-UNIFY-01 D1) already makes
+        // RECOVERY_STATE_WEIGHT win outright rather than stacking to 6.25%. So
+        // one honest rule — "a return is not a live first sighting" — yields
+        // exactly the two weights §5 asks for. The scorer itself is untouched.
         pointsFor: (answerState) =>
           canonicalPointsForAnswer({
             difficulty: question.difficulty,
             answerState,
+            catchUp: isReturnSlot(slot),
           }),
       }),
       selectInsideJokeForViewer(persistedInsideJoke, persistedCreatorId, session.userId),
@@ -541,6 +556,33 @@ export async function POST(request: NextRequest) {
       }),
     ]);
     marks.mastery = Date.now();
+
+    // D-MISSED-RETURN-01 §7-A1 — the author push. Fires only when a WRONG-scope
+    // return just landed correct: that is the wrong→right moment, and it is the
+    // payoff the whole feature exists to produce. The expired scope is excluded
+    // on purpose (the player had never seen it, so nothing "stuck").
+    //
+    // Deferred with after() so the author's notification never sits in front of
+    // the player's verdict, and fire-and-forget — notifyAuthorOfReturnRecovery
+    // swallows its own errors.
+    if (
+      isCorrect &&
+      isReturnSlot(slot) &&
+      slot.return_scope === 'wrong' &&
+      persistedCreatorId &&
+      canonicalQuestionId
+    ) {
+      const authorId = persistedCreatorId;
+      const questionIdForPush = canonicalQuestionId;
+      const answererId = session.userId;
+      after(() =>
+        notifyAuthorOfReturnRecovery({
+          authorUserId: authorId,
+          answererUserId: answererId,
+          questionId: questionIdForPush,
+        }),
+      );
+    }
 
     // Demand-pull bank replenish (D-SUPPLY-DEMAND-PULL-01): THIS answer just
     // completed the round (transition — the prior slot state was incomplete),

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2285,6 +2285,40 @@ export async function register() {
       // Fresh databases may not have User/Question yet — migrate() creates all
       // three in normal migration order.
     }
+    // Migration 0128 (D-MISSED-RETURN-01 §4) adds the per-(user, question) return
+    // state and the Customize toggle. The queue builder reads both on every build
+    // once the flag is on, and the eligibility query would 42P01/42703 if the
+    // migration recorded without them present.
+    // Self-contained; precedent: 0113's MilestoneDismissed guard above.
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "MissedReturnState" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+          "questionId" text NOT NULL REFERENCES "Question"("id") ON DELETE CASCADE,
+          "lastReturnedAt" timestamp with time zone NOT NULL DEFAULT now(),
+          "returnCount" integer NOT NULL DEFAULT 0,
+          "createdAt" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "MissedReturnState" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "MissedReturnState_userId_idx" ON "MissedReturnState" ("userId")`);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_question_unique"
+        ON "MissedReturnState" ("userId", "questionId")
+      `);
+    } catch {
+      // Fresh databases may not have User/Question yet — migrate() creates all
+      // three in normal migration order.
+    }
+    try {
+      await db.execute(sql`
+        ALTER TABLE "DailyPreference"
+        ADD COLUMN IF NOT EXISTS "missed_return_enabled" boolean NOT NULL DEFAULT true
+      `);
+    } catch {
+      // DailyPreference may not exist yet on a fresh database.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/lib/activity-types.ts
+++ b/src/lib/activity-types.ts
@@ -57,7 +57,15 @@ export type ActivityItemType =
   // this is a slow-burn delight with no volume cues; it surfaces only in the
   // full /activities list.
   | 'niche_match_answered_your_question' // author-side: a stranger correctly answered a question you authored
-  | 'niche_match_you_answered'; // answerer-side: you correctly answered a stranger's authored question
+  | 'niche_match_you_answered' // answerer-side: you correctly answered a stranger's authored question
+  // D-MISSED-RETURN-01 §7-A1. Author-side: a question you wrote came back to
+  // someone who once missed it, and this time they got it. Deliberately NOT
+  // friend_answered_your_question — that fires on any correct answer and carries
+  // no history. This one exists because the wrong→right moment is the strongest
+  // positive signal the product makes, and nothing carried it back before. Fires
+  // for the WRONG return scope only (an expired-scope return has never been seen,
+  // so there is no "it stuck" story to tell).
+  | 'missed_return_recovered';
 
 // Events surfaced in Home's top-3 RecentActivity and counted by the bell
 // badge. Light type filtering only — chronological within this set. Single

--- a/src/server/daily/__tests__/missed-return.test.ts
+++ b/src/server/daily/__tests__/missed-return.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MISSED_RETURN_LIFETIME_CAP,
+  MISSED_RETURN_PER_SESSION_CAP,
+  rankReturnCandidates,
+  selectReturnCandidates,
+  type ReturnCandidate,
+} from '@/server/daily/missed-return';
+import { getCoreSlots, isAdditiveSlot, isBonusSlot, isReturnSlot } from '@/server/daily/bonus';
+import { canonicalPointsForAnswer } from '@/lib/game-constants';
+import {
+  CATCHUP_SURFACE_WEIGHT,
+  RECOVERY_STATE_WEIGHT,
+} from '@/server/mastery/constants';
+import { getBasePoints } from '@/server/mastery/scoring';
+import type { QueueSlot } from '@/server/daily/types';
+
+const day = (n: number) => new Date(Date.UTC(2026, 0, n));
+
+function candidate(over: Partial<ReturnCandidate> = {}): ReturnCandidate {
+  return {
+    questionId: 'q1',
+    scope: 'wrong',
+    lastSeenAt: day(1),
+    returnCount: 0,
+    ...over,
+  };
+}
+
+function slot(over: Partial<QueueSlot> = {}): QueueSlot {
+  return {
+    slot_index: 0,
+    source: 'friend',
+    domain: 'jazz',
+    question_text: 'q?',
+    answered: false,
+    ...over,
+  } as QueueSlot;
+}
+
+describe('D-MISSED-RETURN-01 — ranking and selection (§2 R2, R8)', () => {
+  it('ranks expired ahead of wrong — unseen beats re-seen', () => {
+    // The wrong one is OLDER, so only the scope rule can put expired first.
+    const ranked = rankReturnCandidates([
+      candidate({ questionId: 'wrong', scope: 'wrong', lastSeenAt: day(1) }),
+      candidate({ questionId: 'expired', scope: 'expired', lastSeenAt: day(20) }),
+    ]);
+    expect(ranked.map((c) => c.questionId)).toEqual(['expired', 'wrong']);
+  });
+
+  it('orders longest-since-last-seen first within a scope, so the backlog drains', () => {
+    const ranked = rankReturnCandidates([
+      candidate({ questionId: 'recent', lastSeenAt: day(20) }),
+      candidate({ questionId: 'oldest', lastSeenAt: day(2) }),
+      candidate({ questionId: 'middle', lastSeenAt: day(10) }),
+    ]);
+    expect(ranked.map((c) => c.questionId)).toEqual(['oldest', 'middle', 'recent']);
+  });
+
+  it('is deterministic on ties', () => {
+    const input = [
+      candidate({ questionId: 'b', lastSeenAt: day(3) }),
+      candidate({ questionId: 'a', lastSeenAt: day(3) }),
+    ];
+    expect(rankReturnCandidates(input).map((c) => c.questionId)).toEqual(['a', 'b']);
+    // Pure — the input array is not mutated.
+    expect(input.map((c) => c.questionId)).toEqual(['b', 'a']);
+  });
+
+  it('caps at ONE return per session, never two (R2)', () => {
+    const selected = selectReturnCandidates([
+      candidate({ questionId: 'a', scope: 'expired', lastSeenAt: day(1) }),
+      candidate({ questionId: 'b', scope: 'expired', lastSeenAt: day(2) }),
+      candidate({ questionId: 'c', scope: 'wrong', lastSeenAt: day(3) }),
+    ]);
+    expect(selected).toHaveLength(1);
+    expect(MISSED_RETURN_PER_SESSION_CAP).toBe(1);
+    expect(selected[0].questionId).toBe('a');
+  });
+
+  it('selects nothing from an empty candidate set', () => {
+    expect(selectReturnCandidates([])).toEqual([]);
+  });
+
+  it('caps lifetime returns at 3 (R7)', () => {
+    expect(MISSED_RETURN_LIFETIME_CAP).toBe(3);
+  });
+});
+
+describe('D-MISSED-RETURN-01 — the return slot is APPENDED, never one of the five (§2 R3)', () => {
+  it('marks a slot as a return iff it carries return_scope', () => {
+    expect(isReturnSlot(slot({ return_scope: 'wrong' }))).toBe(true);
+    expect(isReturnSlot(slot({ return_scope: 'expired' }))).toBe(true);
+    expect(isReturnSlot(slot())).toBe(false);
+  });
+
+  it('does not confuse a return slot with a +2 bonus slot', () => {
+    const returnSlot = slot({ return_scope: 'wrong' });
+    expect(isBonusSlot(returnSlot)).toBe(false);
+    expect(isAdditiveSlot(returnSlot)).toBe(true);
+
+    const bonus = slot({ presence_source_id: 'u1' });
+    expect(isReturnSlot(bonus)).toBe(false);
+    expect(isAdditiveSlot(bonus)).toBe(true);
+  });
+
+  it('keeps the core five at five when a return slot is appended', () => {
+    const slots = [
+      slot({ slot_index: 0 }),
+      slot({ slot_index: 1 }),
+      slot({ slot_index: 2 }),
+      slot({ slot_index: 3 }),
+      slot({ slot_index: 4 }),
+      slot({ slot_index: 5, presence_source_id: 'u1' }),
+      slot({ slot_index: 6, return_scope: 'wrong' }),
+    ];
+    // Six slots would mean a friend's fresh question lost its seat to a repeat.
+    expect(getCoreSlots(slots)).toHaveLength(5);
+  });
+});
+
+describe('D-MISSED-RETURN-01 §5 — the scoring table, one test per row', () => {
+  const difficulty = 'moderate' as const;
+  const liveBase = getBasePoints(difficulty, 'first_correct');
+
+  it('returning wrong → correct: RECOVERY_STATE_WEIGHT of the full live base', () => {
+    const points = canonicalPointsForAnswer({
+      difficulty,
+      answerState: 'first_correct_after_wrong',
+      catchUp: true, // what the return slot passes
+    });
+    expect(points).toBe(Math.round(liveBase * RECOVERY_STATE_WEIGHT));
+    // MAX-not-compound (D-RECOVERY-SCORING-UNIFY-01 D1): recovery REPLACES the
+    // catch-up surface weight rather than stacking to 6.25%.
+    expect(points).not.toBe(
+      Math.round(liveBase * RECOVERY_STATE_WEIGHT * CATCHUP_SURFACE_WEIGHT),
+    );
+  });
+
+  it('returning wrong → wrong again: 0', () => {
+    expect(
+      canonicalPointsForAnswer({ difficulty, answerState: 'incorrect', catchUp: true }),
+    ).toBe(0);
+  });
+
+  it('returning expired → correct: CATCHUP_SURFACE_WEIGHT, not live credit', () => {
+    const points = canonicalPointsForAnswer({
+      difficulty,
+      answerState: 'first_correct',
+      catchUp: true,
+    });
+    expect(points).toBe(Math.round(liveBase * CATCHUP_SURFACE_WEIGHT));
+    // The bug this guards: without catchUp the same answer scores FULL live
+    // credit, because the player genuinely never answered it before.
+    expect(points).not.toBe(
+      canonicalPointsForAnswer({ difficulty, answerState: 'first_correct' }),
+    );
+  });
+
+  it('returning expired → wrong: 0', () => {
+    expect(
+      canonicalPointsForAnswer({ difficulty, answerState: 'incorrect', catchUp: true }),
+    ).toBe(0);
+  });
+});

--- a/src/server/daily/bonus.ts
+++ b/src/server/daily/bonus.ts
@@ -35,9 +35,38 @@ export function isBonusSlot(slot: QueueSlot): boolean {
   return typeof slot.presence_source_id === 'string' && slot.presence_source_id.trim() !== '';
 }
 
-/** Core (non-bonus) slots, input order preserved. The canonical "five". */
+/**
+ * True iff the slot carries a `return_scope` (the missed-question return marker,
+ * D-MISSED-RETURN-01 §2 R3). Same opt-in rule as bonus: the marker field's
+ * presence is the truth, never position.
+ */
+export function isReturnSlot(slot: QueueSlot): boolean {
+  return slot.return_scope === 'wrong' || slot.return_scope === 'expired';
+}
+
+/**
+ * True iff the slot is APPENDED rather than part of the five — a +2 bonus slot or
+ * a missed-question return slot.
+ */
+export function isAdditiveSlot(slot: QueueSlot): boolean {
+  return isBonusSlot(slot) || isReturnSlot(slot);
+}
+
+/**
+ * Core slots, input order preserved. The canonical "five".
+ *
+ * Excludes BOTH additive kinds. A return slot appends beyond the five exactly as
+ * the +2 does (D-MISSED-RETURN-01 R3: "a friend's fresh question never loses its
+ * seat to a repeat") — counting one here would quietly make the Daily Five a six
+ * and break the D-F3 canon that the spoken count is always 5.
+ */
 export function getCoreSlots(slots: QueueSlot[]): QueueSlot[] {
-  return slots.filter((slot) => !isBonusSlot(slot));
+  return slots.filter((slot) => !isAdditiveSlot(slot));
+}
+
+/** Return slots, input order preserved. */
+export function getReturnSlots(slots: QueueSlot[]): QueueSlot[] {
+  return slots.filter(isReturnSlot);
 }
 
 /** Bonus slots, input order preserved. */

--- a/src/server/daily/missed-return-notify.ts
+++ b/src/server/daily/missed-return-notify.ts
@@ -1,0 +1,91 @@
+import { eq } from 'drizzle-orm';
+
+import { db, users } from '@/server/db';
+import { writeActivity } from '@/server/activity/write-activity';
+import { sendSms } from '@/server/sms';
+
+/**
+ * D-MISSED-RETURN-01 §7-A1 — tell the AUTHOR when a question they wrote came
+ * back to someone who once missed it and this time landed correct.
+ *
+ * "The wrong→right moment is the strongest positive signal the product generates
+ * and today nothing carries it back to the author. Full push, not just a feed
+ * entry."
+ *
+ * WHAT "PUSH" MEANS HERE (searched before building, per the build slate): there
+ * is NO web-push infrastructure in this codebase — no service worker, no
+ * PushSubscription table, no VAPID keys. The two real channels are:
+ *   - `writeActivity`  → the bell / Home activity stream (a feed entry)
+ *   - `sendSms`        → Twilio, the only actual push-to-device path
+ * So §7-A1's "full push, not just a feed entry" is satisfied by doing BOTH, with
+ * SMS as the push. Nothing new was built.
+ *
+ * Both writes are best-effort and swallow their own errors: this fires from the
+ * answer path, and an author's notification must never be able to fail a
+ * player's answer.
+ *
+ * WRONG SCOPE ONLY. An expired-scope return has never been seen by the player,
+ * so a correct answer on it is an ordinary first correct — there is no
+ * "what you taught them stuck" story to carry back, and firing for it would
+ * dilute the signal this notification exists to deliver.
+ *
+ * COPY IS A PLACEHOLDER. §6/§9 hold the copy pass as a separate gate, and Phase 4
+ * of the build slate replaces the string below verbatim from the approved pass.
+ * The register is the hard part: never "they got your question wrong then right",
+ * never a remediation framing. Reference voice is RecoveredDeck (§3.1).
+ */
+export async function notifyAuthorOfReturnRecovery(params: {
+  /** The question's author. */
+  authorUserId: string;
+  /** The player who just recovered it. */
+  answererUserId: string;
+  questionId: string;
+  /** Optional override; resolved from the answerer's profile when omitted. */
+  answererName?: string | null;
+  baseUrl?: string;
+}): Promise<void> {
+  const { authorUserId, answererUserId, questionId } = params;
+
+  // Never notify someone about their own answer.
+  if (!authorUserId || authorUserId === answererUserId) return;
+
+  await writeActivity({
+    userId: authorUserId,
+    type: 'missed_return_recovered',
+    actorUserId: answererUserId,
+    referenceId: questionId,
+    referenceType: 'question',
+  });
+
+  try {
+    const [author] = await db
+      .select({ phone: users.phoneNumber, optIn: users.smsOptIn })
+      .from(users)
+      .where(eq(users.id, authorUserId))
+      .limit(1);
+
+    if (!author?.phone || author.optIn !== 'opted_in') return;
+
+    let name = params.answererName?.trim() || '';
+    if (!name) {
+      const [answerer] = await db
+        .select({ displayName: users.displayName })
+        .from(users)
+        .where(eq(users.id, answererUserId))
+        .limit(1);
+      name = answerer?.displayName?.trim() || '';
+    }
+    if (!name) name = 'Someone';
+    const baseUrl = params.baseUrl ?? process.env.NEXT_PUBLIC_BASE_URL ?? '';
+    // PLACEHOLDER COPY — replaced wholesale in Phase 4 from the approved pass.
+    const message = `${name} came back to your question and got it. ${baseUrl}/activities`.trim();
+
+    await sendSms(author.phone, message, 'missed_return_recovered', authorUserId);
+  } catch (error) {
+    console.warn('[missed-return] author push failed', {
+      authorUserId,
+      questionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/src/server/daily/missed-return.ts
+++ b/src/server/daily/missed-return.ts
@@ -1,0 +1,94 @@
+/**
+ * D-MISSED-RETURN-01 — returning missed questions to the Daily Five.
+ *
+ * The framing, which governs everything here: this is NOT remediation and must
+ * never read as it. A return asks "did what your friend taught you stick?", and
+ * getting it right the second time is itself a connection event — arguably a
+ * stronger one than the original miss. Copy that reads as a quiz retake, a
+ * correction, or a deficiency is a canon violation (§1).
+ *
+ * This module is PURE — constants, the flag, and the ranking rule. The database
+ * side lives in `@/server/db/queries/missed-return`, and the dismiss state in
+ * `@/server/db/queries/missed-return-dismissed`.
+ */
+
+/** R5 — minimum days between sightings of the same question. A FLOOR, not a schedule. */
+export const MISSED_RETURN_COOLDOWN_DAYS = Math.max(
+  0,
+  Number(process.env.MISSED_RETURN_COOLDOWN_DAYS ?? 7),
+);
+
+/**
+ * R7 — lifetime cap of returns per (player, question). A question missed four
+ * times isn't teaching anything; the honest move is to let it go.
+ * Counted for the WRONG scope only (§2).
+ */
+export const MISSED_RETURN_LIFETIME_CAP = Math.max(
+  0,
+  Number(process.env.MISSED_RETURN_LIFETIME_CAP ?? 3),
+);
+
+/**
+ * R2 — at most ONE return per session. Never 2: at five questions, two returns
+ * is 40% recycled, which is a curriculum rather than a grace note.
+ */
+export const MISSED_RETURN_PER_SESSION_CAP = 1;
+
+/**
+ * Feature flag, OFF by default (§9 Phase 4 flips it). Every read path is gated
+ * on this so the feature is fully dark until the copy pass lands — §6 is explicit
+ * that the copy IS the feature here, not polish on top of it.
+ */
+export function isMissedReturnEnabled(): boolean {
+  return process.env.MISSED_RETURN_ENABLED === '1';
+}
+
+/**
+ * The two scopes are NOT treated identically (§2), because an expired question
+ * has never been seen:
+ *
+ *   wrong   — a return. Marked as one ("from March 4"), never disguised as new
+ *             (R9). Scores at RECOVERY_STATE_WEIGHT. Counts toward the 3-cap.
+ *   expired — a first ask, arriving late. NO return framing, no "again" label.
+ *             Scores at CATCHUP_SURFACE_WEIGHT. Does NOT count toward the cap.
+ */
+export type ReturnScope = 'wrong' | 'expired';
+
+export type ReturnCandidate = {
+  questionId: string;
+  scope: ReturnScope;
+  /** When the player last saw it — the wrong answer, or the queue date it expired on. */
+  lastSeenAt: Date;
+  /** Returns served so far (wrong scope only; expired first appearances don't count). */
+  returnCount: number;
+};
+
+/**
+ * R8 + §2 — ranking. Expired before wrong ("unseen beats re-seen"), and within
+ * each, longest-since-last-seen first so the backlog DRAINS rather than the same
+ * two questions cycling.
+ *
+ * Pure and total: ties break on questionId so a build is deterministic given the
+ * same candidate set.
+ */
+export function rankReturnCandidates(candidates: readonly ReturnCandidate[]): ReturnCandidate[] {
+  const scopeRank = (scope: ReturnScope) => (scope === 'expired' ? 0 : 1);
+  return [...candidates].sort((a, b) => {
+    const byScope = scopeRank(a.scope) - scopeRank(b.scope);
+    if (byScope !== 0) return byScope;
+    const byAge = a.lastSeenAt.getTime() - b.lastSeenAt.getTime(); // oldest first
+    if (byAge !== 0) return byAge;
+    return a.questionId.localeCompare(b.questionId);
+  });
+}
+
+/**
+ * The whole selection rule: rank, then take the session cap (R2). Serve-time, not
+ * render-time — §8.5 is explicit that a queue able to hold two return slots while
+ * the UI shows one will leak the second somewhere eventually.
+ */
+export function selectReturnCandidates(
+  candidates: readonly ReturnCandidate[],
+): ReturnCandidate[] {
+  return rankReturnCandidates(candidates).slice(0, MISSED_RETURN_PER_SESSION_CAP);
+}

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -3,6 +3,8 @@ import {
   buildBotSlot,
   buildHouseSlot,
   buildPresenceSlot,
+  buildReturnSlot,
+  resolveCreatorNames,
   carryForwardUntouchedDailyQueue,
   carryForwardQueueWithSlots,
   clearStaleShortTodayQueue,
@@ -19,6 +21,16 @@ import {
   type BonusPresence,
 } from '@/server/db/queries/daily';
 import { ANSWER_COOLDOWN_DAYS, makeAnswerCooldownGate } from '@/server/daily/answer-cooldown';
+import {
+  isMissedReturnEnabled,
+  selectReturnCandidates,
+} from '@/server/daily/missed-return';
+import {
+  getEligibleReturnCandidates,
+  isMissedReturnEnabledForUser,
+  loadReturnQuestions,
+  recordReturnServed,
+} from '@/server/db/queries/missed-return';
 import { SUBJECT_COOLDOWN_DAYS, makeSubjectCooldownGate } from '@/server/daily/subject-cooldown';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { getFriendAndFoFUserIds } from '@/server/db/queries/friends';
@@ -1048,6 +1060,63 @@ async function buildDailyQueueForUser(
     }
   } catch (error) {
     console.warn('[daily/queue-orchestrator] +2 bonus / core-backfill generation failed; serving core only', {
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // D-MISSED-RETURN-01 §2 R3 — the missed-question RETURN slot, appended last.
+  //
+  // Appended, never one of the core five: a friend's fresh question must never
+  // lose its seat to a repeat. `buildReturnSlot` stamps `return_scope`, which is
+  // what keeps it out of getCoreSlots — same marker-field convention as the +2.
+  //
+  // *** DELIBERATE COOLDOWN EXEMPTION — DO NOT "FIX" THIS (§8.1) ***
+  // The answer-cooldown gate (ANSWER_COOLDOWN_DAYS = 28) and the serve-time
+  // repeat gates exist to stop a question the player already answered from
+  // reappearing. A returning question is INTENTIONALLY a repeat, so it is
+  // selected here — outside the gated core-pick loop — and never consulted
+  // against `answerCooldown`. This is narrow on purpose: it exempts only the one
+  // designated return slot, and is NOT a relaxation of the general gate. The
+  // slot's answer is likewise never `record()`ed into the gate, so a return can't
+  // suppress a legitimate core pick that happens to share its answer.
+  // The 28-day answer cooldown and the 7-day return cooldown are different axes
+  // and WILL disagree; for the return slot, the return cooldown governs.
+  try {
+    if (isMissedReturnEnabled() && (await isMissedReturnEnabledForUser(userId))) {
+      const candidates = await getEligibleReturnCandidates(userId);
+      const selected = selectReturnCandidates(candidates);
+      if (selected.length > 0) {
+        const questionRows = await loadReturnQuestions(selected.map((c) => c.questionId));
+        const byId = new Map(questionRows.map((q) => [q.id, q]));
+        const authorNames = await resolveCreatorNames(
+          questionRows.map((q) => q.creatorId).filter((id): id is string => Boolean(id)),
+        );
+        for (const candidate of selected) {
+          const question = byId.get(candidate.questionId);
+          if (!question) continue;
+          slots.push(
+            buildReturnSlot(
+              {
+                ...question,
+                authorName: question.creatorId ? authorNames.get(question.creatorId) ?? null : null,
+                difficultyEstimate: question.difficultyEstimate ?? null,
+              },
+              candidate,
+              position,
+            ),
+          );
+          position += 1;
+          // Serve-time, not render-time (§8.5): the state is written as the slot
+          // is built, so the cap and the 7-day floor hold even if the player
+          // never opens the queue.
+          await recordReturnServed(userId, candidate.questionId, candidate.scope);
+        }
+      }
+    }
+  } catch (error) {
+    // Never let the return slot cost a build — degrade to a queue without one.
+    console.warn('[daily/queue-orchestrator] missed-return slot selection failed; serving without it', {
       userId,
       error: error instanceof Error ? error.message : String(error),
     });

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -53,6 +53,29 @@ export const queueSlotSchema = z.object({
    * just "{Name}".
    */
   presence_source_extra_count: z.number().int().optional(),
+  /**
+   * Missed-question return marker (D-MISSED-RETURN-01 §2 R3). Set only on an
+   * APPENDED return slot — a canonical question the viewer previously got wrong,
+   * or one that expired unanswered and aged out of catch-up. The presence of
+   * `return_scope` is what marks a slot as a return slot, following the same
+   * marker-field convention as `presence_source_*` above rather than adding a
+   * slot-kind enum. Like a bonus slot, a return slot is ADDITIVE and never
+   * counts toward the five — see isReturnSlot / getCoreSlots in ./bonus.
+   *
+   * The two scopes are deliberately different (§2): 'wrong' is a return and must
+   * be visibly marked as one (R9, provenance canon — never disguised as new),
+   * while 'expired' has never been seen and must carry NO return framing at all;
+   * it reads as a normal question that happens to be arriving late.
+   */
+  return_scope: z.enum(['wrong', 'expired']).optional(),
+  /**
+   * The date the viewer last saw this question — the wrong answer, or the queue
+   * date it expired on. Feeds the honest return label ("from March 4", R9). ISO
+   * date string.
+   */
+  return_last_seen_at: z.string().optional(),
+  /** Which return this is (1-based) for the 'wrong' scope. Telemetry + copy. */
+  return_count: z.number().int().optional(),
   domain: z.string(),
   /** Free-text broader topic for this slot (e.g. "Saturday morning cartoons"). Optional — populated for newly built slots. */
   broad_category: z.string().nullish(),

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -686,7 +686,7 @@ export async function getGeneratedQuestionsForQueue(queue: DailyQueueRow) {
 // Resolve creator display names for a set of (possibly null/duplicate) creator
 // ids, returning a id→name map. Null/absent ids are skipped — their questions
 // are LLM-origin and the client labels them non-relationally.
-async function resolveCreatorNames(creatorIds: Array<string | null>): Promise<Map<string, string | null>> {
+export async function resolveCreatorNames(creatorIds: Array<string | null>): Promise<Map<string, string | null>> {
   const ids = [...new Set(creatorIds.filter((id): id is string => Boolean(id)))];
   if (ids.length === 0) return new Map();
   const nameRows = await db
@@ -1481,6 +1481,60 @@ export function buildAuthoredSlot(authored: AuthoredPick, position: number): Que
     difficulty_stepped_up: false,
   };
 }
+
+/**
+ * Build an APPENDED missed-question return slot (D-MISSED-RETURN-01 §2 R3).
+ *
+ * The question is an existing canonical Question the viewer previously got wrong
+ * or let expire, so this looks like an authored slot — same `source: 'friend'`,
+ * same `question_id` — plus the `return_*` markers that designate it a return and
+ * keep it out of the core five (see isReturnSlot / getCoreSlots).
+ *
+ * `return_last_seen_at` carries the honest provenance the return label needs
+ * (R9): a wrong-scope return is visibly a return, never disguised as new. The
+ * expired scope carries the field too (it is cheap and true) but its copy must
+ * NOT use return framing — it has never been seen, so it reads as a normal
+ * question arriving late (§2). That distinction is the renderer's job, on
+ * `return_scope`, and it is the highest-risk surface in this build (§6).
+ */
+export function buildReturnSlot(
+  question: ReturnSlotQuestion,
+  candidate: { scope: 'wrong' | 'expired'; lastSeenAt: Date; returnCount: number },
+  position: number,
+): QueueSlot {
+  return {
+    slot_index: position,
+    source: 'friend',
+    question_id: question.id,
+    author_id: question.creatorId ?? undefined,
+    author_name: question.authorName ?? null,
+    author_note: question.creatorNote ?? null,
+    return_scope: candidate.scope,
+    return_last_seen_at: candidate.lastSeenAt.toISOString(),
+    // 1-based: the return the player is about to see. Expired first appearances
+    // stay at 0 + 1 = 1 but never advance the stored count (§2).
+    return_count: candidate.returnCount + 1,
+    domain: question.canonicalSubcategory ?? question.broadCategory ?? question.category ?? 'general',
+    broad_category: question.broadCategory ?? null,
+    category: question.category || null,
+    question_text: question.questionText,
+    difficulty_estimate: asQueueSlotDifficulty(question.difficultyEstimate) ?? undefined,
+    answered: false,
+    difficulty_stepped_up: false,
+  };
+}
+
+export type ReturnSlotQuestion = {
+  id: string;
+  questionText: string;
+  creatorId: string | null;
+  authorName?: string | null;
+  creatorNote?: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+  category: string | null;
+  difficultyEstimate: string | null;
+};
 
 export async function createDailyQueueItemFromAuthored(
   userId: string,

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -127,7 +127,10 @@ export async function getEligibleReturnCandidates(
         u."lastSeenAt"                     AS "lastSeenAt",
         COALESCE(s."returnCount", 0)       AS "returnCount"
       FROM unioned u
-      JOIN "Question" qq ON qq.id = u."questionId" AND qq."deletedAt" IS NULL
+      -- NOTE: Question is snake_case here ("deleted_at"), unlike the camelCase
+      -- MissedReturn* tables above. Getting this wrong raises 42703, which is
+      -- deliberately NOT swallowed below — see the catch.
+      JOIN "Question" qq ON qq.id = u."questionId" AND qq.deleted_at IS NULL
       LEFT JOIN "MissedReturnState" s
         ON s."userId" = ${userId} AND s."questionId" = u."questionId"
       WHERE u."questionId" NOT IN (SELECT "questionId" FROM ever_correct)
@@ -145,10 +148,19 @@ export async function getEligibleReturnCandidates(
       returnCount: Number(row.returnCount ?? 0),
     }));
   } catch (error) {
-    // A pre-migration database yields no candidates rather than failing the
-    // whole queue build (mirrors getSetAsideQuestionIds' 42P01 handling).
-    const code = pgErrorCode(error);
-    if (code === '42P01' || code === '42703') return [];
+    // A pre-migration database (missing MissedReturnState/MissedReturnDismissed)
+    // yields no candidates rather than failing the whole queue build — mirrors
+    // getSetAsideQuestionIds' 42P01 handling.
+    //
+    // 42703 (undefined_column) is deliberately NOT swallowed. A wrong column name
+    // in the SQL above is a CODING error, not a migration state, and swallowing
+    // it would make this function silently return [] forever — the feature would
+    // ship, the flag would flip, and no return slot would ever appear. That is
+    // exactly the "feature lands dark" failure §8.3 warns about, and it nearly
+    // happened here: Question is snake_case ("deleted_at") while the MissedReturn*
+    // tables are camelCase. The orchestrator's own try/catch still degrades the
+    // build gracefully, but it LOGS instead of failing quietly.
+    if (pgErrorCode(error) === '42P01') return [];
     throw error;
   }
 }

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -1,0 +1,227 @@
+import { and, eq, sql } from 'drizzle-orm';
+
+import {
+  dailyPreferences,
+  db,
+  missedReturnState,
+  questions,
+} from '@/server/db';
+import { pgErrorCode } from '@/server/db/pg-error';
+import { CATCHUP_LOOKBACK_DAYS } from '@/server/daily/catchup';
+import {
+  MISSED_RETURN_COOLDOWN_DAYS,
+  MISSED_RETURN_LIFETIME_CAP,
+  type ReturnCandidate,
+  type ReturnScope,
+} from '@/server/daily/missed-return';
+
+/**
+ * D-MISSED-RETURN-01 §4 — return eligibility, in one query.
+ *
+ * A question is eligible to return to player P when ALL of these hold:
+ *
+ *   1. P's last answer on it was `incorrect`, OR it expired unanswered on P's
+ *      queue
+ *   2. No correct answer from P has ever been recorded on it (R6 — stop on first
+ *      correct; the question retires permanently and becomes a Recovered card)
+ *   3. returnCount < 3 (R7), counted for the WRONG scope only — an expired
+ *      question's first appearance has never been seen, so it is a first ask
+ *      arriving late, not a return (§2)
+ *   4. lastReturnedAt is null or >= 7 days ago (R5 — a FLOOR, not a schedule)
+ *   5. No active MissedReturnDismissed row for (P, question)
+ *   6. P's return toggle is on (§7-B1; absent DailyPreference row reads as ON)
+ *   7. The question is still live (not soft-deleted)
+ *
+ * SCOPE — canonical questions only. Both scopes key on `Question.id`:
+ * MASTERY_EVENTS.question_id is null for LLM-origin generated questions and a
+ * generated daily slot carries `generated_question_id` instead, so neither can
+ * produce a candidate. This matches the Recovered deck, which excludes them for
+ * the same reason, and is why the return loop's exit (§3.1) needs no new code.
+ *
+ * Ranking is NOT done here — see `rankReturnCandidates`. This returns the whole
+ * eligible set because the Customize list (Phase 3) needs it too; the queue
+ * builder takes 1 (R2).
+ */
+
+/** Rows come back pre-shaped for both consumers: the queue builder and Customize. */
+export async function getEligibleReturnCandidates(
+  userId: string,
+  { now = new Date() }: { now?: Date } = {},
+): Promise<ReturnCandidate[]> {
+  try {
+    const cooldownCutoff = new Date(
+      now.getTime() - MISSED_RETURN_COOLDOWN_DAYS * 24 * 60 * 60 * 1000,
+    );
+    // A question only counts as "expired" once it has aged out of catch-up —
+    // before that it is still reachable there and returning it would double-serve.
+    const expiredBefore = new Date(
+      now.getTime() - CATCHUP_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
+    );
+
+    const rows = await db.execute<{
+      questionId: string;
+      scope: ReturnScope;
+      lastSeenAt: Date;
+      returnCount: number;
+    }>(sql`
+      WITH
+      -- (1a) WRONG scope: the player's most recent answer on the question was
+      -- incorrect. answered_by_user_id = user_id keeps this to answers THEY gave.
+      wrong AS (
+        SELECT DISTINCT ON (me.question_id)
+          me.question_id AS "questionId",
+          me.created_at  AS "lastSeenAt"
+        FROM "MASTERY_EVENTS" me
+        WHERE me.user_id = ${userId}
+          AND me.question_id IS NOT NULL
+          AND me.answer_state IS NOT NULL
+        ORDER BY me.question_id, me.created_at DESC
+      ),
+      wrong_scope AS (
+        SELECT "questionId", "lastSeenAt" FROM wrong
+        WHERE "questionId" IN (
+          SELECT me.question_id FROM "MASTERY_EVENTS" me
+          WHERE me.user_id = ${userId}
+            AND me.question_id IS NOT NULL
+            AND me.answer_state = 'incorrect'
+        )
+      ),
+      -- (1b) EXPIRED scope: an unanswered, undismissed daily slot on a queue old
+      -- enough to have fallen out of catch-up. Canonical slots only.
+      expired_scope AS (
+        SELECT DISTINCT
+          slot->>'question_id' AS "questionId",
+          max(q.queue_date::timestamptz) OVER (PARTITION BY slot->>'question_id') AS "lastSeenAt"
+        FROM "DailyQueue" q, LATERAL jsonb_array_elements(q.slots) AS slot
+        WHERE q.user_id = ${userId}
+          AND q.queue_date::timestamptz < ${expiredBefore}
+          AND slot->>'question_id' IS NOT NULL
+          AND slot->>'generated_question_id' IS NULL
+          AND COALESCE(slot->>'answered', 'false') = 'false'
+          AND slot->>'dismissed_at' IS NULL
+      ),
+      -- (2) R6: any correct answer ever retires the question permanently.
+      ever_correct AS (
+        SELECT DISTINCT me.question_id AS "questionId"
+        FROM "MASTERY_EVENTS" me
+        WHERE me.user_id = ${userId}
+          AND me.question_id IS NOT NULL
+          AND me.answer_state IN ('first_correct', 'first_correct_after_wrong', 'repeat_correct')
+      ),
+      -- (5) An ACTIVE dismiss suppresses the question outright.
+      dismissed AS (
+        SELECT "questionId" FROM "MissedReturnDismissed"
+        WHERE "userId" = ${userId} AND "reinstatedAt" IS NULL
+      ),
+      -- Wrong takes precedence when a question qualifies under both: it HAS been
+      -- seen, so it must carry the return framing and the 3-return cap.
+      unioned AS (
+        SELECT "questionId", 'wrong'::text AS scope, "lastSeenAt" FROM wrong_scope
+        UNION ALL
+        SELECT "questionId", 'expired'::text AS scope, "lastSeenAt" FROM expired_scope
+        WHERE "questionId" NOT IN (SELECT "questionId" FROM wrong_scope)
+      )
+      SELECT
+        u."questionId"                     AS "questionId",
+        u.scope                            AS scope,
+        u."lastSeenAt"                     AS "lastSeenAt",
+        COALESCE(s."returnCount", 0)       AS "returnCount"
+      FROM unioned u
+      JOIN "Question" qq ON qq.id = u."questionId" AND qq."deletedAt" IS NULL
+      LEFT JOIN "MissedReturnState" s
+        ON s."userId" = ${userId} AND s."questionId" = u."questionId"
+      WHERE u."questionId" NOT IN (SELECT "questionId" FROM ever_correct)
+        AND u."questionId" NOT IN (SELECT "questionId" FROM dismissed)
+        -- (4) 7-day floor between sightings.
+        AND (s."lastReturnedAt" IS NULL OR s."lastReturnedAt" <= ${cooldownCutoff})
+        -- (3) lifetime cap, wrong scope only.
+        AND (u.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
+    `);
+
+    return (rows as unknown as ReturnCandidate[]).map((row) => ({
+      questionId: row.questionId,
+      scope: row.scope,
+      lastSeenAt: new Date(row.lastSeenAt),
+      returnCount: Number(row.returnCount ?? 0),
+    }));
+  } catch (error) {
+    // A pre-migration database yields no candidates rather than failing the
+    // whole queue build (mirrors getSetAsideQuestionIds' 42P01 handling).
+    const code = pgErrorCode(error);
+    if (code === '42P01' || code === '42703') return [];
+    throw error;
+  }
+}
+
+/**
+ * §7-B1/§7-F1 — the Customize toggle, default ON.
+ *
+ * A user with NO DailyPreference row reads as ENABLED. Reading the column
+ * through a plain join would make "never opened Customize" mean "opted out",
+ * silently withholding the feature from exactly the least-engaged players it is
+ * meant to reach.
+ */
+export async function isMissedReturnEnabledForUser(userId: string): Promise<boolean> {
+  try {
+    const [row] = await db
+      .select({ enabled: dailyPreferences.missedReturnEnabled })
+      .from(dailyPreferences)
+      .where(eq(dailyPreferences.userId, userId))
+      .limit(1);
+    return row ? row.enabled : true;
+  } catch (error) {
+    if (pgErrorCode(error) === '42703') return true; // column not yet migrated
+    throw error;
+  }
+}
+
+/**
+ * Record that a question was served as a return. Upserts the (user, question)
+ * row, always stamping `lastReturnedAt` (which drives the 7-day floor) and
+ * incrementing `returnCount` for the WRONG scope only (§2 — an expired
+ * question's first appearance is a first ask arriving late, not a return).
+ */
+export async function recordReturnServed(
+  userId: string,
+  questionId: string,
+  scope: ReturnScope,
+  { now = new Date() }: { now?: Date } = {},
+): Promise<void> {
+  const increment = scope === 'wrong' ? 1 : 0;
+  try {
+    await db
+      .insert(missedReturnState)
+      .values({ userId, questionId, lastReturnedAt: now, returnCount: increment })
+      .onConflictDoUpdate({
+        target: [missedReturnState.userId, missedReturnState.questionId],
+        set: {
+          lastReturnedAt: now,
+          returnCount: sql`${missedReturnState.returnCount} + ${increment}`,
+        },
+      });
+  } catch (error) {
+    if (pgErrorCode(error) === '42P01') return; // table not yet migrated
+    throw error;
+  }
+}
+
+/** Live question text/answer for the candidates the builder decided to serve. */
+export async function loadReturnQuestions(questionIds: readonly string[]) {
+  if (questionIds.length === 0) return [];
+  return db
+    .select({
+      id: questions.id,
+      questionText: questions.questionText,
+      answerText: questions.answerText,
+      creatorId: questions.creatorId,
+      canonicalSubcategory: questions.canonicalSubcategory,
+      broadCategory: questions.broadCategory,
+      category: questions.category,
+      questionType: questions.questionType,
+      difficultyEstimate: questions.difficultyEstimate,
+      creatorNote: questions.creatorNote,
+      source: questions.source,
+    })
+    .from(questions)
+    .where(and(sql`${questions.id} = ANY(${[...questionIds]})`, sql`${questions.deletedAt} IS NULL`));
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -173,6 +173,11 @@ export const smsMessageTypeEnum = pgEnum('SmsMessageType', [
   'joshing_game_progress',
   'joshing_game_complete',
   'friend_answered_question',
+  // D-MISSED-RETURN-01 §7-A1 — the author push when a question they wrote comes
+  // back to a player who once missed it and this time lands correct. The
+  // wrong→right moment is the strongest positive signal the product makes and
+  // nothing carried it back to the author before.
+  'missed_return_recovered',
 ]);
 export const answerStateEnum = pgEnum('AnswerState', [
   'first_correct',
@@ -1027,6 +1032,16 @@ export const dailyPreferences = pgTable(
       .notNull()
       .default({}),
     difficultyPreference: text('difficulty_preference').notNull().default('normal'),
+    /**
+     * D-MISSED-RETURN-01 §7-B1/§7-F1 — the single on/off toggle governing BOTH
+     * return scopes (expired + wrong) together. Default TRUE: on for everyone,
+     * existing and new alike.
+     *
+     * Read it through `isMissedReturnEnabledForUser`, never directly: a user with
+     * no DailyPreference row at all must also read as ON, and a raw join would
+     * silently make "never opened Customize" mean "opted out".
+     */
+    missedReturnEnabled: boolean('missed_return_enabled').notNull().default(true),
     updatedAt: updatedAt(),
   },
   (table) => [
@@ -1659,6 +1674,43 @@ export const missedReturnDismissed = pgTable(
     uniqueIndex('missed_return_dismissed_active_unique')
       .on(table.userId, table.questionId)
       .where(sql`${table.reinstatedAt} IS NULL`),
+  ],
+);
+
+// Per-(user, question) return state for the missed-question return system
+// (D-MISSED-RETURN-01 §4). Exactly two facts, both of which the eligibility rule
+// needs and neither of which is derivable cheaply from anything else:
+//
+//   lastReturnedAt — enforces the 7-day floor between sightings (R5). A floor,
+//                    not a schedule: nothing promises a return on day 8.
+//   returnCount    — enforces the lifetime cap of 3 (R7). A question missed four
+//                    times isn't teaching anything, so it is let go.
+//
+// One row per (userId, questionId), created on first return and updated in place
+// — this is CURRENT STATE, not an event log (MASTERY_EVENTS already keeps the
+// event history, and deriving these two values from it would mean scanning the
+// whole log per candidate on every queue build).
+//
+// Deliberately NOT tracking retirement: R6's "stop on first correct" is already
+// queryable as "has a first_correct_after_wrong event", which is the same
+// predicate the shipped Recovered deck uses. No retiredAt column (§3.1).
+//
+// Per §2, the count is incremented for the WRONG scope only — an expired
+// question's first appearance has never been seen, so it is a first ask arriving
+// late, not a return.
+export const missedReturnState = pgTable(
+  'MissedReturnState',
+  {
+    id: id(),
+    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    lastReturnedAt: timestamp('lastReturnedAt', { withTimezone: true }).notNull().defaultNow(),
+    returnCount: integer('returnCount').notNull().default(0),
+    createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('MissedReturnState_userId_idx').on(table.userId),
+    uniqueIndex('missed_return_state_user_question_unique').on(table.userId, table.questionId),
   ],
 );
 


### PR DESCRIPTION
**Phase 2 of `B-MISSED-RETURN-01`** — return state, eligibility, selection. Behind `MISSED_RETURN_ENABLED`, **off by default**; the feature is fully dark. Stacks on Phase 1 (#1563, merged).

## What landed

| § | Thing |
|---|---|
| §4 | `getEligibleReturnCandidates` — all seven conditions in one query, both scopes |
| §4 | `MissedReturnState` (migration `0128`): `lastReturnedAt` (7-day floor), `returnCount` (3-cap, wrong scope only) |
| §2 R8/R2 | `rankReturnCandidates` / `selectReturnCandidates` — expired before wrong, oldest first, take 1 |
| §2 R3 | Appended slot via the `return_scope` marker, wired into `queue-orchestrator` before persist |
| §8.1 | Narrow, commented cooldown exemption |
| §5 | Scoring routed through `canonicalPointsForAnswer` |
| §7-A1 | Author push on wrong-scope correct-on-return |
| §7-B1/F1 | `DailyPreference.missed_return_enabled`, default on |

## Four things worth reading

**1. `getCoreSlots` would have made the Daily Five a six.** It treats any slot without `presence_source_id` as core, so an appended return would have been counted in the five — breaking R3 and the D-F3 canon that the spoken count is always 5. Added `isReturnSlot`/`isAdditiveSlot` to that single source of truth, with a test asserting 5 core out of 7 slots.

**2. Scoring needed a one-line fix the slate expected to be a no-op.** The slate said route through `canonicalPointsForAnswer` *unmodified* and confirm both §5 rows resolve. The wrong scope does. The **expired** scope does not: its answer state is `first_correct` (the player genuinely never answered it), so it scored at `LIVE_SURFACE_WEIGHT` — 100% — against §5's `CATCHUP_SURFACE_WEIGHT` of 25%, which would make Daily Five scores incomparable across players (R4). The scorer already had the `catchUp` parameter; the route just never passed it. Now it does, for both scopes — safe because MAX-not-compound already makes recovery win outright for the wrong scope, so one honest rule ("a return is not a live first sighting") yields exactly the two weights §5 asks for. **`canonicalPointsForAnswer` itself is untouched.**

**3. There was no push to reuse.** Searched first, as instructed. This codebase has **no web-push infrastructure** — no service worker, no `PushSubscription` table, no VAPID. `correct_answer_notification` exists in the SMS enum but is dead (never sent anywhere). So §7-A1's "full push, not just a feed entry" is an activity item **plus SMS**, the only real device channel. Nothing new was built. Copy is an explicit placeholder for Phase 4.

**4. Table-vs-column, flagged as asked.** Went with a table. There is no existing per-(user, question) record to hang columns on — `MASTERY_EVENTS` is an append-only event log, and re-deriving `lastReturnedAt`/`returnCount` from it would mean scanning the log per candidate on every queue build. No `retiredAt` column, per §3.1.

## Pre-existing drift found (not fixed here)

Five values declared in `schema.ts` are **absent from the production `SmsMessageType` enum**: `ceremony_ready`, `joshing_game_received`, `joshing_game_progress`, `joshing_game_complete`, `friend_answered_question`. Sends using them fail in prod today. Left alone to keep this PR in scope — `0129` adds only the one value this feature needs. Worth its own fix.

## Verification

- `npx tsc -p tsconfig.typecheck.json` — 0 errors
- `npm run lint` — 0 errors (4 pre-existing warnings, untouched files)
- **Full suite: 2319 passed, 0 failed** (302 files)
- New `missed-return.test.ts` — 13 tests: ranking, scope precedence, session cap, determinism, core-five arithmetic, and **one test per row of the §5 scoring table**
- Journal reconciled report-only; `--apply` deliberately NOT run (it would insert rows for unapplied migrations and make them skip forever)

## ⚠️ Not yet verifiable live — blocked on a deploy, not on code

Phase 1's `0127` **has not applied in prod**, so the Phase 1 backfill (4 rows) is still pending too. Cause is not the migration: production is still serving `dpl_A32BUmrpiMoRfFzUHk6XppdohHZB` (commit `7b5e6b86`). The production build for the #1563 merge is `READY` but has **zero runtime traffic** — it hasn't been promoted, so the code containing `0127` was never live to run `migrate()`. Timestamps are correct (`0127` = 2026-08-24 > last applied 2026-08-23).

That blocks these DONE-WHEN items until the deployment is promoted:
- a seeded test account actually receiving a return slot (§8.3's audit criterion)
- correct-on-return surfacing in the Recovered deck by hand
- the author push firing on a real account
- the Phase 1 backfill

Everything provable without a live DB is proven above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsnxcCmnb1J8Hxx3K7sKSP
