### PR TITLE
Make the return query survive contact with the actual database

### DIFF
--- a/scripts/backfill-missed-return-dismissed.ts
+++ b/scripts/backfill-missed-return-dismissed.ts
@@ -35,7 +35,9 @@
  *   npx tsx scripts/backfill-missed-return-dismissed.ts
  *   npx tsx scripts/backfill-missed-return-dismissed.ts --apply
  */
-import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+import 'dotenv/config';
+
+import { and, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 
 import { db, dailyQueues, feedItems, missedReturnDismissed, questions } from '../src/server/db';
 
@@ -57,7 +59,9 @@ async function collectDailyPairs(): Promise<Pair[]> {
       AND slot->>'question_id' IS NOT NULL
       AND slot->>'generated_question_id' IS NULL
   `);
-  return (rows as unknown as { userId: string; questionId: string }[]).map((r) => ({
+  type Row = { userId: string; questionId: string };
+  const list = (rows as unknown as { rows?: Row[] }).rows ?? (rows as unknown as Row[]);
+  return list.map((r) => ({
     userId: r.userId,
     questionId: r.questionId,
     source: 'daily' as const,
@@ -102,7 +106,7 @@ async function main() {
     const rows = await db
       .select({ id: questions.id })
       .from(questions)
-      .where(sql`${questions.id} = ANY(${chunk})`);
+      .where(inArray(questions.id, chunk));
     for (const r of rows) liveQuestionIds.add(r.id);
   }
 

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 
 import {
   dailyPreferences,
@@ -141,7 +141,14 @@ export async function getEligibleReturnCandidates(
         AND (u.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
     `);
 
-    return (rows as unknown as ReturnCandidate[]).map((row) => ({
+    // db.execute returns a driver result ({ rows }) on node-postgres and a bare
+    // array on some paths — read both shapes, per the house pattern in
+    // domain-fragmentation.ts. Assuming either one alone throws at runtime.
+    type Row = { questionId: string; scope: ReturnScope; lastSeenAt: string | Date; returnCount: number };
+    const list =
+      (rows as unknown as { rows?: Row[] }).rows ?? (rows as unknown as Row[]);
+
+    return list.map((row) => ({
       questionId: row.questionId,
       scope: row.scope,
       lastSeenAt: new Date(row.lastSeenAt),
@@ -235,5 +242,7 @@ export async function loadReturnQuestions(questionIds: readonly string[]) {
       source: questions.source,
     })
     .from(questions)
-    .where(and(sql`${questions.id} = ANY(${[...questionIds]})`, sql`${questions.deletedAt} IS NULL`));
+    // inArray, not `= ANY(...)`: drizzle renders a JS array in a sql template as
+    // a tuple, which Postgres rejects with 42809 against ANY().
+    .where(and(inArray(questions.id, [...questionIds]), isNull(questions.deletedAt)));
 }


### PR DESCRIPTION
Follow-up to #1564 (merged). Three runtime defects found by running the code against production instead of reading it, plus the live verification #1564 couldn't do.

## The bugs

| # | Defect | Effect |
|---|---|---|
| 1 | `db.execute` returns `{ rows }`, not an array — `rows.map` threw `TypeError` | Eligibility query died on its first real call |
| 2 | `loadReturnQuestions` used `= ANY(${jsArray})`; drizzle renders that as a tuple → Postgres `42809` | The only query that loads a to-be-served question could never succeed |
| 3 | Backfill script never imported `dotenv/config` | Couldn't connect at all |

**None of these were reachable by the type checker, the linter, or 2319 unit tests** — each is a runtime contract with the driver or the SQL dialect, not something types can see. Worse, the orchestrator's `try/catch` would have swallowed #1 and #2 into a `console.warn` and served a queue with no return slot. The feature would have "worked," logged a warning nobody was reading, and simply never appeared.

That's three separate ways to land dark found in one file, on top of the `deleted_at` bug from earlier. This surface earns live verification; reading it is not enough.

## Live verification (prod, after `0127`/`0128`/`0129` applied + backfill run)

Ran the real `getEligibleReturnCandidates` → `selectReturnCandidates` chain:

```
user f5ed1c59  toggle=true
  eligible: 177  (wrong=177, expired=0)
  dismissed rows: 3   DISMISS LEAK (must be 0): 0
  would serve: scope=wrong lastSeen=2026-05-19 returnCount=0

user 30c4be4b  toggle=true
  eligible: 80   (wrong=79, expired=1)
  dismissed rows: 1   DISMISS LEAK (must be 0): 0
  would serve: scope=expired lastSeen=2026-05-24 returnCount=0
```

Which confirms, on live data:
- the eligibility query runs against the real schema
- **§8.2's guardrail — dismisses actually suppress returns — checked from live accounts, not tests.** Leak 0 on both
- the toggle reads default-on
- **ranking is right**: user `30c4be4b` has 1 expired against 79 wrong, and the expired one is what gets served (R8 / §2, "unseen beats re-seen")
- §8.3's audit criterion is satisfied — real accounts with known misses do produce return candidates (177 and 80, not 0)

## Migrations + backfill: done

`0127`, `0128`, `0129` all applied to prod (verified: both tables, correct columns, RLS on, 6 indexes, `missed_return_enabled` defaulting true, SMS enum value present).

Backfill applied — **4 rows, 2 users**. Each traced back to a genuine slot-level `not_interested` dismiss (3 answered-incorrect-then-dismissed, 1 unanswered). Feed source contributed 0, as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsnxcCmnb1J8Hxx3K7sKSP
