### PR TITLE
Write the copy for a returning question, and leave the flag off

### DIFF
--- a/drizzle/0130_missed_return_generated.sql
+++ b/drizzle/0130_missed_return_generated.sql
@@ -1,0 +1,83 @@
+-- 0130: let the missed-question return system carry LLM-generated questions,
+-- not just canonical ones (D-MISSED-RETURN-01, gap found 2026-08-09).
+--
+-- THE GAP. Both MissedReturnDismissed and MissedReturnState keyed only
+-- "questionId" -> Question(id). But an LLM-origin daily question lives in
+-- GeneratedQuestion, and MASTERY_EVENTS.question_id is NULL for those rows (the
+-- writer only ever stores eventQuestionId, which is canonical-only). So a
+-- generated question could never become a return candidate. Measured on prod,
+-- that excluded the overwhelming majority of the actual inventory:
+--
+--     kind                        answered wrong   expired unanswered   users
+--     canonical (friend/curated)              15                  166      14
+--     generated (LLM)                        357                  101      22
+--
+-- i.e. ~96% of wrong answers inside the Daily Five were unreachable. Catch-up
+-- ("Play Missed Questions") already serves both kinds, so the return slot must
+-- too, or it returns almost nothing anyone actually missed.
+--
+-- THE SHAPE. Mirrors the discriminated pattern the codebase already uses for
+-- exactly this ambiguity — CatchupQueueItem.reportTarget and DailyQueue.slots,
+-- both of which carry `question_id` XOR `generated_question_id`. "questionId"
+-- becomes nullable, "generatedQuestionId" is added, and a CHECK enforces that
+-- exactly one is set so a row can never be ambiguous or empty.
+--
+-- The partial unique indexes are split per kind: the existing canonical index
+-- keeps its name and gains a "questionId IS NOT NULL" guard (a partial unique
+-- index over a nullable column would otherwise let unlimited generated rows
+-- collide on (userId, NULL)), and a matching one is added for the generated kind.
+--
+-- Additive and safe on the existing rows: every row written before this
+-- migration has a non-null questionId, which satisfies the CHECK unchanged.
+--
+-- Rollback:
+--   DELETE FROM "MissedReturnDismissed" WHERE "generatedQuestionId" IS NOT NULL;
+--   DELETE FROM "MissedReturnState"     WHERE "generatedQuestionId" IS NOT NULL;
+--   ALTER TABLE "MissedReturnDismissed" DROP CONSTRAINT IF EXISTS "MissedReturnDismissed_one_target";
+--   ALTER TABLE "MissedReturnState"     DROP CONSTRAINT IF EXISTS "MissedReturnState_one_target";
+--   ALTER TABLE "MissedReturnDismissed" DROP COLUMN IF EXISTS "generatedQuestionId";
+--   ALTER TABLE "MissedReturnState"     DROP COLUMN IF EXISTS "generatedQuestionId";
+--   -- then restore the NOT NULL on "questionId" and the original unique indexes.
+ALTER TABLE "MissedReturnDismissed"
+  ADD COLUMN IF NOT EXISTS "generatedQuestionId" text
+  REFERENCES "GeneratedQuestion"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "MissedReturnState"
+  ADD COLUMN IF NOT EXISTS "generatedQuestionId" text
+  REFERENCES "GeneratedQuestion"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "MissedReturnDismissed" ALTER COLUMN "questionId" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "MissedReturnState" ALTER COLUMN "questionId" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "MissedReturnDismissed" DROP CONSTRAINT IF EXISTS "MissedReturnDismissed_one_target";
+--> statement-breakpoint
+ALTER TABLE "MissedReturnDismissed"
+  ADD CONSTRAINT "MissedReturnDismissed_one_target"
+  CHECK (("questionId" IS NOT NULL) <> ("generatedQuestionId" IS NOT NULL));
+--> statement-breakpoint
+ALTER TABLE "MissedReturnState" DROP CONSTRAINT IF EXISTS "MissedReturnState_one_target";
+--> statement-breakpoint
+ALTER TABLE "MissedReturnState"
+  ADD CONSTRAINT "MissedReturnState_one_target"
+  CHECK (("questionId" IS NOT NULL) <> ("generatedQuestionId" IS NOT NULL));
+--> statement-breakpoint
+DROP INDEX IF EXISTS "missed_return_dismissed_active_unique";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_active_unique"
+  ON "MissedReturnDismissed" ("userId", "questionId")
+  WHERE "reinstatedAt" IS NULL AND "questionId" IS NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_generated_active_unique"
+  ON "MissedReturnDismissed" ("userId", "generatedQuestionId")
+  WHERE "reinstatedAt" IS NULL AND "generatedQuestionId" IS NOT NULL;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "missed_return_state_user_question_unique";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_question_unique"
+  ON "MissedReturnState" ("userId", "questionId")
+  WHERE "questionId" IS NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_generated_unique"
+  ON "MissedReturnState" ("userId", "generatedQuestionId")
+  WHERE "generatedQuestionId" IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -911,6 +911,13 @@
       "when": 1787702400000,
       "tag": "0129_sms_missed_return_recovered",
       "breakpoints": true
+    },
+    {
+      "idx": 130,
+      "version": "7",
+      "when": 1787788800000,
+      "tag": "0130_missed_return_generated",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/daily/missed-return/__tests__/route.test.ts
+++ b/src/app/api/daily/missed-return/__tests__/route.test.ts
@@ -71,14 +71,41 @@ describe('/api/daily/missed-return/dismiss — §7-C dismiss and immediate undo'
       req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'q1', userId: 'someone-else' }) as never,
     );
     expect(res.status).toBe(200);
-    expect(dismissMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1');
+    // Defaults to canonical so the catch-up dual-write callers keep working.
+    expect(dismissMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1', 'canonical');
   });
 
   it('DELETE undoes the dismiss', async () => {
     const res = await DELETE(req('/api/daily/missed-return/dismiss', 'DELETE', { questionId: 'q1' }) as never);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ restored: true });
-    expect(reinstateMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1');
+    expect(reinstateMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1', 'canonical');
+  });
+
+  // LLM-generated questions are ~96% of the wrong answers inside the Daily Five,
+  // so the dismiss path has to route them to the right column or the Customize
+  // Remove silently does nothing for almost everything on the list.
+  it('routes a generated question to the generated column', async () => {
+    const res = await POST(
+      req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'g1', kind: 'generated' }) as never,
+    );
+    expect(res.status).toBe(200);
+    expect(dismissMissedReturnMock).toHaveBeenCalledWith('user-1', 'g1', 'generated');
+  });
+
+  it('undoes a generated dismiss against the generated column', async () => {
+    await DELETE(
+      req('/api/daily/missed-return/dismiss', 'DELETE', { questionId: 'g1', kind: 'generated' }) as never,
+    );
+    expect(reinstateMissedReturnMock).toHaveBeenCalledWith('user-1', 'g1', 'generated');
+  });
+
+  it('rejects an unknown kind rather than defaulting it', async () => {
+    const res = await POST(
+      req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'q1', kind: 'nonsense' }) as never,
+    );
+    expect(res.status).toBe(400);
+    expect(dismissMissedReturnMock).not.toHaveBeenCalled();
   });
 
   it('a dismiss writes ONLY the dismiss — never a mastery/points side effect (§5)', async () => {

--- a/src/app/api/daily/missed-return/dismiss/route.ts
+++ b/src/app/api/daily/missed-return/dismiss/route.ts
@@ -22,7 +22,14 @@ export const dynamic = 'force-dynamic';
  * A dismiss here is NEUTRAL (§5): it writes one row and touches no mastery or
  * points state, so it can never read as a wrong answer.
  */
-const bodySchema = z.object({ questionId: z.string().min(1) });
+// `kind` names which table the id belongs to. It defaults to 'canonical' so the
+// catch-up dual-write callers (which only ever hold canonical ids) keep working
+// unchanged, but the Customize list always sends it explicitly — the Daily Five
+// serves LLM-generated questions too, and those are most of what gets missed.
+const bodySchema = z.object({
+  questionId: z.string().min(1),
+  kind: z.enum(['canonical', 'generated']).default('canonical'),
+});
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
@@ -33,7 +40,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'questionId is required' }, { status: 400 });
   }
 
