### PR TITLE
Mark a returning question with a banner you'll actually notice

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -52,16 +52,12 @@ function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' 
   if (isBonusSlot(slot) && slot.difficulty_estimate === 'accessible') {
     badges.push({ label: 'Accessible', tone: 'muted' });
   }
-  // D-MISSED-RETURN-01 R9 — a returning question is visibly marked as one and
-  // never disguised as new. The D-doc's own example for this is a date ("from
-  // March 4"), which is badge-shaped, so it rides the existing chip rather than
-  // restyling the attribution banner.
-  //
-  // WRONG SCOPE ONLY. The expired scope has never been seen by the player, so it
-  // gets no return framing at all and reads as a normal question arriving late
-  // (§2). Do not "fix" that asymmetry — it is the whole point of the split.
-  const returnedFrom = returnBadgeLabel(slot);
-  if (returnedFrom) badges.push({ label: returnedFrom, tone: 'muted' });
+  // NOTE: the R9 return mark is NOT a badge. It was a muted chip here until it
+  // proved too quiet to notice — measured on a live account, four returns were
+  // played across five days without the player registering any of them as
+  // returns. It is now the "SECOND LOOK" banner welded to the top of the card
+  // (see returnBannerLastSeen below and the banner in GameplayChat). Do not
+  // re-add a chip: the mark would then render twice.
   return badges;
 }
 
@@ -90,14 +86,17 @@ function returnRecoveryNote(slot: QueueSlot): string | null {
 }
 
 /**
- * The honest return label (R9). Null for anything that isn't a wrong-scope
- * return, which is what keeps the expired scope unmarked.
+ * The honest return mark (R9), as the "SECOND LOOK · LAST SEEN AUGUST 3" banner
+ * on the question card. Returns the raw ISO timestamp; GameplayChat owns the
+ * copy, exactly as it does for the bonus banner's "FROM {NAME}'S KNOWLEDGE".
+ *
+ * WRONG SCOPE ONLY. The expired scope has never been seen by the player, so it
+ * gets no return framing at all and reads as a normal question arriving late
+ * (§2). Do not "fix" that asymmetry — it is the whole point of the split.
  */
