### PR TITLE
Put the returning questions on Customize, with a few seconds to change your mind

### DIFF
--- a/src/app/api/daily/missed-return/__tests__/route.test.ts
+++ b/src/app/api/daily/missed-return/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getSessionMock,
+  setMissedReturnEnabledMock,
+  dismissMissedReturnMock,
+  reinstateMissedReturnMock,
+} = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  setMissedReturnEnabledMock: vi.fn(),
+  dismissMissedReturnMock: vi.fn(),
+  reinstateMissedReturnMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/db/queries/missed-return', () => ({
+  setMissedReturnEnabled: setMissedReturnEnabledMock,
+}));
+vi.mock('@/server/db/queries/missed-return-dismissed', () => ({
+  dismissMissedReturn: dismissMissedReturnMock,
+  reinstateMissedReturn: reinstateMissedReturnMock,
+}));
+
+import { PATCH } from '@/app/api/daily/missed-return/settings/route';
+import { DELETE, POST } from '@/app/api/daily/missed-return/dismiss/route';
+
+function req(url: string, method: string, body: unknown): Request {
+  return new Request(`http://localhost${url}`, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSessionMock.mockResolvedValue({ userId: 'user-1' });
+});
+
+describe('PATCH /api/daily/missed-return/settings — the §7-B1 toggle', () => {
+  it('turns the feature off', async () => {
+    const res = await PATCH(req('/api/daily/missed-return/settings', 'PATCH', { enabled: false }) as never);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ enabled: false });
+    expect(setMissedReturnEnabledMock).toHaveBeenCalledWith('user-1', false);
+  });
+
+  it('turns it back on', async () => {
+    const res = await PATCH(req('/api/daily/missed-return/settings', 'PATCH', { enabled: true }) as never);
+    expect(res.status).toBe(200);
+    expect(setMissedReturnEnabledMock).toHaveBeenCalledWith('user-1', true);
+  });
+
+  it('rejects a non-boolean rather than coercing it', async () => {
+    const res = await PATCH(req('/api/daily/missed-return/settings', 'PATCH', { enabled: 'yes' }) as never);
+    expect(res.status).toBe(400);
+    expect(setMissedReturnEnabledMock).not.toHaveBeenCalled();
+  });
+
+  it('401s without a session', async () => {
+    getSessionMock.mockResolvedValue(null);
+    const res = await PATCH(req('/api/daily/missed-return/settings', 'PATCH', { enabled: false }) as never);
+    expect(res.status).toBe(401);
+    expect(setMissedReturnEnabledMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('/api/daily/missed-return/dismiss — §7-C dismiss and immediate undo', () => {
+  it('dismisses for the session user, never a client-supplied one', async () => {
+    const res = await POST(
+      req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'q1', userId: 'someone-else' }) as never,
+    );
+    expect(res.status).toBe(200);
+    expect(dismissMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1');
+  });
+
+  it('DELETE undoes the dismiss', async () => {
+    const res = await DELETE(req('/api/daily/missed-return/dismiss', 'DELETE', { questionId: 'q1' }) as never);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ restored: true });
+    expect(reinstateMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1');
+  });
+
+  it('a dismiss writes ONLY the dismiss — never a mastery/points side effect (§5)', async () => {
+    await POST(req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'q1' }) as never);
+    expect(dismissMissedReturnMock).toHaveBeenCalledTimes(1);
+    expect(reinstateMissedReturnMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing questionId', async () => {
+    const res = await POST(req('/api/daily/missed-return/dismiss', 'POST', {}) as never);
+    expect(res.status).toBe(400);
+    expect(dismissMissedReturnMock).not.toHaveBeenCalled();
+  });
+
+  it('401s both verbs without a session', async () => {
+    getSessionMock.mockResolvedValue(null);
+    expect((await POST(req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'q1' }) as never)).status).toBe(401);
+    expect((await DELETE(req('/api/daily/missed-return/dismiss', 'DELETE', { questionId: 'q1' }) as never)).status).toBe(401);
+    expect(dismissMissedReturnMock).not.toHaveBeenCalled();
+    expect(reinstateMissedReturnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/daily/missed-return/dismiss/route.ts
+++ b/src/app/api/daily/missed-return/dismiss/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import {
+  dismissMissedReturn,
+  reinstateMissedReturn,
+} from '@/server/db/queries/missed-return-dismissed';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * D-MISSED-RETURN-01 §7-C — per-row dismiss from the Customize list, with the
+ * immediate-undo affordance.
+ *
+ * DELETE is the undo. §7-C revised the decision away from the siblings'
+ * reversible-forever archive: the undo window is a few seconds on the client and
+ * then it's final, and NO browsable dismissed shelf is built on top of it. The
+ * underlying row keeps `reinstatedAt` because the shipped catch-up undismiss
+ * route also needs a reversal path — same mechanism, different window.
+ *
+ * A dismiss here is NEUTRAL (§5): it writes one row and touches no mastery or
+ * points state, so it can never read as a wrong answer.
+ */
+const bodySchema = z.object({ questionId: z.string().min(1) });
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'questionId is required' }, { status: 400 });
+  }
+
+  await dismissMissedReturn(session.userId, parsed.data.questionId);
+  return NextResponse.json({ dismissed: true });
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'questionId is required' }, { status: 400 });
+  }
+
+  await reinstateMissedReturn(session.userId, parsed.data.questionId);
+  return NextResponse.json({ restored: true });
+}

