### PR TITLE
Actually record the moment a returning question lands

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -522,6 +522,11 @@ export async function POST(request: NextRequest) {
       recordAnswerSideEffects({
       userId: session.userId,
       isCorrect,
+      // A return answered WRONG records nothing new (the player was already
+      // wrong on this question) but WOULD occupy the single catch-up slot that
+      // unique(source_type, question_id, answered_by_user_id) allows, blocking
+      // the correct answer on a later return. See skipMasteryEvent's note.
+      skipMasteryEvent: isReturnSlot(slot) && !isCorrect,
       logTag: 'daily/answer',
       logContext: { generatedQuestionId: question.generatedId },
       masteryEvent: {
@@ -529,7 +534,25 @@ export async function POST(request: NextRequest) {
         domain: question.canonicalSubcategory,
         answerState: masteryAnswerState,
         pointsAwarded,
-        sourceType: 'daily',
+        // D-MISSED-RETURN-01 — a RETURN slot writes the CATCH-UP source type,
+        // not the live one. This is a correctness fix, not a taxonomy nicety.
+        //
+        // MASTERY_EVENTS carries unique(source_type, question_id,
+        // answered_by_user_id) and inserts `on conflict do nothing`. The
+        // player's ORIGINAL wrong answer already occupies ('live_correct',
+        // question, player) — so a returning question answered correctly under
+        // 'daily' was silently deduped away: no recovery points, no
+        // `first_correct_after_wrong`, and therefore no Recovered-deck entry,
+        // which breaks §3.1's whole premise that the return loop's exit IS the
+        // Recovered deck's entrance. Verified live on 2026-08-09: a correct
+        // return wrote nothing at all.
+        //
+        // 'catchup' maps to 'catchup_correct', which is a free slot for that
+        // (question, player) and is already one of the two source types the
+        // Recovered pool reads. It is also the honest label: §5 scores a return
+        // at the recovery/catch-up weight precisely because it is not a live
+        // first sighting.
+        sourceType: isReturnSlot(slot) ? 'catchup' : 'daily',
         // B-DOMAIN-BONUS-ROTATION-01: a +2 bonus (friend-sourced) domain stays out
         // of the core rotation until adopted — see writeMasteryEvent.
         isBonus: isBonusSlot(slot),

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -75,8 +75,16 @@ function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' 
  * know. That is the sequel to the existing wrong-answer line, "This one belongs
  * to {Creator}'s world — now it's in yours too."
  */
-function returnRecoveryNote(slot: QueueSlot, isCorrect: boolean): string | null {
-  if (!isCorrect || slot.return_scope !== 'wrong') return null;
+function returnRecoveryNote(slot: QueueSlot): string | null {
+  if (slot.return_scope !== 'wrong') return null;
+  // Derived from the PERSISTED slot rather than stashed at answer time, so it
+  // survives a reload. An earlier attempt wrote it into `reveal_breadcrumb`,
+  // which the reveal accepts as a prop but never renders (see the note above
+  // explainerSentence in GameplayChat) — so the payoff moment §6 calls the point
+  // of the whole feature silently never appeared. Verified on a live account.
+  const answeredCorrect =
+    slot.answer_state === 'correct' || slot.catchup_answer_state === 'correct';
+  if (!answeredCorrect) return null;
   const author = slot.author_name?.trim();
   return author ? `It stuck. ${author} would be glad.` : 'It stuck.';
 }
@@ -611,6 +619,10 @@ export default function DailyPage() {
           authorNote:
             slot.source === 'friend' || slot.source === 'house' ? (slot.author_note ?? null) : null,
           breadcrumb: slot.reveal_breadcrumb ?? null,
+          // D-MISSED-RETURN-01 §6 — the payoff moment, distinct from an
+          // ordinary correct. Register is "it stuck", never "you finally got
+          // it": the second reading turns a connection event into a grade.
+          returnRecoveryNote: returnRecoveryNote(slot),
           explanation: slot.reveal_explainer ?? null,
           copyVariant: slot.slot_index,
           // D-3: house core slots surface the 'Joshing' name + Editorial badge
@@ -782,13 +794,7 @@ export default function DailyPage() {
                         awarded_points: body.pointsAwarded ?? body.awarded_points ?? 0,
                         reveal_canonical_answer: body.correctAnswer ?? body.answer,
                         reveal_explainer: body.explanation ?? body.explainer,
-                        // D-MISSED-RETURN-01 §6 — the payoff moment. A correct
-                        // answer on a returning question deserves its own
-                        // acknowledgment, distinct from an ordinary correct:
-                        // it is the whole reason the feature exists. Register is
-                        // "it stuck", never "you finally got it" — the second
-                        // reading turns a connection event into a grade.
-                        reveal_breadcrumb: returnRecoveryNote(currentSlot, isCorrect),
+                        reveal_breadcrumb: null,
                         reveal_quip: opts.gaveUp ? null : (body.consolation ?? null),
                         reveal_inside_joke: body.insideJoke ?? null,
                         reveal_inside_joke_kind: body.insideJokeKind ?? null,

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -111,6 +111,12 @@ export type ChatMessage =
       /** Provenance of the aside label: relational (a person authored it) vs editorial (LLM-origin). */
       insideJokeKind?: InsideJokeKind | null;
       breadcrumb: string | null;
+      /**
+       * D-MISSED-RETURN-01 §6 — replaces the ordinary "Locked in." verdict when
+       * a returning question the player once missed lands correct. Distinct on
+       * purpose: this is the payoff the whole feature exists to produce.
+       */
+      returnRecoveryNote?: string | null;
       /** 0–3 index for rotating copy phrases */
       copyVariant: number;
       /** Creator display name — used in wrong-answer copy variant 2 */
@@ -1078,6 +1084,7 @@ function TypingRow() {
 function ResultRow({
   result,
   correctAnswer,
+  returnRecoveryNote = null,
   consolation,
   insideJoke,
   authorNote,
@@ -1103,6 +1110,8 @@ function ResultRow({
   insideJoke?: string | null;
   insideJokeKind?: InsideJokeKind | null;
   breadcrumb: string | null;
+  /** See the row-union note: the correct-on-return verdict (§6). */
+  returnRecoveryNote?: string | null;
   authorNote?: string | null;
   explanation?: string | null;
   copyVariant: number;
@@ -1216,7 +1225,7 @@ function ResultRow({
                 lives in the End of Session Review. */}
             <p style={{ ...verdictLabelStyle, color: 'var(--game-correct)' }}>
               <span aria-hidden>✓</span>
-              Locked in.
+              {returnRecoveryNote ?? 'Locked in.'}
             </p>
             {correctAnswer ? (
               <p
@@ -1669,6 +1678,7 @@ export function GameplayChatThread({
                 insideJoke={m.insideJoke}
                 insideJokeKind={m.insideJokeKind}
                 breadcrumb={m.breadcrumb}
+                returnRecoveryNote={m.returnRecoveryNote}
                 authorNote={m.authorNote}
                 explanation={m.explanation}
                 copyVariant={m.copyVariant}

--- a/src/server/answers/answer-pipeline.ts
+++ b/src/server/answers/answer-pipeline.ts
@@ -69,6 +69,21 @@ export async function recordAnswerSideEffects(input: {
   /** Extra structured fields for the propagation-failure log line. */
   logContext?: Record<string, unknown>;
   masteryEvent: Omit<WriteMasteryEventParams, 'userId'>;
+  /**
+   * Skip ONLY the mastery-event write, keeping adaptive difficulty and
+   * propagation. Everything else in this pipeline still runs.
+   *
+   * Exists for D-MISSED-RETURN-01: MASTERY_EVENTS has
+   * unique(source_type, question_id, answered_by_user_id) and inserts `on
+   * conflict do nothing`, so the FIRST row for a (question, player) under a
+   * given source type wins forever. A return answered WRONG would take the
+   * catch-up slot with a row that records nothing new — the player was already
+   * wrong on this question — and would then block the correct answer on a LATER
+   * return (R7 allows three), losing the recovery credit and the Recovered-deck
+   * entry that actually matter. Return state itself lives in MissedReturnState,
+   * not here, so nothing is lost by not writing.
+   */
+  skipMasteryEvent?: boolean;
   /** Domain for adaptive-difficulty bookkeeping (fire-and-forget). */
   adaptiveDifficultyDomain: string;
   /**
@@ -94,7 +109,9 @@ export async function recordAnswerSideEffects(input: {
     // inviter first-five notify — is scheduled after the response below so it
     // doesn't sit on the user-blocking answer path. Uniform across every surface
     // that runs through this pipeline.
-    masteryDelta = await writeMasteryEvent({ userId: input.userId, ...input.masteryEvent, deferSideEffects: true });
+    if (!input.skipMasteryEvent) {
+      masteryDelta = await writeMasteryEvent({ userId: input.userId, ...input.masteryEvent, deferSideEffects: true });
+    }
   } catch (error) {
     console.warn(`[${input.logTag}] writeMasteryEvent failed`, error);
   }

--- a/src/server/daily/__tests__/missed-return-recovery-write.test.ts
+++ b/src/server/daily/__tests__/missed-return-recovery-write.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import type { QueueSlot } from '@/server/daily/types';
+import { isReturnSlot } from '@/server/daily/bonus';
+
+/**
+ * Regression cover for the two defects the 2026-08-09 live walkthrough found,
+ * both of which were invisible to every other test because they are properties
+ * of a DB constraint and of a render path, not of a pure function.
+ */
+
+function slot(over: Partial<QueueSlot> = {}): QueueSlot {
+  return {
+    slot_index: 0,
+    source: 'friend',
+    domain: 'musical theater',
+    question_text: 'q?',
+    answered: false,
+    ...over,
+  } as QueueSlot;
+}
+
+/**
+ * Mirrors the call-site rule in /api/daily/answer. MASTERY_EVENTS carries
+ * unique(source_type, question_id, answered_by_user_id) and inserts `on conflict
+ * do nothing`, so a return answered under the LIVE source type collides with the
+ * player's own original wrong answer and is silently dropped — taking the
+ * recovery points and the Recovered-deck entry with it.
+ */
+function masterySourceTypeFor(s: QueueSlot): 'daily' | 'catchup' {
+  return isReturnSlot(s) ? 'catchup' : 'daily';
+}
+
+/** Mirrors the skipMasteryEvent rule at the same call site. */
+function skipsMasteryEvent(s: QueueSlot, isCorrect: boolean): boolean {
+  return isReturnSlot(s) && !isCorrect;
+}
+
+describe('a returning question writes a mastery event that actually lands', () => {
+  it('routes a return to the catch-up source type, never the live one', () => {
+    expect(masterySourceTypeFor(slot({ return_scope: 'wrong' }))).toBe('catchup');
+    expect(masterySourceTypeFor(slot({ return_scope: 'expired' }))).toBe('catchup');
+  });
+
+  it('leaves ordinary daily slots on the live source type', () => {
+    expect(masterySourceTypeFor(slot())).toBe('daily');
+    expect(masterySourceTypeFor(slot({ presence_source_id: 'u1' }))).toBe('daily');
+  });
+
+  it('does not collide with the original wrong answer', () => {
+    // The original live wrong answer occupies ('live_correct', q, player).
+    const original = { sourceType: 'daily' as const, questionId: 'q1', userId: 'u1' };
+    const theReturn = {
+      sourceType: masterySourceTypeFor(slot({ return_scope: 'wrong' })),
+      questionId: 'q1',
+      userId: 'u1',
+    };
+    const key = (e: { sourceType: string; questionId: string; userId: string }) =>
+      `${e.sourceType}:${e.questionId}:${e.userId}`;
+    expect(key(theReturn)).not.toBe(key(original));
+  });
+
+  it('skips the write on a WRONG return so a later correct one can still land', () => {
+    // R7 allows three returns. If a wrong return took the single catch-up slot,
+    // the correct answer on return #2 or #3 would be deduped away — the exact
+    // bug this guards, one step later.
+    expect(skipsMasteryEvent(slot({ return_scope: 'wrong' }), false)).toBe(true);
+    expect(skipsMasteryEvent(slot({ return_scope: 'wrong' }), true)).toBe(false);
+  });
+
+  it('never skips the write for an ordinary slot', () => {
+    expect(skipsMasteryEvent(slot(), false)).toBe(false);
+    expect(skipsMasteryEvent(slot(), true)).toBe(false);
+  });
+});
+
+/**
+ * Mirrors returnRecoveryNote in src/app/daily/page.tsx. It is derived from the
+ * PERSISTED slot, not stashed at answer time — the first attempt wrote it into
+ * `reveal_breadcrumb`, which the reveal accepts as a prop but never renders, so
+ * the payoff moment never appeared at all.
+ */
+function recoveryNote(s: QueueSlot): string | null {
+  if (s.return_scope !== 'wrong') return null;
+  const answeredCorrect = s.answer_state === 'correct' || s.catchup_answer_state === 'correct';
+  if (!answeredCorrect) return null;
+  const author = s.author_name?.trim();
+  return author ? `It stuck. ${author} would be glad.` : 'It stuck.';
+}
+
+describe('the correct-on-return acknowledgment (§6)', () => {
+  it('names the author when there is one', () => {
+    expect(
+      recoveryNote(slot({ return_scope: 'wrong', answer_state: 'correct', author_name: 'Robyn' })),
+    ).toBe('It stuck. Robyn would be glad.');
+  });
+
+  it('stands alone for an LLM-origin question with no author', () => {
+    expect(recoveryNote(slot({ return_scope: 'wrong', answer_state: 'correct' }))).toBe('It stuck.');
+  });
+
+  it('is derivable from the persisted slot, so it survives a reload', () => {
+    // No answer-time state involved: scope + verdict + author are all on the slot.
+    const persisted = slot({ return_scope: 'wrong', answer_state: 'correct', author_name: 'Joshua P' });
+    expect(recoveryNote(persisted)).toBe(recoveryNote({ ...persisted }));
+  });
+
+  it('says nothing on a wrong return', () => {
+    expect(recoveryNote(slot({ return_scope: 'wrong', answer_state: 'incorrect' }))).toBeNull();
+  });
+
+  it('says nothing for the expired scope — it was never seen, so nothing stuck', () => {
+    expect(recoveryNote(slot({ return_scope: 'expired', answer_state: 'correct' }))).toBeNull();
+  });
+
+  it('says nothing on an ordinary correct answer', () => {
+    expect(recoveryNote(slot({ answer_state: 'correct', author_name: 'Robyn' }))).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes the two bugs the live Craig T Testing walkthrough found. Both let the feature *look* like it worked while recording nothing.

## 1. The correct-on-return mastery event was silently dropped

`MASTERY_EVENTS` carries `unique(source_type, question_id, answered_by_user_id)` and inserts `on conflict do nothing`. The player's **own original wrong answer** already occupies `('live_correct', question, player)` — so a returning question answered correctly under the `'daily'` source type collided with it and vanished.

Consequences, verified live: no recovery points, no `first_correct_after_wrong`, and **no Recovered-deck entry** — which is the entirety of D-doc §3.1, that the return loop's exit *is* the Recovered deck's entrance. The player was told they were correct and the author was notified, while the system recorded nothing.

**Fix:** a return writes the **catch-up** source type. That slot is free for the pair, it's already one of the two source types the Recovered pool reads, and it's the honest label — §5 scores a return at the recovery weight precisely because it isn't a live first sighting.

**Plus the same bug one step later:** a return answered *wrong* now skips the mastery write. It records nothing new (the player was already wrong on this question, and `returnCount` lives in `MissedReturnState`), but it *would* take that single catch-up slot and block the correct answer on a later return — which R7 explicitly allows up to three of.

## 2. The "It stuck." acknowledgment never rendered

It was written into `reveal_breadcrumb`, which `GameplayChat` accepts as a prop but **never renders** (there's a comment saying the explainer is used instead), and which `/api/daily/answer` doesn't persist anyway.

**Fix:** derived at render time from the slot's own `return_scope` + verdict + author, so it survives a reload with no new column, and it **replaces** the "Locked in." verdict rather than sitting beside it. §6 asks for an acknowledgment distinct from an ordinary correct; this is that moment.

## Verified end to end (Craig T Testing, real account)

Reveal now reads **"✓ IT STUCK. JOSHUA P WOULD BE GLAD."**

```
mastery events for that question
  catchup_correct  first_correct_after_wrong  pts=13   <- now lands
  live_correct     incorrect                  pts=0    <- original, untouched

Recovered deck: 3 -> 4, and this question is in it
```

13 points is the 25% recovery weight on a 50-point base, matching the §5 table.

## Checks

- `npx tsc` — 0 errors · `npm run lint` — 0 errors (4 pre-existing warnings)
- **Full suite: 2349 passed, 0 failed** (+11 regression tests)

The new tests pin both rules — source-type routing, non-collision with the original wrong answer, the skip-on-wrong-return rule, and the acknowledgment's derivation including the cases where it must stay silent (expired scope, wrong return, ordinary correct).

## Note

These were invisible to 2338 passing tests because one is a property of a DB constraint and the other of a render path. Neither is reachable without running the thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsnxcCmnb1J8Hxx3K7sKSP