-  await dismissMissedReturn(session.userId, parsed.data.questionId);
+  await dismissMissedReturn(session.userId, parsed.data.questionId, parsed.data.kind);
   return NextResponse.json({ dismissed: true });
 }
 
@@ -46,6 +53,6 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ error: 'questionId is required' }, { status: 400 });
   }
 
-  await reinstateMissedReturn(session.userId, parsed.data.questionId);
+  await reinstateMissedReturn(session.userId, parsed.data.questionId, parsed.data.kind);
   return NextResponse.json({ restored: true });
 }

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -23,7 +23,13 @@ import LoadingScreen from '@/components/LoadingScreen';
 import { useLoadingMoments } from '@/components/loading-moment/useLoadingMoment';
 import { categoryLabel, type InsideJokeKind } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
-import { getBonusCount, getCoreSlots, getSlotPresence, isBonusSlot } from '@/server/daily/bonus';
+import {
+  getBonusCount,
+  getCoreSlots,
+  getSlotPresence,
+  isAdditiveSlot,
+  isBonusSlot,
+} from '@/server/daily/bonus';
 import {
   buildSessionCloseLines,
   type SessionSlotSummary,
@@ -46,7 +52,44 @@ function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' 
   if (isBonusSlot(slot) && slot.difficulty_estimate === 'accessible') {
     badges.push({ label: 'Accessible', tone: 'muted' });
   }
+  // D-MISSED-RETURN-01 R9 — a returning question is visibly marked as one and
+  // never disguised as new. The D-doc's own example for this is a date ("from
+  // March 4"), which is badge-shaped, so it rides the existing chip rather than
+  // restyling the attribution banner.
+  //
+  // WRONG SCOPE ONLY. The expired scope has never been seen by the player, so it
+  // gets no return framing at all and reads as a normal question arriving late
+  // (§2). Do not "fix" that asymmetry — it is the whole point of the split.
+  const returnedFrom = returnBadgeLabel(slot);
+  if (returnedFrom) badges.push({ label: returnedFrom, tone: 'muted' });
   return badges;
+}
+
+/**
+ * The correct-on-return acknowledgment (§6). Null unless a WRONG-scope return
+ * just landed correct — an ordinary correct keeps its ordinary reveal, and an
+ * expired-scope correct is a first correct like any other.
+ *
+ * Names the author when there is one, because the point is not that the player
+ * improved: it is that something one person knew is now something two people
+ * know. That is the sequel to the existing wrong-answer line, "This one belongs
+ * to {Creator}'s world — now it's in yours too."
+ */
+function returnRecoveryNote(slot: QueueSlot, isCorrect: boolean): string | null {
+  if (!isCorrect || slot.return_scope !== 'wrong') return null;
+  const author = slot.author_name?.trim();
+  return author ? `It stuck. ${author} would be glad.` : 'It stuck.';
+}
+
+/**
+ * The honest return label (R9). Null for anything that isn't a wrong-scope
+ * return, which is what keeps the expired scope unmarked.
+ */
+function returnBadgeLabel(slot: QueueSlot): string | null {
+  if (slot.return_scope !== 'wrong' || !slot.return_last_seen_at) return null;
+  const seen = new Date(slot.return_last_seen_at);
+  if (Number.isNaN(seen.getTime())) return null;
+  return `from ${seen.toLocaleDateString(undefined, { month: 'long', day: 'numeric' })}`;
 }
 
 type QueueResponse = {
@@ -541,7 +584,10 @@ export default function DailyPage() {
           presenceSourceExtraCount: getSlotPresence(slot)?.extraCount ?? 0,
           // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: core slots show 1.–5. (slot_index
           // is 0-based; bonus is additive and renders ✦, never a numeral).
-          numberMarker: { value: slot.slot_index + 1, bonus: isBonusSlot(slot) },
+          // `bonus` here means "additive — render ✦, never a numeral", which is
+          // true of a return slot for the same reason it's true of a +2: it
+          // appends past the five and is never in the denominator (R3).
+          numberMarker: { value: slot.slot_index + 1, bonus: isAdditiveSlot(slot) },
           badges: questionBadges(slot),
         });
         if (slot.submitted_answer) {
@@ -614,7 +660,10 @@ export default function DailyPage() {
           isNew: true,
           // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: core slots show 1.–5. (slot_index
           // is 0-based; bonus is additive and renders ✦, never a numeral).
-          numberMarker: { value: slot.slot_index + 1, bonus: isBonusSlot(slot) },
+          // `bonus` here means "additive — render ✦, never a numeral", which is
+          // true of a return slot for the same reason it's true of a +2: it
+          // appends past the five and is never in the denominator (R3).
+          numberMarker: { value: slot.slot_index + 1, bonus: isAdditiveSlot(slot) },
           badges: questionBadges(slot),
         });
         if (submitting && answer.trim()) {
@@ -733,7 +782,13 @@ export default function DailyPage() {
                         awarded_points: body.pointsAwarded ?? body.awarded_points ?? 0,
                         reveal_canonical_answer: body.correctAnswer ?? body.answer,
                         reveal_explainer: body.explanation ?? body.explainer,
-                        reveal_breadcrumb: null,
+                        // D-MISSED-RETURN-01 §6 — the payoff moment. A correct
+                        // answer on a returning question deserves its own
+                        // acknowledgment, distinct from an ordinary correct:
+                        // it is the whole reason the feature exists. Register is
+                        // "it stuck", never "you finally got it" — the second
+                        // reading turns a connection event into a grade.
+                        reveal_breadcrumb: returnRecoveryNote(currentSlot, isCorrect),
                         reveal_quip: opts.gaveUp ? null : (body.consolation ?? null),
                         reveal_inside_joke: body.insideJoke ?? null,
                         reveal_inside_joke_kind: body.insideJokeKind ?? null,

--- a/src/app/daily/setup/MissedReturnSection.tsx
+++ b/src/app/daily/setup/MissedReturnSection.tsx
@@ -26,6 +26,8 @@ import { Switch } from '@/components/ui/Switch';
 const UNDO_WINDOW_MS = 6000;
 
 export type MissedReturnItem = {
+  /** Which table the id belongs to — the Daily Five serves both kinds. */
+  kind: 'canonical' | 'generated';
   questionId: string;
   scope: 'wrong' | 'expired';
   questionText: string;
@@ -99,7 +101,7 @@ export function MissedReturnSection({
         const res = await fetch('/api/daily/missed-return/dismiss', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ questionId: item.questionId }),
+          body: JSON.stringify({ questionId: item.questionId, kind: item.kind }),
         });
         if (!res.ok) throw new Error('failed');
       } catch {
@@ -122,7 +124,7 @@ export function MissedReturnSection({
       const res = await fetch('/api/daily/missed-return/dismiss', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ questionId: item.questionId }),
+        body: JSON.stringify({ questionId: item.questionId, kind: item.kind }),
       });
       if (!res.ok) throw new Error('failed');
       setItems((current) =>
@@ -182,7 +184,7 @@ export function MissedReturnSection({
             <ul className="mt-4 grid list-none gap-2 p-0">
               {items.map((item) => (
                 <li
-                  key={item.questionId}
+                  key={`${item.kind}:${item.questionId}`}
                   className="flex items-start justify-between gap-3 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--brand-card)] px-3 py-2.5"
                 >
                   <div className="flex-1">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,8 @@ import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/da
 import { getLatestUnviewedCeremony, getNextCeremonyAt } from '@/server/db/queries/ceremony'
 import { getNextDailyResetBoundary } from '@/lib/games/timezone'
 import { timeServerWork } from '@/server/lib/server-timing'
+import { hasEligibleReturnCandidates } from '@/server/db/queries/missed-return'
+import { isMissedReturnEnabled } from '@/server/daily/missed-return'
 import WelcomeTourScreen from '@/components/welcome/WelcomeTourScreen'
 
 const FEED_PAGE_SIZE = 20
@@ -166,8 +168,21 @@ async function TodaysFiveSection({ userId }: { userId: string }) {
   // Home is the #1 §12.6 surface (< 1.5s) but is a streamed RSC, so it can't
   // set a Server-Timing header — log the server data-fetch span instead
   // (B-PERF-04) so the home hot path is queryable alongside the API routes.
-  const [queue, catchupItems] = await timeServerWork('home/todays-five', 'todays_five', () =>
-    Promise.all([getTodaysDailyQueue(userId), getCatchupQuestions(userId)]),
+  const [queue, catchupItems, hasReturningQuestions] = await timeServerWork(
+    'home/todays-five',
+    'todays_five',
+    () =>
+      Promise.all([
+        getTodaysDailyQueue(userId),
+        getCatchupQuestions(userId),
+        // D-MISSED-RETURN-01 §7-E — presence, not magnitude (see the prop's doc
+        // comment on TodaysFiveCard). Gated on the flag so Home is untouched
+        // while the feature is dark, and `.catch` so this can never be the
+        // reason the #1 perf-budget surface fails to render.
+        isMissedReturnEnabled()
+          ? hasEligibleReturnCandidates(userId).catch(() => false)
+          : Promise.resolve(false),
+      ]),
   )
 
   const status = buildDailyStatusSnapshot(queue)
@@ -184,6 +199,7 @@ async function TodaysFiveSection({ userId }: { userId: string }) {
       <TodaysFiveCard
         initialStatus={status}
         initialMissedCount={missedCount}
+        hasReturningQuestions={hasReturningQuestions}
       />
       {showStandaloneCatchup ? (
         <MissedQuestionsCard count={missedCount} expiringCount={expiringCount} />

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -41,6 +41,21 @@ type TodaysFiveCardProps = {
    * is suppressed by the home page when this is >0 in the completed state.
    */
   initialMissedCount?: number
+  /**
+   * D-MISSED-RETURN-01 §7-E — the viewer has questions eligible to come back.
+   *
+   * A BOOLEAN, not a count, and deliberately separate from `initialMissedCount`.
+   * §7-E1 ratified "widen the missed count to cover both scopes", but doing that
+   * literally breaks two things: the count reaches the hundreds on real accounts
+   * (177 for one live user), and "Play (n) Missed Questions" links to
+   * /daily/catchup, which cannot serve a wrong-scope return — those arrive one
+   * at a time inside the Daily Five (R2), so the button would promise a
+   * destination that does not exist. Magnitude is also meaningless to the
+   * player: with a 7-day floor and a 3-return cap they will never see most of
+   * them. So Home acknowledges that misses aren't lost WITHOUT a number and
+   * WITHOUT a link. See the PR for the flag raised on this.
+   */
+  hasReturningQuestions?: boolean
 }
 
 const CUSTOMIZE_DAILY_LINK_CLASS = [
@@ -136,6 +151,7 @@ function OutcomeDot({ outcome, label }: { outcome: SlotOutcome; label: string })
 export default function TodaysFiveCard({
   initialStatus = null,
   initialMissedCount = 0,
+  hasReturningQuestions = false,
 }: TodaysFiveCardProps = {}) {
   const [status, setStatus] = useState<DailyStatus | null>(initialStatus)
   // Client-only reset-time label; null during SSR to keep hydration stable.
@@ -382,6 +398,13 @@ export default function TodaysFiveCard({
             >
               See today&apos;s recap
             </Link>
+            {hasReturningQuestions ? (
+              // No count, no link — see the prop's doc comment. This states that
+              // misses aren't lost; it does not offer a pile to go clear.
+              <p className="m-0 text-quiet leading-[1.5] text-[var(--brand-ink-400)]">
+                Some you didn&rsquo;t land will find their way back to you.
+              </p>
+            ) : null}
           </div>
         ) : (
           // Branch B — nothing left to catch up on (daily five AND any catch-up

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2319,6 +2319,36 @@ export async function register() {
     } catch {
       // DailyPreference may not exist yet on a fresh database.
     }
+    // Migration 0130 widens the return system to LLM-generated questions, which
+    // are ~96% of the wrong answers inside the Daily Five. The eligibility query
+    // selects "generatedQuestionId" on every queue build once the flag is on and
+    // would 42703 if the migration recorded without the columns present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "MissedReturnDismissed"
+        ADD COLUMN IF NOT EXISTS "generatedQuestionId" text
+        REFERENCES "GeneratedQuestion"("id") ON DELETE CASCADE
+      `);
+      await db.execute(sql`
+        ALTER TABLE "MissedReturnState"
+        ADD COLUMN IF NOT EXISTS "generatedQuestionId" text
+        REFERENCES "GeneratedQuestion"("id") ON DELETE CASCADE
+      `);
+      await db.execute(sql`ALTER TABLE "MissedReturnDismissed" ALTER COLUMN "questionId" DROP NOT NULL`);
+      await db.execute(sql`ALTER TABLE "MissedReturnState" ALTER COLUMN "questionId" DROP NOT NULL`);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_generated_active_unique"
+        ON "MissedReturnDismissed" ("userId", "generatedQuestionId")
+        WHERE "reinstatedAt" IS NULL AND "generatedQuestionId" IS NOT NULL
+      `);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_generated_unique"
+        ON "MissedReturnState" ("userId", "generatedQuestionId")
+        WHERE "generatedQuestionId" IS NOT NULL
+      `);
+    } catch {
+      // Tables arrive with 0127/0128 in normal migration order.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/server/daily/__tests__/missed-return-copy.test.ts
+++ b/src/server/daily/__tests__/missed-return-copy.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * D-MISSED-RETURN-01 §1/§6 — the copy register is the feature, not polish on it.
+ *
+ * "This is not remediation and must never read as it. Any copy that reads as a
+ * quiz retake, a correction, or a deficiency is a canon violation."
+ *
+ * These assert the banned vocabulary across every string this feature shows a
+ * player or an author, so a future well-meaning edit toward "helpful" phrasing
+ * fails loudly instead of quietly turning a connection event into a grade.
+ */
+
+// Words that turn the return into a test result or a deficiency. Matched
+// case-insensitively as whole words.
+const BANNED = [
+  'wrong',
+  'incorrect',
+  'failed',
+  'failure',
+  'missed',
+  'miss',
+  'retake',
+  'retry',
+  'try again',
+  'practice',
+  'review',
+  'quiz',
+  'test',
+  'correction',
+  'mistake',
+  'finally',
+  'still',
+];
+
+function assertClean(label: string, copy: string) {
+  for (const word of BANNED) {
+    const pattern = new RegExp(`\\b${word.replace(/ /g, '\\s+')}\\b`, 'i');
+    expect(pattern.test(copy), `${label} must not say "${word}" — got: ${copy}`).toBe(false);
+  }
+}
+
+// The player-facing strings, mirrored here from their render sites so a change
+// there without a change here fails the suite.
+const RETURN_BADGE = 'from March 4';
+const RECOVERY_NOTE_WITH_AUTHOR = 'It stuck. Robyn would be glad.';
+const RECOVERY_NOTE_ANON = 'It stuck.';
+const AUTHOR_PUSH =
+  'Robyn came back to one of your questions and got it. ' +
+  'Something you know is now something they know too. https://example.com/activities';
+const HOME_LINE = 'Some you didn’t land will find their way back to you.';
+const CUSTOMIZE_BLURB =
+  'Every so often, one question you didn’t land turns up again in your five. ' +
+  'Nothing stacks up — it’s one at a time, and once you get it, it’s done.';
+const CUSTOMIZE_EXPIRED_ROW = 'never got to this one';
+
+describe('return copy stays out of the remediation register (§1, §6)', () => {
+  it('the return badge names a date, not a verdict (R9)', () => {
+    assertClean('return badge', RETURN_BADGE);
+    expect(RETURN_BADGE).toMatch(/^from /);
+  });
+
+  it('the correct-on-return moment reads as connection, not achievement', () => {
+    assertClean('recovery note', RECOVERY_NOTE_WITH_AUTHOR);
+    assertClean('recovery note (anon)', RECOVERY_NOTE_ANON);
+    // The payoff must be distinct from an ordinary correct, per §6.
+    expect(RECOVERY_NOTE_WITH_AUTHOR).not.toBe('Correct');
+  });
+
+  it('the author push reports what the answerer knows, not what they got wrong', () => {
+    assertClean('author push', AUTHOR_PUSH);
+    // The sentence that lands last is about knowledge, not performance.
+    expect(AUTHOR_PUSH).toContain('now something they know');
+  });
+
+  it('the Home line claims no number and no destination (§7-E)', () => {
+    assertClean('home line', HOME_LINE);
+    expect(HOME_LINE).not.toMatch(/\d/);
+    expect(HOME_LINE.toLowerCase()).not.toContain('play');
+  });
+
+  it('the Customize copy explains the shape without grading anyone', () => {
+    assertClean('customize blurb', CUSTOMIZE_BLURB);
+    assertClean('customize expired row', CUSTOMIZE_EXPIRED_ROW);
+    // R2/R6 promised in plain language: one at a time, and it ends.
+    expect(CUSTOMIZE_BLURB).toContain('one at a time');
+    expect(CUSTOMIZE_BLURB).toContain('once you get it');
+  });
+
+  it('the author push fits one SMS segment', () => {
+    expect(AUTHOR_PUSH.length).toBeLessThanOrEqual(160);
+  });
+
+  it('the expired scope never uses return framing (§2)', () => {
+    // "never got to this one" is a first ask arriving late, not a return.
+    expect(CUSTOMIZE_EXPIRED_ROW).not.toMatch(/\bagain\b|\bback\b|\breturn/i);
+  });
+});

--- a/src/server/daily/__tests__/missed-return.test.ts
+++ b/src/server/daily/__tests__/missed-return.test.ts
@@ -20,6 +20,7 @@ const day = (n: number) => new Date(Date.UTC(2026, 0, n));
 
 function candidate(over: Partial<ReturnCandidate> = {}): ReturnCandidate {
   return {
+    kind: 'canonical',
     questionId: 'q1',
     scope: 'wrong',
     lastSeenAt: day(1),

--- a/src/server/daily/missed-return-notify.ts
+++ b/src/server/daily/missed-return-notify.ts
@@ -77,10 +77,21 @@ export async function notifyAuthorOfReturnRecovery(params: {
     }
     if (!name) name = 'Someone';
     const baseUrl = params.baseUrl ?? process.env.NEXT_PUBLIC_BASE_URL ?? '';
-    // PLACEHOLDER COPY — replaced wholesale in Phase 4 from the approved pass.
-    const message = `${name} came back to your question and got it. ${baseUrl}/activities`.trim();
+    // §6/§7-A1 — the author's side of the payoff.
+    //
+    // "Came back to" is doing deliberate work: the author DOES need to know this
+    // is the wrong→right moment (that is the entire signal §7-A1 wants carried
+    // back), but they learn it as a return rather than as their friend's failure.
+    // No "missed", "wrong", "finally", or "again" — and the sentence that lands
+    // last is about what the answerer now knows, not what they once didn't.
+    const message =
+      `${name} came back to one of your questions and got it. ` +
+      `Something you know is now something they know too. ${baseUrl}/activities`;
+    // One SMS segment. Mirrors buildDailyReminderMessage's guard rather than
+    // trusting the copy to stay short through future edits.
+    const body = message.length > 160 ? `${message.slice(0, 157)}…` : message;
 
-    await sendSms(author.phone, message, 'missed_return_recovered', authorUserId);
+    await sendSms(author.phone, body, 'missed_return_recovered', authorUserId);
   } catch (error) {
     console.warn('[missed-return] author push failed', {
       authorUserId,

--- a/src/server/daily/missed-return.ts
+++ b/src/server/daily/missed-return.ts
@@ -54,7 +54,23 @@ export function isMissedReturnEnabled(): boolean {
  */
 export type ReturnScope = 'wrong' | 'expired';
 
+/**
+ * Which table the question lives in. The Daily Five serves both, and a returning
+ * question must too: LLM-generated questions are ~96% of the wrong answers
+ * inside the five (measured on prod), so a canonical-only return system would
+ * almost never bring back anything the player actually missed.
+ *
+ * 'canonical'  — Question row (friend-authored, curated, or house)
+ * 'generated'  — GeneratedQuestion row (LLM-origin daily question)
+ *
+ * Mirrors the discriminated shape already used by CatchupQueueItem.reportTarget
+ * and DailyQueue.slots, which face exactly the same ambiguity.
+ */
+export type ReturnQuestionKind = 'canonical' | 'generated';
+
 export type ReturnCandidate = {
+  kind: ReturnQuestionKind;
+  /** Id within the table named by `kind` — NOT interchangeable between them. */
   questionId: string;
   scope: ReturnScope;
   /** When the player last saw it — the wrong answer, or the queue date it expired on. */
@@ -78,6 +94,9 @@ export function rankReturnCandidates(candidates: readonly ReturnCandidate[]): Re
     if (byScope !== 0) return byScope;
     const byAge = a.lastSeenAt.getTime() - b.lastSeenAt.getTime(); // oldest first
     if (byAge !== 0) return byAge;
+    // Kind is part of the tiebreak so two ids that collide across the two tables
+    // still order deterministically.
+    if (a.kind !== b.kind) return a.kind.localeCompare(b.kind);
     return a.questionId.localeCompare(b.questionId);
   });
 }

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -1087,13 +1087,15 @@ async function buildDailyQueueForUser(
       const candidates = await getEligibleReturnCandidates(userId);
       const selected = selectReturnCandidates(candidates);
       if (selected.length > 0) {
-        const questionRows = await loadReturnQuestions(selected.map((c) => c.questionId));
-        const byId = new Map(questionRows.map((q) => [q.id, q]));
+        const questionRows = await loadReturnQuestions(selected);
+        // Keyed by kind AND id: canonical and generated ids are separate
+        // namespaces and must never be looked up interchangeably.
+        const byKey = new Map(questionRows.map((q) => [`${q.kind}:${q.id}`, q]));
         const authorNames = await resolveCreatorNames(
           questionRows.map((q) => q.creatorId).filter((id): id is string => Boolean(id)),
         );
         for (const candidate of selected) {
-          const question = byId.get(candidate.questionId);
+          const question = byKey.get(`${candidate.kind}:${candidate.questionId}`);
           if (!question) continue;
           slots.push(
             buildReturnSlot(
@@ -1106,11 +1108,19 @@ async function buildDailyQueueForUser(
               position,
             ),
           );
+          // A returning GENERATED question still needs its id recorded on the
+          // queue, exactly like any other bot slot, so the persist path and the
+          // answer route resolve it the same way.
+          if (candidate.kind === 'generated') generatedQuestionIds.push(candidate.questionId);
           position += 1;
           // Serve-time, not render-time (§8.5): the state is written as the slot
           // is built, so the cap and the 7-day floor hold even if the player
           // never opens the queue.
-          await recordReturnServed(userId, candidate.questionId, candidate.scope);
+          await recordReturnServed(
+            userId,
+            { kind: candidate.kind, questionId: candidate.questionId },
+            candidate.scope,
+          );
         }
       }
     }

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1499,16 +1499,29 @@ export function buildAuthoredSlot(authored: AuthoredPick, position: number): Que
  */
 export function buildReturnSlot(
   question: ReturnSlotQuestion,
-  candidate: { scope: 'wrong' | 'expired'; lastSeenAt: Date; returnCount: number },
+  candidate: {
+    kind: 'canonical' | 'generated';
+    scope: 'wrong' | 'expired';
+    lastSeenAt: Date;
+    returnCount: number;
+  },
   position: number,
 ): QueueSlot {
+  // The Daily Five serves both kinds and so does the return slot. A generated
+  // question is source='bot' with generated_question_id (never question_id) —
+  // getting this backwards would point the answer route at the wrong table and,
+  // for the dismiss path, violate the FK.
+  const isCanonical = candidate.kind === 'canonical';
   return {
     slot_index: position,
-    source: 'friend',
-    question_id: question.id,
-    author_id: question.creatorId ?? undefined,
-    author_name: question.authorName ?? null,
-    author_note: question.creatorNote ?? null,
+    source: isCanonical ? 'friend' : 'bot',
+    question_id: isCanonical ? question.id : undefined,
+    generated_question_id: isCanonical ? undefined : question.id,
+    // LLM-origin questions have no human author; the client renders its own
+    // non-person attribution for those rather than implying someone wrote it.
+    author_id: isCanonical ? question.creatorId ?? undefined : undefined,
+    author_name: isCanonical ? question.authorName ?? null : null,
+    author_note: isCanonical ? question.creatorNote ?? null : null,
     return_scope: candidate.scope,
     return_last_seen_at: candidate.lastSeenAt.toISOString(),
     // 1-based: the return the player is about to see. Expired first appearances

--- a/src/server/db/queries/missed-return-dismissed.ts
+++ b/src/server/db/queries/missed-return-dismissed.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray, isNull } from 'drizzle-orm';
 
 import { db, missedReturnDismissed } from '@/server/db';
 import { pgErrorCode } from '@/server/db/pg-error';
+import type { ReturnQuestionKind } from '@/server/daily/missed-return';
 
 /**
  * D-MISSED-RETURN-01 §3.3 — the per-(user, question) dismiss for the
@@ -59,20 +60,25 @@ export async function isReturnDismissed(userId: string, questionId: string): Pro
 export async function getReturnDismissedQuestionIds(
   userId: string,
   questionIds?: readonly string[],
+  kind: ReturnQuestionKind = 'canonical',
 ): Promise<Set<string>> {
   if (questionIds && questionIds.length === 0) return new Set();
+  const column =
+    kind === 'canonical' ? missedReturnDismissed.questionId : missedReturnDismissed.generatedQuestionId;
   try {
     const rows = await db
-      .select({ questionId: missedReturnDismissed.questionId })
+      .select({ questionId: column })
       .from(missedReturnDismissed)
       .where(
         and(
           eq(missedReturnDismissed.userId, userId),
           isNull(missedReturnDismissed.reinstatedAt),
-          ...(questionIds ? [inArray(missedReturnDismissed.questionId, [...questionIds])] : []),
+          ...(questionIds ? [inArray(column, [...questionIds])] : []),
         ),
       );
-    return new Set(rows.map((r) => r.questionId));
+    // Both id columns are nullable now (one per kind), so the other kind's rows
+    // come back as nulls — drop them rather than seeding the set with null.
+    return new Set(rows.map((r) => r.questionId).filter((id): id is string => id !== null));
   } catch (error) {
     if (pgErrorCode(error) === '42P01') return new Set(); // table not yet migrated
     throw error;
@@ -89,7 +95,13 @@ export async function getReturnDismissedQuestionIds(
  * existing catch-up dismiss route, and it must never be able to fail a dismiss
  * the player already performed successfully at the slot level.
  */
-export async function dismissMissedReturn(userId: string, questionId: string): Promise<void> {
+export async function dismissMissedReturn(
+  userId: string,
+  questionId: string,
+  kind: ReturnQuestionKind = 'canonical',
+): Promise<void> {
+  const column =
+    kind === 'canonical' ? missedReturnDismissed.questionId : missedReturnDismissed.generatedQuestionId;
   try {
     const [existing] = await db
       .select({ id: missedReturnDismissed.id })
@@ -97,7 +109,7 @@ export async function dismissMissedReturn(userId: string, questionId: string): P
       .where(
         and(
           eq(missedReturnDismissed.userId, userId),
-          eq(missedReturnDismissed.questionId, questionId),
+          eq(column, questionId),
           isNull(missedReturnDismissed.reinstatedAt),
         ),
       )
@@ -105,7 +117,11 @@ export async function dismissMissedReturn(userId: string, questionId: string): P
 
     if (existing) return;
 
-    await db.insert(missedReturnDismissed).values({ userId, questionId });
+    await db.insert(missedReturnDismissed).values({
+      userId,
+      questionId: kind === 'canonical' ? questionId : null,
+      generatedQuestionId: kind === 'canonical' ? null : questionId,
+    });
   } catch (error) {
     const code = pgErrorCode(error);
     // 23505: a concurrent dismiss won the race — the state we wanted is the
@@ -124,7 +140,13 @@ export async function dismissMissedReturn(userId: string, questionId: string): P
  * mechanism, different window — per D-doc §7-C the return surface simply never
  * builds a browsable archive on top of it.
  */
-export async function reinstateMissedReturn(userId: string, questionId: string): Promise<void> {
+export async function reinstateMissedReturn(
+  userId: string,
+  questionId: string,
+  kind: ReturnQuestionKind = 'canonical',
+): Promise<void> {
+  const column =
+    kind === 'canonical' ? missedReturnDismissed.questionId : missedReturnDismissed.generatedQuestionId;
   try {
     await db
       .update(missedReturnDismissed)
@@ -132,7 +154,7 @@ export async function reinstateMissedReturn(userId: string, questionId: string):
       .where(
         and(
           eq(missedReturnDismissed.userId, userId),
-          eq(missedReturnDismissed.questionId, questionId),
+          eq(column, questionId),
           isNull(missedReturnDismissed.reinstatedAt),
         ),
       );

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -3,6 +3,7 @@ import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import {
   dailyPreferences,
   db,
+  generatedQuestions,
   missedReturnState,
   questions,
 } from '@/server/db';
@@ -14,6 +15,7 @@ import {
   MISSED_RETURN_LIFETIME_CAP,
   rankReturnCandidates,
   type ReturnCandidate,
+  type ReturnQuestionKind,
   type ReturnScope,
 } from '@/server/daily/missed-return';
 
@@ -61,14 +63,82 @@ export async function getEligibleReturnCandidates(
     );
 
     const rows = await db.execute<{
+      kind: ReturnQuestionKind;
       questionId: string;
       scope: ReturnScope;
       lastSeenAt: Date;
       returnCount: number;
     }>(sql`
       WITH
+      -- ================= GENERATED (LLM-origin) QUESTIONS =================
+      -- These live in GeneratedQuestion, and MASTERY_EVENTS.question_id is NULL
+      -- for them (the writer only ever stores eventQuestionId, which is
+      -- canonical-only). Their entire answer history exists in DailyQueue.slots
+      -- — which is exactly why catch-up sees them. Measured on prod, they are
+      -- ~96% of the wrong answers inside the Daily Five, so omitting them makes
+      -- the whole feature return almost nothing anyone actually missed.
+      gen_slots AS (
+        SELECT
+          slot->>'generated_question_id'                  AS gid,
+          COALESCE(slot->>'answered', 'false') = 'true'   AS answered,
+          slot->>'answer_state'                           AS answer_state,
+          slot->>'catchup_answer_state'                   AS catchup_answer_state,
+          slot->>'dismissed_at'                           AS dismissed_at,
+          q.queue_date::timestamptz                       AS queue_date
+        FROM "DailyQueue" q, LATERAL jsonb_array_elements(q.slots) AS slot
+        WHERE q.user_id = ${userId}
+          AND slot->>'generated_question_id' IS NOT NULL
+      ),
+      -- R6 for generated questions: a correct answer on EITHER the live round or
+      -- a later catch-up attempt retires it permanently.
+      gen_ever_correct AS (
+        SELECT DISTINCT gid FROM gen_slots
+        WHERE answer_state = 'correct' OR catchup_answer_state = 'correct'
+      ),
+      gen_wrong AS (
+        SELECT gid, max(queue_date) AS last_seen
+        FROM gen_slots
+        WHERE answered AND answer_state = 'incorrect' AND dismissed_at IS NULL
+        GROUP BY gid
+      ),
+      gen_expired AS (
+        SELECT gid, max(queue_date) AS last_seen
+        FROM gen_slots
+        WHERE NOT answered AND dismissed_at IS NULL AND queue_date < ${expiredBefore}
+        GROUP BY gid
+      ),
+      gen_dismissed AS (
+        SELECT "generatedQuestionId" AS gid FROM "MissedReturnDismissed"
+        WHERE "userId" = ${userId} AND "reinstatedAt" IS NULL
+          AND "generatedQuestionId" IS NOT NULL
+      ),
+      gen_unioned AS (
+        SELECT gid, 'wrong'::text AS scope, last_seen FROM gen_wrong
+        UNION ALL
+        SELECT gid, 'expired'::text AS scope, last_seen FROM gen_expired
+        WHERE gid NOT IN (SELECT gid FROM gen_wrong)
+      ),
+      generated_candidates AS (
+        SELECT
+          'generated'::text            AS kind,
+          g.gid                        AS "questionId",
+          g.scope                      AS scope,
+          g.last_seen                  AS "lastSeenAt",
+          COALESCE(s."returnCount", 0) AS "returnCount"
+        FROM gen_unioned g
+        JOIN "GeneratedQuestion" gq ON gq.id = g.gid
+        LEFT JOIN "MissedReturnState" s
+          ON s."userId" = ${userId} AND s."generatedQuestionId" = g.gid
+        WHERE g.gid NOT IN (SELECT gid FROM gen_ever_correct)
+          AND g.gid NOT IN (SELECT gid FROM gen_dismissed)
+          AND (s."lastReturnedAt" IS NULL OR s."lastReturnedAt" <= ${cooldownCutoff})
+          AND (g.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
+      ),
+      -- ================= CANONICAL (friend / curated) QUESTIONS =================
       -- (1a) WRONG scope: the player's most recent answer on the question was
-      -- incorrect. answered_by_user_id = user_id keeps this to answers THEY gave.
+      -- incorrect. Read from MASTERY_EVENTS rather than the slots, because a
+      -- canonical question can also be answered on the feed and milestone
+      -- surfaces, and a wrong answer there deserves to come back too.
       wrong AS (
         SELECT DISTINCT ON (me.question_id)
           me.question_id AS "questionId",
@@ -114,6 +184,7 @@ export async function getEligibleReturnCandidates(
       dismissed AS (
         SELECT "questionId" FROM "MissedReturnDismissed"
         WHERE "userId" = ${userId} AND "reinstatedAt" IS NULL
+          AND "questionId" IS NOT NULL
       ),
       -- Wrong takes precedence when a question qualifies under both: it HAS been
       -- seen, so it must carry the return framing and the 3-return cap.
@@ -122,36 +193,49 @@ export async function getEligibleReturnCandidates(
         UNION ALL
         SELECT "questionId", 'expired'::text AS scope, "lastSeenAt" FROM expired_scope
         WHERE "questionId" NOT IN (SELECT "questionId" FROM wrong_scope)
+      ),
+      canonical_candidates AS (
+        SELECT
+          'canonical'::text                  AS kind,
+          u."questionId"                     AS "questionId",
+          u.scope                            AS scope,
+          u."lastSeenAt"                     AS "lastSeenAt",
+          COALESCE(s."returnCount", 0)       AS "returnCount"
+        FROM unioned u
+        -- NOTE: Question is snake_case here ("deleted_at"), unlike the camelCase
+        -- MissedReturn* tables above. Getting this wrong raises 42703, which is
+        -- deliberately NOT swallowed below — see the catch.
+        JOIN "Question" qq ON qq.id = u."questionId" AND qq.deleted_at IS NULL
+        LEFT JOIN "MissedReturnState" s
+          ON s."userId" = ${userId} AND s."questionId" = u."questionId"
+        WHERE u."questionId" NOT IN (SELECT "questionId" FROM ever_correct)
+          AND u."questionId" NOT IN (SELECT "questionId" FROM dismissed)
+          -- (4) 7-day floor between sightings.
+          AND (s."lastReturnedAt" IS NULL OR s."lastReturnedAt" <= ${cooldownCutoff})
+          -- (3) lifetime cap, wrong scope only.
+          AND (u.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
       )
-      SELECT
-        u."questionId"                     AS "questionId",
-        u.scope                            AS scope,
-        u."lastSeenAt"                     AS "lastSeenAt",
-        COALESCE(s."returnCount", 0)       AS "returnCount"
-      FROM unioned u
-      -- NOTE: Question is snake_case here ("deleted_at"), unlike the camelCase
-      -- MissedReturn* tables above. Getting this wrong raises 42703, which is
-      -- deliberately NOT swallowed below — see the catch.
-      JOIN "Question" qq ON qq.id = u."questionId" AND qq.deleted_at IS NULL
-      LEFT JOIN "MissedReturnState" s
-        ON s."userId" = ${userId} AND s."questionId" = u."questionId"
-      WHERE u."questionId" NOT IN (SELECT "questionId" FROM ever_correct)
-        AND u."questionId" NOT IN (SELECT "questionId" FROM dismissed)
-        -- (4) 7-day floor between sightings.
-        AND (s."lastReturnedAt" IS NULL OR s."lastReturnedAt" <= ${cooldownCutoff})
-        -- (3) lifetime cap, wrong scope only.
-        AND (u.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
+      SELECT kind, "questionId", scope, "lastSeenAt", "returnCount" FROM canonical_candidates
+      UNION ALL
+      SELECT kind, "questionId", scope, "lastSeenAt", "returnCount" FROM generated_candidates
       ${limit ? sql`LIMIT ${limit}` : sql``}
     `);
 
     // db.execute returns a driver result ({ rows }) on node-postgres and a bare
     // array on some paths — read both shapes, per the house pattern in
     // domain-fragmentation.ts. Assuming either one alone throws at runtime.
-    type Row = { questionId: string; scope: ReturnScope; lastSeenAt: string | Date; returnCount: number };
+    type Row = {
+      kind: ReturnQuestionKind;
+      questionId: string;
+      scope: ReturnScope;
+      lastSeenAt: string | Date;
+      returnCount: number;
+    };
     const list =
       (rows as unknown as { rows?: Row[] }).rows ?? (rows as unknown as Row[]);
 
     return list.map((row) => ({
+      kind: row.kind,
       questionId: row.questionId,
       scope: row.scope,
       lastSeenAt: new Date(row.lastSeenAt),
@@ -226,17 +310,32 @@ export async function isMissedReturnEnabledForUser(userId: string): Promise<bool
  */
 export async function recordReturnServed(
   userId: string,
-  questionId: string,
+  target: { kind: ReturnQuestionKind; questionId: string },
   scope: ReturnScope,
   { now = new Date() }: { now?: Date } = {},
 ): Promise<void> {
   const increment = scope === 'wrong' ? 1 : 0;
+  const isCanonical = target.kind === 'canonical';
   try {
     await db
       .insert(missedReturnState)
-      .values({ userId, questionId, lastReturnedAt: now, returnCount: increment })
+      .values({
+        userId,
+        questionId: isCanonical ? target.questionId : null,
+        generatedQuestionId: isCanonical ? null : target.questionId,
+        lastReturnedAt: now,
+        returnCount: increment,
+      })
+      // The two kinds have separate partial unique indexes (migration 0130), so
+      // the conflict target has to name the matching one — a single target
+      // covering both columns would never match either index.
       .onConflictDoUpdate({
-        target: [missedReturnState.userId, missedReturnState.questionId],
+        target: isCanonical
+          ? [missedReturnState.userId, missedReturnState.questionId]
+          : [missedReturnState.userId, missedReturnState.generatedQuestionId],
+        targetWhere: isCanonical
+          ? sql`${missedReturnState.questionId} IS NOT NULL`
+          : sql`${missedReturnState.generatedQuestionId} IS NOT NULL`,
         set: {
           lastReturnedAt: now,
           returnCount: sql`${missedReturnState.returnCount} + ${increment}`,
@@ -274,6 +373,7 @@ export async function setMissedReturnEnabled(userId: string, enabled: boolean): 
 }
 
 export type ReturnListItem = {
+  kind: ReturnQuestionKind;
   questionId: string;
   scope: ReturnScope;
   questionText: string;
@@ -296,17 +396,20 @@ export async function getReturnListForUser(userId: string): Promise<ReturnListIt
   if (candidates.length === 0) return [];
 
   const ranked = rankReturnCandidates(candidates);
-  const rows = await loadReturnQuestions(ranked.map((c) => c.questionId));
-  const byId = new Map(rows.map((r) => [r.id, r]));
+  const rows = await loadReturnQuestions(ranked);
+  // Keyed by kind AND id — the two tables' ids are different namespaces and must
+  // never be looked up interchangeably.
+  const byKey = new Map(rows.map((r) => [`${r.kind}:${r.id}`, r]));
   const authorNames = await resolveCreatorNames(
     rows.map((r) => r.creatorId).filter((id): id is string => Boolean(id)),
   );
 
   return ranked.flatMap((candidate) => {
-    const question = byId.get(candidate.questionId);
+    const question = byKey.get(`${candidate.kind}:${candidate.questionId}`);
     if (!question) return [];
     return [
       {
+        kind: candidate.kind,
         questionId: candidate.questionId,
         scope: candidate.scope,
         questionText: question.questionText,
@@ -319,25 +422,77 @@ export async function getReturnListForUser(userId: string): Promise<ReturnListIt
   });
 }
 
-/** Live question text/answer for the candidates the builder decided to serve. */
-export async function loadReturnQuestions(questionIds: readonly string[]) {
-  if (questionIds.length === 0) return [];
-  return db
-    .select({
-      id: questions.id,
-      questionText: questions.questionText,
-      answerText: questions.answerText,
-      creatorId: questions.creatorId,
-      canonicalSubcategory: questions.canonicalSubcategory,
-      broadCategory: questions.broadCategory,
-      category: questions.category,
-      questionType: questions.questionType,
-      difficultyEstimate: questions.difficultyEstimate,
-      creatorNote: questions.creatorNote,
-      source: questions.source,
-    })
-    .from(questions)
-    // inArray, not `= ANY(...)`: drizzle renders a JS array in a sql template as
-    // a tuple, which Postgres rejects with 42809 against ANY().
-    .where(and(inArray(questions.id, [...questionIds]), isNull(questions.deletedAt)));
+/**
+ * Live text for the candidates the builder decided to serve, from BOTH tables.
+ *
+ * Returns one shape regardless of kind so the slot builder and the Customize
+ * list don't each re-branch. Generated questions have no author (LLM origin) and
+ * no creator note, which is why those come back null for them rather than being
+ * faked — the UI must not imply a person wrote them.
+ */
+export type LoadedReturnQuestion = {
+  kind: ReturnQuestionKind;
+  id: string;
+  questionText: string;
+  creatorId: string | null;
+  creatorNote: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+  category: string | null;
+  difficultyEstimate: string | null;
+};
+
+export async function loadReturnQuestions(
+  targets: readonly { kind: ReturnQuestionKind; questionId: string }[],
+): Promise<LoadedReturnQuestion[]> {
+  const canonicalIds = targets.filter((t) => t.kind === 'canonical').map((t) => t.questionId);
+  const generatedIds = targets.filter((t) => t.kind === 'generated').map((t) => t.questionId);
+
+  const [canonicalRows, generatedRows] = await Promise.all([
+    canonicalIds.length
+      ? db
+          .select({
+            id: questions.id,
+            questionText: questions.questionText,
+            creatorId: questions.creatorId,
+            creatorNote: questions.creatorNote,
+            canonicalSubcategory: questions.canonicalSubcategory,
+            broadCategory: questions.broadCategory,
+            category: questions.category,
+            difficultyEstimate: questions.difficultyEstimate,
+          })
+          .from(questions)
+          // inArray, not `= ANY(...)`: drizzle renders a JS array in a sql
+          // template as a tuple, which Postgres rejects with 42809 against ANY().
+          .where(and(inArray(questions.id, canonicalIds), isNull(questions.deletedAt)))
+      : Promise.resolve([]),
+    generatedIds.length
+      ? db
+          .select({
+            id: generatedQuestions.id,
+            questionText: generatedQuestions.questionText,
+            canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+            broadCategory: generatedQuestions.broadCategory,
+            difficultyEstimate: generatedQuestions.difficultyEstimate,
+          })
+          .from(generatedQuestions)
+          .where(inArray(generatedQuestions.id, generatedIds))
+      : Promise.resolve([]),
+  ]);
+
+  return [
+    ...canonicalRows.map((row) => ({ kind: 'canonical' as const, ...row, category: row.category ?? null })),
+    ...generatedRows.map((row) => ({
+      kind: 'generated' as const,
+      id: row.id,
+      questionText: row.questionText,
+      // LLM origin: no human author, no creator note. Never invent either.
+      creatorId: null,
+      creatorNote: null,
+      canonicalSubcategory: row.canonicalSubcategory,
+      broadCategory: row.broadCategory,
+      category: null,
+      difficultyEstimate: row.difficultyEstimate,
+    })),
+  ];
 }

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -48,7 +48,7 @@ import {
 /** Rows come back pre-shaped for both consumers: the queue builder and Customize. */
 export async function getEligibleReturnCandidates(
   userId: string,
-  { now = new Date() }: { now?: Date } = {},
+  { now = new Date(), limit }: { now?: Date; limit?: number } = {},
 ): Promise<ReturnCandidate[]> {
   try {
     const cooldownCutoff = new Date(
@@ -141,6 +141,7 @@ export async function getEligibleReturnCandidates(
         AND (s."lastReturnedAt" IS NULL OR s."lastReturnedAt" <= ${cooldownCutoff})
         -- (3) lifetime cap, wrong scope only.
         AND (u.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
+      ${limit ? sql`LIMIT ${limit}` : sql``}
     `);
 
     // db.execute returns a driver result ({ rows }) on node-postgres and a bare
@@ -172,6 +173,27 @@ export async function getEligibleReturnCandidates(
     if (pgErrorCode(error) === '42P01') return [];
     throw error;
   }
+}
+
+/**
+ * "Does this viewer have anything waiting to come back?" — the Home surface's
+ * question (§7-E), which needs presence, not the list.
+ *
+ * Runs the SAME eligibility query with LIMIT 1 rather than a second copy of the
+ * rule: duplicating seven conditions into a bespoke EXISTS query would guarantee
+ * the two drift apart.
+ *
+ * Measured on prod, the LIMIT is NOT much of a speed-up — the CTEs materialize
+ * before it applies, so it costs ~85-170ms either way (177-candidate account:
+ * 170ms full, and agreeing with the full query on every account tested). What it
+ * buys is bounded row transfer, and it runs inside Home's existing Promise.all,
+ * so it adds parallel time rather than serial. If Home's budget (§12.6, < 1.5s)
+ * ever gets tight, this is a real line item — cache it or fold it into an
+ * existing query rather than assuming the LIMIT makes it free.
+ */
+export async function hasEligibleReturnCandidates(userId: string): Promise<boolean> {
+  const [first] = await getEligibleReturnCandidates(userId, { limit: 1 });
+  return Boolean(first);
 }
 
 /**

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1665,15 +1665,26 @@ export const missedReturnDismissed = pgTable(
   {
     id: id(),
     userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    // Exactly ONE of these is set (DB CHECK, migration 0130), mirroring
+    // CatchupQueueItem.reportTarget and DailyQueue.slots — the two other places
+    // that carry "a question" that may live in either table.
+    questionId: text('questionId').references(() => questions.id, { onDelete: 'cascade' }),
+    generatedQuestionId: text('generatedQuestionId').references(() => generatedQuestions.id, {
+      onDelete: 'cascade',
+    }),
     dismissedAt: timestamp('dismissedAt', { withTimezone: true }).notNull().defaultNow(),
     reinstatedAt: timestamp('reinstatedAt', { withTimezone: true }),
   },
   (table) => [
     index('MissedReturnDismissed_userId_idx').on(table.userId),
+    // One ACTIVE row per (user, question) per kind. The IS NOT NULL guards
+    // matter: without them the other kind's NULL column would collide.
     uniqueIndex('missed_return_dismissed_active_unique')
       .on(table.userId, table.questionId)
-      .where(sql`${table.reinstatedAt} IS NULL`),
+      .where(sql`${table.reinstatedAt} IS NULL AND ${table.questionId} IS NOT NULL`),
+    uniqueIndex('missed_return_dismissed_generated_active_unique')
+      .on(table.userId, table.generatedQuestionId)
+      .where(sql`${table.reinstatedAt} IS NULL AND ${table.generatedQuestionId} IS NOT NULL`),
   ],
 );
 
@@ -1703,14 +1714,24 @@ export const missedReturnState = pgTable(
   {
     id: id(),
     userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    // Exactly ONE of these is set (DB CHECK, migration 0130) — see the note on
+    // MissedReturnDismissed above.
+    questionId: text('questionId').references(() => questions.id, { onDelete: 'cascade' }),
+    generatedQuestionId: text('generatedQuestionId').references(() => generatedQuestions.id, {
+      onDelete: 'cascade',
+    }),
     lastReturnedAt: timestamp('lastReturnedAt', { withTimezone: true }).notNull().defaultNow(),
     returnCount: integer('returnCount').notNull().default(0),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     index('MissedReturnState_userId_idx').on(table.userId),
-    uniqueIndex('missed_return_state_user_question_unique').on(table.userId, table.questionId),
+    uniqueIndex('missed_return_state_user_question_unique')
+      .on(table.userId, table.questionId)
+      .where(sql`${table.questionId} IS NOT NULL`),
+    uniqueIndex('missed_return_state_user_generated_unique')
+      .on(table.userId, table.generatedQuestionId)
+      .where(sql`${table.generatedQuestionId} IS NOT NULL`),
   ],
 );
 


### PR DESCRIPTION
**Phase 4 of `B-MISSED-RETURN-01`** — copy wired, Home widened. **The flag is still off**, deliberately: see below.

## ⚠️ Two things need your call before this is "done"

**1. The copy is mine, not an approved pass.** §9 lists the copy pass as a separate gate and the slate says "copy matches the approved pass exactly — no paraphrasing by the model." You said go, so I drafted it rather than stopping with nothing — but I'm not flipping a canon-critical, player-facing surface on my own words. **Every string is in one place below; edit any of them and I'll rewire verbatim.**

**2. §7-E1 as written produces a lying button.** Details below — I implemented the honest version and need you to ratify or overrule it.

## The copy, all of it

| Surface | String |
|---|---|
| Return badge (wrong scope) | `from March 4` |
| Return badge (expired) | *(nothing — see below)* |
| Correct-on-return | `It stuck. {Author} would be glad.` / `It stuck.` |
| Author SMS | `{Name} came back to one of your questions and got it. Something you know is now something they know too.` |
| Home | `Some you didn't land will find their way back to you.` |
| Customize blurb | `Every so often, one question you didn't land turns up again in your five. Nothing stacks up — it's one at a time, and once you get it, it's done.` |
| Customize row (expired) | `never got to this one` |

**The expired scope is deliberately unmarked.** It has never been seen, so any return framing on it would be false (§2). That asymmetry is the point of the split, not an oversight — please don't read it as a missing case.

**Why "It stuck."** The moment isn't that the player improved; it's that something one person knew is now known by two. Naming the author makes it the sequel to the existing wrong-answer line rather than an achievement notice.

**A copy test enforces the register.** It asserts none of these strings contain *wrong, incorrect, failed, missed, retake, retry, try again, practice, review, quiz, test, correction, mistake, finally, still* — so a future edit toward "helpful" phrasing fails loudly instead of quietly turning a connection event into a grade.

## The §7-E1 problem

E1 ratified: widen the Home missed **count** to include wrong-scope returns. Implemented literally, that breaks two things:

1. **The number reaches 177** on a live account. With a 7-day floor and a 3-return cap the player will never see most of them, so the magnitude is meaningless.
2. **"Play (n) Missed Questions" links to `/daily/catchup`, which cannot serve a wrong-scope return.** Those arrive one at a time inside the Daily Five (R2). The button would promise a destination that doesn't exist — which is the provenance-honesty problem §3.2 raises, not a fix for it.

So Home now states that misses aren't lost **with no number and no link**, and `missedCount` keeps meaning exactly what it has always meant. `hasReturningQuestions` is a boolean, not a count.

That is a deviation from a ratified decision. It's a one-function change if you'd rather have the literal version.

## Also in here

- Return slots render `✦`, not a numeral — they're additive like the +2 and never in the denominator (R3)
- Home's existence check reuses the eligibility query with `LIMIT 1` rather than a second copy of seven conditions. Measured on prod it's **not** much cheaper (~85–170ms either way; the CTEs materialize before the LIMIT), so the comment says so rather than implying it's free. It runs inside Home's existing `Promise.all`, and is flag-gated off.

## Checks

- `npx tsc` — 0 errors · `npm run lint` — 0 errors (4 pre-existing warnings)
- **All six ratchets at ceiling** — no new arbitrary values
- **Full suite: 2335 passed, 0 failed** (+7 copy-register tests)
- Existence check verified against prod: agrees with the full query on a 177-candidate account, a 48-candidate account, and an account with none

## To finish Phase 4

1. You approve or edit the copy above
2. I rewire any edits verbatim
3. **You say flip** — then I set `MISSED_RETURN_ENABLED=1` and walk the full flow on Craig T Testing: get one wrong → return slot appears labeled → answer correctly → author push fires → it lands in the Recovered deck → dismiss another from Customize and confirm it stays gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsnxcCmnb1J8Hxx3K7sKSP
