### PR TITLE
Lift the returning-questions toggle up the page and drop the list

### DIFF
--- a/src/app/daily/setup/MissedReturnSection.tsx
+++ b/src/app/daily/setup/MissedReturnSection.tsx
@@ -1,71 +1,32 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { Switch } from '@/components/ui/Switch';
 
 /**
- * D-MISSED-RETURN-01 §7-D — the Customize surface for returning questions.
+ * D-MISSED-RETURN-01 §7-D — the Customize control for returning questions.
  *
- * ONE surface, not two (R11): the toggle at the top, the currently-eligible
- * questions below it, each with a dismiss.
+ * ONE control: on or off. Deliberately NOT a list.
  *
- * Deliberately lighter than the Recovered pattern. §7-C rules out a browsable
- * dismissed archive and a dimmed/archived section — a dismissed row simply
- * leaves the list, with a few seconds to undo. That is the whole reversal story.
+ * §7-D originally paired the toggle with a list of currently-eligible questions
+ * and a per-row dismiss. That shipped, and then didn't survive contact with real
+ * data (Josh, 2026-08-10): a heavy account had 135 eligible rows, which buried
+ * the rest of the page and turned a settings screen into an inventory nobody
+ * asked to read. "I don't need to see those."
  *
- * REGISTER (§1, §6): this is not remediation and must never read as it. No
- * "you got this wrong", no "practice", no "review", no counts of failure. A
- * returning question is something a friend taught you, coming back to see if it
- * stuck. The expired scope gets NO return framing at all — it has never been
- * seen, so it reads as a question that simply hasn't been asked yet.
+ * Dropping the list also removes two hazards the walkthrough surfaced — the
+ * unbounded scroll, and the undo strip whose disappearance shifted the list
+ * under an in-flight tap.
  *
- * Copy here is the working pass; Phase 4 replaces it from the approved copy pass.
+ * The dismiss capability itself is unchanged and still reachable where it has
+ * always made sense: waving a question off in catch-up dual-writes
+ * MissedReturnDismissed, which suppresses the return. What's gone is the
+ * separate browsable surface for doing that in advance.
  */