-function returnBadgeLabel(slot: QueueSlot): string | null {
-  if (slot.return_scope !== 'wrong' || !slot.return_last_seen_at) return null;
-  const seen = new Date(slot.return_last_seen_at);
-  if (Number.isNaN(seen.getTime())) return null;
-  return `from ${seen.toLocaleDateString(undefined, { month: 'long', day: 'numeric' })}`;
+function returnBannerLastSeen(slot: QueueSlot): string | null {
+  if (slot.return_scope !== 'wrong') return null;
+  return slot.return_last_seen_at ?? null;
 }
 
 type QueueResponse = {
@@ -590,6 +589,7 @@ export default function DailyPage() {
           creatorName: null,
           presenceSourceName: getSlotPresence(slot)?.name ?? null,
           presenceSourceExtraCount: getSlotPresence(slot)?.extraCount ?? 0,
+          returnLastSeenAt: returnBannerLastSeen(slot),
           // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: core slots show 1.–5. (slot_index
           // is 0-based; bonus is additive and renders ✦, never a numeral).
           // `bonus` here means "additive — render ✦, never a numeral", which is
@@ -669,6 +669,7 @@ export default function DailyPage() {
           creatorName: null,
           presenceSourceName: getSlotPresence(slot)?.name ?? null,
           presenceSourceExtraCount: getSlotPresence(slot)?.extraCount ?? 0,
+          returnLastSeenAt: returnBannerLastSeen(slot),
           isNew: true,
           // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: core slots show 1.–5. (slot_index
           // is 0-based; bonus is additive and renders ✦, never a numeral).

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -65,6 +65,17 @@ export type ChatMessage =
        */
       presenceSourceName?: string | null;
       presenceSourceExtraCount?: number;
+      /**
+       * D-MISSED-RETURN-01 R9 — ISO timestamp of when the player last saw this
+       * question, set ONLY for a wrong-scope return. Drives the "SECOND LOOK"
+       * banner, which is the honest mark that keeps a return from reading as new.
+       *
+       * WRONG SCOPE ONLY. An expired-scope return has never been seen, so the
+       * caller passes null and it renders as an ordinary question arriving late
+       * (§2). The gate lives in the caller (`daily/page.tsx`), next to the
+       * comment explaining why the asymmetry is deliberate.
+       */
+      returnLastSeenAt?: string | null;
       isNew?: boolean;
       subhead?: string | null;
       badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
@@ -254,6 +265,22 @@ function bonusSourceLabel(sourceName: string, extraCount: number): string {
   return extraCount > 0 ? `FROM ${source} + OTHERS’ KNOWLEDGE` : `FROM ${source}’S KNOWLEDGE`;
 }
 
+/**
+ * D-MISSED-RETURN-01 R9 — the date half of the return banner ("LAST SEEN
+ * AUGUST 3"). Purely descriptive by design: it states what the card is without
+ * asking anything or implying a verdict, because §1 is explicit that a return
+ * must never read as remediation.
+ *
+ * Returns null on an unparseable timestamp so a bad date degrades to no banner
+ * rather than to "LAST SEEN INVALID DATE".
+ */
+function returnSourceLabel(lastSeenAt: string): string | null {
+  const seen = new Date(lastSeenAt);
+  if (Number.isNaN(seen.getTime())) return null;
+  const date = seen.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
+  return `LAST SEEN ${date.toUpperCase()}`;
+}
+
 function SystemRow({ text }: { text: string }) {
   return (
     <div className="flex justify-center py-0.5">
@@ -397,6 +424,7 @@ function QuestionRow({
   creatorIsHouse = false,
   presenceSourceName = null,
   presenceSourceExtraCount = 0,
+  returnLastSeenAt = null,
   isNew = false,
   numberMarker = null,
   dismissing = false,
@@ -418,6 +446,7 @@ function QuestionRow({
   creatorIsHouse?: boolean;
   presenceSourceName?: string | null;
   presenceSourceExtraCount?: number;
+  returnLastSeenAt?: string | null;
   isNew?: boolean;
   onGiveUp?: () => void;
   giveUpDisabled?: boolean;
@@ -437,6 +466,17 @@ function QuestionRow({
   // A bonus slot is one drawn from a followed friend's knowledge (D-4 §B). It
   // gets a distinct gold treatment so it reads as a gift, not just another card.
   const isBonus = Boolean(presenceSourceName);
+  // D-MISSED-RETURN-01 R9 — a returning question wears the same banner FORM as a
+  // bonus (so the two read as one system) in a deliberately quieter neutral key:
+  // no gold ✦, no warm card tint, no inset rail. Those stay unique to a friend's
+  // gift, which a return is not. Bonus wins if both are somehow set, so a card
+  // can never grow two stacked banners.
+  const returnLabel =
+    !isBonus && returnLastSeenAt ? returnSourceLabel(returnLastSeenAt) : null;
+  const isReturn = Boolean(returnLabel);
+  // Either banner welds to the top of the card, so the card must square off its
+  // top corners for exactly the same reason in both cases.
+  const hasBanner = isBonus || isReturn;
 
   useEffect(() => {
     if (!isNew) return;
@@ -549,6 +589,66 @@ function QuestionRow({
             </div>
           </div>
         ) : null}
+        {returnLabel ? (
+          <div
+            style={{
+              borderRadius: 'var(--radius-md) var(--radius-md) 0 0',
+              border: '1px solid var(--brand-rule)',
+              borderBottom: 'none',
+              // Neutral, not navy: present and unmissable, but visibly
+              // subordinate to both a core question and a friend's bonus. Built
+              // from existing tokens so the color ratchet (check:colors) stays
+              // clean. Deliberately NOT a grading color — red/green here would
+              // turn an honest label into "you got this wrong", which is the
+              // remediation framing §1 forbids.
+              background: 'color-mix(in srgb, var(--brand-ink-400) 14%, var(--game-card-question))',
+              color: 'var(--brand-ink-700)',
+              padding: '9px 13px 8px',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: '6px 10px',
+              }}
+            >
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: '0.64rem',
+                  fontWeight: 800,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.16em',
+                  lineHeight: 1.25,
+                }}
+              >
+                <span aria-hidden style={{ fontSize: '0.8rem', lineHeight: 1 }}>
+                  ↩
+                </span>
+                Second look
+              </span>
+              <span
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: '0.6rem',
+                  fontWeight: 800,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.12em',
+                  lineHeight: 1.25,
+                  color: 'var(--text-muted-warm)',
+                }}
+              >
+                {returnLabel}
+              </span>
+            </div>
+          </div>
+        ) : null}
         <div
           style={{
             // Bonus questions get a navy banner plus warm card tint so the
@@ -559,7 +659,9 @@ function QuestionRow({
             border: isBonus
               ? '1px solid color-mix(in srgb, var(--brand-navy) 72%, var(--accent-gold))'
               : '1px solid var(--brand-rule)',
-            borderRadius: isBonus ? '0 0 var(--radius-md) var(--radius-md)' : 'var(--radius-md)',
+            // hasBanner, not isBonus: a return banner welds to the top edge the
+            // same way, so the card squares off under either one.
+            borderRadius: hasBanner ? '0 0 var(--radius-md) var(--radius-md)' : 'var(--radius-md)',
             // effect/card/question — soft layered drop shadow (bonus adds a gold inset rail).
             boxShadow: isBonus
               ? '0 8px 22px rgba(13, 31, 58, 0.14), 0 1px 3px rgba(40, 32, 30, 0.08), inset 4px 0 0 var(--accent-gold)'
@@ -1640,6 +1742,7 @@ export function GameplayChatThread({
                 creatorIsHouse={m.creatorIsHouse}
                 presenceSourceName={m.presenceSourceName}
                 presenceSourceExtraCount={m.presenceSourceExtraCount}
+                returnLastSeenAt={m.returnLastSeenAt}
                 isNew={m.isNew}
                 subhead={m.subhead}
                 numberMarker={m.numberMarker}

--- a/src/components/play/__tests__/GameplayChat.returnBanner.test.tsx
+++ b/src/components/play/__tests__/GameplayChat.returnBanner.test.tsx
@@ -1,0 +1,89 @@
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { GameplayChatThread, type ChatMessage } from '@/components/play/GameplayChat';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('lucide-react', () => ({
+  Flag: () => <span aria-hidden="true" />,
+  MoreHorizontal: () => <span aria-hidden="true" />,
+  X: () => <span aria-hidden="true" />,
+}));
+
+function html(messages: ChatMessage[]) {
+  return renderToStaticMarkup(<GameplayChatThread messages={messages} />);
+}
+
+function questionMessage(over: Partial<Extract<ChatMessage, { kind: 'question' }>>): ChatMessage {
+  return {
+    id: 'q1',
+    kind: 'question',
+    assignmentId: 'a1',
+    questionText: 'Which composer wrote the Goldberg Variations?',
+    creatorName: null,
+    ...over,
+  };
+}
+
+// D-MISSED-RETURN-01 R9 — the "SECOND LOOK" banner is the honest mark that keeps
+// a returning question from reading as new. It replaced a muted badge chip that
+// proved too quiet to notice: measured on a live account, four returns were
+// played across five days without the player registering any as returns.
+describe('GameplayChat returning-question banner', () => {
+  it('marks a wrong-scope return with SECOND LOOK and the date last seen', () => {
+    const rendered = html([
+      questionMessage({ returnLastSeenAt: '2026-08-03T14:00:00.000Z' }),
+    ]);
+    expect(rendered).toContain('Second look');
+    expect(rendered).toContain('LAST SEEN AUGUST 3');
+  });
+
+  it('renders NO banner when returnLastSeenAt is absent', () => {
+    // The expired scope routes here: it has never been seen by the player, so it
+    // gets no return framing at all and reads as a normal question arriving late
+    // (§2). The caller (daily/page.tsx) enforces that by passing null.
+    const rendered = html([questionMessage({})]);
+    expect(rendered).not.toContain('Second look');
+    expect(rendered).not.toContain('LAST SEEN');
+  });
+
+  it('degrades to no banner on an unparseable timestamp rather than "INVALID DATE"', () => {
+    const rendered = html([questionMessage({ returnLastSeenAt: 'not-a-date' })]);
+    expect(rendered).not.toContain('Second look');
+    expect(rendered).not.toContain('INVALID');
+  });
+
+  it('never stacks two banners — a bonus slot keeps its own attribution', () => {
+    // Bonus wins if both are somehow set, so the card can only ever grow one
+    // banner. The gold ✦ treatment stays unique to a friend's gift.
+    const rendered = html([
+      questionMessage({
+        presenceSourceName: 'Sarah Kim',
+        returnLastSeenAt: '2026-08-03T14:00:00.000Z',
+      }),
+    ]);
+    expect(rendered).toContain('Bonus item');
+    expect(rendered).toContain('FROM SARAH’S KNOWLEDGE');
+    expect(rendered).not.toContain('Second look');
+  });
+
+  it('keeps grading colors out of the mark (§1 — a return is not remediation)', () => {
+    // A red/green banner would turn an honest label into "you got this wrong".
+    // The banner is built from neutral tokens only.
+    const rendered = html([
+      questionMessage({ returnLastSeenAt: '2026-08-03T14:00:00.000Z' }),
+    ]);
+    const banner = rendered.slice(0, rendered.indexOf('Goldberg'));
+    // The grading tokens are reserved (globals.css §"Correct/wrong (grading)").
+    expect(banner).not.toContain('--game-correct');
+    expect(banner).not.toContain('--game-wrong');
+    // Gold is the friend's-gift signal and stays unique to the bonus banner.
+    expect(banner).not.toContain('--accent-gold');
+  });
+});


### PR DESCRIPTION
## Why

`MISSED_RETURN_ENABLED` is live in production, and returns are being served — but the R9 mark on them was a muted badge chip riding the existing chip row, alongside things like "Accessible".

Measured on a live account (Josh's), across five days:

| Queue date | Domain | Scope | Result |
|---|---|---|---|
| Aug 14 | Ancient Rome | wrong | answered **incorrect** |
| Aug 12 | Star Wars Universe | wrong | answered **incorrect** |
| Aug 11 | Virginia Woolf | wrong | answered **correct** |
| Aug 10 | Victor Wembanyama | expired | answered **correct** |

All four were played. None registered as returns. An honest label nobody reads isn't an honest label — and R9 exists precisely so a return is *never disguised as new*.

Slot count doesn't help either: these queues run 5–7 slots routinely (Aug 3 and Aug 4 both had 7 with zero returns, from +2 bonus slots), so a sixth slot signals nothing on its own.

## What

The mark moves from a chip to a **banner welded to the top of the question card**, borrowing the form of the friend-bonus banner so the two read as one system — in a deliberately quieter neutral key.

```
┌────────────────────────────────────────────┐
│  ↩ SECOND LOOK      LAST SEEN AUGUST 3     │  ← neutral banner
├────────────────────────────────────────────┤
│  After Julius Caesar's assassination,      │
│  which legal office did Octavian use...    │
└────────────────────────────────────────────┘
```

Copy is deliberately descriptive — it states what the card is without asking anything or implying a verdict, because §1 is explicit that a return must never read as remediation.

- **`GameplayChat.tsx`** — new `returnLastSeenAt` prop on the question message, a `returnSourceLabel` helper mirroring `bonusSourceLabel` (so copy stays with the other gameplay copy), and the banner.
- **`page.tsx`** — chip removed, replaced by `returnBannerLastSeen(slot)`. The wrong-scope gate stays here, next to the comment explaining why the asymmetry is deliberate.

### Design constraints held

- **No gold, no warm card tint, no inset rail.** Those stay unique to a friend's gift, which a return is not. Built from `--brand-ink-400` / `--brand-rule` / `--text-muted-warm`.
- **No grading colors.** A red or green banner turns an honest label into "you got this wrong" — the remediation framing §1 forbids. Asserted in a test.
- **Wrong scope only, unchanged.** The expired scope has never been seen by the player, so it still gets no return framing at all (§2).

### Three details

- **Bonus wins if both are set**, so a card can never grow two stacked banners.
- **An unparseable timestamp degrades to no banner**, not `LAST SEEN INVALID DATE`.
- **Top-corner squaring moved from `isBonus` to `hasBanner`** — the one existing line that would otherwise have broken visually under the new banner.

## Verification

- `npx tsc -p tsconfig.typecheck.json` — clean
- `npm run lint` — 0 errors (4 pre-existing warnings, cap 16)
- All six ratchets pass; **color held at exactly 41/41** (banner uses existing tokens only)
- Full suite: **2349 passed, 23 skipped, 0 failures**
- 5 new tests in `GameplayChat.returnBanner.test.tsx` — the mark, expired-scope silence, bad-date degrade, no-stacking, reserved grading colors

## Not in this PR

Two known gaps, both flagged rather than fixed:

1. **The expired scope stays unmarked.** Correct per §2, but it means roughly a quarter of returns are still invisible as returns.
2. **The bare "It stuck."** Every return served so far has been LLM-generated, so `author_name` is null and the named payoff — *"It stuck. {Name} would be glad."* — currently never fires for anyone. That's the §6 moment and needs a copy decision about what a generated question's return says when there's no friend to credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbKTaLJhWx2ewGtGr62ASt