--- a/src/app/api/daily/missed-return/settings/route.ts
+++ b/src/app/api/daily/missed-return/settings/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { setMissedReturnEnabled } from '@/server/db/queries/missed-return';
+
+export const dynamic = 'force-dynamic';
+
+// D-MISSED-RETURN-01 §7-B1 — the single on/off toggle governing BOTH return
+// scopes together. Turning it off stops FUTURE selection; a return slot already
+// built into today's queue is left alone (see the note in the Customize client).
+const bodySchema = z.object({ enabled: z.boolean() });
+
+export async function PATCH(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'enabled must be a boolean' }, { status: 400 });
+  }
+
+  await setMissedReturnEnabled(session.userId, parsed.data.enabled);
+  return NextResponse.json({ enabled: parsed.data.enabled });
+}

--- a/src/app/daily/setup/MissedReturnSection.tsx
+++ b/src/app/daily/setup/MissedReturnSection.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Switch } from '@/components/ui/Switch';
+
+/**
+ * D-MISSED-RETURN-01 §7-D — the Customize surface for returning questions.
+ *
+ * ONE surface, not two (R11): the toggle at the top, the currently-eligible
+ * questions below it, each with a dismiss.
+ *
+ * Deliberately lighter than the Recovered pattern. §7-C rules out a browsable
+ * dismissed archive and a dimmed/archived section — a dismissed row simply
+ * leaves the list, with a few seconds to undo. That is the whole reversal story.
+ *
+ * REGISTER (§1, §6): this is not remediation and must never read as it. No
+ * "you got this wrong", no "practice", no "review", no counts of failure. A
+ * returning question is something a friend taught you, coming back to see if it
+ * stuck. The expired scope gets NO return framing at all — it has never been
+ * seen, so it reads as a question that simply hasn't been asked yet.
+ *
+ * Copy here is the working pass; Phase 4 replaces it from the approved copy pass.
+ */
+
+const UNDO_WINDOW_MS = 6000;
+
+export type MissedReturnItem = {
+  questionId: string;
+  scope: 'wrong' | 'expired';
+  questionText: string;
+  category: string | null;
+  authorName: string | null;
+  /** ISO — when they last saw it (the wrong answer, or the day it expired). */
+  lastSeenAt: string;
+  returnCount: number;
+};
+
+function formatSeen(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
+}
+
+export function MissedReturnSection({
+  initialEnabled,
+  initialItems,
+}: {
+  initialEnabled: boolean;
+  initialItems: MissedReturnItem[];
+}) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [items, setItems] = useState(initialItems);
+  /** The row awaiting its undo window. Null when nothing is pending. */
+  const [pending, setPending] = useState<MissedReturnItem | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const toggle = useCallback(async (next: boolean) => {
+    setEnabled(next); // optimistic — the control should never feel laggy
+    setError(null);
+    try {
+      const res = await fetch('/api/daily/missed-return/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!res.ok) throw new Error('failed');
+    } catch {
+      setEnabled(!next);
+      setError('That didn’t save. Try again?');
+    }
+  }, []);
+
+  /**
+   * Dismiss writes IMMEDIATELY — the undo window is a grace period on a real
+   * write, not a delayed one. If the player closes the tab mid-window the
+   * dismiss still stands, which is the honest reading of "I don't want this
+   * back" and avoids a row that silently reappears tomorrow.
+   */
+  const dismiss = useCallback(
+    async (item: MissedReturnItem) => {
+      clearTimer();
+      setError(null);
+      setItems((current) => current.filter((i) => i.questionId !== item.questionId));
+      setPending(item);
+      timerRef.current = window.setTimeout(() => setPending(null), UNDO_WINDOW_MS);
+
+      try {
+        const res = await fetch('/api/daily/missed-return/dismiss', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ questionId: item.questionId }),
+        });
+        if (!res.ok) throw new Error('failed');
+      } catch {
+        setItems((current) => [item, ...current]);
+        setPending(null);
+        clearTimer();
+        setError('That didn’t save. Try again?');
+      }
+    },
+    [clearTimer],
+  );
+
+  const undo = useCallback(async () => {
+    if (!pending) return;
+    const item = pending;
+    clearTimer();
+    setPending(null);
+    setError(null);
+    try {
+      const res = await fetch('/api/daily/missed-return/dismiss', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ questionId: item.questionId }),
+      });
+      if (!res.ok) throw new Error('failed');
+      setItems((current) =>
+        current.some((i) => i.questionId === item.questionId) ? current : [item, ...current],
+      );
+    } catch {
+      setError('Couldn’t undo that. Try again?');
+    }
+  }, [pending, clearTimer]);
+
+  return (
+    <section className="mx-auto mt-2 w-[min(672px,94vw)] px-1 pb-10">
+      <div className="border-t border-[var(--border-warm)] pt-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <h2 className="m-0 font-serif text-lg font-semibold text-[var(--brand-ink)]">
+              Questions that come back
+            </h2>
+            <p className="mt-1 mb-0 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
+              Every so often, one question you didn’t land turns up again in your five. Nothing
+              stacks up — it’s one at a time, and once you get it, it’s done.
+            </p>
+          </div>
+          <Switch
+            checked={enabled}
+            onCheckedChange={(next) => void toggle(next)}
+            label="Let missed questions come back"
+            className="mt-1"
+          />
+        </div>
+
+        {error ? (
+          <p className="mt-3 mb-0 text-quiet text-[var(--brand-ink)]" role="status" aria-live="polite">
+            {error}
+          </p>
+        ) : null}
+
+        {pending ? (
+          <div
+            className="mt-3 flex items-center justify-between gap-3 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--cream-warm)] px-3 py-2"
+            role="status"
+            aria-live="polite"
+          >
+            <p className="m-0 text-quiet text-[var(--ink)]">Removed</p>
+            <button
+              type="button"
+              className="text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70"
+              onClick={() => void undo()}
+            >
+              Undo
+            </button>
+          </div>
+        ) : null}
+
+        {enabled ? (
+          items.length > 0 ? (
+            <ul className="mt-4 grid list-none gap-2 p-0">
+              {items.map((item) => (
+                <li
+                  key={item.questionId}
+                  className="flex items-start justify-between gap-3 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--brand-card)] px-3 py-2.5"
+                >
+                  <div className="flex-1">
+                    <p className="m-0 text-sm leading-[1.45] text-[var(--brand-ink)]">
+                      {item.questionText}
+                    </p>
+                    <p className="mt-1 mb-0 text-quiet text-[var(--text-muted-warm)]">
+                      {/* Provenance, honestly (R9). The 'wrong' scope says when
+                          they last saw it; 'expired' never implies they did. */}
+                      {item.scope === 'wrong'
+                        ? `${item.authorName ? `${item.authorName} · ` : ''}from ${formatSeen(item.lastSeenAt)}`
+                        : `${item.authorName ? `${item.authorName} · ` : ''}never got to this one`}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="shrink-0 text-xs font-semibold tracking-[0.08em] text-[var(--text-muted-warm)] uppercase transition hover:text-[var(--brand-ink)]"
+                    onClick={() => void dismiss(item)}
+                    aria-label={`Don’t bring back: ${item.questionText}`}
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-4 mb-0 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
+              Nothing’s waiting to come back right now.
+            </p>
+          )
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -5,6 +5,11 @@ import { getSession } from '@/server/auth/session';
 import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
 import { getFullyExploredDomains } from '@/server/knowledge/fully-explored';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
+import {
+  getReturnListForUser,
+  isMissedReturnEnabledForUser,
+} from '@/server/db/queries/missed-return';
+import { MissedReturnSection } from './MissedReturnSection';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,18 +24,33 @@ export default async function DailySetupPage() {
   const session = await getSession();
   if (!session) redirect('/login');
 
-  const [{ tree }, preferences, fullyExplored] = await Promise.all([
+  // D-MISSED-RETURN-01 §7-D: the returning-questions toggle + list live here,
+  // on the page that already owns Daily Five tuning, rather than on a net-new
+  // route (R11, revised). The list is fetched even when the toggle is off so
+  // flipping it back on doesn't need a round-trip.
+  const [{ tree }, preferences, fullyExplored, returnEnabled, returnItems] = await Promise.all([
     getKnowledgeMapData(session.userId),
     getDailyPreferences(session.userId),
     getFullyExploredDomains(session.userId),
+    isMissedReturnEnabledForUser(session.userId),
+    getReturnListForUser(session.userId).catch(() => []),
   ]);
 
   return (
-    <KnowledgeFlatClient
-      variant="manage"
-      tree={tree}
-      frequencyByDomain={preferences.domainPreferenceFrequency}
-      fullyExploredDomains={fullyExplored}
-    />
+    <>
+      <KnowledgeFlatClient
+        variant="manage"
+        tree={tree}
+        frequencyByDomain={preferences.domainPreferenceFrequency}
+        fullyExploredDomains={fullyExplored}
+      />
+      <MissedReturnSection
+        initialEnabled={returnEnabled}
+        initialItems={returnItems.map((item) => ({
+          ...item,
+          lastSeenAt: item.lastSeenAt.toISOString(),
+        }))}
+      />
+    </>
   );
 }

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -8,9 +8,11 @@ import {
 } from '@/server/db';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { CATCHUP_LOOKBACK_DAYS } from '@/server/daily/catchup';
+import { resolveCreatorNames } from '@/server/db/queries/daily';
 import {
   MISSED_RETURN_COOLDOWN_DAYS,
   MISSED_RETURN_LIFETIME_CAP,
+  rankReturnCandidates,
   type ReturnCandidate,
   type ReturnScope,
 } from '@/server/daily/missed-return';
@@ -222,6 +224,77 @@ export async function recordReturnServed(
     if (pgErrorCode(error) === '42P01') return; // table not yet migrated
     throw error;
   }
+}
+
+/**
+ * Set the Customize toggle (§7-B1). Upserts so a user who has never opened
+ * Customize (and therefore has no DailyPreference row) can still turn the
+ * feature off. Deliberately narrow — it touches ONLY this column, so it can
+ * never clobber topics, frequency, or difficulty the way a full
+ * updateDailyPreferences round-trip could.
+ *
+ * Materializing a row for a user who had none is safe, and was verified against
+ * production: the DB column defaults (difficulty 'adaptive', domain_mode
+ * 'random', empty selected_domains / domain_preference_frequency) are exactly
+ * what defaultDailyPreferences() synthesizes for a missing row, so
+ * getDailyPreferences returns the same values either way. Keep that true — if
+ * the two default sets ever diverge, this upsert silently changes behavior for
+ * anyone who touches the toggle.
+ */
+export async function setMissedReturnEnabled(userId: string, enabled: boolean): Promise<void> {
+  await db
+    .insert(dailyPreferences)
+    .values({ userId, missedReturnEnabled: enabled })
+    .onConflictDoUpdate({
+      target: dailyPreferences.userId,
+      set: { missedReturnEnabled: enabled, updatedAt: new Date() },
+    });
+}
+
+export type ReturnListItem = {
+  questionId: string;
+  scope: ReturnScope;
+  questionText: string;
+  category: string | null;
+  authorName: string | null;
+  lastSeenAt: Date;
+  returnCount: number;
+};
+
+/**
+ * The Customize list (§7-D): every question currently eligible to return, in the
+ * order they would actually be served, so what the player sees matches what the
+ * queue would pick. Both scopes, since one toggle governs both (§7-B1).
+ *
+ * Dismissed questions are absent, not dimmed — §7-C rules out an archive view,
+ * and this list is the lighter surface, not the RecoveredSetAside pattern.
+ */
+export async function getReturnListForUser(userId: string): Promise<ReturnListItem[]> {
+  const candidates = await getEligibleReturnCandidates(userId);
+  if (candidates.length === 0) return [];
+
+  const ranked = rankReturnCandidates(candidates);
+  const rows = await loadReturnQuestions(ranked.map((c) => c.questionId));
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  const authorNames = await resolveCreatorNames(
+    rows.map((r) => r.creatorId).filter((id): id is string => Boolean(id)),
+  );
+
+  return ranked.flatMap((candidate) => {
+    const question = byId.get(candidate.questionId);
+    if (!question) return [];
+    return [
+      {
+        questionId: candidate.questionId,
+        scope: candidate.scope,
+        questionText: question.questionText,
+        category: question.canonicalSubcategory ?? question.broadCategory ?? null,
+        authorName: question.creatorId ? authorNames.get(question.creatorId) ?? null : null,
+        lastSeenAt: candidate.lastSeenAt,
+        returnCount: candidate.returnCount,
+      },
+    ];
+  });
 }
 
 /** Live question text/answer for the candidates the builder decided to serve. */


### PR DESCRIPTION
**Phase 3 of `B-MISSED-RETURN-01`** — the §7-D Customize addition. Feature still dark (`MISSED_RETURN_ENABLED` off); this is the surface that manages it.

## What's on the page

Added to `/daily/setup`, below the topics manager — no new route, per §7-D:

- **Toggle** (§7-B1), default on (§7-F1), governing both scopes together
- **List** of currently-eligible questions, in the exact order the queue would serve them
- **Per-row Remove** with a "Removed · Undo" strip for a few seconds, then final (§7-C)

## Decisions worth flagging

**No toast library.** §7-C says "toast pattern," but this page already ships a "Removed · Undo" status strip for adding a topic. I mirrored that rather than import a new system for one use — same affordance, same few-second window, one less dependency.

**The dismiss writes immediately; undo reverses it.** The alternative — hold the write until the window closes — means closing the tab mid-window silently loses the dismiss and the question reappears tomorrow. Writing now is the honest reading of "don't bring this back."

**Toggling off leaves today's already-built return slot alone** — the slate called this out as a build-time judgment call. It stops *future* selection only. Removing a slot from a persisted queue mid-day would renumber the round underneath someone who might be halfway through it, for a question they can simply answer or ignore. Flagging rather than deciding silently.

**Register.** Nothing counts failures; no "review", "practice", "try again", or "wrong". The **wrong** scope shows when they last saw it (R9, provenance honest); the **expired** scope says "never got to this one" and carries no return framing, because they haven't seen it. Copy is a working pass — Phase 4 replaces it from the approved one.

**`setMissedReturnEnabled` upserts only its own column** so it can't clobber topics/difficulty. Materializing a `DailyPreference` row for someone who had none is safe — the DB defaults match what `defaultDailyPreferences()` synthesizes, verified against prod, and the comment says to keep it that way.

## Verified against production, not just mocked

```
toggle round-trip (Craig T Testing)
  initial (no row => default): true
  after set false: false
  after set true:  true

Customize list — 48 items
  [expired] What is the name of the chemical process of browning meat?  | author=Robyn
  [expired] Which Tom Stoppard play takes its title from two characters | author=Joshua P
  ...
  ordering ok (all expired before all wrong): true

heavy account list size: 177   first row: [wrong] …
```

Author names resolve, ranking holds at volume, and the upsert works against the real unique constraint.

## Checks

- `npx tsc -p tsconfig.typecheck.json` — 0 errors
- `npm run lint` — 0 errors (4 pre-existing warnings, untouched files)
- **All six design ratchets pass at ceiling** (colors 41/41, spacing 0/0, radius 0/0, typesize 213/213, zindex 0/0, fonts 0/0) — no new arbitrary values
- **Full suite: 2328 passed, 0 failed** (+9 new route tests: toggle on/off, non-boolean rejected, 401s, dismiss uses the session user not a client-supplied one, DELETE undoes, and a dismiss writing *only* the dismiss per §5)

## DONE-WHEN

- ✓ Toggle on Customize, defaults on, persists
- ✓ Toggling off stops future selection (orchestrator gates on it before building)
- ✓ List shows eligible questions; dismiss writes `MissedReturnDismissed` and the row leaves the list
- ✓ Undo within the window fully reverses — row eligible again
- ✓ **No archive/history view was built** — verifiable by its absence

## Remaining

Phase 4 is gated on the copy pass (§6), which is chat work, not a build task. The author-push string is still an explicit placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsnxcCmnb1J8Hxx3K7sKSP