-
-const UNDO_WINDOW_MS = 6000;
-
-export type MissedReturnItem = {
-  /** Which table the id belongs to — the Daily Five serves both kinds. */
-  kind: 'canonical' | 'generated';
-  questionId: string;
-  scope: 'wrong' | 'expired';
-  questionText: string;
-  category: string | null;
-  authorName: string | null;
-  /** ISO — when they last saw it (the wrong answer, or the day it expired). */
-  lastSeenAt: string;
-  returnCount: number;
-};
-
-function formatSeen(iso: string): string {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return '';
-  return date.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
-}
-
-export function MissedReturnSection({
-  initialEnabled,
-  initialItems,
-}: {
-  initialEnabled: boolean;
-  initialItems: MissedReturnItem[];
-}) {
+export function MissedReturnSection({ initialEnabled }: { initialEnabled: boolean }) {
   const [enabled, setEnabled] = useState(initialEnabled);
-  const [items, setItems] = useState(initialItems);
-  /** The row awaiting its undo window. Null when nothing is pending. */
-  const [pending, setPending] = useState<MissedReturnItem | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const timerRef = useRef<number | null>(null);
-
-  const clearTimer = useCallback(() => {
-    if (timerRef.current !== null) {
-      window.clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => clearTimer, [clearTimer]);
 
   const toggle = useCallback(async (next: boolean) => {
     setEnabled(next); // optimistic — the control should never feel laggy
@@ -83,140 +44,31 @@ export function MissedReturnSection({
     }
   }, []);
 
-  /**
-   * Dismiss writes IMMEDIATELY — the undo window is a grace period on a real
-   * write, not a delayed one. If the player closes the tab mid-window the
-   * dismiss still stands, which is the honest reading of "I don't want this
-   * back" and avoids a row that silently reappears tomorrow.
-   */
-  const dismiss = useCallback(
-    async (item: MissedReturnItem) => {
-      clearTimer();
-      setError(null);
-      setItems((current) => current.filter((i) => i.questionId !== item.questionId));
-      setPending(item);
-      timerRef.current = window.setTimeout(() => setPending(null), UNDO_WINDOW_MS);
-
-      try {
-        const res = await fetch('/api/daily/missed-return/dismiss', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ questionId: item.questionId, kind: item.kind }),
-        });
-        if (!res.ok) throw new Error('failed');
-      } catch {
-        setItems((current) => [item, ...current]);
-        setPending(null);
-        clearTimer();
-        setError('That didn’t save. Try again?');
-      }
-    },
-    [clearTimer],
-  );
-
-  const undo = useCallback(async () => {
-    if (!pending) return;
-    const item = pending;
-    clearTimer();
-    setPending(null);
-    setError(null);
-    try {
-      const res = await fetch('/api/daily/missed-return/dismiss', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ questionId: item.questionId, kind: item.kind }),
-      });
-      if (!res.ok) throw new Error('failed');
-      setItems((current) =>
-        current.some((i) => i.questionId === item.questionId) ? current : [item, ...current],
-      );
-    } catch {
-      setError('Couldn’t undo that. Try again?');
-    }
-  }, [pending, clearTimer]);
-
   return (
-    <section className="mx-auto mt-2 w-[min(672px,94vw)] px-1 pb-10">
-      <div className="border-t border-[var(--border-warm)] pt-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex-1">
-            <h2 className="m-0 font-serif text-lg font-semibold text-[var(--brand-ink)]">
-              Questions that come back
-            </h2>
-            <p className="mt-1 mb-0 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
-              Every so often, one question you didn’t land turns up again in your five. Nothing
-              stacks up — it’s one at a time, and once you get it, it’s done.
-            </p>
-          </div>
-          <Switch
-            checked={enabled}
-            onCheckedChange={(next) => void toggle(next)}
-            label="Let missed questions come back"
-            className="mt-1"
-          />
-        </div>
-
-        {error ? (
-          <p className="mt-3 mb-0 text-quiet text-[var(--brand-ink)]" role="status" aria-live="polite">
-            {error}
+    <section className="border-t border-[var(--border-warm)] pt-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1">
+          <h2 className="m-0 font-serif text-lg font-semibold text-[var(--brand-ink)]">
+            Questions that come back
+          </h2>
+          <p className="mt-1 mb-0 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
+            Every so often, one question you didn’t land turns up again in your five. Nothing
+            stacks up — it’s one at a time, and once you get it, it’s done.
           </p>
-        ) : null}
-
-        {pending ? (
-          <div
-            className="mt-3 flex items-center justify-between gap-3 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--cream-warm)] px-3 py-2"
-            role="status"
-            aria-live="polite"
-          >
-            <p className="m-0 text-quiet text-[var(--ink)]">Removed</p>
-            <button
-              type="button"
-              className="text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70"
-              onClick={() => void undo()}
-            >
-              Undo
-            </button>
-          </div>
-        ) : null}
-
-        {enabled ? (
-          items.length > 0 ? (
-            <ul className="mt-4 grid list-none gap-2 p-0">
-              {items.map((item) => (
-                <li
-                  key={`${item.kind}:${item.questionId}`}
-                  className="flex items-start justify-between gap-3 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--brand-card)] px-3 py-2.5"
-                >
-                  <div className="flex-1">
-                    <p className="m-0 text-sm leading-[1.45] text-[var(--brand-ink)]">
-                      {item.questionText}
-                    </p>
-                    <p className="mt-1 mb-0 text-quiet text-[var(--text-muted-warm)]">
-                      {/* Provenance, honestly (R9). The 'wrong' scope says when
-                          they last saw it; 'expired' never implies they did. */}
-                      {item.scope === 'wrong'
-                        ? `${item.authorName ? `${item.authorName} · ` : ''}from ${formatSeen(item.lastSeenAt)}`
-                        : `${item.authorName ? `${item.authorName} · ` : ''}never got to this one`}
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    className="shrink-0 text-xs font-semibold tracking-[0.08em] text-[var(--text-muted-warm)] uppercase transition hover:text-[var(--brand-ink)]"
-                    onClick={() => void dismiss(item)}
-                    aria-label={`Don’t bring back: ${item.questionText}`}
-                  >
-                    Remove
-                  </button>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="mt-4 mb-0 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
-              Nothing’s waiting to come back right now.
-            </p>
-          )
-        ) : null}
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={(next) => void toggle(next)}
+          label="Let missed questions come back"
+          className="mt-1"
+        />
       </div>
+
+      {error ? (
+        <p className="mt-3 mb-0 text-quiet text-[var(--brand-ink)]" role="status" aria-live="polite">
+          {error}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -5,10 +5,7 @@ import { getSession } from '@/server/auth/session';
 import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
 import { getFullyExploredDomains } from '@/server/knowledge/fully-explored';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
-import {
-  getReturnListForUser,
-  isMissedReturnEnabledForUser,
-} from '@/server/db/queries/missed-return';
+import { isMissedReturnEnabledForUser } from '@/server/db/queries/missed-return';
 import { MissedReturnSection } from './MissedReturnSection';
 
 export const dynamic = 'force-dynamic';
@@ -24,33 +21,25 @@ export default async function DailySetupPage() {
   const session = await getSession();
   if (!session) redirect('/login');
 
-  // D-MISSED-RETURN-01 §7-D: the returning-questions toggle + list live here,
-  // on the page that already owns Daily Five tuning, rather than on a net-new
-  // route (R11, revised). The list is fetched even when the toggle is off so
-  // flipping it back on doesn't need a round-trip.
-  const [{ tree }, preferences, fullyExplored, returnEnabled, returnItems] = await Promise.all([
+  // D-MISSED-RETURN-01 §7-D: the returning-questions toggle lives here, on the
+  // page that already owns Daily Five tuning, rather than on a net-new route
+  // (R11, revised). It goes through `manageExtra` so it renders near the TOP —
+  // as a sibling it landed below the Done button, stranded past the page's own
+  // terminal action (Josh, 2026-08-10).
+  const [{ tree }, preferences, fullyExplored, returnEnabled] = await Promise.all([
     getKnowledgeMapData(session.userId),
     getDailyPreferences(session.userId),
     getFullyExploredDomains(session.userId),
     isMissedReturnEnabledForUser(session.userId),
-    getReturnListForUser(session.userId).catch(() => []),
   ]);
 
   return (
-    <>
-      <KnowledgeFlatClient
-        variant="manage"
-        tree={tree}
-        frequencyByDomain={preferences.domainPreferenceFrequency}
-        fullyExploredDomains={fullyExplored}
-      />
-      <MissedReturnSection
-        initialEnabled={returnEnabled}
-        initialItems={returnItems.map((item) => ({
-          ...item,
-          lastSeenAt: item.lastSeenAt.toISOString(),
-        }))}
-      />
-    </>
+    <KnowledgeFlatClient
+      variant="manage"
+      tree={tree}
+      frequencyByDomain={preferences.domainPreferenceFrequency}
+      fullyExploredDomains={fullyExplored}
+      manageExtra={<MissedReturnSection initialEnabled={returnEnabled} />}
+    />
   );
 }

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Check, Combine, Plus, Trash2, X } from 'lucide-react';
@@ -156,6 +156,11 @@ type PeaksDetailData = {
   tree: KnowledgeTreeNode;
   frequencyByDomain: DomainPreferenceFrequency;
   fullyExploredDomains: ReadonlySet<string>;
+  /**
+   * Manage-variant only: Daily Five settings rendered near the TOP of the page,
+   * above the topic tooling and the Done button. Ignored on the portrait variant.
+   */
+  manageExtra?: ReactNode;
 };
 
 type TreeIndex = { byId: Map<string, LeafInfo>; byFreqKey: Map<string, LeafInfo> };
@@ -237,7 +242,13 @@ export function KnowledgeFlatClient(props: PeaksDetailData) {
   );
 }
 
-function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, fullyExploredDomains }: PeaksDetailData) {
+function KnowledgePageContent({
+  variant = 'portrait',
+  tree,
+  frequencyByDomain,
+  fullyExploredDomains,
+  manageExtra,
+}: PeaksDetailData) {
   const isManage = variant === 'manage';
   const searchParams = useSearchParams();
   const highlightedDomainSlug = searchParams.get('domain');
@@ -872,6 +883,12 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
           options &mdash; change how often it comes up, add a related topic, or remove it.
         </p>
       )}
+
+      {/* Manage-only settings slot, rendered high on the page. Anything passed
+          here is a Daily Five SETTING rather than a topic, so it sits above the
+          topic tooling and — critically — above the Done button, which used to
+          be the page's terminal action with content stranded after it. */}
+      {isManage && manageExtra ? <div className="px-1">{manageExtra}</div> : null}
 
       {tierCrossed && highlightedDomainSlug && (
         <section className="bg-[var(--cream-accent)] text-[var(--ink)] px-4 py-3 text-base">

--- a/src/server/daily/__tests__/missed-return-copy.test.ts
+++ b/src/server/daily/__tests__/missed-return-copy.test.ts
@@ -52,7 +52,6 @@ const HOME_LINE = 'Some you didn’t land will find their way back to you.';
 const CUSTOMIZE_BLURB =
   'Every so often, one question you didn’t land turns up again in your five. ' +
   'Nothing stacks up — it’s one at a time, and once you get it, it’s done.';
-const CUSTOMIZE_EXPIRED_ROW = 'never got to this one';
 
 describe('return copy stays out of the remediation register (§1, §6)', () => {
   it('the return badge names a date, not a verdict (R9)', () => {
@@ -81,7 +80,6 @@ describe('return copy stays out of the remediation register (§1, §6)', () => {
 
   it('the Customize copy explains the shape without grading anyone', () => {
     assertClean('customize blurb', CUSTOMIZE_BLURB);
-    assertClean('customize expired row', CUSTOMIZE_EXPIRED_ROW);
     // R2/R6 promised in plain language: one at a time, and it ends.
     expect(CUSTOMIZE_BLURB).toContain('one at a time');
     expect(CUSTOMIZE_BLURB).toContain('once you get it');
@@ -91,8 +89,10 @@ describe('return copy stays out of the remediation register (§1, §6)', () => {
     expect(AUTHOR_PUSH.length).toBeLessThanOrEqual(160);
   });
 
-  it('the expired scope never uses return framing (§2)', () => {
-    // "never got to this one" is a first ask arriving late, not a return.
-    expect(CUSTOMIZE_EXPIRED_ROW).not.toMatch(/\bagain\b|\bback\b|\breturn/i);
+  it('Customize is a single control, not an inventory', () => {
+    // The eligible-questions list was removed 2026-08-10 (Josh): 135 rows on a
+    // real account buried the rest of the page. The blurb now carries the whole
+    // explanation, so it has to stand on its own with nothing beneath it.
+    expect(CUSTOMIZE_BLURB).toContain('turns up again in your five');
   });
 });

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -9,11 +9,9 @@ import {
 } from '@/server/db';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { CATCHUP_LOOKBACK_DAYS } from '@/server/daily/catchup';
-import { resolveCreatorNames } from '@/server/db/queries/daily';
 import {
   MISSED_RETURN_COOLDOWN_DAYS,
   MISSED_RETURN_LIFETIME_CAP,
-  rankReturnCandidates,
   type ReturnCandidate,
   type ReturnQuestionKind,
   type ReturnScope,
@@ -370,56 +368,6 @@ export async function setMissedReturnEnabled(userId: string, enabled: boolean): 
       target: dailyPreferences.userId,
       set: { missedReturnEnabled: enabled, updatedAt: new Date() },
     });
-}
-
-export type ReturnListItem = {
-  kind: ReturnQuestionKind;
-  questionId: string;
-  scope: ReturnScope;
-  questionText: string;
-  category: string | null;
-  authorName: string | null;
-  lastSeenAt: Date;
-  returnCount: number;
-};
-
-/**
- * The Customize list (§7-D): every question currently eligible to return, in the
- * order they would actually be served, so what the player sees matches what the
- * queue would pick. Both scopes, since one toggle governs both (§7-B1).
- *
- * Dismissed questions are absent, not dimmed — §7-C rules out an archive view,
- * and this list is the lighter surface, not the RecoveredSetAside pattern.
- */
-export async function getReturnListForUser(userId: string): Promise<ReturnListItem[]> {
-  const candidates = await getEligibleReturnCandidates(userId);
-  if (candidates.length === 0) return [];
-
-  const ranked = rankReturnCandidates(candidates);
-  const rows = await loadReturnQuestions(ranked);
-  // Keyed by kind AND id — the two tables' ids are different namespaces and must
-  // never be looked up interchangeably.
-  const byKey = new Map(rows.map((r) => [`${r.kind}:${r.id}`, r]));
-  const authorNames = await resolveCreatorNames(
-    rows.map((r) => r.creatorId).filter((id): id is string => Boolean(id)),
-  );
-
-  return ranked.flatMap((candidate) => {
-    const question = byKey.get(`${candidate.kind}:${candidate.questionId}`);
-    if (!question) return [];
-    return [
-      {
-        kind: candidate.kind,
-        questionId: candidate.questionId,
-        scope: candidate.scope,
-        questionText: question.questionText,
-        category: question.canonicalSubcategory ?? question.broadCategory ?? null,
-        authorName: question.creatorId ? authorNames.get(question.creatorId) ?? null : null,
-        lastSeenAt: candidate.lastSeenAt,
-        returnCount: candidate.returnCount,
-      },
-    ];
-  });
 }
 
 /**


### PR DESCRIPTION
Two changes from Josh's screenshot: move the toggle up, remove the list.

## The toggle was below the Done button

It rendered as a sibling *after* `KnowledgeFlatClient`, which meant it landed past the page's own terminal action — you had to scroll through every topic you own to reach a setting. It now goes through a manage-only `manageExtra` slot and sits directly under the page intro, above "Add a topic".

## The list is gone

It shipped as §7-D specified, then didn't survive contact with real data: **135 rows** on a live account, burying the rest of the page and turning a settings screen into an inventory nobody asked to read. *"I don't need to see those."*

That also removes the two hazards the walkthrough surfaced — the unbounded scroll, and the undo strip whose disappearance shifted the list under an in-flight tap (which is exactly how a click aimed at Undo landed on the next row's Remove).

**Dismissing still works.** Waving a question off in catch-up dual-writes `MissedReturnDismissed` and suppresses the return, unchanged. What's gone is the separate surface for doing it in advance — along with `getReturnListForUser` and `ReturnListItem`, which nothing calls any more.

Net **−194 lines**.

## Verified

Screenshot check on Craig T Testing: toggle visible immediately under the intro, no list, and off→on round-trips to `DailyPreference.missed_return_enabled` (confirmed `false` then `true` in the DB).

- `npx tsc` — 0 errors · `npm run lint` — 0 errors (back to the 4 pre-existing warnings; removed two imports the deletion orphaned)
- **Full suite: 2349 passed, 0 failed**
- All six ratchets at ceiling

## Note

`POST`/`DELETE /api/daily/missed-return/dismiss` now has no caller — the Customize list was its only one. I kept it (and its tests): it's a small, tested endpoint and the obvious hook if a dismiss affordance comes back on the question card itself, which is where R10 originally wanted it. Say the word if you'd rather it go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsnxcCmnb1J8Hxx3K7sKSP
