### PR TITLE
Give friend-bonus questions a way forward instead of a way out

### DIFF
--- a/drizzle/0127_missed_return_dismissed.sql
+++ b/drizzle/0127_missed_return_dismissed.sql
@@ -1,0 +1,39 @@
+-- 0127: MissedReturnDismissed — per-(user, question) "don't ask me this again"
+-- for the missed-question return system (D-MISSED-RETURN-01 §3.3, Phase 1 of
+-- B-MISSED-RETURN-01).
+--
+-- Catch-up's existing dismiss is SLOT-scoped: it stamps `dismissed_at` into
+-- that day's "DailyQueue".slots JSONB blob, or "FeedItem"."catchupResolvedAt".
+-- A returning question is by definition a NEW slot in a DIFFERENT queue, so
+-- that slot-level state is invisible to it — a question the player explicitly
+-- waved off would resurface days later. This table holds the dismiss at the
+-- (userId, questionId) level so it survives across queue instances. The
+-- catch-up dismiss/undismiss routes dual-write here; the old slot-level write
+-- is retained because other code still reads it.
+--
+-- Shape mirrors "RecoveredSetAside"/"MilestoneDismissed" exactly (migrations
+-- 0093 and 0113): dismissedAt + nullable reinstatedAt, with a partial unique
+-- index keeping at most one ACTIVE row per (userId, questionId). It is a
+-- distinct table from "RecoveredSetAside" on purpose — same shape, opposite
+-- meaning ("a question I now know" vs "a question I don't know and don't want
+-- back"), and the rows must never be conflated.
+--
+-- Purely additive; RLS enabled per B-SECURITY-RLS-01 (no policies — the app
+-- connects as the owner role, which bypasses RLS).
+--
+-- Rollback: DROP TABLE IF EXISTS "MissedReturnDismissed";
+CREATE TABLE IF NOT EXISTS "MissedReturnDismissed" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "questionId" text NOT NULL REFERENCES "Question"("id") ON DELETE CASCADE,
+  "dismissedAt" timestamp with time zone NOT NULL DEFAULT now(),
+  "reinstatedAt" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "MissedReturnDismissed_userId_idx" ON "MissedReturnDismissed" ("userId");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_active_unique"
+  ON "MissedReturnDismissed" ("userId", "questionId")
+  WHERE "reinstatedAt" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "MissedReturnDismissed" ENABLE ROW LEVEL SECURITY;

--- a/drizzle/0128_missed_return_state.sql
+++ b/drizzle/0128_missed_return_state.sql
@@ -1,0 +1,46 @@
+-- 0128: MissedReturnState + the DailyPreference toggle — Phase 2 of
+-- B-MISSED-RETURN-01 (D-MISSED-RETURN-01 §4, §7-B1, §7-F1).
+--
+-- "MissedReturnState" holds the two per-(user, question) facts the return
+-- eligibility rule needs and cannot get cheaply from anywhere else:
+--   lastReturnedAt — the 7-day floor between sightings of the same question (R5)
+--   returnCount    — the lifetime cap of 3 returns per (player, question) (R7)
+-- One row per pair, updated in place: this is CURRENT STATE, not an event log.
+-- MASTERY_EVENTS already keeps the history, and re-deriving these two values
+-- from it would mean scanning the whole log per candidate on every queue build.
+--
+-- There is deliberately NO retiredAt column. R6 ("stop on first correct") is
+-- already queryable as "has a first_correct_after_wrong event" — the same
+-- predicate the shipped Recovered deck uses, which is exactly why a correct
+-- return lands the question in that deck with no new plumbing (§3.1).
+--
+-- "DailyPreference"."missed_return_enabled" is the single on/off toggle (§7-B1)
+-- governing both scopes together, defaulting TRUE for everyone (§7-F1). The
+-- default covers existing rows; users with NO DailyPreference row are treated as
+-- enabled in code, so "never opened Customize" never reads as "opted out".
+--
+-- Purely additive — the new column carries a DEFAULT so it is safe on the
+-- existing non-empty table. RLS enabled on the new table per B-SECURITY-RLS-01
+-- (no policies — the app connects as the owner role, which bypasses RLS).
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "MissedReturnState";
+--   ALTER TABLE "DailyPreference" DROP COLUMN IF EXISTS "missed_return_enabled";
+CREATE TABLE IF NOT EXISTS "MissedReturnState" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "questionId" text NOT NULL REFERENCES "Question"("id") ON DELETE CASCADE,
+  "lastReturnedAt" timestamp with time zone NOT NULL DEFAULT now(),
+  "returnCount" integer NOT NULL DEFAULT 0,
+  "createdAt" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "MissedReturnState_userId_idx" ON "MissedReturnState" ("userId");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_question_unique"
+  ON "MissedReturnState" ("userId", "questionId");
+--> statement-breakpoint
+ALTER TABLE "MissedReturnState" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "DailyPreference"
+  ADD COLUMN IF NOT EXISTS "missed_return_enabled" boolean NOT NULL DEFAULT true;

--- a/drizzle/0129_sms_missed_return_recovered.sql
+++ b/drizzle/0129_sms_missed_return_recovered.sql
@@ -1,0 +1,22 @@
+-- 0129: add 'missed_return_recovered' to the SmsMessageType enum
+-- (D-MISSED-RETURN-01 §7-A1).
+--
+-- The author push for the wrong→right moment: a question someone wrote comes
+-- back to a player who once missed it, and this time they get it. Nothing
+-- carried that signal back to the author before. Kept in its OWN migration
+-- (precedent: 0094's MasterySourceType addition) because ALTER TYPE ... ADD
+-- VALUE is a different class of change from the table work in 0128 and the new
+-- value cannot be used in the same transaction that adds it.
+--
+-- NOTE — pre-existing drift, NOT introduced here: five values already declared
+-- in schema.ts are absent from the production enum (ceremony_ready,
+-- joshing_game_received, joshing_game_progress, joshing_game_complete,
+-- friend_answered_question), so sends using them currently fail in prod. That is
+-- a separate bug with its own fix (standalone ALTER TYPE ADD VALUE per value)
+-- and is deliberately left alone here to keep this migration to its authorized
+-- scope. This migration adds only the one value this feature needs.
+--
+-- Rollback: enum values cannot be dropped in Postgres without recreating the
+-- type. This value is additive and unused until the return feature's flag is
+-- turned on, so the rollback is to leave it in place (a no-op) and stop writing it.
+ALTER TYPE "SmsMessageType" ADD VALUE IF NOT EXISTS 'missed_return_recovered';

--- a/drizzle/0130_missed_return_generated.sql
+++ b/drizzle/0130_missed_return_generated.sql
@@ -1,0 +1,83 @@
+-- 0130: let the missed-question return system carry LLM-generated questions,
+-- not just canonical ones (D-MISSED-RETURN-01, gap found 2026-08-09).
+--
+-- THE GAP. Both MissedReturnDismissed and MissedReturnState keyed only
+-- "questionId" -> Question(id). But an LLM-origin daily question lives in
+-- GeneratedQuestion, and MASTERY_EVENTS.question_id is NULL for those rows (the
+-- writer only ever stores eventQuestionId, which is canonical-only). So a
+-- generated question could never become a return candidate. Measured on prod,
+-- that excluded the overwhelming majority of the actual inventory:
+--
+--     kind                        answered wrong   expired unanswered   users
+--     canonical (friend/curated)              15                  166      14
+--     generated (LLM)                        357                  101      22
+--
+-- i.e. ~96% of wrong answers inside the Daily Five were unreachable. Catch-up
+-- ("Play Missed Questions") already serves both kinds, so the return slot must
+-- too, or it returns almost nothing anyone actually missed.
+--
+-- THE SHAPE. Mirrors the discriminated pattern the codebase already uses for
+-- exactly this ambiguity — CatchupQueueItem.reportTarget and DailyQueue.slots,
+-- both of which carry `question_id` XOR `generated_question_id`. "questionId"
+-- becomes nullable, "generatedQuestionId" is added, and a CHECK enforces that
+-- exactly one is set so a row can never be ambiguous or empty.
+--
+-- The partial unique indexes are split per kind: the existing canonical index
+-- keeps its name and gains a "questionId IS NOT NULL" guard (a partial unique
+-- index over a nullable column would otherwise let unlimited generated rows
+-- collide on (userId, NULL)), and a matching one is added for the generated kind.
+--
+-- Additive and safe on the existing rows: every row written before this
+-- migration has a non-null questionId, which satisfies the CHECK unchanged.
+--
+-- Rollback:
+--   DELETE FROM "MissedReturnDismissed" WHERE "generatedQuestionId" IS NOT NULL;
+--   DELETE FROM "MissedReturnState"     WHERE "generatedQuestionId" IS NOT NULL;
+--   ALTER TABLE "MissedReturnDismissed" DROP CONSTRAINT IF EXISTS "MissedReturnDismissed_one_target";
+--   ALTER TABLE "MissedReturnState"     DROP CONSTRAINT IF EXISTS "MissedReturnState_one_target";
+--   ALTER TABLE "MissedReturnDismissed" DROP COLUMN IF EXISTS "generatedQuestionId";
+--   ALTER TABLE "MissedReturnState"     DROP COLUMN IF EXISTS "generatedQuestionId";
+--   -- then restore the NOT NULL on "questionId" and the original unique indexes.
+ALTER TABLE "MissedReturnDismissed"
+  ADD COLUMN IF NOT EXISTS "generatedQuestionId" text
+  REFERENCES "GeneratedQuestion"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "MissedReturnState"
+  ADD COLUMN IF NOT EXISTS "generatedQuestionId" text
+  REFERENCES "GeneratedQuestion"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "MissedReturnDismissed" ALTER COLUMN "questionId" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "MissedReturnState" ALTER COLUMN "questionId" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "MissedReturnDismissed" DROP CONSTRAINT IF EXISTS "MissedReturnDismissed_one_target";
+--> statement-breakpoint
+ALTER TABLE "MissedReturnDismissed"
+  ADD CONSTRAINT "MissedReturnDismissed_one_target"
+  CHECK (("questionId" IS NOT NULL) <> ("generatedQuestionId" IS NOT NULL));
+--> statement-breakpoint
+ALTER TABLE "MissedReturnState" DROP CONSTRAINT IF EXISTS "MissedReturnState_one_target";
+--> statement-breakpoint
+ALTER TABLE "MissedReturnState"
+  ADD CONSTRAINT "MissedReturnState_one_target"
+  CHECK (("questionId" IS NOT NULL) <> ("generatedQuestionId" IS NOT NULL));
+--> statement-breakpoint
+DROP INDEX IF EXISTS "missed_return_dismissed_active_unique";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_active_unique"
+  ON "MissedReturnDismissed" ("userId", "questionId")
+  WHERE "reinstatedAt" IS NULL AND "questionId" IS NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_generated_active_unique"
+  ON "MissedReturnDismissed" ("userId", "generatedQuestionId")
+  WHERE "reinstatedAt" IS NULL AND "generatedQuestionId" IS NOT NULL;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "missed_return_state_user_question_unique";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_question_unique"
+  ON "MissedReturnState" ("userId", "questionId")
+  WHERE "questionId" IS NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_generated_unique"
+  ON "MissedReturnState" ("userId", "generatedQuestionId")
+  WHERE "generatedQuestionId" IS NOT NULL;

--- a/drizzle/0131_bonus_offer_seen_at.sql
+++ b/drizzle/0131_bonus_offer_seen_at.sql
@@ -1,0 +1,34 @@
+-- 0131: one-time gate for the friend-bonus interstitial (B-BONUS-OFFER-01).
+--
+-- WHY. The +2 friend-bonus slots append past the core five with no explanation
+-- and no "continue" affordance. Measured on prod 2026-08-24: of the 7 players who
+-- ever met a bonus slot on their first session, 3 tapped the destructive
+-- "This is {Name}'s bag but not mine" opt-out immediately — Neil (hazelvision) and
+-- Carolyn Loh on BOTH of their bonus slots, Todderick on one. Established players
+-- never do this on day one (Robyn first rested on ~day 30 of 40, Josh ~day 60 of
+-- 98), so it reads as a comprehension failure at first exposure, not a
+-- preference. Across all time, 18 of 221 bonus slots served (8.1%, 8 users) ended
+-- in a permanent domain rest.
+--
+-- The fix restores the already-built-but-never-wired bonus interstitial as a
+-- first-run explainer, which needs somewhere durable to record "this player has
+-- seen it". This column is that record.
+--
+-- SHAPE. Nullable timestamptz, stamped when the interstitial is RESOLVED — on
+-- both "Keep going" and "No thanks" — so it can fire at most once per account and
+-- never nags a returning player (product call, Josh 2026-08-25). NULL = not yet
+-- seen, which is the correct default for every existing row: they have not seen
+-- the interstitial, and the next bonus slot they meet should explain itself once.
+--
+-- Deliberately a User column and not a DailyPreference one: this is a one-shot
+-- "has been told" marker, not a preference the player can set. It mirrors
+-- reminder_interstitial_seen_at (D-REMINDER-INTERSTITIAL-01), which solves the
+-- identical "show this exactly once, on either resolution" problem.
+--
+-- Additive and nullable, so it is safe on a non-empty table and needs no backfill.
+--
+-- ROLLBACK. `ALTER TABLE "User" DROP COLUMN IF EXISTS "bonus_offer_seen_at";`
+-- Dropping it loses only the "already explained" marks, so some players would see
+-- the interstitial a second time. No other surface reads the column.
+
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "bonus_offer_seen_at" timestamp with time zone;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -911,6 +911,13 @@
       "when": 1787702400000,
       "tag": "0129_sms_missed_return_recovered",
       "breakpoints": true
+    },
+    {
+      "idx": 130,
+      "version": "7",
+      "when": 1787788800000,
+      "tag": "0130_missed_return_generated",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -897,6 +897,20 @@
       "when": 1787529600000,
       "tag": "0127_missed_return_dismissed",
       "breakpoints": true
+    },
+    {
+      "idx": 128,
+      "version": "7",
+      "when": 1787616000000,
+      "tag": "0128_missed_return_state",
+      "breakpoints": true
+    },
+    {
+      "idx": 129,
+      "version": "7",
+      "when": 1787702400000,
+      "tag": "0129_sms_missed_return_recovered",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -918,6 +918,13 @@
       "when": 1787788800000,
       "tag": "0130_missed_return_generated",
       "breakpoints": true
+    },
+    {
+      "idx": 131,
+      "version": "7",
+      "when": 1787875200000,
+      "tag": "0131_bonus_offer_seen_at",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -890,6 +890,13 @@
       "when": 1787443200000,
       "tag": "0126_llm_usage_daily",
       "breakpoints": true
+    },
+    {
+      "idx": 127,
+      "version": "7",
+      "when": 1787529600000,
+      "tag": "0127_missed_return_dismissed",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-missed-return-dismissed.ts
+++ b/scripts/backfill-missed-return-dismissed.ts
@@ -35,7 +35,9 @@
  *   npx tsx scripts/backfill-missed-return-dismissed.ts
  *   npx tsx scripts/backfill-missed-return-dismissed.ts --apply
  */
-import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+import 'dotenv/config';
+
+import { and, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 
 import { db, dailyQueues, feedItems, missedReturnDismissed, questions } from '../src/server/db';
 
@@ -57,7 +59,9 @@ async function collectDailyPairs(): Promise<Pair[]> {
       AND slot->>'question_id' IS NOT NULL
       AND slot->>'generated_question_id' IS NULL
   `);
-  return (rows as unknown as { userId: string; questionId: string }[]).map((r) => ({
+  type Row = { userId: string; questionId: string };
+  const list = (rows as unknown as { rows?: Row[] }).rows ?? (rows as unknown as Row[]);
+  return list.map((r) => ({
     userId: r.userId,
     questionId: r.questionId,
     source: 'daily' as const,
@@ -102,7 +106,7 @@ async function main() {
     const rows = await db
       .select({ id: questions.id })
       .from(questions)
-      .where(sql`${questions.id} = ANY(${chunk})`);
+      .where(inArray(questions.id, chunk));
     for (const r of rows) liveQuestionIds.add(r.id);
   }
 

--- a/scripts/backfill-missed-return-dismissed.ts
+++ b/scripts/backfill-missed-return-dismissed.ts
@@ -1,0 +1,162 @@
+/**
+ * D-MISSED-RETURN-01 §7-G — one-time backfill of existing slot-level catch-up
+ * dismisses into `MissedReturnDismissed`.
+ *
+ * Before this table existed, a catch-up dismiss was recorded SLOT-scoped:
+ *   - `DailyQueue.slots[]` entries with `dismissed_at IS NOT NULL`
+ *   - `FeedItem.catchupResolvedAt IS NOT NULL`
+ *
+ * A return slot is a new slot in a different queue and cannot see either. This
+ * script promotes those historical dismisses to (userId, questionId) rows so no
+ * previously-waved-off question can resurface when the return feature ships.
+ *
+ * SCOPE — canonical questions only. A daily slot carrying `generated_question_id`
+ * is LLM-origin, has no `Question` row to key on, and is skipped: it is out of
+ * this feature's scope by construction (MASTERY_EVENTS.question_id is null for
+ * generated questions too, so the Recovered pool excludes them as well).
+ *
+ * !! THE FEED SOURCE IS NOT A DISMISS MARKER — measured 2026-08-09 !!
+ * D-MISSED-RETURN-01 §7-G names `FeedItem.catchupResolvedAt` as a dismiss
+ * source. It is not: `catchup/answer/route.ts` stamps the SAME column when the
+ * player ANSWERS a feed catch-up item. On live data all 49 resolved feed rows
+ * were answers (state='answered', answerResult set on every one — 36 correct,
+ * 13 incorrect) and ZERO were clean dismisses. Backfilling that column blind
+ * would have permanently suppressed 13 wrong-answered questions — precisely the
+ * inventory this feature exists to return — with no player-facing way to undo.
+ *
+ * So the feed collector below filters to rows bearing NO answer evidence at all.
+ * That yields 0 rows today and is the semantically correct rule going forward.
+ * Erring toward UNDER-suppression is deliberate: a missed dismiss means a
+ * question returns once and can be dismissed again (and now it sticks), while an
+ * over-suppression silently kills eligibility forever.
+ *
+ * DRY RUN BY DEFAULT. Pass --apply to write.
+ *
+ *   npx tsx scripts/backfill-missed-return-dismissed.ts
+ *   npx tsx scripts/backfill-missed-return-dismissed.ts --apply
+ */
+import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+
+import { db, dailyQueues, feedItems, missedReturnDismissed, questions } from '../src/server/db';
+
+const APPLY = process.argv.includes('--apply');
+
+type Pair = { userId: string; questionId: string; source: 'daily' | 'feed' };
+
+function keyOf(p: Pair): string {
+  return `${p.userId}::${p.questionId}`;
+}
+
+async function collectDailyPairs(): Promise<Pair[]> {
+  // Unnest the slots JSONB and keep dismissed, canonical-question slots.
+  const rows = await db.execute<{ userId: string; questionId: string }>(sql`
+    SELECT DISTINCT q.user_id AS "userId", slot->>'question_id' AS "questionId"
+    FROM "DailyQueue" q,
+         LATERAL jsonb_array_elements(q.slots) AS slot
+    WHERE slot->>'dismissed_at' IS NOT NULL
+      AND slot->>'question_id' IS NOT NULL
+      AND slot->>'generated_question_id' IS NULL
+  `);
+  return (rows as unknown as { userId: string; questionId: string }[]).map((r) => ({
+    userId: r.userId,
+    questionId: r.questionId,
+    source: 'daily' as const,
+  }));
+}
+
+async function collectFeedPairs(): Promise<Pair[]> {
+  // Resolved AND carrying no answer evidence — see the header. `catchupResolvedAt`
+  // alone is stamped by the answer path too, so it cannot stand on its own.
+  const rows = await db
+    .select({ userId: feedItems.recipientUserId, questionId: feedItems.questionId })
+    .from(feedItems)
+    .where(
+      and(
+        isNotNull(feedItems.catchupResolvedAt),
+        isNotNull(feedItems.questionId),
+        isNull(feedItems.answerResult),
+        isNull(feedItems.answeredAt),
+        isNull(feedItems.submittedAnswer),
+      ),
+    );
+  return rows
+    .filter((r): r is { userId: string; questionId: string } => Boolean(r.userId && r.questionId))
+    .map((r) => ({ userId: r.userId, questionId: r.questionId, source: 'feed' as const }));
+}
+
+async function main() {
+  const [dailyPairs, feedPairs] = await Promise.all([collectDailyPairs(), collectFeedPairs()]);
+
+  // Dedupe across both sources.
+  const byKey = new Map<string, Pair>();
+  for (const p of [...dailyPairs, ...feedPairs]) {
+    if (!byKey.has(keyOf(p))) byKey.set(keyOf(p), p);
+  }
+
+  // Drop pairs whose question no longer exists (the FK would reject them).
+  const allQuestionIds = [...new Set([...byKey.values()].map((p) => p.questionId))];
+  const liveQuestionIds = new Set<string>();
+  const CHUNK = 500;
+  for (let i = 0; i < allQuestionIds.length; i += CHUNK) {
+    const chunk = allQuestionIds.slice(i, i + CHUNK);
+    const rows = await db
+      .select({ id: questions.id })
+      .from(questions)
+      .where(sql`${questions.id} = ANY(${chunk})`);
+    for (const r of rows) liveQuestionIds.add(r.id);
+  }
+
+  // Skip pairs that already have an active row.
+  const existing = await db
+    .select({ userId: missedReturnDismissed.userId, questionId: missedReturnDismissed.questionId })
+    .from(missedReturnDismissed)
+    .where(isNull(missedReturnDismissed.reinstatedAt));
+  const existingKeys = new Set(existing.map((r) => `${r.userId}::${r.questionId}`));
+
+  const toInsert = [...byKey.values()].filter(
+    (p) => liveQuestionIds.has(p.questionId) && !existingKeys.has(keyOf(p)),
+  );
+
+  const orphaned = [...byKey.values()].filter((p) => !liveQuestionIds.has(p.questionId));
+
+  console.log('--- MissedReturnDismissed backfill ---');
+  console.log(`Daily slot-level dismisses (canonical only): ${dailyPairs.length}`);
+  console.log(`Feed dismisses (resolved, no answer):        ${feedPairs.length}`);
+  console.log(`Distinct (user, question) pairs:             ${byKey.size}`);
+  console.log(`  already present (active row):              ${byKey.size - toInsert.length - orphaned.length}`);
+  console.log(`  skipped, question row is gone:             ${orphaned.length}`);
+  console.log(`  TO INSERT:                                 ${toInsert.length}`);
+  console.log(`Distinct users affected:                     ${new Set(toInsert.map((p) => p.userId)).size}`);
+  console.log('');
+  console.log(
+    'NOTE: feed rows are filtered to those with NO answer evidence. FeedItem.catchupResolvedAt',
+  );
+  console.log(
+    'is also stamped by the catch-up ANSWER path, so it is not a dismiss marker on its own',
+  );
+  console.log('(see the header). A count above 0 here is unusual — inspect before applying.');
+
+  if (!APPLY) {
+    console.log('\nDRY RUN — pass --apply to write these rows.');
+    return;
+  }
+
+  let inserted = 0;
+  for (let i = 0; i < toInsert.length; i += CHUNK) {
+    const chunk = toInsert.slice(i, i + CHUNK);
+    await db
+      .insert(missedReturnDismissed)
+      .values(chunk.map((p) => ({ userId: p.userId, questionId: p.questionId })))
+      .onConflictDoNothing();
+    inserted += chunk.length;
+    console.log(`  inserted ${inserted}/${toInsert.length}`);
+  }
+  console.log(`\n✓ Backfill complete — ${inserted} rows written.`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -522,6 +522,11 @@ export async function POST(request: NextRequest) {
       recordAnswerSideEffects({
       userId: session.userId,
       isCorrect,
+      // A return answered WRONG records nothing new (the player was already
+      // wrong on this question) but WOULD occupy the single catch-up slot that
+      // unique(source_type, question_id, answered_by_user_id) allows, blocking
+      // the correct answer on a later return. See skipMasteryEvent's note.
+      skipMasteryEvent: isReturnSlot(slot) && !isCorrect,
       logTag: 'daily/answer',
       logContext: { generatedQuestionId: question.generatedId },
       masteryEvent: {
@@ -529,7 +534,25 @@ export async function POST(request: NextRequest) {
         domain: question.canonicalSubcategory,
         answerState: masteryAnswerState,
         pointsAwarded,
-        sourceType: 'daily',
+        // D-MISSED-RETURN-01 — a RETURN slot writes the CATCH-UP source type,
+        // not the live one. This is a correctness fix, not a taxonomy nicety.
+        //
+        // MASTERY_EVENTS carries unique(source_type, question_id,
+        // answered_by_user_id) and inserts `on conflict do nothing`. The
+        // player's ORIGINAL wrong answer already occupies ('live_correct',
+        // question, player) — so a returning question answered correctly under
+        // 'daily' was silently deduped away: no recovery points, no
+        // `first_correct_after_wrong`, and therefore no Recovered-deck entry,
+        // which breaks §3.1's whole premise that the return loop's exit IS the
+        // Recovered deck's entrance. Verified live on 2026-08-09: a correct
+        // return wrote nothing at all.
+        //
+        // 'catchup' maps to 'catchup_correct', which is a free slot for that
+        // (question, player) and is already one of the two source types the
+        // Recovered pool reads. It is also the honest label: §5 scores a return
+        // at the recovery/catch-up weight precisely because it is not a live
+        // first sighting.
+        sourceType: isReturnSlot(slot) ? 'catchup' : 'daily',
         // B-DOMAIN-BONUS-ROTATION-01: a +2 bonus (friend-sourced) domain stays out
         // of the core rotation until adopted — see writeMasteryEvent.
         isBonus: isBonusSlot(slot),

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -14,7 +14,8 @@ import { deriveAnswerOutcome, recordAnswerSideEffects } from '@/server/answers/a
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
 import { isRoundComplete, type QueueSlot } from '@/server/daily/types';
 import { isDailyReplenishEnabled, replenishBankAfterPlay } from '@/server/daily/replenish-bank';
-import { isBonusSlot } from '@/server/daily/bonus';
+import { isBonusSlot, isReturnSlot } from '@/server/daily/bonus';
+import { notifyAuthorOfReturnRecovery } from '@/server/daily/missed-return-notify';
 import { asQueueSlots } from '@/server/daily/catchup';
 import { resolveDailyBasePoints } from '@/server/daily/types';
 import { resolveEffectiveDifficulty } from '@/server/daily/empirical-difficulty';
@@ -468,10 +469,24 @@ export async function POST(request: NextRequest) {
         // (D-RECOVERY-SCORING-UNIFY-01). question.difficulty reproduces
         // `basePoints` as the first-correct base; recovery earns
         // round(base × RECOVERY_STATE_WEIGHT). Live surface (catchUp omitted).
+        // D-MISSED-RETURN-01 §5 — a RETURN slot never earns live credit, in
+        // either scope. Without `catchUp`, an expired-scope return scores
+        // `first_correct` at LIVE_SURFACE_WEIGHT (100%) because the player has
+        // genuinely never answered it, which contradicts the §5 table's
+        // CATCHUP_SURFACE_WEIGHT (25%) and would make Daily Five scores
+        // incomparable across players (R4).
+        //
+        // Passing it for BOTH scopes is deliberate and safe: for the wrong scope
+        // the state is `first_correct_after_wrong`, and canonicalPointsForAnswer's
+        // MAX-not-compound rule (D-RECOVERY-SCORING-UNIFY-01 D1) already makes
+        // RECOVERY_STATE_WEIGHT win outright rather than stacking to 6.25%. So
+        // one honest rule — "a return is not a live first sighting" — yields
+        // exactly the two weights §5 asks for. The scorer itself is untouched.
         pointsFor: (answerState) =>
           canonicalPointsForAnswer({
             difficulty: question.difficulty,
             answerState,
+            catchUp: isReturnSlot(slot),
           }),
       }),
       selectInsideJokeForViewer(persistedInsideJoke, persistedCreatorId, session.userId),
@@ -541,6 +556,33 @@ export async function POST(request: NextRequest) {
       }),
     ]);
     marks.mastery = Date.now();
+
+    // D-MISSED-RETURN-01 §7-A1 — the author push. Fires only when a WRONG-scope
+    // return just landed correct: that is the wrong→right moment, and it is the
+    // payoff the whole feature exists to produce. The expired scope is excluded
+    // on purpose (the player had never seen it, so nothing "stuck").
+    //
+    // Deferred with after() so the author's notification never sits in front of
+    // the player's verdict, and fire-and-forget — notifyAuthorOfReturnRecovery
+    // swallows its own errors.
+    if (
+      isCorrect &&
+      isReturnSlot(slot) &&
+      slot.return_scope === 'wrong' &&
+      persistedCreatorId &&
+      canonicalQuestionId
+    ) {
+      const authorId = persistedCreatorId;
+      const questionIdForPush = canonicalQuestionId;
+      const answererId = session.userId;
+      after(() =>
+        notifyAuthorOfReturnRecovery({
+          authorUserId: authorId,
+          answererUserId: answererId,
+          questionId: questionIdForPush,
+        }),
+      );
+    }
 
     // Demand-pull bank replenish (D-SUPPLY-DEMAND-PULL-01): THIS answer just
     // completed the round (transition — the prior slot state was incomplete),

--- a/src/app/api/daily/bonus-offer/seen/route.ts
+++ b/src/app/api/daily/bonus-offer/seen/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { markBonusOfferSeen } from '@/server/daily/bonus-offer';
+
+export const dynamic = 'force-dynamic';
+
+// B-BONUS-OFFER-01: persist the seen-signal so the friend-bonus interstitial never
+// fires again. Called on BOTH resolutions ("Keep going" and "No thanks") — the
+// player has been told what the +2 is either way. Idempotent on the server.
+export async function POST() {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  await markBonusOfferSeen(session.userId);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/daily/catchup/dismiss/route.ts
+++ b/src/app/api/daily/catchup/dismiss/route.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { getSession } from '@/server/auth/session';
 import { dailyQueues, db, feedItems } from '@/server/db';
 import { getCatchupQuestions } from '@/server/db/queries/daily';
+import { dismissMissedReturn } from '@/server/db/queries/missed-return-dismissed';
 import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
 import { catchUpErrorResponse } from '@/server/play/catch-up-submit-error';
@@ -39,6 +40,19 @@ export async function POST(request: NextRequest) {
     .find((item) => item.dailyQueueItemId === parsed.dailyQueueItemId);
   if (!catchupItem) return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found');
 
+  // D-MISSED-RETURN-01 §3.3 — dual-write the dismiss at (userId, questionId) so
+  // it survives across queue instances. The slot-level writes below are
+  // SLOT-scoped and invisible to a future return slot, which is by definition a
+  // new slot in a different queue; without this row a waved-off question would
+  // resurface days later. The old writes are retained — other code reads them.
+  //
+  // Resolved from `reportTarget`, NOT the flat `catchupItem.questionId`: that
+  // field holds either a `questions.id` OR a `generatedQuestions.id` and cannot
+  // disambiguate the two FK targets. LLM-origin daily questions have no
+  // canonical row to key on and are out of this feature's scope (they are
+  // likewise absent from the Recovered pool).
+  const canonicalQuestionId = catchupItem.reportTarget.questionId;
+
   if (catchupItem.surface === 'feed') {
     if (!catchupItem.feedItemId) {
       return catchUpErrorResponse(500, 'invalid_state', 'Feed catch-up item missing feed reference');
@@ -59,6 +73,10 @@ export async function POST(request: NextRequest) {
       .update(feedItems)
       .set({ catchupResolvedAt: new Date() })
       .where(eq(feedItems.id, feedItem.id));
+
+    if (canonicalQuestionId) {
+      await dismissMissedReturn(session.userId, canonicalQuestionId);
+    }
 
     return Response.json({ dismissed: true });
   }
@@ -100,6 +118,10 @@ export async function POST(request: NextRequest) {
     .update(dailyQueues)
     .set({ slots: nextSlots })
     .where(eq(dailyQueues.id, catchupItem.queueId));
+
+  if (canonicalQuestionId) {
+    await dismissMissedReturn(session.userId, canonicalQuestionId);
+  }
 
   return Response.json({ dismissed: true });
 }

--- a/src/app/api/daily/catchup/undismiss/route.ts
+++ b/src/app/api/daily/catchup/undismiss/route.ts
@@ -10,6 +10,7 @@ import {
   replaceQueueSlot,
 } from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
+import { reinstateMissedReturn } from '@/server/db/queries/missed-return-dismissed';
 import { catchUpErrorResponse } from '@/server/play/catch-up-submit-error';
 
 export const dynamic = 'force-dynamic';
@@ -53,6 +54,15 @@ export async function POST(request: NextRequest) {
       .set({ catchupResolvedAt: null })
       .where(eq(feedItems.id, feedItem.id));
 
+    // D-MISSED-RETURN-01 §3.3 — mirror of the dismiss route's dual-write. This
+    // reversal is NOT optional: without it, un-dismissing in catch-up would
+    // leave the (userId, questionId) row active and suppress the question from
+    // returning forever, which is the exact bug the dual-write exists to
+    // prevent, inverted. feedItems.questionId is always canonical.
+    if (feedItem.questionId) {
+      await reinstateMissedReturn(session.userId, feedItem.questionId);
+    }
+
     return Response.json({ restored: true });
   }
 
@@ -83,6 +93,13 @@ export async function POST(request: NextRequest) {
   );
 
   await db.update(dailyQueues).set({ slots: nextSlots }).where(eq(dailyQueues.id, target.queueId));
+
+  // Mirror of the dismiss route's dual-write — see the feed branch above.
+  // `question_id` is the canonical FK; a slot carrying `generated_question_id`
+  // instead is LLM-origin and has no canonical row to reinstate.
+  if (slot.question_id && !slot.generated_question_id) {
+    await reinstateMissedReturn(session.userId, slot.question_id);
+  }
 
   return Response.json({ restored: true });
 }

--- a/src/app/api/daily/missed-return/__tests__/route.test.ts
+++ b/src/app/api/daily/missed-return/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getSessionMock,
+  setMissedReturnEnabledMock,
+  dismissMissedReturnMock,
+  reinstateMissedReturnMock,
+} = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  setMissedReturnEnabledMock: vi.fn(),
+  dismissMissedReturnMock: vi.fn(),
+  reinstateMissedReturnMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/db/queries/missed-return', () => ({
+  setMissedReturnEnabled: setMissedReturnEnabledMock,
+}));
+vi.mock('@/server/db/queries/missed-return-dismissed', () => ({
+  dismissMissedReturn: dismissMissedReturnMock,
+  reinstateMissedReturn: reinstateMissedReturnMock,
+}));
+
+import { PATCH } from '@/app/api/daily/missed-return/settings/route';
+import { DELETE, POST } from '@/app/api/daily/missed-return/dismiss/route';
+
+function req(url: string, method: string, body: unknown): Request {
+  return new Request(`http://localhost${url}`, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSessionMock.mockResolvedValue({ userId: 'user-1' });
+});
+
+describe('PATCH /api/daily/missed-return/settings — the §7-B1 toggle', () => {
+  it('turns the feature off', async () => {
+    const res = await PATCH(req('/api/daily/missed-return/settings', 'PATCH', { enabled: false }) as never);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ enabled: false });
+    expect(setMissedReturnEnabledMock).toHaveBeenCalledWith('user-1', false);
+  });
+
+  it('turns it back on', async () => {
+    const res = await PATCH(req('/api/daily/missed-return/settings', 'PATCH', { enabled: true }) as never);
+    expect(res.status).toBe(200);
+    expect(setMissedReturnEnabledMock).toHaveBeenCalledWith('user-1', true);
+  });
+
+  it('rejects a non-boolean rather than coercing it', async () => {
+    const res = await PATCH(req('/api/daily/missed-return/settings', 'PATCH', { enabled: 'yes' }) as never);
+    expect(res.status).toBe(400);
+    expect(setMissedReturnEnabledMock).not.toHaveBeenCalled();
+  });
+
+  it('401s without a session', async () => {
+    getSessionMock.mockResolvedValue(null);
+    const res = await PATCH(req('/api/daily/missed-return/settings', 'PATCH', { enabled: false }) as never);
+    expect(res.status).toBe(401);
+    expect(setMissedReturnEnabledMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('/api/daily/missed-return/dismiss — §7-C dismiss and immediate undo', () => {
+  it('dismisses for the session user, never a client-supplied one', async () => {
+    const res = await POST(
+      req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'q1', userId: 'someone-else' }) as never,
+    );
+    expect(res.status).toBe(200);
+    expect(dismissMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1');
+  });
+
+  it('DELETE undoes the dismiss', async () => {
+    const res = await DELETE(req('/api/daily/missed-return/dismiss', 'DELETE', { questionId: 'q1' }) as never);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ restored: true });
+    expect(reinstateMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1');
+  });
+
+  it('a dismiss writes ONLY the dismiss — never a mastery/points side effect (§5)', async () => {
+    await POST(req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'q1' }) as never);
+    expect(dismissMissedReturnMock).toHaveBeenCalledTimes(1);
+    expect(reinstateMissedReturnMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing questionId', async () => {
+    const res = await POST(req('/api/daily/missed-return/dismiss', 'POST', {}) as never);
+    expect(res.status).toBe(400);
+    expect(dismissMissedReturnMock).not.toHaveBeenCalled();
+  });
+
+  it('401s both verbs without a session', async () => {
+    getSessionMock.mockResolvedValue(null);
+    expect((await POST(req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'q1' }) as never)).status).toBe(401);
+    expect((await DELETE(req('/api/daily/missed-return/dismiss', 'DELETE', { questionId: 'q1' }) as never)).status).toBe(401);
+    expect(dismissMissedReturnMock).not.toHaveBeenCalled();
+    expect(reinstateMissedReturnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/daily/missed-return/__tests__/route.test.ts
+++ b/src/app/api/daily/missed-return/__tests__/route.test.ts
@@ -71,14 +71,41 @@ describe('/api/daily/missed-return/dismiss — §7-C dismiss and immediate undo'
       req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'q1', userId: 'someone-else' }) as never,
     );
     expect(res.status).toBe(200);
-    expect(dismissMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1');
+    // Defaults to canonical so the catch-up dual-write callers keep working.
+    expect(dismissMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1', 'canonical');
   });
 
   it('DELETE undoes the dismiss', async () => {
     const res = await DELETE(req('/api/daily/missed-return/dismiss', 'DELETE', { questionId: 'q1' }) as never);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ restored: true });
-    expect(reinstateMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1');
+    expect(reinstateMissedReturnMock).toHaveBeenCalledWith('user-1', 'q1', 'canonical');
+  });
+
+  // LLM-generated questions are ~96% of the wrong answers inside the Daily Five,
+  // so the dismiss path has to route them to the right column or the Customize
+  // Remove silently does nothing for almost everything on the list.
+  it('routes a generated question to the generated column', async () => {
+    const res = await POST(
+      req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'g1', kind: 'generated' }) as never,
+    );
+    expect(res.status).toBe(200);
+    expect(dismissMissedReturnMock).toHaveBeenCalledWith('user-1', 'g1', 'generated');
+  });
+
+  it('undoes a generated dismiss against the generated column', async () => {
+    await DELETE(
+      req('/api/daily/missed-return/dismiss', 'DELETE', { questionId: 'g1', kind: 'generated' }) as never,
+    );
+    expect(reinstateMissedReturnMock).toHaveBeenCalledWith('user-1', 'g1', 'generated');
+  });
+
+  it('rejects an unknown kind rather than defaulting it', async () => {
+    const res = await POST(
+      req('/api/daily/missed-return/dismiss', 'POST', { questionId: 'q1', kind: 'nonsense' }) as never,
+    );
+    expect(res.status).toBe(400);
+    expect(dismissMissedReturnMock).not.toHaveBeenCalled();
   });
 
   it('a dismiss writes ONLY the dismiss — never a mastery/points side effect (§5)', async () => {

--- a/src/app/api/daily/missed-return/dismiss/route.ts
+++ b/src/app/api/daily/missed-return/dismiss/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import {
+  dismissMissedReturn,
+  reinstateMissedReturn,
+} from '@/server/db/queries/missed-return-dismissed';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * D-MISSED-RETURN-01 §7-C — per-row dismiss from the Customize list, with the
+ * immediate-undo affordance.
+ *
+ * DELETE is the undo. §7-C revised the decision away from the siblings'
+ * reversible-forever archive: the undo window is a few seconds on the client and
+ * then it's final, and NO browsable dismissed shelf is built on top of it. The
+ * underlying row keeps `reinstatedAt` because the shipped catch-up undismiss
+ * route also needs a reversal path — same mechanism, different window.
+ *
+ * A dismiss here is NEUTRAL (§5): it writes one row and touches no mastery or
+ * points state, so it can never read as a wrong answer.
+ */
+const bodySchema = z.object({ questionId: z.string().min(1) });
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'questionId is required' }, { status: 400 });
+  }
+
+  await dismissMissedReturn(session.userId, parsed.data.questionId);
+  return NextResponse.json({ dismissed: true });
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'questionId is required' }, { status: 400 });
+  }
+
+  await reinstateMissedReturn(session.userId, parsed.data.questionId);
+  return NextResponse.json({ restored: true });
+}

--- a/src/app/api/daily/missed-return/dismiss/route.ts
+++ b/src/app/api/daily/missed-return/dismiss/route.ts
@@ -22,7 +22,14 @@ export const dynamic = 'force-dynamic';
  * A dismiss here is NEUTRAL (§5): it writes one row and touches no mastery or
  * points state, so it can never read as a wrong answer.
  */
-const bodySchema = z.object({ questionId: z.string().min(1) });
+// `kind` names which table the id belongs to. It defaults to 'canonical' so the
+// catch-up dual-write callers (which only ever hold canonical ids) keep working
+// unchanged, but the Customize list always sends it explicitly — the Daily Five
+// serves LLM-generated questions too, and those are most of what gets missed.
+const bodySchema = z.object({
+  questionId: z.string().min(1),
+  kind: z.enum(['canonical', 'generated']).default('canonical'),
+});
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
@@ -33,7 +40,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'questionId is required' }, { status: 400 });
   }
 
-  await dismissMissedReturn(session.userId, parsed.data.questionId);
+  await dismissMissedReturn(session.userId, parsed.data.questionId, parsed.data.kind);
   return NextResponse.json({ dismissed: true });
 }
 
@@ -46,6 +53,6 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ error: 'questionId is required' }, { status: 400 });
   }
 
-  await reinstateMissedReturn(session.userId, parsed.data.questionId);
+  await reinstateMissedReturn(session.userId, parsed.data.questionId, parsed.data.kind);
   return NextResponse.json({ restored: true });
 }

--- a/src/app/api/daily/missed-return/settings/route.ts
+++ b/src/app/api/daily/missed-return/settings/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { setMissedReturnEnabled } from '@/server/db/queries/missed-return';
+
+export const dynamic = 'force-dynamic';
+
+// D-MISSED-RETURN-01 §7-B1 — the single on/off toggle governing BOTH return
+// scopes together. Turning it off stops FUTURE selection; a return slot already
+// built into today's queue is left alone (see the note in the Customize client).
+const bodySchema = z.object({ enabled: z.boolean() });
+
+export async function PATCH(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'enabled must be a boolean' }, { status: 400 });
+  }
+
+  await setMissedReturnEnabled(session.userId, parsed.data.enabled);
+  return NextResponse.json({ enabled: parsed.data.enabled });
+}

--- a/src/app/api/daily/queue/route.ts
+++ b/src/app/api/daily/queue/route.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { countDailyQueues, getTodaysDailyQueue, refreshQueueSlotQuestionTexts } from '@/server/db/queries/daily';
+import {
+  countDailyQueues,
+  getTodaysDailyQueue,
+  refreshQueueSlotQuestionTexts,
+} from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
+import { hasSeenBonusOffer } from '@/server/daily/bonus-offer';
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
 import { DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
@@ -49,8 +54,7 @@ async function serializeQueue(
   const { kept, dropped } = partitionGenericSlots(raw);
 
   // First-run intro gate: their only queue, fully untouched.
-  const isFirstDaily =
-    totalQueues <= 1 && raw.every((slot) => !slot.answered && !slot.skipped);
+  const isFirstDaily = totalQueues <= 1 && raw.every((slot) => !slot.answered && !slot.skipped);
 
   // A served queue shorter than DAILY_QUEUE_SIZE is the exact symptom a user
   // reports as "only 3 of my 5 showed up." Trace it at the moment of serving,
@@ -70,15 +74,23 @@ async function serializeQueue(
     });
   }
 
-  return {
-    queue_id: queue.id,
-    queue_date: queue.queueDate,
+  const [slots, bonusOfferSeen] = await Promise.all([
     // Serve live question text (slot.question_text is an assignment-time
     // snapshot; grading resolves the live row, so an admin edit made after
     // assignment must reach the display too).
-    slots: await refreshQueueSlotQuestionTexts(kept),
+    refreshQueueSlotQuestionTexts(kept),
+    // B-BONUS-OFFER-01: drives the one-time friend-bonus interstitial. Read here
+    // rather than on the client so a second device can't re-show it.
+    hasSeenBonusOffer(userId),
+  ]);
+
+  return {
+    queue_id: queue.id,
+    queue_date: queue.queueDate,
+    slots,
     difficulty_mode: difficultyMode,
     is_first_daily: isFirstDaily,
+    bonus_offer_seen: bonusOfferSeen,
   };
 }
 
@@ -135,7 +147,9 @@ export async function GET() {
     return withTiming(NextResponse.json({ queue: null, slots: [], building: true }));
   }
 
-  return withTiming(NextResponse.json(await serializeQueue(queue, prefs.difficulty, userId, totalQueues)));
+  return withTiming(
+    NextResponse.json(await serializeQueue(queue, prefs.difficulty, userId, totalQueues)),
+  );
 }
 
 export async function POST() {

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -75,8 +75,16 @@ function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' 
  * know. That is the sequel to the existing wrong-answer line, "This one belongs
  * to {Creator}'s world — now it's in yours too."
  */
-function returnRecoveryNote(slot: QueueSlot, isCorrect: boolean): string | null {
-  if (!isCorrect || slot.return_scope !== 'wrong') return null;
+function returnRecoveryNote(slot: QueueSlot): string | null {
+  if (slot.return_scope !== 'wrong') return null;
+  // Derived from the PERSISTED slot rather than stashed at answer time, so it
+  // survives a reload. An earlier attempt wrote it into `reveal_breadcrumb`,
+  // which the reveal accepts as a prop but never renders (see the note above
+  // explainerSentence in GameplayChat) — so the payoff moment §6 calls the point
+  // of the whole feature silently never appeared. Verified on a live account.
+  const answeredCorrect =
+    slot.answer_state === 'correct' || slot.catchup_answer_state === 'correct';
+  if (!answeredCorrect) return null;
   const author = slot.author_name?.trim();
   return author ? `It stuck. ${author} would be glad.` : 'It stuck.';
 }
@@ -611,6 +619,10 @@ export default function DailyPage() {
           authorNote:
             slot.source === 'friend' || slot.source === 'house' ? (slot.author_note ?? null) : null,
           breadcrumb: slot.reveal_breadcrumb ?? null,
+          // D-MISSED-RETURN-01 §6 — the payoff moment, distinct from an
+          // ordinary correct. Register is "it stuck", never "you finally got
+          // it": the second reading turns a connection event into a grade.
+          returnRecoveryNote: returnRecoveryNote(slot),
           explanation: slot.reveal_explainer ?? null,
           copyVariant: slot.slot_index,
           // D-3: house core slots surface the 'Joshing' name + Editorial badge
@@ -782,13 +794,7 @@ export default function DailyPage() {
                         awarded_points: body.pointsAwarded ?? body.awarded_points ?? 0,
                         reveal_canonical_answer: body.correctAnswer ?? body.answer,
                         reveal_explainer: body.explanation ?? body.explainer,
-                        // D-MISSED-RETURN-01 §6 — the payoff moment. A correct
-                        // answer on a returning question deserves its own
-                        // acknowledgment, distinct from an ordinary correct:
-                        // it is the whole reason the feature exists. Register is
-                        // "it stuck", never "you finally got it" — the second
-                        // reading turns a connection event into a grade.
-                        reveal_breadcrumb: returnRecoveryNote(currentSlot, isCorrect),
+                        reveal_breadcrumb: null,
                         reveal_quip: opts.gaveUp ? null : (body.consolation ?? null),
                         reveal_inside_joke: body.insideJoke ?? null,
                         reveal_inside_joke_kind: body.insideJokeKind ?? null,

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -52,16 +52,12 @@ function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' 
   if (isBonusSlot(slot) && slot.difficulty_estimate === 'accessible') {
     badges.push({ label: 'Accessible', tone: 'muted' });
   }
-  // D-MISSED-RETURN-01 R9 — a returning question is visibly marked as one and
-  // never disguised as new. The D-doc's own example for this is a date ("from
-  // March 4"), which is badge-shaped, so it rides the existing chip rather than
-  // restyling the attribution banner.
-  //
-  // WRONG SCOPE ONLY. The expired scope has never been seen by the player, so it
-  // gets no return framing at all and reads as a normal question arriving late
-  // (§2). Do not "fix" that asymmetry — it is the whole point of the split.
-  const returnedFrom = returnBadgeLabel(slot);
-  if (returnedFrom) badges.push({ label: returnedFrom, tone: 'muted' });
+  // NOTE: the R9 return mark is NOT a badge. It was a muted chip here until it
+  // proved too quiet to notice — measured on a live account, four returns were
+  // played across five days without the player registering any of them as
+  // returns. It is now the "SECOND LOOK" banner welded to the top of the card
+  // (see returnBannerLastSeen below and the banner in GameplayChat). Do not
+  // re-add a chip: the mark would then render twice.
   return badges;
 }
 
@@ -90,14 +86,17 @@ function returnRecoveryNote(slot: QueueSlot): string | null {
 }
 
 /**
- * The honest return label (R9). Null for anything that isn't a wrong-scope
- * return, which is what keeps the expired scope unmarked.
+ * The honest return mark (R9), as the "SECOND LOOK · LAST SEEN AUGUST 3" banner
+ * on the question card. Returns the raw ISO timestamp; GameplayChat owns the
+ * copy, exactly as it does for the bonus banner's "FROM {NAME}'S KNOWLEDGE".
+ *
+ * WRONG SCOPE ONLY. The expired scope has never been seen by the player, so it
+ * gets no return framing at all and reads as a normal question arriving late
+ * (§2). Do not "fix" that asymmetry — it is the whole point of the split.
  */
-function returnBadgeLabel(slot: QueueSlot): string | null {
-  if (slot.return_scope !== 'wrong' || !slot.return_last_seen_at) return null;
-  const seen = new Date(slot.return_last_seen_at);
-  if (Number.isNaN(seen.getTime())) return null;
-  return `from ${seen.toLocaleDateString(undefined, { month: 'long', day: 'numeric' })}`;
+function returnBannerLastSeen(slot: QueueSlot): string | null {
+  if (slot.return_scope !== 'wrong') return null;
+  return slot.return_last_seen_at ?? null;
 }
 
 type QueueResponse = {
@@ -590,6 +589,7 @@ export default function DailyPage() {
           creatorName: null,
           presenceSourceName: getSlotPresence(slot)?.name ?? null,
           presenceSourceExtraCount: getSlotPresence(slot)?.extraCount ?? 0,
+          returnLastSeenAt: returnBannerLastSeen(slot),
           // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: core slots show 1.–5. (slot_index
           // is 0-based; bonus is additive and renders ✦, never a numeral).
           // `bonus` here means "additive — render ✦, never a numeral", which is
@@ -669,6 +669,7 @@ export default function DailyPage() {
           creatorName: null,
           presenceSourceName: getSlotPresence(slot)?.name ?? null,
           presenceSourceExtraCount: getSlotPresence(slot)?.extraCount ?? 0,
+          returnLastSeenAt: returnBannerLastSeen(slot),
           isNew: true,
           // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: core slots show 1.–5. (slot_index
           // is 0-based; bonus is additive and renders ✦, never a numeral).

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -104,6 +104,10 @@ type QueueResponse = {
   queue_date: string;
   slots: QueueSlot[];
   is_first_daily?: boolean;
+  // B-BONUS-OFFER-01: server-resolved one-shot gate for the friend-bonus
+  // interstitial. Defaults to "already seen" when absent so a stale client that
+  // predates the field never shows it.
+  bonus_offer_seen?: boolean;
 };
 
 // One-time intro shown before a brand-new user's first question, explaining that
@@ -249,6 +253,12 @@ export default function DailyPage() {
   const [pausedAfterSlotIndex, setPausedAfterSlotIndex] = useState<number | null>(null);
   const [pendingGiveUp, setPendingGiveUp] = useState(false);
   const [openedTerritoryBySlot, setOpenedTerritoryBySlot] = useState<Record<number, string>>({});
+  // B-BONUS-OFFER-01: domains rested by the opt-out in THIS round, so the notice
+  // for those slots can offer an undo. Session-scoped on purpose — a bonus slot
+  // closed by "No thanks" rested nothing and must not offer to un-rest it. After
+  // a reload the affordance degrades to a plain "Skipped for today"; the rest
+  // itself is durable and still reversible from the Knowledge page.
+  const [restedDomains, setRestedDomains] = useState<string[]>([]);
   const [showFirstRunIntro, setShowFirstRunIntro] = useState(false);
   const answerInputRef = useRef<HTMLInputElement>(null);
   // Guards the one-shot end-of-round revalidation below (B-DAILY-PARTIAL-QUEUE-01).
@@ -575,6 +585,73 @@ export default function DailyPage() {
     [queue],
   );
 
+  // B-BONUS-OFFER-01: clear a rest written by the opt-out. `frequency: null`
+  // restores the domain to its default rotation (the same revert the reveal-card
+  // undo uses). Scoped to the durable preference on purpose — the closed slot is
+  // not reopened, and the notice copy says only what this actually restores.
+  const unrestDomain = useCallback(async (domain: string) => {
+    const response = await fetch('/api/daily/preferences/domain-frequency', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ domain, frequency: null }),
+    });
+    if (!response.ok) throw new Error('Could not restore that category.');
+  }, []);
+
+  // B-BONUS-OFFER-01: resolve the one-time interstitial. Stamped on BOTH
+  // resolutions, so it fires at most once per account either way.
+  const resolveBonusOffer = useCallback(
+    async (accepted: boolean) => {
+      if (!queue) return;
+      setQueue((existing) => (existing ? { ...existing, bonus_offer_seen: true } : existing));
+      void fetch('/api/daily/bonus-offer/seen', { method: 'POST', credentials: 'include' });
+      if (accepted) return;
+
+      // "No thanks" closes the round's bonus slots WITHOUT resting anything —
+      // that separation is the whole point of the interstitial. Declining today
+      // must not be the same gesture as opting out of a category forever.
+      const bonusSlots = queue.slots.filter(
+        (slot) => isBonusSlot(slot) && !slot.answered && !slot.skipped,
+      );
+      for (const slot of bonusSlots) {
+        try {
+          const response = await fetch('/api/daily/skip', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ queue_id: queue.queue_id, slot_index: slot.slot_index }),
+          });
+          if (!response.ok) continue;
+          const body = (await response.json().catch(() => null)) as { slots?: QueueSlot[] } | null;
+          if (Array.isArray(body?.slots)) {
+            const nextSlots = body.slots;
+            setQueue((existing) => (existing ? { ...existing, slots: nextSlots } : existing));
+          }
+        } catch {
+          // Best-effort: a failed skip just leaves that bonus question open.
+        }
+      }
+    },
+    [queue],
+  );
+
+  // B-BONUS-OFFER-01. `bonus_offer_seen` is absent on responses from a server
+  // that predates the field — treat that as "seen" so a rollout can never
+  // re-surface the explainer to an established player.
+  const bonusOfferSeen = queue?.bonus_offer_seen ?? true;
+  const pendingBonusCount = useMemo(
+    () =>
+      (queue?.slots ?? []).filter((slot) => isBonusSlot(slot) && !slot.answered && !slot.skipped)
+        .length,
+    [queue?.slots],
+  );
+  // True while the interstitial is standing in for the current question: the
+  // answer bar must not render behind it (there is nothing to answer yet).
+  const bonusOfferPending = Boolean(
+    currentSlot && isBonusSlot(currentSlot) && !bonusOfferSeen && pendingBonusCount > 0,
+  );
+
   const messages = useMemo<ChatMessage[]>(() => {
     if (!queue) return [];
     const rows: ChatMessage[] = [];
@@ -651,16 +728,52 @@ export default function DailyPage() {
           (slot.broad_category && slot.broad_category.trim()) ||
           (slot.category ? categoryLabel(slot.category) : '') ||
           slot.domain;
+        if (isBonusSlot(slot)) {
+          // Only a REST gets the undo. A bonus slot closed by declining the
+          // interstitial ("No thanks") wrote no preference, so there is nothing
+          // to undo and it reads as an ordinary skip.
+          const restedDomain = slot.domain;
+          const isRested =
+            restedDomain != null &&
+            restedDomains.some((d) => d.toLowerCase() === restedDomain.toLowerCase());
+          rows.push(
+            isRested
+              ? {
+                  id: `s-${slot.slot_index}`,
+                  kind: 'rest_notice',
+                  text: `Resting ${restedLabel}. You won't see these in your five.`,
+                  onUndo: () => unrestDomain(restedDomain),
+                }
+              : {
+                  id: `s-${slot.slot_index}`,
+                  kind: 'system',
+                  text: 'Skipped for today.',
+                },
+          );
+          continue;
+        }
         rows.push({
           id: `s-${slot.slot_index}`,
           kind: 'system',
-          text: isBonusSlot(slot)
-            ? `Resting ${restedLabel}. You won't see these in your five.`
-            : "Skipped. We'll bring it back later.",
+          text: "Skipped. We'll bring it back later.",
         });
         continue;
       }
       if (currentSlot?.slot_index === slot.slot_index) {
+        // B-BONUS-OFFER-01: the one-time explainer. It stands IN PLACE OF the
+        // first bonus question rather than above it — the player chooses to see
+        // the bonus round before it starts, which is the affordance that was
+        // missing when new players reached for the opt-out to move forward.
+        if (isBonusSlot(slot) && !bonusOfferSeen) {
+          rows.push({
+            id: 'bonus-offer',
+            kind: 'bonus_offer',
+            available: pendingBonusCount,
+            onAccept: () => void resolveBonusOffer(true),
+            onDecline: () => void resolveBonusOffer(false),
+          });
+          break;
+        }
         rows.push({
           id: `q-${slot.slot_index}`,
           kind: 'question',
@@ -715,6 +828,11 @@ export default function DailyPage() {
     answer,
     pendingGiveUp,
     openedTerritoryBySlot,
+    bonusOfferSeen,
+    pendingBonusCount,
+    resolveBonusOffer,
+    restedDomains,
+    unrestDomain,
   ]);
 
   const results = useMemo(() => {
@@ -747,8 +865,7 @@ export default function DailyPage() {
             // a stale slot_index against a different question (see the answer
             // route's identity guard). Bot slots carry generated_question_id,
             // friend/house slots carry question_id.
-            expected_question_id:
-              currentSlot.generated_question_id ?? currentSlot.question_id,
+            expected_question_id: currentSlot.generated_question_id ?? currentSlot.question_id,
             submitted_answer: opts.submittedAnswer,
             gave_up: opts.gaveUp,
           },
@@ -818,9 +935,7 @@ export default function DailyPage() {
           const failed = caught.body as FailedAnswerResponse | null;
           if (failed?.error === 'slot_changed' && Array.isArray(failed.slots)) {
             const reconciledSlots = failed.slots;
-            setQueue((existing) =>
-              existing ? { ...existing, slots: reconciledSlots } : existing,
-            );
+            setQueue((existing) => (existing ? { ...existing, slots: reconciledSlots } : existing));
             setAnswer('');
             setSubmitNotice(null);
             return;
@@ -895,6 +1010,8 @@ export default function DailyPage() {
         body: JSON.stringify({ domain, frequency: 'resting' }),
       });
       if (!restResponse.ok) throw new Error('Could not update that category.');
+      // Remember it so this slot's notice can offer an undo (B-BONUS-OFFER-01).
+      if (domain) setRestedDomains((existing) => [...existing, domain]);
 
       const skipResponse = await fetch('/api/daily/skip', {
         method: 'POST',
@@ -968,7 +1085,7 @@ export default function DailyPage() {
         className="flex-1 overflow-y-auto px-4 py-4"
         style={{
           paddingBottom:
-            currentSlot && !loading
+            currentSlot && !loading && !bonusOfferPending
               ? 'calc(120px + env(safe-area-inset-bottom))'
               : 'calc(24px + env(safe-area-inset-bottom))',
         }}
@@ -1011,7 +1128,7 @@ export default function DailyPage() {
         )}
       </section>
 
-      {currentSlot && !loading ? (
+      {currentSlot && !loading && !bonusOfferPending ? (
         <AnswerInputBar
           value={answer}
           onChange={setAnswer}

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -23,7 +23,13 @@ import LoadingScreen from '@/components/LoadingScreen';
 import { useLoadingMoments } from '@/components/loading-moment/useLoadingMoment';
 import { categoryLabel, type InsideJokeKind } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
-import { getBonusCount, getCoreSlots, getSlotPresence, isBonusSlot } from '@/server/daily/bonus';
+import {
+  getBonusCount,
+  getCoreSlots,
+  getSlotPresence,
+  isAdditiveSlot,
+  isBonusSlot,
+} from '@/server/daily/bonus';
 import {
   buildSessionCloseLines,
   type SessionSlotSummary,
@@ -46,7 +52,44 @@ function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' 
   if (isBonusSlot(slot) && slot.difficulty_estimate === 'accessible') {
     badges.push({ label: 'Accessible', tone: 'muted' });
   }
+  // D-MISSED-RETURN-01 R9 — a returning question is visibly marked as one and
+  // never disguised as new. The D-doc's own example for this is a date ("from
+  // March 4"), which is badge-shaped, so it rides the existing chip rather than
+  // restyling the attribution banner.
+  //
+  // WRONG SCOPE ONLY. The expired scope has never been seen by the player, so it
+  // gets no return framing at all and reads as a normal question arriving late
+  // (§2). Do not "fix" that asymmetry — it is the whole point of the split.
+  const returnedFrom = returnBadgeLabel(slot);
+  if (returnedFrom) badges.push({ label: returnedFrom, tone: 'muted' });
   return badges;
+}
+
+/**
+ * The correct-on-return acknowledgment (§6). Null unless a WRONG-scope return
+ * just landed correct — an ordinary correct keeps its ordinary reveal, and an
+ * expired-scope correct is a first correct like any other.
+ *
+ * Names the author when there is one, because the point is not that the player
+ * improved: it is that something one person knew is now something two people
+ * know. That is the sequel to the existing wrong-answer line, "This one belongs
+ * to {Creator}'s world — now it's in yours too."
+ */
+function returnRecoveryNote(slot: QueueSlot, isCorrect: boolean): string | null {
+  if (!isCorrect || slot.return_scope !== 'wrong') return null;
+  const author = slot.author_name?.trim();
+  return author ? `It stuck. ${author} would be glad.` : 'It stuck.';
+}
+
+/**
+ * The honest return label (R9). Null for anything that isn't a wrong-scope
+ * return, which is what keeps the expired scope unmarked.
+ */
+function returnBadgeLabel(slot: QueueSlot): string | null {
+  if (slot.return_scope !== 'wrong' || !slot.return_last_seen_at) return null;
+  const seen = new Date(slot.return_last_seen_at);
+  if (Number.isNaN(seen.getTime())) return null;
+  return `from ${seen.toLocaleDateString(undefined, { month: 'long', day: 'numeric' })}`;
 }
 
 type QueueResponse = {
@@ -541,7 +584,10 @@ export default function DailyPage() {
           presenceSourceExtraCount: getSlotPresence(slot)?.extraCount ?? 0,
           // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: core slots show 1.–5. (slot_index
           // is 0-based; bonus is additive and renders ✦, never a numeral).
-          numberMarker: { value: slot.slot_index + 1, bonus: isBonusSlot(slot) },
+          // `bonus` here means "additive — render ✦, never a numeral", which is
+          // true of a return slot for the same reason it's true of a +2: it
+          // appends past the five and is never in the denominator (R3).
+          numberMarker: { value: slot.slot_index + 1, bonus: isAdditiveSlot(slot) },
           badges: questionBadges(slot),
         });
         if (slot.submitted_answer) {
@@ -614,7 +660,10 @@ export default function DailyPage() {
           isNew: true,
           // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: core slots show 1.–5. (slot_index
           // is 0-based; bonus is additive and renders ✦, never a numeral).
-          numberMarker: { value: slot.slot_index + 1, bonus: isBonusSlot(slot) },
+          // `bonus` here means "additive — render ✦, never a numeral", which is
+          // true of a return slot for the same reason it's true of a +2: it
+          // appends past the five and is never in the denominator (R3).
+          numberMarker: { value: slot.slot_index + 1, bonus: isAdditiveSlot(slot) },
           badges: questionBadges(slot),
         });
         if (submitting && answer.trim()) {
@@ -733,7 +782,13 @@ export default function DailyPage() {
                         awarded_points: body.pointsAwarded ?? body.awarded_points ?? 0,
                         reveal_canonical_answer: body.correctAnswer ?? body.answer,
                         reveal_explainer: body.explanation ?? body.explainer,
-                        reveal_breadcrumb: null,
+                        // D-MISSED-RETURN-01 §6 — the payoff moment. A correct
+                        // answer on a returning question deserves its own
+                        // acknowledgment, distinct from an ordinary correct:
+                        // it is the whole reason the feature exists. Register is
+                        // "it stuck", never "you finally got it" — the second
+                        // reading turns a connection event into a grade.
+                        reveal_breadcrumb: returnRecoveryNote(currentSlot, isCorrect),
                         reveal_quip: opts.gaveUp ? null : (body.consolation ?? null),
                         reveal_inside_joke: body.insideJoke ?? null,
                         reveal_inside_joke_kind: body.insideJokeKind ?? null,

--- a/src/app/daily/setup/MissedReturnSection.tsx
+++ b/src/app/daily/setup/MissedReturnSection.tsx
@@ -26,6 +26,8 @@ import { Switch } from '@/components/ui/Switch';
 const UNDO_WINDOW_MS = 6000;
 
 export type MissedReturnItem = {
+  /** Which table the id belongs to — the Daily Five serves both kinds. */
+  kind: 'canonical' | 'generated';
   questionId: string;
   scope: 'wrong' | 'expired';
   questionText: string;
@@ -99,7 +101,7 @@ export function MissedReturnSection({
         const res = await fetch('/api/daily/missed-return/dismiss', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ questionId: item.questionId }),
+          body: JSON.stringify({ questionId: item.questionId, kind: item.kind }),
         });
         if (!res.ok) throw new Error('failed');
       } catch {
@@ -122,7 +124,7 @@ export function MissedReturnSection({
       const res = await fetch('/api/daily/missed-return/dismiss', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ questionId: item.questionId }),
+        body: JSON.stringify({ questionId: item.questionId, kind: item.kind }),
       });
       if (!res.ok) throw new Error('failed');
       setItems((current) =>
@@ -182,7 +184,7 @@ export function MissedReturnSection({
             <ul className="mt-4 grid list-none gap-2 p-0">
               {items.map((item) => (
                 <li
-                  key={item.questionId}
+                  key={`${item.kind}:${item.questionId}`}
                   className="flex items-start justify-between gap-3 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--brand-card)] px-3 py-2.5"
                 >
                   <div className="flex-1">

--- a/src/app/daily/setup/MissedReturnSection.tsx
+++ b/src/app/daily/setup/MissedReturnSection.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Switch } from '@/components/ui/Switch';
+
+/**
+ * D-MISSED-RETURN-01 §7-D — the Customize surface for returning questions.
+ *
+ * ONE surface, not two (R11): the toggle at the top, the currently-eligible
+ * questions below it, each with a dismiss.
+ *
+ * Deliberately lighter than the Recovered pattern. §7-C rules out a browsable
+ * dismissed archive and a dimmed/archived section — a dismissed row simply
+ * leaves the list, with a few seconds to undo. That is the whole reversal story.
+ *
+ * REGISTER (§1, §6): this is not remediation and must never read as it. No
+ * "you got this wrong", no "practice", no "review", no counts of failure. A
+ * returning question is something a friend taught you, coming back to see if it
+ * stuck. The expired scope gets NO return framing at all — it has never been
+ * seen, so it reads as a question that simply hasn't been asked yet.
+ *
+ * Copy here is the working pass; Phase 4 replaces it from the approved copy pass.
+ */
+
+const UNDO_WINDOW_MS = 6000;
+
+export type MissedReturnItem = {
+  questionId: string;
+  scope: 'wrong' | 'expired';
+  questionText: string;
+  category: string | null;
+  authorName: string | null;
+  /** ISO — when they last saw it (the wrong answer, or the day it expired). */
+  lastSeenAt: string;
+  returnCount: number;
+};
+
+function formatSeen(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
+}
+
+export function MissedReturnSection({
+  initialEnabled,
+  initialItems,
+}: {
+  initialEnabled: boolean;
+  initialItems: MissedReturnItem[];
+}) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [items, setItems] = useState(initialItems);
+  /** The row awaiting its undo window. Null when nothing is pending. */
+  const [pending, setPending] = useState<MissedReturnItem | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const toggle = useCallback(async (next: boolean) => {
+    setEnabled(next); // optimistic — the control should never feel laggy
+    setError(null);
+    try {
+      const res = await fetch('/api/daily/missed-return/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!res.ok) throw new Error('failed');
+    } catch {
+      setEnabled(!next);
+      setError('That didn’t save. Try again?');
+    }
+  }, []);
+
+  /**
+   * Dismiss writes IMMEDIATELY — the undo window is a grace period on a real
+   * write, not a delayed one. If the player closes the tab mid-window the
+   * dismiss still stands, which is the honest reading of "I don't want this
+   * back" and avoids a row that silently reappears tomorrow.
+   */
+  const dismiss = useCallback(
+    async (item: MissedReturnItem) => {
+      clearTimer();
+      setError(null);
+      setItems((current) => current.filter((i) => i.questionId !== item.questionId));
+      setPending(item);
+      timerRef.current = window.setTimeout(() => setPending(null), UNDO_WINDOW_MS);
+
+      try {
+        const res = await fetch('/api/daily/missed-return/dismiss', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ questionId: item.questionId }),
+        });
+        if (!res.ok) throw new Error('failed');
+      } catch {
+        setItems((current) => [item, ...current]);
+        setPending(null);
+        clearTimer();
+        setError('That didn’t save. Try again?');
+      }
+    },
+    [clearTimer],
+  );
+
+  const undo = useCallback(async () => {
+    if (!pending) return;
+    const item = pending;
+    clearTimer();
+    setPending(null);
+    setError(null);
+    try {
+      const res = await fetch('/api/daily/missed-return/dismiss', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ questionId: item.questionId }),
+      });
+      if (!res.ok) throw new Error('failed');
+      setItems((current) =>
+        current.some((i) => i.questionId === item.questionId) ? current : [item, ...current],
+      );
+    } catch {
+      setError('Couldn’t undo that. Try again?');
+    }
+  }, [pending, clearTimer]);
+
+  return (
+    <section className="mx-auto mt-2 w-[min(672px,94vw)] px-1 pb-10">
+      <div className="border-t border-[var(--border-warm)] pt-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <h2 className="m-0 font-serif text-lg font-semibold text-[var(--brand-ink)]">
+              Questions that come back
+            </h2>
+            <p className="mt-1 mb-0 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
+              Every so often, one question you didn’t land turns up again in your five. Nothing
+              stacks up — it’s one at a time, and once you get it, it’s done.
+            </p>
+          </div>
+          <Switch
+            checked={enabled}
+            onCheckedChange={(next) => void toggle(next)}
+            label="Let missed questions come back"
+            className="mt-1"
+          />
+        </div>
+
+        {error ? (
+          <p className="mt-3 mb-0 text-quiet text-[var(--brand-ink)]" role="status" aria-live="polite">
+            {error}
+          </p>
+        ) : null}
+
+        {pending ? (
+          <div
+            className="mt-3 flex items-center justify-between gap-3 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--cream-warm)] px-3 py-2"
+            role="status"
+            aria-live="polite"
+          >
+            <p className="m-0 text-quiet text-[var(--ink)]">Removed</p>
+            <button
+              type="button"
+              className="text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70"
+              onClick={() => void undo()}
+            >
+              Undo
+            </button>
+          </div>
+        ) : null}
+
+        {enabled ? (
+          items.length > 0 ? (
+            <ul className="mt-4 grid list-none gap-2 p-0">
+              {items.map((item) => (
+                <li
+                  key={item.questionId}
+                  className="flex items-start justify-between gap-3 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--brand-card)] px-3 py-2.5"
+                >
+                  <div className="flex-1">
+                    <p className="m-0 text-sm leading-[1.45] text-[var(--brand-ink)]">
+                      {item.questionText}
+                    </p>
+                    <p className="mt-1 mb-0 text-quiet text-[var(--text-muted-warm)]">
+                      {/* Provenance, honestly (R9). The 'wrong' scope says when
+                          they last saw it; 'expired' never implies they did. */}
+                      {item.scope === 'wrong'
+                        ? `${item.authorName ? `${item.authorName} · ` : ''}from ${formatSeen(item.lastSeenAt)}`
+                        : `${item.authorName ? `${item.authorName} · ` : ''}never got to this one`}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="shrink-0 text-xs font-semibold tracking-[0.08em] text-[var(--text-muted-warm)] uppercase transition hover:text-[var(--brand-ink)]"
+                    onClick={() => void dismiss(item)}
+                    aria-label={`Don’t bring back: ${item.questionText}`}
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-4 mb-0 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
+              Nothing’s waiting to come back right now.
+            </p>
+          )
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/app/daily/setup/MissedReturnSection.tsx
+++ b/src/app/daily/setup/MissedReturnSection.tsx
@@ -1,71 +1,32 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { Switch } from '@/components/ui/Switch';
 
 /**
- * D-MISSED-RETURN-01 §7-D — the Customize surface for returning questions.
+ * D-MISSED-RETURN-01 §7-D — the Customize control for returning questions.
  *
- * ONE surface, not two (R11): the toggle at the top, the currently-eligible
- * questions below it, each with a dismiss.
+ * ONE control: on or off. Deliberately NOT a list.
  *
- * Deliberately lighter than the Recovered pattern. §7-C rules out a browsable
- * dismissed archive and a dimmed/archived section — a dismissed row simply
- * leaves the list, with a few seconds to undo. That is the whole reversal story.
+ * §7-D originally paired the toggle with a list of currently-eligible questions
+ * and a per-row dismiss. That shipped, and then didn't survive contact with real
+ * data (Josh, 2026-08-10): a heavy account had 135 eligible rows, which buried
+ * the rest of the page and turned a settings screen into an inventory nobody
+ * asked to read. "I don't need to see those."
  *
- * REGISTER (§1, §6): this is not remediation and must never read as it. No
- * "you got this wrong", no "practice", no "review", no counts of failure. A
- * returning question is something a friend taught you, coming back to see if it
- * stuck. The expired scope gets NO return framing at all — it has never been
- * seen, so it reads as a question that simply hasn't been asked yet.
+ * Dropping the list also removes two hazards the walkthrough surfaced — the
+ * unbounded scroll, and the undo strip whose disappearance shifted the list
+ * under an in-flight tap.
  *
- * Copy here is the working pass; Phase 4 replaces it from the approved copy pass.
+ * The dismiss capability itself is unchanged and still reachable where it has
+ * always made sense: waving a question off in catch-up dual-writes
+ * MissedReturnDismissed, which suppresses the return. What's gone is the
+ * separate browsable surface for doing that in advance.
  */
-
-const UNDO_WINDOW_MS = 6000;
-
-export type MissedReturnItem = {
-  /** Which table the id belongs to — the Daily Five serves both kinds. */
-  kind: 'canonical' | 'generated';
-  questionId: string;
-  scope: 'wrong' | 'expired';
-  questionText: string;
-  category: string | null;
-  authorName: string | null;
-  /** ISO — when they last saw it (the wrong answer, or the day it expired). */
-  lastSeenAt: string;
-  returnCount: number;
-};
-
-function formatSeen(iso: string): string {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return '';
-  return date.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
-}
-
-export function MissedReturnSection({
-  initialEnabled,
-  initialItems,
-}: {
-  initialEnabled: boolean;
-  initialItems: MissedReturnItem[];
-}) {
+export function MissedReturnSection({ initialEnabled }: { initialEnabled: boolean }) {
   const [enabled, setEnabled] = useState(initialEnabled);
-  const [items, setItems] = useState(initialItems);
-  /** The row awaiting its undo window. Null when nothing is pending. */
-  const [pending, setPending] = useState<MissedReturnItem | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const timerRef = useRef<number | null>(null);
-
-  const clearTimer = useCallback(() => {
-    if (timerRef.current !== null) {
-      window.clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => clearTimer, [clearTimer]);
 
   const toggle = useCallback(async (next: boolean) => {
     setEnabled(next); // optimistic — the control should never feel laggy
@@ -83,140 +44,31 @@ export function MissedReturnSection({
     }
   }, []);
 
-  /**
-   * Dismiss writes IMMEDIATELY — the undo window is a grace period on a real
-   * write, not a delayed one. If the player closes the tab mid-window the
-   * dismiss still stands, which is the honest reading of "I don't want this
-   * back" and avoids a row that silently reappears tomorrow.
-   */
-  const dismiss = useCallback(
-    async (item: MissedReturnItem) => {
-      clearTimer();
-      setError(null);
-      setItems((current) => current.filter((i) => i.questionId !== item.questionId));
-      setPending(item);
-      timerRef.current = window.setTimeout(() => setPending(null), UNDO_WINDOW_MS);
-
-      try {
-        const res = await fetch('/api/daily/missed-return/dismiss', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ questionId: item.questionId, kind: item.kind }),
-        });
-        if (!res.ok) throw new Error('failed');
-      } catch {
-        setItems((current) => [item, ...current]);
-        setPending(null);
-        clearTimer();
-        setError('That didn’t save. Try again?');
-      }
-    },
-    [clearTimer],
-  );
-
-  const undo = useCallback(async () => {
-    if (!pending) return;
-    const item = pending;
-    clearTimer();
-    setPending(null);
-    setError(null);
-    try {
-      const res = await fetch('/api/daily/missed-return/dismiss', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ questionId: item.questionId, kind: item.kind }),
-      });
-      if (!res.ok) throw new Error('failed');
-      setItems((current) =>
-        current.some((i) => i.questionId === item.questionId) ? current : [item, ...current],
-      );
-    } catch {
-      setError('Couldn’t undo that. Try again?');
-    }
-  }, [pending, clearTimer]);
-
   return (
-    <section className="mx-auto mt-2 w-[min(672px,94vw)] px-1 pb-10">
-      <div className="border-t border-[var(--border-warm)] pt-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex-1">
-            <h2 className="m-0 font-serif text-lg font-semibold text-[var(--brand-ink)]">
-              Questions that come back
-            </h2>
-            <p className="mt-1 mb-0 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
-              Every so often, one question you didn’t land turns up again in your five. Nothing
-              stacks up — it’s one at a time, and once you get it, it’s done.
-            </p>
-          </div>
-          <Switch
-            checked={enabled}
-            onCheckedChange={(next) => void toggle(next)}
-            label="Let missed questions come back"
-            className="mt-1"
-          />
-        </div>
-
-        {error ? (
-          <p className="mt-3 mb-0 text-quiet text-[var(--brand-ink)]" role="status" aria-live="polite">
-            {error}
+    <section className="border-t border-[var(--border-warm)] pt-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1">
+          <h2 className="m-0 font-serif text-lg font-semibold text-[var(--brand-ink)]">
+            Questions that come back
+          </h2>
+          <p className="mt-1 mb-0 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
+            Every so often, one question you didn’t land turns up again in your five. Nothing
+            stacks up — it’s one at a time, and once you get it, it’s done.
           </p>
-        ) : null}
-
-        {pending ? (
-          <div
-            className="mt-3 flex items-center justify-between gap-3 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--cream-warm)] px-3 py-2"
-            role="status"
-            aria-live="polite"
-          >
-            <p className="m-0 text-quiet text-[var(--ink)]">Removed</p>
-            <button
-              type="button"
-              className="text-xs font-semibold tracking-[0.08em] text-[var(--brand-link)] uppercase transition hover:opacity-70"
-              onClick={() => void undo()}
-            >
-              Undo
-            </button>
-          </div>
-        ) : null}
-
-        {enabled ? (
-          items.length > 0 ? (
-            <ul className="mt-4 grid list-none gap-2 p-0">
-              {items.map((item) => (
-                <li
-                  key={`${item.kind}:${item.questionId}`}
-                  className="flex items-start justify-between gap-3 rounded-[var(--radius-xs)] border border-[var(--border-warm)] bg-[var(--brand-card)] px-3 py-2.5"
-                >
-                  <div className="flex-1">
-                    <p className="m-0 text-sm leading-[1.45] text-[var(--brand-ink)]">
-                      {item.questionText}
-                    </p>
-                    <p className="mt-1 mb-0 text-quiet text-[var(--text-muted-warm)]">
-                      {/* Provenance, honestly (R9). The 'wrong' scope says when
-                          they last saw it; 'expired' never implies they did. */}
-                      {item.scope === 'wrong'
-                        ? `${item.authorName ? `${item.authorName} · ` : ''}from ${formatSeen(item.lastSeenAt)}`
-                        : `${item.authorName ? `${item.authorName} · ` : ''}never got to this one`}
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    className="shrink-0 text-xs font-semibold tracking-[0.08em] text-[var(--text-muted-warm)] uppercase transition hover:text-[var(--brand-ink)]"
-                    onClick={() => void dismiss(item)}
-                    aria-label={`Don’t bring back: ${item.questionText}`}
-                  >
-                    Remove
-                  </button>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="mt-4 mb-0 text-quiet leading-[1.5] text-[var(--text-muted-warm)]">
-              Nothing’s waiting to come back right now.
-            </p>
-          )
-        ) : null}
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={(next) => void toggle(next)}
+          label="Let missed questions come back"
+          className="mt-1"
+        />
       </div>
+
+      {error ? (
+        <p className="mt-3 mb-0 text-quiet text-[var(--brand-ink)]" role="status" aria-live="polite">
+          {error}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -5,10 +5,7 @@ import { getSession } from '@/server/auth/session';
 import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
 import { getFullyExploredDomains } from '@/server/knowledge/fully-explored';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
-import {
-  getReturnListForUser,
-  isMissedReturnEnabledForUser,
-} from '@/server/db/queries/missed-return';
+import { isMissedReturnEnabledForUser } from '@/server/db/queries/missed-return';
 import { MissedReturnSection } from './MissedReturnSection';
 
 export const dynamic = 'force-dynamic';
@@ -24,33 +21,25 @@ export default async function DailySetupPage() {
   const session = await getSession();
   if (!session) redirect('/login');
 
-  // D-MISSED-RETURN-01 §7-D: the returning-questions toggle + list live here,
-  // on the page that already owns Daily Five tuning, rather than on a net-new
-  // route (R11, revised). The list is fetched even when the toggle is off so
-  // flipping it back on doesn't need a round-trip.
-  const [{ tree }, preferences, fullyExplored, returnEnabled, returnItems] = await Promise.all([
+  // D-MISSED-RETURN-01 §7-D: the returning-questions toggle lives here, on the
+  // page that already owns Daily Five tuning, rather than on a net-new route
+  // (R11, revised). It goes through `manageExtra` so it renders near the TOP —
+  // as a sibling it landed below the Done button, stranded past the page's own
+  // terminal action (Josh, 2026-08-10).
+  const [{ tree }, preferences, fullyExplored, returnEnabled] = await Promise.all([
     getKnowledgeMapData(session.userId),
     getDailyPreferences(session.userId),
     getFullyExploredDomains(session.userId),
     isMissedReturnEnabledForUser(session.userId),
-    getReturnListForUser(session.userId).catch(() => []),
   ]);
 
   return (
-    <>
-      <KnowledgeFlatClient
-        variant="manage"
-        tree={tree}
-        frequencyByDomain={preferences.domainPreferenceFrequency}
-        fullyExploredDomains={fullyExplored}
-      />
-      <MissedReturnSection
-        initialEnabled={returnEnabled}
-        initialItems={returnItems.map((item) => ({
-          ...item,
-          lastSeenAt: item.lastSeenAt.toISOString(),
-        }))}
-      />
-    </>
+    <KnowledgeFlatClient
+      variant="manage"
+      tree={tree}
+      frequencyByDomain={preferences.domainPreferenceFrequency}
+      fullyExploredDomains={fullyExplored}
+      manageExtra={<MissedReturnSection initialEnabled={returnEnabled} />}
+    />
   );
 }

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -5,6 +5,11 @@ import { getSession } from '@/server/auth/session';
 import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
 import { getFullyExploredDomains } from '@/server/knowledge/fully-explored';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
+import {
+  getReturnListForUser,
+  isMissedReturnEnabledForUser,
+} from '@/server/db/queries/missed-return';
+import { MissedReturnSection } from './MissedReturnSection';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,18 +24,33 @@ export default async function DailySetupPage() {
   const session = await getSession();
   if (!session) redirect('/login');
 
-  const [{ tree }, preferences, fullyExplored] = await Promise.all([
+  // D-MISSED-RETURN-01 §7-D: the returning-questions toggle + list live here,
+  // on the page that already owns Daily Five tuning, rather than on a net-new
+  // route (R11, revised). The list is fetched even when the toggle is off so
+  // flipping it back on doesn't need a round-trip.
+  const [{ tree }, preferences, fullyExplored, returnEnabled, returnItems] = await Promise.all([
     getKnowledgeMapData(session.userId),
     getDailyPreferences(session.userId),
     getFullyExploredDomains(session.userId),
+    isMissedReturnEnabledForUser(session.userId),
+    getReturnListForUser(session.userId).catch(() => []),
   ]);
 
   return (
-    <KnowledgeFlatClient
-      variant="manage"
-      tree={tree}
-      frequencyByDomain={preferences.domainPreferenceFrequency}
-      fullyExploredDomains={fullyExplored}
-    />
+    <>
+      <KnowledgeFlatClient
+        variant="manage"
+        tree={tree}
+        frequencyByDomain={preferences.domainPreferenceFrequency}
+        fullyExploredDomains={fullyExplored}
+      />
+      <MissedReturnSection
+        initialEnabled={returnEnabled}
+        initialItems={returnItems.map((item) => ({
+          ...item,
+          lastSeenAt: item.lastSeenAt.toISOString(),
+        }))}
+      />
+    </>
   );
 }

--- a/src/app/knowledge/KnowledgeFlatClient.tsx
+++ b/src/app/knowledge/KnowledgeFlatClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Check, Combine, Plus, Trash2, X } from 'lucide-react';
@@ -156,6 +156,11 @@ type PeaksDetailData = {
   tree: KnowledgeTreeNode;
   frequencyByDomain: DomainPreferenceFrequency;
   fullyExploredDomains: ReadonlySet<string>;
+  /**
+   * Manage-variant only: Daily Five settings rendered near the TOP of the page,
+   * above the topic tooling and the Done button. Ignored on the portrait variant.
+   */
+  manageExtra?: ReactNode;
 };
 
 type TreeIndex = { byId: Map<string, LeafInfo>; byFreqKey: Map<string, LeafInfo> };
@@ -237,7 +242,13 @@ export function KnowledgeFlatClient(props: PeaksDetailData) {
   );
 }
 
-function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, fullyExploredDomains }: PeaksDetailData) {
+function KnowledgePageContent({
+  variant = 'portrait',
+  tree,
+  frequencyByDomain,
+  fullyExploredDomains,
+  manageExtra,
+}: PeaksDetailData) {
   const isManage = variant === 'manage';
   const searchParams = useSearchParams();
   const highlightedDomainSlug = searchParams.get('domain');
@@ -872,6 +883,12 @@ function KnowledgePageContent({ variant = 'portrait', tree, frequencyByDomain, f
           options &mdash; change how often it comes up, add a related topic, or remove it.
         </p>
       )}
+
+      {/* Manage-only settings slot, rendered high on the page. Anything passed
+          here is a Daily Five SETTING rather than a topic, so it sits above the
+          topic tooling and — critically — above the Done button, which used to
+          be the page's terminal action with content stranded after it. */}
+      {isManage && manageExtra ? <div className="px-1">{manageExtra}</div> : null}
 
       {tierCrossed && highlightedDomainSlug && (
         <section className="bg-[var(--cream-accent)] text-[var(--ink)] px-4 py-3 text-base">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,8 @@ import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/da
 import { getLatestUnviewedCeremony, getNextCeremonyAt } from '@/server/db/queries/ceremony'
 import { getNextDailyResetBoundary } from '@/lib/games/timezone'
 import { timeServerWork } from '@/server/lib/server-timing'
+import { hasEligibleReturnCandidates } from '@/server/db/queries/missed-return'
+import { isMissedReturnEnabled } from '@/server/daily/missed-return'
 import WelcomeTourScreen from '@/components/welcome/WelcomeTourScreen'
 
 const FEED_PAGE_SIZE = 20
@@ -166,8 +168,21 @@ async function TodaysFiveSection({ userId }: { userId: string }) {
   // Home is the #1 §12.6 surface (< 1.5s) but is a streamed RSC, so it can't
   // set a Server-Timing header — log the server data-fetch span instead
   // (B-PERF-04) so the home hot path is queryable alongside the API routes.
-  const [queue, catchupItems] = await timeServerWork('home/todays-five', 'todays_five', () =>
-    Promise.all([getTodaysDailyQueue(userId), getCatchupQuestions(userId)]),
+  const [queue, catchupItems, hasReturningQuestions] = await timeServerWork(
+    'home/todays-five',
+    'todays_five',
+    () =>
+      Promise.all([
+        getTodaysDailyQueue(userId),
+        getCatchupQuestions(userId),
+        // D-MISSED-RETURN-01 §7-E — presence, not magnitude (see the prop's doc
+        // comment on TodaysFiveCard). Gated on the flag so Home is untouched
+        // while the feature is dark, and `.catch` so this can never be the
+        // reason the #1 perf-budget surface fails to render.
+        isMissedReturnEnabled()
+          ? hasEligibleReturnCandidates(userId).catch(() => false)
+          : Promise.resolve(false),
+      ]),
   )
 
   const status = buildDailyStatusSnapshot(queue)
@@ -184,6 +199,7 @@ async function TodaysFiveSection({ userId }: { userId: string }) {
       <TodaysFiveCard
         initialStatus={status}
         initialMissedCount={missedCount}
+        hasReturningQuestions={hasReturningQuestions}
       />
       {showStandaloneCatchup ? (
         <MissedQuestionsCard count={missedCount} expiringCount={expiringCount} />

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -41,6 +41,21 @@ type TodaysFiveCardProps = {
    * is suppressed by the home page when this is >0 in the completed state.
    */
   initialMissedCount?: number
+  /**
+   * D-MISSED-RETURN-01 §7-E — the viewer has questions eligible to come back.
+   *
+   * A BOOLEAN, not a count, and deliberately separate from `initialMissedCount`.
+   * §7-E1 ratified "widen the missed count to cover both scopes", but doing that
+   * literally breaks two things: the count reaches the hundreds on real accounts
+   * (177 for one live user), and "Play (n) Missed Questions" links to
+   * /daily/catchup, which cannot serve a wrong-scope return — those arrive one
+   * at a time inside the Daily Five (R2), so the button would promise a
+   * destination that does not exist. Magnitude is also meaningless to the
+   * player: with a 7-day floor and a 3-return cap they will never see most of
+   * them. So Home acknowledges that misses aren't lost WITHOUT a number and
+   * WITHOUT a link. See the PR for the flag raised on this.
+   */
+  hasReturningQuestions?: boolean
 }
 
 const CUSTOMIZE_DAILY_LINK_CLASS = [
@@ -136,6 +151,7 @@ function OutcomeDot({ outcome, label }: { outcome: SlotOutcome; label: string })
 export default function TodaysFiveCard({
   initialStatus = null,
   initialMissedCount = 0,
+  hasReturningQuestions = false,
 }: TodaysFiveCardProps = {}) {
   const [status, setStatus] = useState<DailyStatus | null>(initialStatus)
   // Client-only reset-time label; null during SSR to keep hydration stable.
@@ -382,6 +398,13 @@ export default function TodaysFiveCard({
             >
               See today&apos;s recap
             </Link>
+            {hasReturningQuestions ? (
+              // No count, no link — see the prop's doc comment. This states that
+              // misses aren't lost; it does not offer a pile to go clear.
+              <p className="m-0 text-quiet leading-[1.5] text-[var(--brand-ink-400)]">
+                Some you didn&rsquo;t land will find their way back to you.
+              </p>
+            ) : null}
           </div>
         ) : (
           // Branch B — nothing left to catch up on (daily five AND any catch-up

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -65,6 +65,17 @@ export type ChatMessage =
        */
       presenceSourceName?: string | null;
       presenceSourceExtraCount?: number;
+      /**
+       * D-MISSED-RETURN-01 R9 — ISO timestamp of when the player last saw this
+       * question, set ONLY for a wrong-scope return. Drives the "SECOND LOOK"
+       * banner, which is the honest mark that keeps a return from reading as new.
+       *
+       * WRONG SCOPE ONLY. An expired-scope return has never been seen, so the
+       * caller passes null and it renders as an ordinary question arriving late
+       * (§2). The gate lives in the caller (`daily/page.tsx`), next to the
+       * comment explaining why the asymmetry is deliberate.
+       */
+      returnLastSeenAt?: string | null;
       isNew?: boolean;
       subhead?: string | null;
       badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
@@ -254,6 +265,22 @@ function bonusSourceLabel(sourceName: string, extraCount: number): string {
   return extraCount > 0 ? `FROM ${source} + OTHERS’ KNOWLEDGE` : `FROM ${source}’S KNOWLEDGE`;
 }
 
+/**
+ * D-MISSED-RETURN-01 R9 — the date half of the return banner ("LAST SEEN
+ * AUGUST 3"). Purely descriptive by design: it states what the card is without
+ * asking anything or implying a verdict, because §1 is explicit that a return
+ * must never read as remediation.
+ *
+ * Returns null on an unparseable timestamp so a bad date degrades to no banner
+ * rather than to "LAST SEEN INVALID DATE".
+ */
+function returnSourceLabel(lastSeenAt: string): string | null {
+  const seen = new Date(lastSeenAt);
+  if (Number.isNaN(seen.getTime())) return null;
+  const date = seen.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
+  return `LAST SEEN ${date.toUpperCase()}`;
+}
+
 function SystemRow({ text }: { text: string }) {
   return (
     <div className="flex justify-center py-0.5">
@@ -397,6 +424,7 @@ function QuestionRow({
   creatorIsHouse = false,
   presenceSourceName = null,
   presenceSourceExtraCount = 0,
+  returnLastSeenAt = null,
   isNew = false,
   numberMarker = null,
   dismissing = false,
@@ -418,6 +446,7 @@ function QuestionRow({
   creatorIsHouse?: boolean;
   presenceSourceName?: string | null;
   presenceSourceExtraCount?: number;
+  returnLastSeenAt?: string | null;
   isNew?: boolean;
   onGiveUp?: () => void;
   giveUpDisabled?: boolean;
@@ -437,6 +466,17 @@ function QuestionRow({
   // A bonus slot is one drawn from a followed friend's knowledge (D-4 §B). It
   // gets a distinct gold treatment so it reads as a gift, not just another card.
   const isBonus = Boolean(presenceSourceName);
+  // D-MISSED-RETURN-01 R9 — a returning question wears the same banner FORM as a
+  // bonus (so the two read as one system) in a deliberately quieter neutral key:
+  // no gold ✦, no warm card tint, no inset rail. Those stay unique to a friend's
+  // gift, which a return is not. Bonus wins if both are somehow set, so a card
+  // can never grow two stacked banners.
+  const returnLabel =
+    !isBonus && returnLastSeenAt ? returnSourceLabel(returnLastSeenAt) : null;
+  const isReturn = Boolean(returnLabel);
+  // Either banner welds to the top of the card, so the card must square off its
+  // top corners for exactly the same reason in both cases.
+  const hasBanner = isBonus || isReturn;
 
   useEffect(() => {
     if (!isNew) return;
@@ -549,6 +589,66 @@ function QuestionRow({
             </div>
           </div>
         ) : null}
+        {returnLabel ? (
+          <div
+            style={{
+              borderRadius: 'var(--radius-md) var(--radius-md) 0 0',
+              border: '1px solid var(--brand-rule)',
+              borderBottom: 'none',
+              // Neutral, not navy: present and unmissable, but visibly
+              // subordinate to both a core question and a friend's bonus. Built
+              // from existing tokens so the color ratchet (check:colors) stays
+              // clean. Deliberately NOT a grading color — red/green here would
+              // turn an honest label into "you got this wrong", which is the
+              // remediation framing §1 forbids.
+              background: 'color-mix(in srgb, var(--brand-ink-400) 14%, var(--game-card-question))',
+              color: 'var(--brand-ink-700)',
+              padding: '9px 13px 8px',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: '6px 10px',
+              }}
+            >
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: '0.64rem',
+                  fontWeight: 800,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.16em',
+                  lineHeight: 1.25,
+                }}
+              >
+                <span aria-hidden style={{ fontSize: '0.8rem', lineHeight: 1 }}>
+                  ↩
+                </span>
+                Second look
+              </span>
+              <span
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: '0.6rem',
+                  fontWeight: 800,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.12em',
+                  lineHeight: 1.25,
+                  color: 'var(--text-muted-warm)',
+                }}
+              >
+                {returnLabel}
+              </span>
+            </div>
+          </div>
+        ) : null}
         <div
           style={{
             // Bonus questions get a navy banner plus warm card tint so the
@@ -559,7 +659,9 @@ function QuestionRow({
             border: isBonus
               ? '1px solid color-mix(in srgb, var(--brand-navy) 72%, var(--accent-gold))'
               : '1px solid var(--brand-rule)',
-            borderRadius: isBonus ? '0 0 var(--radius-md) var(--radius-md)' : 'var(--radius-md)',
+            // hasBanner, not isBonus: a return banner welds to the top edge the
+            // same way, so the card squares off under either one.
+            borderRadius: hasBanner ? '0 0 var(--radius-md) var(--radius-md)' : 'var(--radius-md)',
             // effect/card/question — soft layered drop shadow (bonus adds a gold inset rail).
             boxShadow: isBonus
               ? '0 8px 22px rgba(13, 31, 58, 0.14), 0 1px 3px rgba(40, 32, 30, 0.08), inset 4px 0 0 var(--accent-gold)'
@@ -1640,6 +1742,7 @@ export function GameplayChatThread({
                 creatorIsHouse={m.creatorIsHouse}
                 presenceSourceName={m.presenceSourceName}
                 presenceSourceExtraCount={m.presenceSourceExtraCount}
+                returnLastSeenAt={m.returnLastSeenAt}
                 isNew={m.isNew}
                 subhead={m.subhead}
                 numberMarker={m.numberMarker}

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -41,6 +41,11 @@ export type RecheckAction = {
 
 export type ChatMessage =
   | { id: string; kind: 'system'; text: string }
+  // B-BONUS-OFFER-01: the "Resting {category}" line, made reversible. The plain
+  // skip path already promises reversibility ("we'll bring it back later"); this
+  // one is permanent and said so only in passing, so the undo closes that gap.
+  // Undo clears the durable rest — it does not reopen the closed slot.
+  | { id: string; kind: 'rest_notice'; text: string; onUndo: () => Promise<void> }
   | {
       id: string;
       kind: 'question';
@@ -370,8 +375,8 @@ function DismissNoticeRow({
         }}
       >
         <span>
-          Removed {snippet ? <span style={{ opacity: 0.85 }}>“{snippet}”</span> : null} from
-          catch up
+          Removed {snippet ? <span style={{ opacity: 0.85 }}>“{snippet}”</span> : null} from catch
+          up
         </span>
         <span style={{ margin: '0 6px', opacity: 0.6 }}>·</span>
         {state === 'undoing' ? (
@@ -394,6 +399,92 @@ function DismissNoticeRow({
           >
             Undo
           </button>
+        )}
+      </p>
+      {state === 'error' ? (
+        <p
+          style={{
+            ...monoStyle,
+            fontSize: '0.54rem',
+            color: 'var(--danger)',
+            textAlign: 'left',
+            background: 'var(--surface)',
+            border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '3px 9px',
+          }}
+        >
+          Could not undo. Try again.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+// B-BONUS-OFFER-01 — "Resting {category}. You won't see these in your five. · Undo".
+// Same chip/undo shape as DismissNoticeRow above (see its note on why the chip is
+// opaque). Undo clears the durable frequency preference; it deliberately does NOT
+// reopen the closed slot, so the label says what it actually restores.
+function RestNoticeRow({ text, onUndo }: { text: string; onUndo: () => Promise<void> }) {
+  const [state, setState] = useState<'idle' | 'undoing' | 'done' | 'error'>('idle');
+
+  const handleUndo = async () => {
+    if (state === 'undoing' || state === 'done') return;
+    setState('undoing');
+    try {
+      await onUndo();
+      setState('done');
+    } catch {
+      setState('error');
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-start gap-0.5 py-0.5" style={{ paddingLeft: '6px' }}>
+      <p
+        style={{
+          ...monoStyle,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          flexWrap: 'wrap',
+          maxWidth: 'min(22rem, 90%)',
+          fontSize: '0.58rem',
+          lineHeight: 1.4,
+          color: 'var(--text-muted)',
+          textAlign: 'left',
+          background: 'var(--surface)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-sm)',
+          padding: '4px 10px',
+        }}
+      >
+        <span>{state === 'done' ? 'Back in rotation.' : text}</span>
+        {state === 'done' ? null : (
+          <>
+            <span style={{ margin: '0 6px', opacity: 0.6 }}>·</span>
+            {state === 'undoing' ? (
+              <span style={{ opacity: 0.7 }}>Undoing…</span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => void handleUndo()}
+                style={{
+                  ...monoStyle,
+                  fontSize: '0.58rem',
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  cursor: 'pointer',
+                  color: 'var(--text-muted)',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: '2px',
+                }}
+              >
+                Undo
+              </button>
+            )}
+          </>
         )}
       </p>
       {state === 'error' ? (
@@ -452,8 +543,12 @@ function QuestionRow({
   giveUpDisabled?: boolean;
   onDismiss?: () => void;
   dismissDisabled?: boolean;
-  // Bonus slots only (D-4 §B): "This is {Name}'s bag but not mine" — rests the
-  // slot's domain so the category stops surfacing, and closes this question.
+  // Bonus slots only (D-4 §B). Rests the slot's domain so the category stops
+  // surfacing, and closes this question. B-BONUS-OFFER-01 moved this OUT of the
+  // peer action row and into the ⋯ overflow: as a peer link it sat at the same
+  // weight as the way forward, and new players read it as "continue" (3 of the 7
+  // players who ever met a bonus slot on day one tapped it immediately). It is
+  // rare and durable, so it belongs behind the menu.
   onMutePresence?: () => void;
   muteDisabled?: boolean;
   reportTarget?: ReportReasonTarget | null;
@@ -462,6 +557,20 @@ function QuestionRow({
   // Wired to the same dismiss path as the "Dismiss" link, so undo still works.
   onReportedInappropriate?: () => void;
 }) {
+  // B-BONUS-OFFER-01: the demoted opt-out. Category-led copy — the old label
+  // ("This is {Name}'s bag but not mine") led with the inviting friend's name,
+  // which read as affiliation, and buried the negation at the very end.
+  const overflowItems =
+    onMutePresence && presenceSourceName
+      ? [
+          {
+            label: 'Stop showing me this category',
+            onSelect: onMutePresence,
+            disabled: muteDisabled,
+          },
+        ]
+      : undefined;
+
   const [visible, setVisible] = useState(!isNew);
   // A bonus slot is one drawn from a followed friend's knowledge (D-4 §B). It
   // gets a distinct gold treatment so it reads as a gift, not just another card.
@@ -471,8 +580,7 @@ function QuestionRow({
   // no gold ✦, no warm card tint, no inset rail. Those stay unique to a friend's
   // gift, which a return is not. Bonus wins if both are somehow set, so a card
   // can never grow two stacked banners.
-  const returnLabel =
-    !isBonus && returnLastSeenAt ? returnSourceLabel(returnLastSeenAt) : null;
+  const returnLabel = !isBonus && returnLastSeenAt ? returnSourceLabel(returnLastSeenAt) : null;
   const isReturn = Boolean(returnLabel);
   // Either banner welds to the top of the card, so the card must square off its
   // top corners for exactly the same reason in both cases.
@@ -513,334 +621,328 @@ function QuestionRow({
           ...(isNew ? { opacity: visible ? 1 : 0, transition: 'opacity 0.3s ease' } : {}),
         }}
       >
-      {numberMarker ? (
-        // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: editorial number marker in the
-        // gutter above the card — left-aligned, ~6px inset, ~10px gap to the
-        // card (8px here + the column's 2px gap). Positional only; it persists
-        // unchanged after the question is answered (F2) and never reflects
-        // result state.
-        <div style={{ paddingLeft: '6px', marginBottom: '8px' }}>
-          <QuestionNumberMarker value={numberMarker.value} bonus={numberMarker.bonus} />
-        </div>
-      ) : null}
-      <div
-        style={{
-          alignSelf: 'flex-start',
-          maxWidth: THREAD_CARD_MAX_WIDTH,
-          width: '100%',
-        }}
-      >
-        {presenceSourceName ? (
-          <div
-            style={{
-              borderRadius: 'var(--radius-md) var(--radius-md) 0 0',
-              border: '1px solid var(--brand-navy)',
-              borderBottom: 'none',
-              background:
-                'linear-gradient(135deg, var(--brand-navy), color-mix(in srgb, var(--brand-navy) 82%, var(--accent)))',
-              boxShadow: '0 8px 20px rgba(13, 31, 58, 0.18)',
-              color: 'var(--primary-foreground)',
-              padding: '9px 13px 8px',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: '6px 10px',
-              }}
-            >
-              <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '6px',
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: '0.64rem',
-                  fontWeight: 800,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.16em',
-                  lineHeight: 1.25,
-                }}
-              >
-                <span
-                  aria-hidden
-                  style={{ color: 'var(--accent-gold)', fontSize: '0.8rem', lineHeight: 1 }}
-                >
-                  ✦
-                </span>
-                Bonus item
-              </span>
-              <span
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: '0.6rem',
-                  fontWeight: 800,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.12em',
-                  lineHeight: 1.25,
-                  color: 'color-mix(in srgb, var(--accent-gold) 35%, white)',
-                }}
-              >
-                {bonusSourceLabel(presenceSourceName, presenceSourceExtraCount)}
-              </span>
-            </div>
-          </div>
-        ) : null}
-        {returnLabel ? (
-          <div
-            style={{
-              borderRadius: 'var(--radius-md) var(--radius-md) 0 0',
-              border: '1px solid var(--brand-rule)',
-              borderBottom: 'none',
-              // Neutral, not navy: present and unmissable, but visibly
-              // subordinate to both a core question and a friend's bonus. Built
-              // from existing tokens so the color ratchet (check:colors) stays
-              // clean. Deliberately NOT a grading color — red/green here would
-              // turn an honest label into "you got this wrong", which is the
-              // remediation framing §1 forbids.
-              background: 'color-mix(in srgb, var(--brand-ink-400) 14%, var(--game-card-question))',
-              color: 'var(--brand-ink-700)',
-              padding: '9px 13px 8px',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: '6px 10px',
-              }}
-            >
-              <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '6px',
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: '0.64rem',
-                  fontWeight: 800,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.16em',
-                  lineHeight: 1.25,
-                }}
-              >
-                <span aria-hidden style={{ fontSize: '0.8rem', lineHeight: 1 }}>
-                  ↩
-                </span>
-                Second look
-              </span>
-              <span
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: '0.6rem',
-                  fontWeight: 800,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.12em',
-                  lineHeight: 1.25,
-                  color: 'var(--text-muted-warm)',
-                }}
-              >
-                {returnLabel}
-              </span>
-            </div>
+        {numberMarker ? (
+          // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: editorial number marker in the
+          // gutter above the card — left-aligned, ~6px inset, ~10px gap to the
+          // card (8px here + the column's 2px gap). Positional only; it persists
+          // unchanged after the question is answered (F2) and never reflects
+          // result state.
+          <div style={{ paddingLeft: '6px', marginBottom: '8px' }}>
+            <QuestionNumberMarker value={numberMarker.value} bonus={numberMarker.bonus} />
           </div>
         ) : null}
         <div
           style={{
-            // Bonus questions get a navy banner plus warm card tint so the
-            // gifted-from-a-friend item reads as an extra, not an ordinary prompt.
-            background: isBonus
-              ? 'color-mix(in srgb, var(--accent-gold) 10%, var(--game-card-question))'
-              : 'var(--game-card-question)',
-            border: isBonus
-              ? '1px solid color-mix(in srgb, var(--brand-navy) 72%, var(--accent-gold))'
-              : '1px solid var(--brand-rule)',
-            // hasBanner, not isBonus: a return banner welds to the top edge the
-            // same way, so the card squares off under either one.
-            borderRadius: hasBanner ? '0 0 var(--radius-md) var(--radius-md)' : 'var(--radius-md)',
-            // effect/card/question — soft layered drop shadow (bonus adds a gold inset rail).
-            boxShadow: isBonus
-              ? '0 8px 22px rgba(13, 31, 58, 0.14), 0 1px 3px rgba(40, 32, 30, 0.08), inset 4px 0 0 var(--accent-gold)'
-              : '0 4px 16px rgba(40, 32, 30, 0.08), 0 1px 3px rgba(40, 32, 30, 0.06)',
-            padding: '20px 22px',
-            fontFamily: 'var(--font-serif)',
-            fontSize: '1.4875rem',
-            fontWeight: 700,
-            letterSpacing: 0,
-            color: 'var(--brand-ink)',
-            lineHeight: 1.3,
+            alignSelf: 'flex-start',
+            maxWidth: THREAD_CARD_MAX_WIDTH,
+            width: '100%',
           }}
         >
-          {/* Attribution ("FROM YESTERDAY · Maid Acasa") lives INSIDE the cream
+          {presenceSourceName ? (
+            <div
+              style={{
+                borderRadius: 'var(--radius-md) var(--radius-md) 0 0',
+                border: '1px solid var(--brand-navy)',
+                borderBottom: 'none',
+                background:
+                  'linear-gradient(135deg, var(--brand-navy), color-mix(in srgb, var(--brand-navy) 82%, var(--accent)))',
+                boxShadow: '0 8px 20px rgba(13, 31, 58, 0.18)',
+                color: 'var(--primary-foreground)',
+                padding: '9px 13px 8px',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: '6px 10px',
+                }}
+              >
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: '0.64rem',
+                    fontWeight: 800,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.16em',
+                    lineHeight: 1.25,
+                  }}
+                >
+                  <span
+                    aria-hidden
+                    style={{ color: 'var(--accent-gold)', fontSize: '0.8rem', lineHeight: 1 }}
+                  >
+                    ✦
+                  </span>
+                  Bonus item
+                </span>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: '0.6rem',
+                    fontWeight: 800,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.12em',
+                    lineHeight: 1.25,
+                    color: 'color-mix(in srgb, var(--accent-gold) 35%, white)',
+                  }}
+                >
+                  {bonusSourceLabel(presenceSourceName, presenceSourceExtraCount)}
+                </span>
+              </div>
+            </div>
+          ) : null}
+          {returnLabel ? (
+            <div
+              style={{
+                borderRadius: 'var(--radius-md) var(--radius-md) 0 0',
+                border: '1px solid var(--brand-rule)',
+                borderBottom: 'none',
+                // Neutral, not navy: present and unmissable, but visibly
+                // subordinate to both a core question and a friend's bonus. Built
+                // from existing tokens so the color ratchet (check:colors) stays
+                // clean. Deliberately NOT a grading color — red/green here would
+                // turn an honest label into "you got this wrong", which is the
+                // remediation framing §1 forbids.
+                background:
+                  'color-mix(in srgb, var(--brand-ink-400) 14%, var(--game-card-question))',
+                color: 'var(--brand-ink-700)',
+                padding: '9px 13px 8px',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: '6px 10px',
+                }}
+              >
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: '0.64rem',
+                    fontWeight: 800,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.16em',
+                    lineHeight: 1.25,
+                  }}
+                >
+                  <span aria-hidden style={{ fontSize: '0.8rem', lineHeight: 1 }}>
+                    ↩
+                  </span>
+                  Second look
+                </span>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: '0.6rem',
+                    fontWeight: 800,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.12em',
+                    lineHeight: 1.25,
+                    color: 'var(--text-muted-warm)',
+                  }}
+                >
+                  {returnLabel}
+                </span>
+              </div>
+            </div>
+          ) : null}
+          <div
+            style={{
+              // Bonus questions get a navy banner plus warm card tint so the
+              // gifted-from-a-friend item reads as an extra, not an ordinary prompt.
+              background: isBonus
+                ? 'color-mix(in srgb, var(--accent-gold) 10%, var(--game-card-question))'
+                : 'var(--game-card-question)',
+              border: isBonus
+                ? '1px solid color-mix(in srgb, var(--brand-navy) 72%, var(--accent-gold))'
+                : '1px solid var(--brand-rule)',
+              // hasBanner, not isBonus: a return banner welds to the top edge the
+              // same way, so the card squares off under either one.
+              borderRadius: hasBanner
+                ? '0 0 var(--radius-md) var(--radius-md)'
+                : 'var(--radius-md)',
+              // effect/card/question — soft layered drop shadow (bonus adds a gold inset rail).
+              boxShadow: isBonus
+                ? '0 8px 22px rgba(13, 31, 58, 0.14), 0 1px 3px rgba(40, 32, 30, 0.08), inset 4px 0 0 var(--accent-gold)'
+                : '0 4px 16px rgba(40, 32, 30, 0.08), 0 1px 3px rgba(40, 32, 30, 0.06)',
+              padding: '20px 22px',
+              fontFamily: 'var(--font-serif)',
+              fontSize: '1.4875rem',
+              fontWeight: 700,
+              letterSpacing: 0,
+              color: 'var(--brand-ink)',
+              lineHeight: 1.3,
+            }}
+          >
+            {/* Attribution ("FROM YESTERDAY · Maid Acasa") lives INSIDE the cream
               question card, not above it: on the full-strength triangle surface
               (daily/page.tsx) bare muted text floated on the pattern was illegible
               (see the questionActionLinkStyle note). On the cream fill it reads
               cleanly, sitting as one quiet line above the prompt. */}
-          {subhead || creatorName || reportTarget ? (
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'flex-start',
-                justifyContent: 'space-between',
-                gap: '10px',
-                marginBottom: '14px',
-              }}
-            >
-            <div
-              style={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                alignItems: 'baseline',
-                gap: '6px',
-                minWidth: 0,
-              }}
-            >
-              {subhead ? (
-                <span
+            {subhead || creatorName || reportTarget || overflowItems?.length ? (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  justifyContent: 'space-between',
+                  gap: '10px',
+                  marginBottom: '14px',
+                }}
+              >
+                <div
                   style={{
-                    ...monoStyle,
-                    fontSize: '0.58rem',
-                    fontWeight: 400,
-                    color: 'var(--text-muted)',
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    alignItems: 'baseline',
+                    gap: '6px',
+                    minWidth: 0,
                   }}
                 >
-                  {subhead}
-                </span>
-              ) : null}
-              {subhead && creatorName ? (
-                <span
-                  aria-hidden
-                  style={{ fontSize: '0.58rem', color: 'var(--text-muted)', opacity: 0.6 }}
-                >
-                  ·
-                </span>
-              ) : null}
-              {creatorName ? (
-                <span
-                  style={{
-                    fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
-                    fontSize: '0.86rem',
-                    fontWeight: 400,
-                    letterSpacing: 0,
-                    color: 'var(--text)',
-                    opacity: 0.82,
-                    lineHeight: 1.3,
-                  }}
-                >
-                  {/* The timeframe subhead already carries "FROM"; only prefix it
-                      here when the subhead is absent so the line never doubles up. */}
-                  {subhead ? null : (
+                  {subhead ? (
                     <span
                       style={{
                         ...monoStyle,
-                        fontSize: '0.55rem',
+                        fontSize: '0.58rem',
+                        fontWeight: 400,
                         color: 'var(--text-muted)',
-                        marginRight: '6px',
                       }}
                     >
-                      FROM
+                      {subhead}
                     </span>
-                  )}
-                  <span style={{ fontWeight: 600 }}>{creatorName}</span>
-                  {creatorIsHouse ? <EditorialBadge style={{ marginLeft: '6px' }} /> : null}
-                  {creatorIsHouse || isLlmAttribution(creatorName) ? null : (
-                    <span style={{ marginLeft: '6px', opacity: 0.55, fontStyle: 'italic' }}>
-                      gave you this
+                  ) : null}
+                  {subhead && creatorName ? (
+                    <span
+                      aria-hidden
+                      style={{ fontSize: '0.58rem', color: 'var(--text-muted)', opacity: 0.6 }}
+                    >
+                      ·
                     </span>
-                  )}
-                </span>
-              ) : null}
-            </div>
-            {reportTarget ? (
-              <span style={reportMenuFontResetStyle}>
-                <AnsweredRowActions
-                  target={reportTarget}
-                  surface="catchup_thread"
-                  onReportSubmitted={(category) => {
-                    if (category === 'inappropriate') onReportedInappropriate?.();
-                  }}
-                />
-              </span>
+                  ) : null}
+                  {creatorName ? (
+                    <span
+                      style={{
+                        fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
+                        fontSize: '0.86rem',
+                        fontWeight: 400,
+                        letterSpacing: 0,
+                        color: 'var(--text)',
+                        opacity: 0.82,
+                        lineHeight: 1.3,
+                      }}
+                    >
+                      {/* The timeframe subhead already carries "FROM"; only prefix it
+                      here when the subhead is absent so the line never doubles up. */}
+                      {subhead ? null : (
+                        <span
+                          style={{
+                            ...monoStyle,
+                            fontSize: '0.55rem',
+                            color: 'var(--text-muted)',
+                            marginRight: '6px',
+                          }}
+                        >
+                          FROM
+                        </span>
+                      )}
+                      <span style={{ fontWeight: 600 }}>{creatorName}</span>
+                      {creatorIsHouse ? <EditorialBadge style={{ marginLeft: '6px' }} /> : null}
+                      {creatorIsHouse || isLlmAttribution(creatorName) ? null : (
+                        <span style={{ marginLeft: '6px', opacity: 0.55, fontStyle: 'italic' }}>
+                          gave you this
+                        </span>
+                      )}
+                    </span>
+                  ) : null}
+                </div>
+                {reportTarget || overflowItems?.length ? (
+                  <span style={reportMenuFontResetStyle}>
+                    <AnsweredRowActions
+                      target={reportTarget}
+                      extraItems={overflowItems}
+                      surface="catchup_thread"
+                      onReportSubmitted={(category) => {
+                        if (category === 'inappropriate') onReportedInappropriate?.();
+                      }}
+                    />
+                  </span>
+                ) : null}
+              </div>
             ) : null}
-            </div>
-          ) : null}
-          <p style={{ margin: 0 }}>{questionText}</p>
-          {badges.length > 0 ? (
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginTop: '12px' }}>
-              {badges.map((badge) => (
-                <span
-                  key={badge.label}
-                  style={{
-                    // Figma display/pill/sans — serif, 12px, title-case (not the
-                    // mono uppercase used elsewhere).
-                    fontFamily: 'var(--font-serif)',
-                    fontSize: '0.675rem',
-                    lineHeight: 1.1,
-                    letterSpacing: '0.01em',
-                    borderRadius: '999px',
-                    border: '1px solid var(--border)',
-                    background:
-                      badge.tone === 'warning'
-                        ? 'color-mix(in srgb, var(--accent-gold) 14%, var(--surface))'
-                        : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
-                    color: badge.tone === 'warning' ? GOLD_INK : 'var(--text-muted)',
-                    opacity: 0.9,
-                    padding: '3px 9px',
-                  }}
-                >
-                  {badge.label}
-                </span>
-              ))}
-            </div>
-          ) : null}
+            <p style={{ margin: 0 }}>{questionText}</p>
+            {badges.length > 0 ? (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginTop: '12px' }}>
+                {badges.map((badge) => (
+                  <span
+                    key={badge.label}
+                    style={{
+                      // Figma display/pill/sans — serif, 12px, title-case (not the
+                      // mono uppercase used elsewhere).
+                      fontFamily: 'var(--font-serif)',
+                      fontSize: '0.675rem',
+                      lineHeight: 1.1,
+                      letterSpacing: '0.01em',
+                      borderRadius: '999px',
+                      border: '1px solid var(--border)',
+                      background:
+                        badge.tone === 'warning'
+                          ? 'color-mix(in srgb, var(--accent-gold) 14%, var(--surface))'
+                          : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
+                      color: badge.tone === 'warning' ? GOLD_INK : 'var(--text-muted)',
+                      opacity: 0.9,
+                      padding: '3px 9px',
+                    }}
+                  >
+                    {badge.label}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
         </div>
-      </div>
-      {onGiveUp || onDismiss || onMutePresence ? (
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: '10px',
-            marginTop: '8px',
-            paddingLeft: '2px',
-          }}
-        >
-          {onGiveUp ? (
-            <button
-              type="button"
-              onClick={onGiveUp}
-              disabled={giveUpDisabled}
-              style={questionActionLinkStyle}
-            >
-              Show me the answer
-            </button>
-          ) : null}
-          {onMutePresence && presenceSourceName ? (
-            <button
-              type="button"
-              onClick={onMutePresence}
-              disabled={muteDisabled}
-              style={questionActionLinkStyle}
-            >
-              This is {firstNameFrom(presenceSourceName)}&rsquo;s bag but not mine
-            </button>
-          ) : null}
-          {onDismiss ? (
-            <button
-              type="button"
-              onClick={onDismiss}
-              disabled={dismissDisabled}
-              style={questionActionLinkStyle}
-            >
-              Dismiss
-            </button>
-          ) : null}
-        </div>
-      ) : null}
+        {onGiveUp || onDismiss ? (
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: '10px',
+              marginTop: '8px',
+              paddingLeft: '2px',
+            }}
+          >
+            {onGiveUp ? (
+              <button
+                type="button"
+                onClick={onGiveUp}
+                disabled={giveUpDisabled}
+                style={questionActionLinkStyle}
+              >
+                Show me the answer
+              </button>
+            ) : null}
+            {onDismiss ? (
+              <button
+                type="button"
+                onClick={onDismiss}
+                disabled={dismissDisabled}
+                style={questionActionLinkStyle}
+              >
+                Dismiss
+              </button>
+            ) : null}
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -1675,10 +1777,11 @@ function BonusOfferRow({
           lineHeight: 1.2,
         }}
       >
-        {available} more {available === 1 ? 'question' : 'questions'} in the pool.
+        {available} more {available === 1 ? 'question' : 'questions'} from friends&rsquo;
+        categories.
       </p>
       <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
-        Untimed. Counts toward your score.
+        Untimed. They earn points, but they&rsquo;re not part of your five.
       </p>
       <div style={{ display: 'flex', gap: '0.6rem', marginTop: '1rem', flexWrap: 'wrap' }}>
         <button type="button" className="btn-primary" onClick={onAccept}>
@@ -1731,6 +1834,8 @@ export function GameplayChatThread({
         switch (m.kind) {
           case 'system':
             return <SystemRow key={m.id} text={m.text} />;
+          case 'rest_notice':
+            return <RestNoticeRow key={m.id} text={m.text} onUndo={m.onUndo} />;
           case 'dismiss_notice':
             return <DismissNoticeRow key={m.id} questionText={m.questionText} onUndo={m.onUndo} />;
           case 'question':

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -111,6 +111,12 @@ export type ChatMessage =
       /** Provenance of the aside label: relational (a person authored it) vs editorial (LLM-origin). */
       insideJokeKind?: InsideJokeKind | null;
       breadcrumb: string | null;
+      /**
+       * D-MISSED-RETURN-01 §6 — replaces the ordinary "Locked in." verdict when
+       * a returning question the player once missed lands correct. Distinct on
+       * purpose: this is the payoff the whole feature exists to produce.
+       */
+      returnRecoveryNote?: string | null;
       /** 0–3 index for rotating copy phrases */
       copyVariant: number;
       /** Creator display name — used in wrong-answer copy variant 2 */
@@ -1078,6 +1084,7 @@ function TypingRow() {
 function ResultRow({
   result,
   correctAnswer,
+  returnRecoveryNote = null,
   consolation,
   insideJoke,
   authorNote,
@@ -1103,6 +1110,8 @@ function ResultRow({
   insideJoke?: string | null;
   insideJokeKind?: InsideJokeKind | null;
   breadcrumb: string | null;
+  /** See the row-union note: the correct-on-return verdict (§6). */
+  returnRecoveryNote?: string | null;
   authorNote?: string | null;
   explanation?: string | null;
   copyVariant: number;
@@ -1216,7 +1225,7 @@ function ResultRow({
                 lives in the End of Session Review. */}
             <p style={{ ...verdictLabelStyle, color: 'var(--game-correct)' }}>
               <span aria-hidden>✓</span>
-              Locked in.
+              {returnRecoveryNote ?? 'Locked in.'}
             </p>
             {correctAnswer ? (
               <p
@@ -1669,6 +1678,7 @@ export function GameplayChatThread({
                 insideJoke={m.insideJoke}
                 insideJokeKind={m.insideJokeKind}
                 breadcrumb={m.breadcrumb}
+                returnRecoveryNote={m.returnRecoveryNote}
                 authorNote={m.authorNote}
                 explanation={m.explanation}
                 copyVariant={m.copyVariant}

--- a/src/components/play/__tests__/GameplayChat.bonusOffer.test.tsx
+++ b/src/components/play/__tests__/GameplayChat.bonusOffer.test.tsx
@@ -1,0 +1,151 @@
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { GameplayChatThread, type ChatMessage } from '@/components/play/GameplayChat';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('lucide-react', () => ({
+  Flag: () => <span aria-hidden="true" />,
+  MoreHorizontal: () => <span aria-hidden="true" />,
+  X: () => <span aria-hidden="true" />,
+}));
+
+function html(messages: ChatMessage[]) {
+  return renderToStaticMarkup(<GameplayChatThread messages={messages} />);
+}
+
+/**
+ * B-BONUS-OFFER-01. The regression these guard is the one Neil (and Carolyn, and
+ * Todderick) hit: with no "continue" affordance on a bonus slot, the durable
+ * category opt-out was the most forward-looking control on screen, and new
+ * players tapped it to proceed. See drizzle/0131_bonus_offer_seen_at.sql.
+ */
+describe('friend-bonus interstitial', () => {
+  it('names friends’ categories and states the points/five split', () => {
+    const markup = html([
+      {
+        id: 'bonus-offer',
+        kind: 'bonus_offer',
+        available: 2,
+        onAccept: () => {},
+        onDecline: () => {},
+      },
+    ]);
+
+    expect(markup).toContain('2 more questions from friends');
+    expect(markup).toContain('categories');
+    // Must not repeat the old "Counts toward your score" line, which contradicted
+    // D-F3 (bonus is additive and never enters the spoken X/Y).
+    expect(markup).toContain('not part of your five');
+    expect(markup).toContain('Keep going');
+    expect(markup).toContain('No thanks');
+  });
+
+  it('singularizes a lone bonus question', () => {
+    const markup = html([
+      {
+        id: 'bonus-offer',
+        kind: 'bonus_offer',
+        available: 1,
+        onAccept: () => {},
+        onDecline: () => {},
+      },
+    ]);
+
+    expect(markup).toContain('1 more question from friends');
+    expect(markup).not.toContain('1 more questions');
+  });
+});
+
+describe('bonus-slot opt-out placement', () => {
+  const bonusQuestion = (over: Partial<Extract<ChatMessage, { kind: 'question' }>> = {}) =>
+    ({
+      id: 'q-5',
+      kind: 'question',
+      assignmentId: '5',
+      questionText: 'What is a letter of marque?',
+      creatorName: null,
+      presenceSourceName: 'Joshua P',
+      presenceSourceExtraCount: 0,
+      isNew: false,
+      ...over,
+    }) as ChatMessage;
+
+  it('no longer offers the opt-out as a peer action link', () => {
+    const markup = renderToStaticMarkup(
+      <GameplayChatThread
+        messages={[bonusQuestion()]}
+        onGiveUp={() => {}}
+        onDismiss={() => {}}
+        onMutePresence={() => {}}
+      />,
+    );
+
+    // The old peer-row label led with the inviting friend's name and buried the
+    // negation at the end — that is what read as "continue".
+    expect(markup).not.toContain('bag but not mine');
+    // The genuine ways forward stay where they were.
+    expect(markup).toContain('Show me the answer');
+    expect(markup).toContain('Dismiss');
+  });
+
+  // The menu renders collapsed in static markup, so the ITEM copy ("Stop showing
+  // me this category") isn't assertable here — this repo has no DOM-interaction
+  // test setup. What is assertable, and what the regression is actually about, is
+  // that a bonus slot now routes the opt-out through a ⋯ trigger instead of a
+  // peer link (asserted above).
+  it('gives a bonus slot a ⋯ overflow to hold the demoted opt-out', () => {
+    const markup = renderToStaticMarkup(
+      <GameplayChatThread messages={[bonusQuestion()]} onMutePresence={() => {}} />,
+    );
+
+    expect(markup).toContain('More actions');
+    expect(markup).toContain('aria-haspopup="menu"');
+  });
+
+  it('renders no overflow for a non-bonus slot', () => {
+    const markup = renderToStaticMarkup(
+      <GameplayChatThread
+        messages={[bonusQuestion({ presenceSourceName: null })]}
+        onMutePresence={() => {}}
+      />,
+    );
+
+    expect(markup).not.toContain('Stop showing me this category');
+    expect(markup).not.toContain('More actions');
+  });
+});
+
+describe('rest notice', () => {
+  it('offers an undo on a rested category', () => {
+    const markup = html([
+      {
+        id: 's-5',
+        kind: 'rest_notice',
+        text: "Resting Golden Age of Piracy. You won't see these in your five.",
+        onUndo: async () => {},
+      },
+    ]);
+
+    expect(markup).toContain('Resting Golden Age of Piracy');
+    expect(markup).toContain('Undo');
+  });
+
+  it('a declined bonus slot is a plain skip with nothing to undo', () => {
+    // "No thanks" writes no preference, so the notice must not imply one was made
+    // — offering "Undo" there would suggest a rest the player never performed.
+    const markup = html([{ id: 's-5', kind: 'system', text: 'Skipped for today.' }]);
+
+    expect(markup).toContain('Skipped for today.');
+    expect(markup).not.toContain('Undo');
+    expect(markup).not.toContain('Resting');
+  });
+});

--- a/src/components/play/__tests__/GameplayChat.returnBanner.test.tsx
+++ b/src/components/play/__tests__/GameplayChat.returnBanner.test.tsx
@@ -1,0 +1,89 @@
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { GameplayChatThread, type ChatMessage } from '@/components/play/GameplayChat';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('lucide-react', () => ({
+  Flag: () => <span aria-hidden="true" />,
+  MoreHorizontal: () => <span aria-hidden="true" />,
+  X: () => <span aria-hidden="true" />,
+}));
+
+function html(messages: ChatMessage[]) {
+  return renderToStaticMarkup(<GameplayChatThread messages={messages} />);
+}
+
+function questionMessage(over: Partial<Extract<ChatMessage, { kind: 'question' }>>): ChatMessage {
+  return {
+    id: 'q1',
+    kind: 'question',
+    assignmentId: 'a1',
+    questionText: 'Which composer wrote the Goldberg Variations?',
+    creatorName: null,
+    ...over,
+  };
+}
+
+// D-MISSED-RETURN-01 R9 — the "SECOND LOOK" banner is the honest mark that keeps
+// a returning question from reading as new. It replaced a muted badge chip that
+// proved too quiet to notice: measured on a live account, four returns were
+// played across five days without the player registering any as returns.
+describe('GameplayChat returning-question banner', () => {
+  it('marks a wrong-scope return with SECOND LOOK and the date last seen', () => {
+    const rendered = html([
+      questionMessage({ returnLastSeenAt: '2026-08-03T14:00:00.000Z' }),
+    ]);
+    expect(rendered).toContain('Second look');
+    expect(rendered).toContain('LAST SEEN AUGUST 3');
+  });
+
+  it('renders NO banner when returnLastSeenAt is absent', () => {
+    // The expired scope routes here: it has never been seen by the player, so it
+    // gets no return framing at all and reads as a normal question arriving late
+    // (§2). The caller (daily/page.tsx) enforces that by passing null.
+    const rendered = html([questionMessage({})]);
+    expect(rendered).not.toContain('Second look');
+    expect(rendered).not.toContain('LAST SEEN');
+  });
+
+  it('degrades to no banner on an unparseable timestamp rather than "INVALID DATE"', () => {
+    const rendered = html([questionMessage({ returnLastSeenAt: 'not-a-date' })]);
+    expect(rendered).not.toContain('Second look');
+    expect(rendered).not.toContain('INVALID');
+  });
+
+  it('never stacks two banners — a bonus slot keeps its own attribution', () => {
+    // Bonus wins if both are somehow set, so the card can only ever grow one
+    // banner. The gold ✦ treatment stays unique to a friend's gift.
+    const rendered = html([
+      questionMessage({
+        presenceSourceName: 'Sarah Kim',
+        returnLastSeenAt: '2026-08-03T14:00:00.000Z',
+      }),
+    ]);
+    expect(rendered).toContain('Bonus item');
+    expect(rendered).toContain('FROM SARAH’S KNOWLEDGE');
+    expect(rendered).not.toContain('Second look');
+  });
+
+  it('keeps grading colors out of the mark (§1 — a return is not remediation)', () => {
+    // A red/green banner would turn an honest label into "you got this wrong".
+    // The banner is built from neutral tokens only.
+    const rendered = html([
+      questionMessage({ returnLastSeenAt: '2026-08-03T14:00:00.000Z' }),
+    ]);
+    const banner = rendered.slice(0, rendered.indexOf('Goldberg'));
+    // The grading tokens are reserved (globals.css §"Correct/wrong (grading)").
+    expect(banner).not.toContain('--game-correct');
+    expect(banner).not.toContain('--game-wrong');
+    // Gold is the friend's-gift signal and stays unique to the bonus banner.
+    expect(banner).not.toContain('--accent-gold');
+  });
+});

--- a/src/components/questions/AnsweredRowActions.tsx
+++ b/src/components/questions/AnsweredRowActions.tsx
@@ -15,13 +15,21 @@ export function AnsweredRowActions({
   target,
   surface = 'answered_list',
   onReportSubmitted,
+  extraItems,
 }: {
-  target: ReportReasonTarget;
+  // Null when the row has nothing reportable but still needs the ⋯ menu for
+  // `extraItems` (the live daily question, which passes no report target).
+  target?: ReportReasonTarget | null;
   surface?: 'round_recap' | 'lately_result' | 'answered_list' | 'catchup_thread' | 'recovered';
   // Optional: fires once on a successful report so a surface can react (e.g. the
   // round-recap hides a card reported as inappropriate, matching daily-summary).
   // The answered-list caller omits it and the menu just closes, as before.
   onReportSubmitted?: (category: 'incorrect' | 'inappropriate') => void;
+  // B-BONUS-OFFER-01: row-specific actions that belong in the overflow rather
+  // than the peer action row. Rendered above the report items, separated, so a
+  // destructive-but-rare choice (resting a category) can't be mistaken for the
+  // way forward — which is exactly how new players were misreading it.
+  extraItems?: Array<{ label: string; onSelect: () => void; disabled?: boolean }>;
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [reportCategory, setReportCategory] = useState<'incorrect' | 'inappropriate' | null>(null);
@@ -43,6 +51,9 @@ export function AnsweredRowActions({
     };
   }, [isMenuOpen]);
 
+  // Nothing to offer — render no trigger at all rather than an empty menu.
+  if (!target && !extraItems?.length) return null;
+
   return (
     <div className="relative" ref={menuRef}>
       <button
@@ -51,7 +62,7 @@ export function AnsweredRowActions({
         aria-haspopup="menu"
         aria-expanded={isMenuOpen}
         onClick={() => setIsMenuOpen((current) => !current)}
-        className="inline-flex size-9 items-center justify-center rounded-md border text-muted-foreground transition hover:bg-muted hover:text-foreground"
+        className="text-muted-foreground hover:bg-muted hover:text-foreground inline-flex size-9 items-center justify-center rounded-md border transition"
       >
         <MoreHorizontal className="size-4" />
       </button>
@@ -80,33 +91,55 @@ export function AnsweredRowActions({
                 <X className="size-4" />
               </button>
             </div>
-            <button
-              type="button"
-              role="menuitem"
-              onClick={() => {
-                setIsMenuOpen(false);
-                setReportCategory('incorrect');
-              }}
-              className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
-            >
-              This is incorrect
-            </button>
-            <button
-              type="button"
-              role="menuitem"
-              onClick={() => {
-                setIsMenuOpen(false);
-                setReportCategory('inappropriate');
-              }}
-              className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
-            >
-              This is inappropriate
-            </button>
+            {extraItems?.map((item) => (
+              <button
+                key={item.label}
+                type="button"
+                role="menuitem"
+                disabled={item.disabled}
+                onClick={() => {
+                  setIsMenuOpen(false);
+                  item.onSelect();
+                }}
+                className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition disabled:opacity-50"
+              >
+                {item.label}
+              </button>
+            ))}
+            {extraItems?.length && target ? (
+              <div className="my-1 border-t" role="separator" />
+            ) : null}
+            {target ? (
+              <>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    setReportCategory('incorrect');
+                  }}
+                  className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
+                >
+                  This is incorrect
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    setReportCategory('inappropriate');
+                  }}
+                  className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
+                >
+                  This is inappropriate
+                </button>
+              </>
+            ) : null}
           </div>
         </div>
       ) : null}
 
-      {reportCategory ? (
+      {reportCategory && target ? (
         <ReportReasonSheet
           category={reportCategory}
           target={target}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2259,6 +2259,32 @@ export async function register() {
       // Fresh databases may not have User/Question yet — migrate() creates all
       // three in normal migration order.
     }
+    // Migration 0127 (D-MISSED-RETURN-01 §3.3) adds the per-(user, question)
+    // dismiss table for the missed-question return system. The catch-up
+    // dismiss/undismiss routes dual-write it on every call and would 42P01 if
+    // the migration recorded without the table present.
+    // Self-contained; precedent: 0113's MilestoneDismissed guard above.
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "MissedReturnDismissed" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+          "questionId" text NOT NULL REFERENCES "Question"("id") ON DELETE CASCADE,
+          "dismissedAt" timestamp with time zone NOT NULL DEFAULT now(),
+          "reinstatedAt" timestamp with time zone
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "MissedReturnDismissed" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "MissedReturnDismissed_userId_idx" ON "MissedReturnDismissed" ("userId")`);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_active_unique"
+        ON "MissedReturnDismissed" ("userId", "questionId")
+        WHERE "reinstatedAt" IS NULL
+      `);
+    } catch {
+      // Fresh databases may not have User/Question yet — migrate() creates all
+      // three in normal migration order.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2349,6 +2349,18 @@ export async function register() {
     } catch {
       // Tables arrive with 0127/0128 in normal migration order.
     }
+    // Migration 0131 adds the one-shot gate for the friend-bonus interstitial.
+    // The daily-queue read selects "bonus_offer_seen_at" on every round build, so
+    // a database that recorded 0131 without the column present would 42703 on the
+    // hot path. Same additive-column shape as the DailyPreference guard above.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "User"
+        ADD COLUMN IF NOT EXISTS "bonus_offer_seen_at" timestamp with time zone
+      `);
+    } catch {
+      // User may not exist yet on a fresh database; migrate() creates it first.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2319,6 +2319,36 @@ export async function register() {
     } catch {
       // DailyPreference may not exist yet on a fresh database.
     }
+    // Migration 0130 widens the return system to LLM-generated questions, which
+    // are ~96% of the wrong answers inside the Daily Five. The eligibility query
+    // selects "generatedQuestionId" on every queue build once the flag is on and
+    // would 42703 if the migration recorded without the columns present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "MissedReturnDismissed"
+        ADD COLUMN IF NOT EXISTS "generatedQuestionId" text
+        REFERENCES "GeneratedQuestion"("id") ON DELETE CASCADE
+      `);
+      await db.execute(sql`
+        ALTER TABLE "MissedReturnState"
+        ADD COLUMN IF NOT EXISTS "generatedQuestionId" text
+        REFERENCES "GeneratedQuestion"("id") ON DELETE CASCADE
+      `);
+      await db.execute(sql`ALTER TABLE "MissedReturnDismissed" ALTER COLUMN "questionId" DROP NOT NULL`);
+      await db.execute(sql`ALTER TABLE "MissedReturnState" ALTER COLUMN "questionId" DROP NOT NULL`);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_generated_active_unique"
+        ON "MissedReturnDismissed" ("userId", "generatedQuestionId")
+        WHERE "reinstatedAt" IS NULL AND "generatedQuestionId" IS NOT NULL
+      `);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_generated_unique"
+        ON "MissedReturnState" ("userId", "generatedQuestionId")
+        WHERE "generatedQuestionId" IS NOT NULL
+      `);
+    } catch {
+      // Tables arrive with 0127/0128 in normal migration order.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2285,6 +2285,40 @@ export async function register() {
       // Fresh databases may not have User/Question yet — migrate() creates all
       // three in normal migration order.
     }
+    // Migration 0128 (D-MISSED-RETURN-01 §4) adds the per-(user, question) return
+    // state and the Customize toggle. The queue builder reads both on every build
+    // once the flag is on, and the eligibility query would 42P01/42703 if the
+    // migration recorded without them present.
+    // Self-contained; precedent: 0113's MilestoneDismissed guard above.
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "MissedReturnState" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+          "questionId" text NOT NULL REFERENCES "Question"("id") ON DELETE CASCADE,
+          "lastReturnedAt" timestamp with time zone NOT NULL DEFAULT now(),
+          "returnCount" integer NOT NULL DEFAULT 0,
+          "createdAt" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "MissedReturnState" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "MissedReturnState_userId_idx" ON "MissedReturnState" ("userId")`);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_question_unique"
+        ON "MissedReturnState" ("userId", "questionId")
+      `);
+    } catch {
+      // Fresh databases may not have User/Question yet — migrate() creates all
+      // three in normal migration order.
+    }
+    try {
+      await db.execute(sql`
+        ALTER TABLE "DailyPreference"
+        ADD COLUMN IF NOT EXISTS "missed_return_enabled" boolean NOT NULL DEFAULT true
+      `);
+    } catch {
+      // DailyPreference may not exist yet on a fresh database.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/lib/activity-types.ts
+++ b/src/lib/activity-types.ts
@@ -57,7 +57,15 @@ export type ActivityItemType =
   // this is a slow-burn delight with no volume cues; it surfaces only in the
   // full /activities list.
   | 'niche_match_answered_your_question' // author-side: a stranger correctly answered a question you authored
-  | 'niche_match_you_answered'; // answerer-side: you correctly answered a stranger's authored question
+  | 'niche_match_you_answered' // answerer-side: you correctly answered a stranger's authored question
+  // D-MISSED-RETURN-01 §7-A1. Author-side: a question you wrote came back to
+  // someone who once missed it, and this time they got it. Deliberately NOT
+  // friend_answered_your_question — that fires on any correct answer and carries
+  // no history. This one exists because the wrong→right moment is the strongest
+  // positive signal the product makes, and nothing carried it back before. Fires
+  // for the WRONG return scope only (an expired-scope return has never been seen,
+  // so there is no "it stuck" story to tell).
+  | 'missed_return_recovered';
 
 // Events surfaced in Home's top-3 RecentActivity and counted by the bell
 // badge. Light type filtering only — chronological within this set. Single

--- a/src/server/answers/answer-pipeline.ts
+++ b/src/server/answers/answer-pipeline.ts
@@ -69,6 +69,21 @@ export async function recordAnswerSideEffects(input: {
   /** Extra structured fields for the propagation-failure log line. */
   logContext?: Record<string, unknown>;
   masteryEvent: Omit<WriteMasteryEventParams, 'userId'>;
+  /**
+   * Skip ONLY the mastery-event write, keeping adaptive difficulty and
+   * propagation. Everything else in this pipeline still runs.
+   *
+   * Exists for D-MISSED-RETURN-01: MASTERY_EVENTS has
+   * unique(source_type, question_id, answered_by_user_id) and inserts `on
+   * conflict do nothing`, so the FIRST row for a (question, player) under a
+   * given source type wins forever. A return answered WRONG would take the
+   * catch-up slot with a row that records nothing new — the player was already
+   * wrong on this question — and would then block the correct answer on a LATER
+   * return (R7 allows three), losing the recovery credit and the Recovered-deck
+   * entry that actually matter. Return state itself lives in MissedReturnState,
+   * not here, so nothing is lost by not writing.
+   */
+  skipMasteryEvent?: boolean;
   /** Domain for adaptive-difficulty bookkeeping (fire-and-forget). */
   adaptiveDifficultyDomain: string;
   /**
@@ -94,7 +109,9 @@ export async function recordAnswerSideEffects(input: {
     // inviter first-five notify — is scheduled after the response below so it
     // doesn't sit on the user-blocking answer path. Uniform across every surface
     // that runs through this pipeline.
-    masteryDelta = await writeMasteryEvent({ userId: input.userId, ...input.masteryEvent, deferSideEffects: true });
+    if (!input.skipMasteryEvent) {
+      masteryDelta = await writeMasteryEvent({ userId: input.userId, ...input.masteryEvent, deferSideEffects: true });
+    }
   } catch (error) {
     console.warn(`[${input.logTag}] writeMasteryEvent failed`, error);
   }

--- a/src/server/daily/__tests__/missed-return-copy.test.ts
+++ b/src/server/daily/__tests__/missed-return-copy.test.ts
@@ -52,7 +52,6 @@ const HOME_LINE = 'Some you didn’t land will find their way back to you.';
 const CUSTOMIZE_BLURB =
   'Every so often, one question you didn’t land turns up again in your five. ' +
   'Nothing stacks up — it’s one at a time, and once you get it, it’s done.';
-const CUSTOMIZE_EXPIRED_ROW = 'never got to this one';
 
 describe('return copy stays out of the remediation register (§1, §6)', () => {
   it('the return badge names a date, not a verdict (R9)', () => {
@@ -81,7 +80,6 @@ describe('return copy stays out of the remediation register (§1, §6)', () => {
 
   it('the Customize copy explains the shape without grading anyone', () => {
     assertClean('customize blurb', CUSTOMIZE_BLURB);
-    assertClean('customize expired row', CUSTOMIZE_EXPIRED_ROW);
     // R2/R6 promised in plain language: one at a time, and it ends.
     expect(CUSTOMIZE_BLURB).toContain('one at a time');
     expect(CUSTOMIZE_BLURB).toContain('once you get it');
@@ -91,8 +89,10 @@ describe('return copy stays out of the remediation register (§1, §6)', () => {
     expect(AUTHOR_PUSH.length).toBeLessThanOrEqual(160);
   });
 
-  it('the expired scope never uses return framing (§2)', () => {
-    // "never got to this one" is a first ask arriving late, not a return.
-    expect(CUSTOMIZE_EXPIRED_ROW).not.toMatch(/\bagain\b|\bback\b|\breturn/i);
+  it('Customize is a single control, not an inventory', () => {
+    // The eligible-questions list was removed 2026-08-10 (Josh): 135 rows on a
+    // real account buried the rest of the page. The blurb now carries the whole
+    // explanation, so it has to stand on its own with nothing beneath it.
+    expect(CUSTOMIZE_BLURB).toContain('turns up again in your five');
   });
 });

--- a/src/server/daily/__tests__/missed-return-copy.test.ts
+++ b/src/server/daily/__tests__/missed-return-copy.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * D-MISSED-RETURN-01 §1/§6 — the copy register is the feature, not polish on it.
+ *
+ * "This is not remediation and must never read as it. Any copy that reads as a
+ * quiz retake, a correction, or a deficiency is a canon violation."
+ *
+ * These assert the banned vocabulary across every string this feature shows a
+ * player or an author, so a future well-meaning edit toward "helpful" phrasing
+ * fails loudly instead of quietly turning a connection event into a grade.
+ */
+
+// Words that turn the return into a test result or a deficiency. Matched
+// case-insensitively as whole words.
+const BANNED = [
+  'wrong',
+  'incorrect',
+  'failed',
+  'failure',
+  'missed',
+  'miss',
+  'retake',
+  'retry',
+  'try again',
+  'practice',
+  'review',
+  'quiz',
+  'test',
+  'correction',
+  'mistake',
+  'finally',
+  'still',
+];
+
+function assertClean(label: string, copy: string) {
+  for (const word of BANNED) {
+    const pattern = new RegExp(`\\b${word.replace(/ /g, '\\s+')}\\b`, 'i');
+    expect(pattern.test(copy), `${label} must not say "${word}" — got: ${copy}`).toBe(false);
+  }
+}
+
+// The player-facing strings, mirrored here from their render sites so a change
+// there without a change here fails the suite.
+const RETURN_BADGE = 'from March 4';
+const RECOVERY_NOTE_WITH_AUTHOR = 'It stuck. Robyn would be glad.';
+const RECOVERY_NOTE_ANON = 'It stuck.';
+const AUTHOR_PUSH =
+  'Robyn came back to one of your questions and got it. ' +
+  'Something you know is now something they know too. https://example.com/activities';
+const HOME_LINE = 'Some you didn’t land will find their way back to you.';
+const CUSTOMIZE_BLURB =
+  'Every so often, one question you didn’t land turns up again in your five. ' +
+  'Nothing stacks up — it’s one at a time, and once you get it, it’s done.';
+const CUSTOMIZE_EXPIRED_ROW = 'never got to this one';
+
+describe('return copy stays out of the remediation register (§1, §6)', () => {
+  it('the return badge names a date, not a verdict (R9)', () => {
+    assertClean('return badge', RETURN_BADGE);
+    expect(RETURN_BADGE).toMatch(/^from /);
+  });
+
+  it('the correct-on-return moment reads as connection, not achievement', () => {
+    assertClean('recovery note', RECOVERY_NOTE_WITH_AUTHOR);
+    assertClean('recovery note (anon)', RECOVERY_NOTE_ANON);
+    // The payoff must be distinct from an ordinary correct, per §6.
+    expect(RECOVERY_NOTE_WITH_AUTHOR).not.toBe('Correct');
+  });
+
+  it('the author push reports what the answerer knows, not what they got wrong', () => {
+    assertClean('author push', AUTHOR_PUSH);
+    // The sentence that lands last is about knowledge, not performance.
+    expect(AUTHOR_PUSH).toContain('now something they know');
+  });
+
+  it('the Home line claims no number and no destination (§7-E)', () => {
+    assertClean('home line', HOME_LINE);
+    expect(HOME_LINE).not.toMatch(/\d/);
+    expect(HOME_LINE.toLowerCase()).not.toContain('play');
+  });
+
+  it('the Customize copy explains the shape without grading anyone', () => {
+    assertClean('customize blurb', CUSTOMIZE_BLURB);
+    assertClean('customize expired row', CUSTOMIZE_EXPIRED_ROW);
+    // R2/R6 promised in plain language: one at a time, and it ends.
+    expect(CUSTOMIZE_BLURB).toContain('one at a time');
+    expect(CUSTOMIZE_BLURB).toContain('once you get it');
+  });
+
+  it('the author push fits one SMS segment', () => {
+    expect(AUTHOR_PUSH.length).toBeLessThanOrEqual(160);
+  });
+
+  it('the expired scope never uses return framing (§2)', () => {
+    // "never got to this one" is a first ask arriving late, not a return.
+    expect(CUSTOMIZE_EXPIRED_ROW).not.toMatch(/\bagain\b|\bback\b|\breturn/i);
+  });
+});

--- a/src/server/daily/__tests__/missed-return-recovery-write.test.ts
+++ b/src/server/daily/__tests__/missed-return-recovery-write.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import type { QueueSlot } from '@/server/daily/types';
+import { isReturnSlot } from '@/server/daily/bonus';
+
+/**
+ * Regression cover for the two defects the 2026-08-09 live walkthrough found,
+ * both of which were invisible to every other test because they are properties
+ * of a DB constraint and of a render path, not of a pure function.
+ */
+
+function slot(over: Partial<QueueSlot> = {}): QueueSlot {
+  return {
+    slot_index: 0,
+    source: 'friend',
+    domain: 'musical theater',
+    question_text: 'q?',
+    answered: false,
+    ...over,
+  } as QueueSlot;
+}
+
+/**
+ * Mirrors the call-site rule in /api/daily/answer. MASTERY_EVENTS carries
+ * unique(source_type, question_id, answered_by_user_id) and inserts `on conflict
+ * do nothing`, so a return answered under the LIVE source type collides with the
+ * player's own original wrong answer and is silently dropped — taking the
+ * recovery points and the Recovered-deck entry with it.
+ */
+function masterySourceTypeFor(s: QueueSlot): 'daily' | 'catchup' {
+  return isReturnSlot(s) ? 'catchup' : 'daily';
+}
+
+/** Mirrors the skipMasteryEvent rule at the same call site. */
+function skipsMasteryEvent(s: QueueSlot, isCorrect: boolean): boolean {
+  return isReturnSlot(s) && !isCorrect;
+}
+
+describe('a returning question writes a mastery event that actually lands', () => {
+  it('routes a return to the catch-up source type, never the live one', () => {
+    expect(masterySourceTypeFor(slot({ return_scope: 'wrong' }))).toBe('catchup');
+    expect(masterySourceTypeFor(slot({ return_scope: 'expired' }))).toBe('catchup');
+  });
+
+  it('leaves ordinary daily slots on the live source type', () => {
+    expect(masterySourceTypeFor(slot())).toBe('daily');
+    expect(masterySourceTypeFor(slot({ presence_source_id: 'u1' }))).toBe('daily');
+  });
+
+  it('does not collide with the original wrong answer', () => {
+    // The original live wrong answer occupies ('live_correct', q, player).
+    const original = { sourceType: 'daily' as const, questionId: 'q1', userId: 'u1' };
+    const theReturn = {
+      sourceType: masterySourceTypeFor(slot({ return_scope: 'wrong' })),
+      questionId: 'q1',
+      userId: 'u1',
+    };
+    const key = (e: { sourceType: string; questionId: string; userId: string }) =>
+      `${e.sourceType}:${e.questionId}:${e.userId}`;
+    expect(key(theReturn)).not.toBe(key(original));
+  });
+
+  it('skips the write on a WRONG return so a later correct one can still land', () => {
+    // R7 allows three returns. If a wrong return took the single catch-up slot,
+    // the correct answer on return #2 or #3 would be deduped away — the exact
+    // bug this guards, one step later.
+    expect(skipsMasteryEvent(slot({ return_scope: 'wrong' }), false)).toBe(true);
+    expect(skipsMasteryEvent(slot({ return_scope: 'wrong' }), true)).toBe(false);
+  });
+
+  it('never skips the write for an ordinary slot', () => {
+    expect(skipsMasteryEvent(slot(), false)).toBe(false);
+    expect(skipsMasteryEvent(slot(), true)).toBe(false);
+  });
+});
+
+/**
+ * Mirrors returnRecoveryNote in src/app/daily/page.tsx. It is derived from the
+ * PERSISTED slot, not stashed at answer time — the first attempt wrote it into
+ * `reveal_breadcrumb`, which the reveal accepts as a prop but never renders, so
+ * the payoff moment never appeared at all.
+ */
+function recoveryNote(s: QueueSlot): string | null {
+  if (s.return_scope !== 'wrong') return null;
+  const answeredCorrect = s.answer_state === 'correct' || s.catchup_answer_state === 'correct';
+  if (!answeredCorrect) return null;
+  const author = s.author_name?.trim();
+  return author ? `It stuck. ${author} would be glad.` : 'It stuck.';
+}
+
+describe('the correct-on-return acknowledgment (§6)', () => {
+  it('names the author when there is one', () => {
+    expect(
+      recoveryNote(slot({ return_scope: 'wrong', answer_state: 'correct', author_name: 'Robyn' })),
+    ).toBe('It stuck. Robyn would be glad.');
+  });
+
+  it('stands alone for an LLM-origin question with no author', () => {
+    expect(recoveryNote(slot({ return_scope: 'wrong', answer_state: 'correct' }))).toBe('It stuck.');
+  });
+
+  it('is derivable from the persisted slot, so it survives a reload', () => {
+    // No answer-time state involved: scope + verdict + author are all on the slot.
+    const persisted = slot({ return_scope: 'wrong', answer_state: 'correct', author_name: 'Joshua P' });
+    expect(recoveryNote(persisted)).toBe(recoveryNote({ ...persisted }));
+  });
+
+  it('says nothing on a wrong return', () => {
+    expect(recoveryNote(slot({ return_scope: 'wrong', answer_state: 'incorrect' }))).toBeNull();
+  });
+
+  it('says nothing for the expired scope — it was never seen, so nothing stuck', () => {
+    expect(recoveryNote(slot({ return_scope: 'expired', answer_state: 'correct' }))).toBeNull();
+  });
+
+  it('says nothing on an ordinary correct answer', () => {
+    expect(recoveryNote(slot({ answer_state: 'correct', author_name: 'Robyn' }))).toBeNull();
+  });
+});

--- a/src/server/daily/__tests__/missed-return.test.ts
+++ b/src/server/daily/__tests__/missed-return.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MISSED_RETURN_LIFETIME_CAP,
+  MISSED_RETURN_PER_SESSION_CAP,
+  rankReturnCandidates,
+  selectReturnCandidates,
+  type ReturnCandidate,
+} from '@/server/daily/missed-return';
+import { getCoreSlots, isAdditiveSlot, isBonusSlot, isReturnSlot } from '@/server/daily/bonus';
+import { canonicalPointsForAnswer } from '@/lib/game-constants';
+import {
+  CATCHUP_SURFACE_WEIGHT,
+  RECOVERY_STATE_WEIGHT,
+} from '@/server/mastery/constants';
+import { getBasePoints } from '@/server/mastery/scoring';
+import type { QueueSlot } from '@/server/daily/types';
+
+const day = (n: number) => new Date(Date.UTC(2026, 0, n));
+
+function candidate(over: Partial<ReturnCandidate> = {}): ReturnCandidate {
+  return {
+    questionId: 'q1',
+    scope: 'wrong',
+    lastSeenAt: day(1),
+    returnCount: 0,
+    ...over,
+  };
+}
+
+function slot(over: Partial<QueueSlot> = {}): QueueSlot {
+  return {
+    slot_index: 0,
+    source: 'friend',
+    domain: 'jazz',
+    question_text: 'q?',
+    answered: false,
+    ...over,
+  } as QueueSlot;
+}
+
+describe('D-MISSED-RETURN-01 — ranking and selection (§2 R2, R8)', () => {
+  it('ranks expired ahead of wrong — unseen beats re-seen', () => {
+    // The wrong one is OLDER, so only the scope rule can put expired first.
+    const ranked = rankReturnCandidates([
+      candidate({ questionId: 'wrong', scope: 'wrong', lastSeenAt: day(1) }),
+      candidate({ questionId: 'expired', scope: 'expired', lastSeenAt: day(20) }),
+    ]);
+    expect(ranked.map((c) => c.questionId)).toEqual(['expired', 'wrong']);
+  });
+
+  it('orders longest-since-last-seen first within a scope, so the backlog drains', () => {
+    const ranked = rankReturnCandidates([
+      candidate({ questionId: 'recent', lastSeenAt: day(20) }),
+      candidate({ questionId: 'oldest', lastSeenAt: day(2) }),
+      candidate({ questionId: 'middle', lastSeenAt: day(10) }),
+    ]);
+    expect(ranked.map((c) => c.questionId)).toEqual(['oldest', 'middle', 'recent']);
+  });
+
+  it('is deterministic on ties', () => {
+    const input = [
+      candidate({ questionId: 'b', lastSeenAt: day(3) }),
+      candidate({ questionId: 'a', lastSeenAt: day(3) }),
+    ];
+    expect(rankReturnCandidates(input).map((c) => c.questionId)).toEqual(['a', 'b']);
+    // Pure — the input array is not mutated.
+    expect(input.map((c) => c.questionId)).toEqual(['b', 'a']);
+  });
+
+  it('caps at ONE return per session, never two (R2)', () => {
+    const selected = selectReturnCandidates([
+      candidate({ questionId: 'a', scope: 'expired', lastSeenAt: day(1) }),
+      candidate({ questionId: 'b', scope: 'expired', lastSeenAt: day(2) }),
+      candidate({ questionId: 'c', scope: 'wrong', lastSeenAt: day(3) }),
+    ]);
+    expect(selected).toHaveLength(1);
+    expect(MISSED_RETURN_PER_SESSION_CAP).toBe(1);
+    expect(selected[0].questionId).toBe('a');
+  });
+
+  it('selects nothing from an empty candidate set', () => {
+    expect(selectReturnCandidates([])).toEqual([]);
+  });
+
+  it('caps lifetime returns at 3 (R7)', () => {
+    expect(MISSED_RETURN_LIFETIME_CAP).toBe(3);
+  });
+});
+
+describe('D-MISSED-RETURN-01 — the return slot is APPENDED, never one of the five (§2 R3)', () => {
+  it('marks a slot as a return iff it carries return_scope', () => {
+    expect(isReturnSlot(slot({ return_scope: 'wrong' }))).toBe(true);
+    expect(isReturnSlot(slot({ return_scope: 'expired' }))).toBe(true);
+    expect(isReturnSlot(slot())).toBe(false);
+  });
+
+  it('does not confuse a return slot with a +2 bonus slot', () => {
+    const returnSlot = slot({ return_scope: 'wrong' });
+    expect(isBonusSlot(returnSlot)).toBe(false);
+    expect(isAdditiveSlot(returnSlot)).toBe(true);
+
+    const bonus = slot({ presence_source_id: 'u1' });
+    expect(isReturnSlot(bonus)).toBe(false);
+    expect(isAdditiveSlot(bonus)).toBe(true);
+  });
+
+  it('keeps the core five at five when a return slot is appended', () => {
+    const slots = [
+      slot({ slot_index: 0 }),
+      slot({ slot_index: 1 }),
+      slot({ slot_index: 2 }),
+      slot({ slot_index: 3 }),
+      slot({ slot_index: 4 }),
+      slot({ slot_index: 5, presence_source_id: 'u1' }),
+      slot({ slot_index: 6, return_scope: 'wrong' }),
+    ];
+    // Six slots would mean a friend's fresh question lost its seat to a repeat.
+    expect(getCoreSlots(slots)).toHaveLength(5);
+  });
+});
+
+describe('D-MISSED-RETURN-01 §5 — the scoring table, one test per row', () => {
+  const difficulty = 'moderate' as const;
+  const liveBase = getBasePoints(difficulty, 'first_correct');
+
+  it('returning wrong → correct: RECOVERY_STATE_WEIGHT of the full live base', () => {
+    const points = canonicalPointsForAnswer({
+      difficulty,
+      answerState: 'first_correct_after_wrong',
+      catchUp: true, // what the return slot passes
+    });
+    expect(points).toBe(Math.round(liveBase * RECOVERY_STATE_WEIGHT));
+    // MAX-not-compound (D-RECOVERY-SCORING-UNIFY-01 D1): recovery REPLACES the
+    // catch-up surface weight rather than stacking to 6.25%.
+    expect(points).not.toBe(
+      Math.round(liveBase * RECOVERY_STATE_WEIGHT * CATCHUP_SURFACE_WEIGHT),
+    );
+  });
+
+  it('returning wrong → wrong again: 0', () => {
+    expect(
+      canonicalPointsForAnswer({ difficulty, answerState: 'incorrect', catchUp: true }),
+    ).toBe(0);
+  });
+
+  it('returning expired → correct: CATCHUP_SURFACE_WEIGHT, not live credit', () => {
+    const points = canonicalPointsForAnswer({
+      difficulty,
+      answerState: 'first_correct',
+      catchUp: true,
+    });
+    expect(points).toBe(Math.round(liveBase * CATCHUP_SURFACE_WEIGHT));
+    // The bug this guards: without catchUp the same answer scores FULL live
+    // credit, because the player genuinely never answered it before.
+    expect(points).not.toBe(
+      canonicalPointsForAnswer({ difficulty, answerState: 'first_correct' }),
+    );
+  });
+
+  it('returning expired → wrong: 0', () => {
+    expect(
+      canonicalPointsForAnswer({ difficulty, answerState: 'incorrect', catchUp: true }),
+    ).toBe(0);
+  });
+});

--- a/src/server/daily/__tests__/missed-return.test.ts
+++ b/src/server/daily/__tests__/missed-return.test.ts
@@ -20,6 +20,7 @@ const day = (n: number) => new Date(Date.UTC(2026, 0, n));
 
 function candidate(over: Partial<ReturnCandidate> = {}): ReturnCandidate {
   return {
+    kind: 'canonical',
     questionId: 'q1',
     scope: 'wrong',
     lastSeenAt: day(1),

--- a/src/server/daily/bonus-offer.ts
+++ b/src/server/daily/bonus-offer.ts
@@ -1,0 +1,41 @@
+import { and, eq, isNull } from 'drizzle-orm';
+
+import { db } from '@/server/db';
+import { users } from '@/server/db/schema';
+
+/**
+ * B-BONUS-OFFER-01 — the one-time friend-bonus interstitial.
+ *
+ * The +2 additive slots append past the core five with no explanation and, until
+ * this build, no "continue" affordance at all: the action row offered only
+ * "Show me the answer", "Dismiss", and the durable opt-out. New players read the
+ * opt-out as the way forward. Measured on prod 2026-08-24 — of the 7 players who
+ * ever met a bonus slot on their first session, 3 tapped the opt-out immediately
+ * (two of them on BOTH bonus slots), while no established player has ever done
+ * it on day one.
+ *
+ * So the interstitial is a FIRST-RUN EXPLAINER, not a recurring gate: it fires at
+ * most once per account and is stamped on either resolution (Josh, 2026-08-25 —
+ * "only appear once, I think it would be annoying multiple times"). After it has
+ * been seen, bonus slots flow inline exactly as they do today.
+ */
+export async function markBonusOfferSeen(userId: string): Promise<void> {
+  await db
+    .update(users)
+    .set({ bonusOfferSeenAt: new Date() })
+    .where(and(eq(users.id, userId), isNull(users.bonusOfferSeenAt)));
+}
+
+/**
+ * Has this player already been shown the interstitial? Fails CLOSED (true) if the
+ * lookup comes back empty: a missing user row should suppress a first-run
+ * explainer, never re-nag someone who has already seen it.
+ */
+export async function hasSeenBonusOffer(userId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ seenAt: users.bonusOfferSeenAt })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return row ? row.seenAt !== null : true;
+}

--- a/src/server/daily/bonus.ts
+++ b/src/server/daily/bonus.ts
@@ -35,9 +35,38 @@ export function isBonusSlot(slot: QueueSlot): boolean {
   return typeof slot.presence_source_id === 'string' && slot.presence_source_id.trim() !== '';
 }
 
-/** Core (non-bonus) slots, input order preserved. The canonical "five". */
+/**
+ * True iff the slot carries a `return_scope` (the missed-question return marker,
+ * D-MISSED-RETURN-01 §2 R3). Same opt-in rule as bonus: the marker field's
+ * presence is the truth, never position.
+ */
+export function isReturnSlot(slot: QueueSlot): boolean {
+  return slot.return_scope === 'wrong' || slot.return_scope === 'expired';
+}
+
+/**
+ * True iff the slot is APPENDED rather than part of the five — a +2 bonus slot or
+ * a missed-question return slot.
+ */
+export function isAdditiveSlot(slot: QueueSlot): boolean {
+  return isBonusSlot(slot) || isReturnSlot(slot);
+}
+
+/**
+ * Core slots, input order preserved. The canonical "five".
+ *
+ * Excludes BOTH additive kinds. A return slot appends beyond the five exactly as
+ * the +2 does (D-MISSED-RETURN-01 R3: "a friend's fresh question never loses its
+ * seat to a repeat") — counting one here would quietly make the Daily Five a six
+ * and break the D-F3 canon that the spoken count is always 5.
+ */
 export function getCoreSlots(slots: QueueSlot[]): QueueSlot[] {
-  return slots.filter((slot) => !isBonusSlot(slot));
+  return slots.filter((slot) => !isAdditiveSlot(slot));
+}
+
+/** Return slots, input order preserved. */
+export function getReturnSlots(slots: QueueSlot[]): QueueSlot[] {
+  return slots.filter(isReturnSlot);
 }
 
 /** Bonus slots, input order preserved. */

--- a/src/server/daily/missed-return-notify.ts
+++ b/src/server/daily/missed-return-notify.ts
@@ -1,0 +1,91 @@
+import { eq } from 'drizzle-orm';
+
+import { db, users } from '@/server/db';
+import { writeActivity } from '@/server/activity/write-activity';
+import { sendSms } from '@/server/sms';
+
+/**
+ * D-MISSED-RETURN-01 §7-A1 — tell the AUTHOR when a question they wrote came
+ * back to someone who once missed it and this time landed correct.
+ *
+ * "The wrong→right moment is the strongest positive signal the product generates
+ * and today nothing carries it back to the author. Full push, not just a feed
+ * entry."
+ *
+ * WHAT "PUSH" MEANS HERE (searched before building, per the build slate): there
+ * is NO web-push infrastructure in this codebase — no service worker, no
+ * PushSubscription table, no VAPID keys. The two real channels are:
+ *   - `writeActivity`  → the bell / Home activity stream (a feed entry)
+ *   - `sendSms`        → Twilio, the only actual push-to-device path
+ * So §7-A1's "full push, not just a feed entry" is satisfied by doing BOTH, with
+ * SMS as the push. Nothing new was built.
+ *
+ * Both writes are best-effort and swallow their own errors: this fires from the
+ * answer path, and an author's notification must never be able to fail a
+ * player's answer.
+ *
+ * WRONG SCOPE ONLY. An expired-scope return has never been seen by the player,
+ * so a correct answer on it is an ordinary first correct — there is no
+ * "what you taught them stuck" story to carry back, and firing for it would
+ * dilute the signal this notification exists to deliver.
+ *
+ * COPY IS A PLACEHOLDER. §6/§9 hold the copy pass as a separate gate, and Phase 4
+ * of the build slate replaces the string below verbatim from the approved pass.
+ * The register is the hard part: never "they got your question wrong then right",
+ * never a remediation framing. Reference voice is RecoveredDeck (§3.1).
+ */
+export async function notifyAuthorOfReturnRecovery(params: {
+  /** The question's author. */
+  authorUserId: string;
+  /** The player who just recovered it. */
+  answererUserId: string;
+  questionId: string;
+  /** Optional override; resolved from the answerer's profile when omitted. */
+  answererName?: string | null;
+  baseUrl?: string;
+}): Promise<void> {
+  const { authorUserId, answererUserId, questionId } = params;
+
+  // Never notify someone about their own answer.
+  if (!authorUserId || authorUserId === answererUserId) return;
+
+  await writeActivity({
+    userId: authorUserId,
+    type: 'missed_return_recovered',
+    actorUserId: answererUserId,
+    referenceId: questionId,
+    referenceType: 'question',
+  });
+
+  try {
+    const [author] = await db
+      .select({ phone: users.phoneNumber, optIn: users.smsOptIn })
+      .from(users)
+      .where(eq(users.id, authorUserId))
+      .limit(1);
+
+    if (!author?.phone || author.optIn !== 'opted_in') return;
+
+    let name = params.answererName?.trim() || '';
+    if (!name) {
+      const [answerer] = await db
+        .select({ displayName: users.displayName })
+        .from(users)
+        .where(eq(users.id, answererUserId))
+        .limit(1);
+      name = answerer?.displayName?.trim() || '';
+    }
+    if (!name) name = 'Someone';
+    const baseUrl = params.baseUrl ?? process.env.NEXT_PUBLIC_BASE_URL ?? '';
+    // PLACEHOLDER COPY — replaced wholesale in Phase 4 from the approved pass.
+    const message = `${name} came back to your question and got it. ${baseUrl}/activities`.trim();
+
+    await sendSms(author.phone, message, 'missed_return_recovered', authorUserId);
+  } catch (error) {
+    console.warn('[missed-return] author push failed', {
+      authorUserId,
+      questionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/src/server/daily/missed-return-notify.ts
+++ b/src/server/daily/missed-return-notify.ts
@@ -77,10 +77,21 @@ export async function notifyAuthorOfReturnRecovery(params: {
     }
     if (!name) name = 'Someone';
     const baseUrl = params.baseUrl ?? process.env.NEXT_PUBLIC_BASE_URL ?? '';
-    // PLACEHOLDER COPY — replaced wholesale in Phase 4 from the approved pass.
-    const message = `${name} came back to your question and got it. ${baseUrl}/activities`.trim();
+    // §6/§7-A1 — the author's side of the payoff.
+    //
+    // "Came back to" is doing deliberate work: the author DOES need to know this
+    // is the wrong→right moment (that is the entire signal §7-A1 wants carried
+    // back), but they learn it as a return rather than as their friend's failure.
+    // No "missed", "wrong", "finally", or "again" — and the sentence that lands
+    // last is about what the answerer now knows, not what they once didn't.
+    const message =
+      `${name} came back to one of your questions and got it. ` +
+      `Something you know is now something they know too. ${baseUrl}/activities`;
+    // One SMS segment. Mirrors buildDailyReminderMessage's guard rather than
+    // trusting the copy to stay short through future edits.
+    const body = message.length > 160 ? `${message.slice(0, 157)}…` : message;
 
-    await sendSms(author.phone, message, 'missed_return_recovered', authorUserId);
+    await sendSms(author.phone, body, 'missed_return_recovered', authorUserId);
   } catch (error) {
     console.warn('[missed-return] author push failed', {
       authorUserId,

--- a/src/server/daily/missed-return.ts
+++ b/src/server/daily/missed-return.ts
@@ -1,0 +1,94 @@
+/**
+ * D-MISSED-RETURN-01 — returning missed questions to the Daily Five.
+ *
+ * The framing, which governs everything here: this is NOT remediation and must
+ * never read as it. A return asks "did what your friend taught you stick?", and
+ * getting it right the second time is itself a connection event — arguably a
+ * stronger one than the original miss. Copy that reads as a quiz retake, a
+ * correction, or a deficiency is a canon violation (§1).
+ *
+ * This module is PURE — constants, the flag, and the ranking rule. The database
+ * side lives in `@/server/db/queries/missed-return`, and the dismiss state in
+ * `@/server/db/queries/missed-return-dismissed`.
+ */
+
+/** R5 — minimum days between sightings of the same question. A FLOOR, not a schedule. */
+export const MISSED_RETURN_COOLDOWN_DAYS = Math.max(
+  0,
+  Number(process.env.MISSED_RETURN_COOLDOWN_DAYS ?? 7),
+);
+
+/**
+ * R7 — lifetime cap of returns per (player, question). A question missed four
+ * times isn't teaching anything; the honest move is to let it go.
+ * Counted for the WRONG scope only (§2).
+ */
+export const MISSED_RETURN_LIFETIME_CAP = Math.max(
+  0,
+  Number(process.env.MISSED_RETURN_LIFETIME_CAP ?? 3),
+);
+
+/**
+ * R2 — at most ONE return per session. Never 2: at five questions, two returns
+ * is 40% recycled, which is a curriculum rather than a grace note.
+ */
+export const MISSED_RETURN_PER_SESSION_CAP = 1;
+
+/**
+ * Feature flag, OFF by default (§9 Phase 4 flips it). Every read path is gated
+ * on this so the feature is fully dark until the copy pass lands — §6 is explicit
+ * that the copy IS the feature here, not polish on top of it.
+ */
+export function isMissedReturnEnabled(): boolean {
+  return process.env.MISSED_RETURN_ENABLED === '1';
+}
+
+/**
+ * The two scopes are NOT treated identically (§2), because an expired question
+ * has never been seen:
+ *
+ *   wrong   — a return. Marked as one ("from March 4"), never disguised as new
+ *             (R9). Scores at RECOVERY_STATE_WEIGHT. Counts toward the 3-cap.
+ *   expired — a first ask, arriving late. NO return framing, no "again" label.
+ *             Scores at CATCHUP_SURFACE_WEIGHT. Does NOT count toward the cap.
+ */
+export type ReturnScope = 'wrong' | 'expired';
+
+export type ReturnCandidate = {
+  questionId: string;
+  scope: ReturnScope;
+  /** When the player last saw it — the wrong answer, or the queue date it expired on. */
+  lastSeenAt: Date;
+  /** Returns served so far (wrong scope only; expired first appearances don't count). */
+  returnCount: number;
+};
+
+/**
+ * R8 + §2 — ranking. Expired before wrong ("unseen beats re-seen"), and within
+ * each, longest-since-last-seen first so the backlog DRAINS rather than the same
+ * two questions cycling.
+ *
+ * Pure and total: ties break on questionId so a build is deterministic given the
+ * same candidate set.
+ */
+export function rankReturnCandidates(candidates: readonly ReturnCandidate[]): ReturnCandidate[] {
+  const scopeRank = (scope: ReturnScope) => (scope === 'expired' ? 0 : 1);
+  return [...candidates].sort((a, b) => {
+    const byScope = scopeRank(a.scope) - scopeRank(b.scope);
+    if (byScope !== 0) return byScope;
+    const byAge = a.lastSeenAt.getTime() - b.lastSeenAt.getTime(); // oldest first
+    if (byAge !== 0) return byAge;
+    return a.questionId.localeCompare(b.questionId);
+  });
+}
+
+/**
+ * The whole selection rule: rank, then take the session cap (R2). Serve-time, not
+ * render-time — §8.5 is explicit that a queue able to hold two return slots while
+ * the UI shows one will leak the second somewhere eventually.
+ */
+export function selectReturnCandidates(
+  candidates: readonly ReturnCandidate[],
+): ReturnCandidate[] {
+  return rankReturnCandidates(candidates).slice(0, MISSED_RETURN_PER_SESSION_CAP);
+}

--- a/src/server/daily/missed-return.ts
+++ b/src/server/daily/missed-return.ts
@@ -54,7 +54,23 @@ export function isMissedReturnEnabled(): boolean {
  */
 export type ReturnScope = 'wrong' | 'expired';
 
+/**
+ * Which table the question lives in. The Daily Five serves both, and a returning
+ * question must too: LLM-generated questions are ~96% of the wrong answers
+ * inside the five (measured on prod), so a canonical-only return system would
+ * almost never bring back anything the player actually missed.
+ *
+ * 'canonical'  — Question row (friend-authored, curated, or house)
+ * 'generated'  — GeneratedQuestion row (LLM-origin daily question)
+ *
+ * Mirrors the discriminated shape already used by CatchupQueueItem.reportTarget
+ * and DailyQueue.slots, which face exactly the same ambiguity.
+ */
+export type ReturnQuestionKind = 'canonical' | 'generated';
+
 export type ReturnCandidate = {
+  kind: ReturnQuestionKind;
+  /** Id within the table named by `kind` — NOT interchangeable between them. */
   questionId: string;
   scope: ReturnScope;
   /** When the player last saw it — the wrong answer, or the queue date it expired on. */
@@ -78,6 +94,9 @@ export function rankReturnCandidates(candidates: readonly ReturnCandidate[]): Re
     if (byScope !== 0) return byScope;
     const byAge = a.lastSeenAt.getTime() - b.lastSeenAt.getTime(); // oldest first
     if (byAge !== 0) return byAge;
+    // Kind is part of the tiebreak so two ids that collide across the two tables
+    // still order deterministically.
+    if (a.kind !== b.kind) return a.kind.localeCompare(b.kind);
     return a.questionId.localeCompare(b.questionId);
   });
 }

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -1087,13 +1087,15 @@ async function buildDailyQueueForUser(
       const candidates = await getEligibleReturnCandidates(userId);
       const selected = selectReturnCandidates(candidates);
       if (selected.length > 0) {
-        const questionRows = await loadReturnQuestions(selected.map((c) => c.questionId));
-        const byId = new Map(questionRows.map((q) => [q.id, q]));
+        const questionRows = await loadReturnQuestions(selected);
+        // Keyed by kind AND id: canonical and generated ids are separate
+        // namespaces and must never be looked up interchangeably.
+        const byKey = new Map(questionRows.map((q) => [`${q.kind}:${q.id}`, q]));
         const authorNames = await resolveCreatorNames(
           questionRows.map((q) => q.creatorId).filter((id): id is string => Boolean(id)),
         );
         for (const candidate of selected) {
-          const question = byId.get(candidate.questionId);
+          const question = byKey.get(`${candidate.kind}:${candidate.questionId}`);
           if (!question) continue;
           slots.push(
             buildReturnSlot(
@@ -1106,11 +1108,19 @@ async function buildDailyQueueForUser(
               position,
             ),
           );
+          // A returning GENERATED question still needs its id recorded on the
+          // queue, exactly like any other bot slot, so the persist path and the
+          // answer route resolve it the same way.
+          if (candidate.kind === 'generated') generatedQuestionIds.push(candidate.questionId);
           position += 1;
           // Serve-time, not render-time (§8.5): the state is written as the slot
           // is built, so the cap and the 7-day floor hold even if the player
           // never opens the queue.
-          await recordReturnServed(userId, candidate.questionId, candidate.scope);
+          await recordReturnServed(
+            userId,
+            { kind: candidate.kind, questionId: candidate.questionId },
+            candidate.scope,
+          );
         }
       }
     }

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -3,6 +3,8 @@ import {
   buildBotSlot,
   buildHouseSlot,
   buildPresenceSlot,
+  buildReturnSlot,
+  resolveCreatorNames,
   carryForwardUntouchedDailyQueue,
   carryForwardQueueWithSlots,
   clearStaleShortTodayQueue,
@@ -19,6 +21,16 @@ import {
   type BonusPresence,
 } from '@/server/db/queries/daily';
 import { ANSWER_COOLDOWN_DAYS, makeAnswerCooldownGate } from '@/server/daily/answer-cooldown';
+import {
+  isMissedReturnEnabled,
+  selectReturnCandidates,
+} from '@/server/daily/missed-return';
+import {
+  getEligibleReturnCandidates,
+  isMissedReturnEnabledForUser,
+  loadReturnQuestions,
+  recordReturnServed,
+} from '@/server/db/queries/missed-return';
 import { SUBJECT_COOLDOWN_DAYS, makeSubjectCooldownGate } from '@/server/daily/subject-cooldown';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { getFriendAndFoFUserIds } from '@/server/db/queries/friends';
@@ -1048,6 +1060,63 @@ async function buildDailyQueueForUser(
     }
   } catch (error) {
     console.warn('[daily/queue-orchestrator] +2 bonus / core-backfill generation failed; serving core only', {
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // D-MISSED-RETURN-01 §2 R3 — the missed-question RETURN slot, appended last.
+  //
+  // Appended, never one of the core five: a friend's fresh question must never
+  // lose its seat to a repeat. `buildReturnSlot` stamps `return_scope`, which is
+  // what keeps it out of getCoreSlots — same marker-field convention as the +2.
+  //
+  // *** DELIBERATE COOLDOWN EXEMPTION — DO NOT "FIX" THIS (§8.1) ***
+  // The answer-cooldown gate (ANSWER_COOLDOWN_DAYS = 28) and the serve-time
+  // repeat gates exist to stop a question the player already answered from
+  // reappearing. A returning question is INTENTIONALLY a repeat, so it is
+  // selected here — outside the gated core-pick loop — and never consulted
+  // against `answerCooldown`. This is narrow on purpose: it exempts only the one
+  // designated return slot, and is NOT a relaxation of the general gate. The
+  // slot's answer is likewise never `record()`ed into the gate, so a return can't
+  // suppress a legitimate core pick that happens to share its answer.
+  // The 28-day answer cooldown and the 7-day return cooldown are different axes
+  // and WILL disagree; for the return slot, the return cooldown governs.
+  try {
+    if (isMissedReturnEnabled() && (await isMissedReturnEnabledForUser(userId))) {
+      const candidates = await getEligibleReturnCandidates(userId);
+      const selected = selectReturnCandidates(candidates);
+      if (selected.length > 0) {
+        const questionRows = await loadReturnQuestions(selected.map((c) => c.questionId));
+        const byId = new Map(questionRows.map((q) => [q.id, q]));
+        const authorNames = await resolveCreatorNames(
+          questionRows.map((q) => q.creatorId).filter((id): id is string => Boolean(id)),
+        );
+        for (const candidate of selected) {
+          const question = byId.get(candidate.questionId);
+          if (!question) continue;
+          slots.push(
+            buildReturnSlot(
+              {
+                ...question,
+                authorName: question.creatorId ? authorNames.get(question.creatorId) ?? null : null,
+                difficultyEstimate: question.difficultyEstimate ?? null,
+              },
+              candidate,
+              position,
+            ),
+          );
+          position += 1;
+          // Serve-time, not render-time (§8.5): the state is written as the slot
+          // is built, so the cap and the 7-day floor hold even if the player
+          // never opens the queue.
+          await recordReturnServed(userId, candidate.questionId, candidate.scope);
+        }
+      }
+    }
+  } catch (error) {
+    // Never let the return slot cost a build — degrade to a queue without one.
+    console.warn('[daily/queue-orchestrator] missed-return slot selection failed; serving without it', {
       userId,
       error: error instanceof Error ? error.message : String(error),
     });

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -53,6 +53,29 @@ export const queueSlotSchema = z.object({
    * just "{Name}".
    */
   presence_source_extra_count: z.number().int().optional(),
+  /**
+   * Missed-question return marker (D-MISSED-RETURN-01 §2 R3). Set only on an
+   * APPENDED return slot — a canonical question the viewer previously got wrong,
+   * or one that expired unanswered and aged out of catch-up. The presence of
+   * `return_scope` is what marks a slot as a return slot, following the same
+   * marker-field convention as `presence_source_*` above rather than adding a
+   * slot-kind enum. Like a bonus slot, a return slot is ADDITIVE and never
+   * counts toward the five — see isReturnSlot / getCoreSlots in ./bonus.
+   *
+   * The two scopes are deliberately different (§2): 'wrong' is a return and must
+   * be visibly marked as one (R9, provenance canon — never disguised as new),
+   * while 'expired' has never been seen and must carry NO return framing at all;
+   * it reads as a normal question that happens to be arriving late.
+   */
+  return_scope: z.enum(['wrong', 'expired']).optional(),
+  /**
+   * The date the viewer last saw this question — the wrong answer, or the queue
+   * date it expired on. Feeds the honest return label ("from March 4", R9). ISO
+   * date string.
+   */
+  return_last_seen_at: z.string().optional(),
+  /** Which return this is (1-based) for the 'wrong' scope. Telemetry + copy. */
+  return_count: z.number().int().optional(),
   domain: z.string(),
   /** Free-text broader topic for this slot (e.g. "Saturday morning cartoons"). Optional — populated for newly built slots. */
   broad_category: z.string().nullish(),

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -686,7 +686,7 @@ export async function getGeneratedQuestionsForQueue(queue: DailyQueueRow) {
 // Resolve creator display names for a set of (possibly null/duplicate) creator
 // ids, returning a id→name map. Null/absent ids are skipped — their questions
 // are LLM-origin and the client labels them non-relationally.
-async function resolveCreatorNames(creatorIds: Array<string | null>): Promise<Map<string, string | null>> {
+export async function resolveCreatorNames(creatorIds: Array<string | null>): Promise<Map<string, string | null>> {
   const ids = [...new Set(creatorIds.filter((id): id is string => Boolean(id)))];
   if (ids.length === 0) return new Map();
   const nameRows = await db
@@ -1481,6 +1481,60 @@ export function buildAuthoredSlot(authored: AuthoredPick, position: number): Que
     difficulty_stepped_up: false,
   };
 }
+
+/**
+ * Build an APPENDED missed-question return slot (D-MISSED-RETURN-01 §2 R3).
+ *
+ * The question is an existing canonical Question the viewer previously got wrong
+ * or let expire, so this looks like an authored slot — same `source: 'friend'`,
+ * same `question_id` — plus the `return_*` markers that designate it a return and
+ * keep it out of the core five (see isReturnSlot / getCoreSlots).
+ *
+ * `return_last_seen_at` carries the honest provenance the return label needs
+ * (R9): a wrong-scope return is visibly a return, never disguised as new. The
+ * expired scope carries the field too (it is cheap and true) but its copy must
+ * NOT use return framing — it has never been seen, so it reads as a normal
+ * question arriving late (§2). That distinction is the renderer's job, on
+ * `return_scope`, and it is the highest-risk surface in this build (§6).
+ */
+export function buildReturnSlot(
+  question: ReturnSlotQuestion,
+  candidate: { scope: 'wrong' | 'expired'; lastSeenAt: Date; returnCount: number },
+  position: number,
+): QueueSlot {
+  return {
+    slot_index: position,
+    source: 'friend',
+    question_id: question.id,
+    author_id: question.creatorId ?? undefined,
+    author_name: question.authorName ?? null,
+    author_note: question.creatorNote ?? null,
+    return_scope: candidate.scope,
+    return_last_seen_at: candidate.lastSeenAt.toISOString(),
+    // 1-based: the return the player is about to see. Expired first appearances
+    // stay at 0 + 1 = 1 but never advance the stored count (§2).
+    return_count: candidate.returnCount + 1,
+    domain: question.canonicalSubcategory ?? question.broadCategory ?? question.category ?? 'general',
+    broad_category: question.broadCategory ?? null,
+    category: question.category || null,
+    question_text: question.questionText,
+    difficulty_estimate: asQueueSlotDifficulty(question.difficultyEstimate) ?? undefined,
+    answered: false,
+    difficulty_stepped_up: false,
+  };
+}
+
+export type ReturnSlotQuestion = {
+  id: string;
+  questionText: string;
+  creatorId: string | null;
+  authorName?: string | null;
+  creatorNote?: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+  category: string | null;
+  difficultyEstimate: string | null;
+};
 
 export async function createDailyQueueItemFromAuthored(
   userId: string,

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1499,16 +1499,29 @@ export function buildAuthoredSlot(authored: AuthoredPick, position: number): Que
  */
 export function buildReturnSlot(
   question: ReturnSlotQuestion,
-  candidate: { scope: 'wrong' | 'expired'; lastSeenAt: Date; returnCount: number },
+  candidate: {
+    kind: 'canonical' | 'generated';
+    scope: 'wrong' | 'expired';
+    lastSeenAt: Date;
+    returnCount: number;
+  },
   position: number,
 ): QueueSlot {
+  // The Daily Five serves both kinds and so does the return slot. A generated
+  // question is source='bot' with generated_question_id (never question_id) —
+  // getting this backwards would point the answer route at the wrong table and,
+  // for the dismiss path, violate the FK.
+  const isCanonical = candidate.kind === 'canonical';
   return {
     slot_index: position,
-    source: 'friend',
-    question_id: question.id,
-    author_id: question.creatorId ?? undefined,
-    author_name: question.authorName ?? null,
-    author_note: question.creatorNote ?? null,
+    source: isCanonical ? 'friend' : 'bot',
+    question_id: isCanonical ? question.id : undefined,
+    generated_question_id: isCanonical ? undefined : question.id,
+    // LLM-origin questions have no human author; the client renders its own
+    // non-person attribution for those rather than implying someone wrote it.
+    author_id: isCanonical ? question.creatorId ?? undefined : undefined,
+    author_name: isCanonical ? question.authorName ?? null : null,
+    author_note: isCanonical ? question.creatorNote ?? null : null,
     return_scope: candidate.scope,
     return_last_seen_at: candidate.lastSeenAt.toISOString(),
     // 1-based: the return the player is about to see. Expired first appearances

--- a/src/server/db/queries/missed-return-dismissed.ts
+++ b/src/server/db/queries/missed-return-dismissed.ts
@@ -1,0 +1,143 @@
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+
+import { db, missedReturnDismissed } from '@/server/db';
+import { pgErrorCode } from '@/server/db/pg-error';
+
+/**
+ * D-MISSED-RETURN-01 §3.3 — the per-(user, question) dismiss for the
+ * missed-question return system.
+ *
+ * Catch-up's own dismiss is SLOT-scoped (it stamps `dismissed_at` into that
+ * day's DailyQueue.slots blob, or feedItems.catchupResolvedAt). A return is by
+ * definition a new slot in a different queue, so slot-level state cannot answer
+ * "has this player waved this question off for good?". These helpers own that
+ * question.
+ *
+ * A dismiss here is NEUTRAL — it writes only this row and touches no
+ * mastery/points state, so it never reads as a wrong answer (§5).
+ *
+ * SCOPE: `questionId` is a `questions.id` (canonical questions only). LLM-origin
+ * daily questions live in `generatedQuestions` and carry no `questions.id`; they
+ * are out of this feature's scope by construction, exactly as they are out of
+ * the Recovered pool's (MASTERY_EVENTS.question_id is null for them). Callers
+ * holding a catch-up item must resolve the canonical id via `reportTarget`
+ * rather than the flat `questionId` field, which can hold either FK target.
+ *
+ * Every read is resilient to the table not existing yet: a pre-migration
+ * database returns "nothing dismissed" rather than failing the calling surface
+ * (mirrors getSetAsideQuestionIds / getDismissedDomains' 42P01 handling).
+ */
+
+/** True when the viewer has an ACTIVE dismiss on this question. */
+export async function isReturnDismissed(userId: string, questionId: string): Promise<boolean> {
+  try {
+    const [row] = await db
+      .select({ id: missedReturnDismissed.id })
+      .from(missedReturnDismissed)
+      .where(
+        and(
+          eq(missedReturnDismissed.userId, userId),
+          eq(missedReturnDismissed.questionId, questionId),
+          isNull(missedReturnDismissed.reinstatedAt),
+        ),
+      )
+      .limit(1);
+    return Boolean(row);
+  } catch (error) {
+    if (pgErrorCode(error) === '42P01') return false; // table not yet migrated
+    throw error;
+  }
+}
+
+/**
+ * The viewer's actively-dismissed question ids. The batched form the eligibility
+ * query wants — one round trip instead of one per candidate.
+ *
+ * Pass `questionIds` to bound the scan to a candidate set; omit it for the whole
+ * set (what the Customize list needs).
+ */
+export async function getReturnDismissedQuestionIds(
+  userId: string,
+  questionIds?: readonly string[],
+): Promise<Set<string>> {
+  if (questionIds && questionIds.length === 0) return new Set();
+  try {
+    const rows = await db
+      .select({ questionId: missedReturnDismissed.questionId })
+      .from(missedReturnDismissed)
+      .where(
+        and(
+          eq(missedReturnDismissed.userId, userId),
+          isNull(missedReturnDismissed.reinstatedAt),
+          ...(questionIds ? [inArray(missedReturnDismissed.questionId, [...questionIds])] : []),
+        ),
+      );
+    return new Set(rows.map((r) => r.questionId));
+  } catch (error) {
+    if (pgErrorCode(error) === '42P01') return new Set(); // table not yet migrated
+    throw error;
+  }
+}
+
+/**
+ * Record a dismiss. A no-op if one is already active — the partial unique index
+ * guarantees at most one active row per (user, question). Mirrors
+ * setAsideRecoveredQuestion.
+ *
+ * Deliberately swallows 42P01 (table not yet migrated) and 23503 (the question
+ * is not a canonical `questions.id`): this is a dual-write riding along on the
+ * existing catch-up dismiss route, and it must never be able to fail a dismiss
+ * the player already performed successfully at the slot level.
+ */
+export async function dismissMissedReturn(userId: string, questionId: string): Promise<void> {
+  try {
+    const [existing] = await db
+      .select({ id: missedReturnDismissed.id })
+      .from(missedReturnDismissed)
+      .where(
+        and(
+          eq(missedReturnDismissed.userId, userId),
+          eq(missedReturnDismissed.questionId, questionId),
+          isNull(missedReturnDismissed.reinstatedAt),
+        ),
+      )
+      .limit(1);
+
+    if (existing) return;
+
+    await db.insert(missedReturnDismissed).values({ userId, questionId });
+  } catch (error) {
+    const code = pgErrorCode(error);
+    // 23505: a concurrent dismiss won the race — the state we wanted is the
+    // state we have. 23503: not a canonical question (see SCOPE above).
+    if (code === '42P01' || code === '23503' || code === '23505') return;
+    throw error;
+  }
+}
+
+/**
+ * Reverse a dismiss, putting the question back in return rotation. A no-op if
+ * none was active. Mirrors restoreRecoveredQuestion.
+ *
+ * This backs BOTH reversal paths: the catch-up undismiss route (reversible
+ * forever, already shipped) and Phase 3's immediate toast-undo window. Same
+ * mechanism, different window — per D-doc §7-C the return surface simply never
+ * builds a browsable archive on top of it.
+ */
+export async function reinstateMissedReturn(userId: string, questionId: string): Promise<void> {
+  try {
+    await db
+      .update(missedReturnDismissed)
+      .set({ reinstatedAt: new Date() })
+      .where(
+        and(
+          eq(missedReturnDismissed.userId, userId),
+          eq(missedReturnDismissed.questionId, questionId),
+          isNull(missedReturnDismissed.reinstatedAt),
+        ),
+      );
+  } catch (error) {
+    if (pgErrorCode(error) === '42P01') return; // table not yet migrated
+    throw error;
+  }
+}

--- a/src/server/db/queries/missed-return-dismissed.ts
+++ b/src/server/db/queries/missed-return-dismissed.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray, isNull } from 'drizzle-orm';
 
 import { db, missedReturnDismissed } from '@/server/db';
 import { pgErrorCode } from '@/server/db/pg-error';
+import type { ReturnQuestionKind } from '@/server/daily/missed-return';
 
 /**
  * D-MISSED-RETURN-01 §3.3 — the per-(user, question) dismiss for the
@@ -59,20 +60,25 @@ export async function isReturnDismissed(userId: string, questionId: string): Pro
 export async function getReturnDismissedQuestionIds(
   userId: string,
   questionIds?: readonly string[],
+  kind: ReturnQuestionKind = 'canonical',
 ): Promise<Set<string>> {
   if (questionIds && questionIds.length === 0) return new Set();
+  const column =
+    kind === 'canonical' ? missedReturnDismissed.questionId : missedReturnDismissed.generatedQuestionId;
   try {
     const rows = await db
-      .select({ questionId: missedReturnDismissed.questionId })
+      .select({ questionId: column })
       .from(missedReturnDismissed)
       .where(
         and(
           eq(missedReturnDismissed.userId, userId),
           isNull(missedReturnDismissed.reinstatedAt),
-          ...(questionIds ? [inArray(missedReturnDismissed.questionId, [...questionIds])] : []),
+          ...(questionIds ? [inArray(column, [...questionIds])] : []),
         ),
       );
-    return new Set(rows.map((r) => r.questionId));
+    // Both id columns are nullable now (one per kind), so the other kind's rows
+    // come back as nulls — drop them rather than seeding the set with null.
+    return new Set(rows.map((r) => r.questionId).filter((id): id is string => id !== null));
   } catch (error) {
     if (pgErrorCode(error) === '42P01') return new Set(); // table not yet migrated
     throw error;
@@ -89,7 +95,13 @@ export async function getReturnDismissedQuestionIds(
  * existing catch-up dismiss route, and it must never be able to fail a dismiss
  * the player already performed successfully at the slot level.
  */
-export async function dismissMissedReturn(userId: string, questionId: string): Promise<void> {
+export async function dismissMissedReturn(
+  userId: string,
+  questionId: string,
+  kind: ReturnQuestionKind = 'canonical',
+): Promise<void> {
+  const column =
+    kind === 'canonical' ? missedReturnDismissed.questionId : missedReturnDismissed.generatedQuestionId;
   try {
     const [existing] = await db
       .select({ id: missedReturnDismissed.id })
@@ -97,7 +109,7 @@ export async function dismissMissedReturn(userId: string, questionId: string): P
       .where(
         and(
           eq(missedReturnDismissed.userId, userId),
-          eq(missedReturnDismissed.questionId, questionId),
+          eq(column, questionId),
           isNull(missedReturnDismissed.reinstatedAt),
         ),
       )
@@ -105,7 +117,11 @@ export async function dismissMissedReturn(userId: string, questionId: string): P
 
     if (existing) return;
 
-    await db.insert(missedReturnDismissed).values({ userId, questionId });
+    await db.insert(missedReturnDismissed).values({
+      userId,
+      questionId: kind === 'canonical' ? questionId : null,
+      generatedQuestionId: kind === 'canonical' ? null : questionId,
+    });
   } catch (error) {
     const code = pgErrorCode(error);
     // 23505: a concurrent dismiss won the race — the state we wanted is the
@@ -124,7 +140,13 @@ export async function dismissMissedReturn(userId: string, questionId: string): P
  * mechanism, different window — per D-doc §7-C the return surface simply never
  * builds a browsable archive on top of it.
  */
-export async function reinstateMissedReturn(userId: string, questionId: string): Promise<void> {
+export async function reinstateMissedReturn(
+  userId: string,
+  questionId: string,
+  kind: ReturnQuestionKind = 'canonical',
+): Promise<void> {
+  const column =
+    kind === 'canonical' ? missedReturnDismissed.questionId : missedReturnDismissed.generatedQuestionId;
   try {
     await db
       .update(missedReturnDismissed)
@@ -132,7 +154,7 @@ export async function reinstateMissedReturn(userId: string, questionId: string):
       .where(
         and(
           eq(missedReturnDismissed.userId, userId),
-          eq(missedReturnDismissed.questionId, questionId),
+          eq(column, questionId),
           isNull(missedReturnDismissed.reinstatedAt),
         ),
       );

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -9,11 +9,9 @@ import {
 } from '@/server/db';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { CATCHUP_LOOKBACK_DAYS } from '@/server/daily/catchup';
-import { resolveCreatorNames } from '@/server/db/queries/daily';
 import {
   MISSED_RETURN_COOLDOWN_DAYS,
   MISSED_RETURN_LIFETIME_CAP,
-  rankReturnCandidates,
   type ReturnCandidate,
   type ReturnQuestionKind,
   type ReturnScope,
@@ -370,56 +368,6 @@ export async function setMissedReturnEnabled(userId: string, enabled: boolean): 
       target: dailyPreferences.userId,
       set: { missedReturnEnabled: enabled, updatedAt: new Date() },
     });
-}
-
-export type ReturnListItem = {
-  kind: ReturnQuestionKind;
-  questionId: string;
-  scope: ReturnScope;
-  questionText: string;
-  category: string | null;
-  authorName: string | null;
-  lastSeenAt: Date;
-  returnCount: number;
-};
-
-/**
- * The Customize list (§7-D): every question currently eligible to return, in the
- * order they would actually be served, so what the player sees matches what the
- * queue would pick. Both scopes, since one toggle governs both (§7-B1).
- *
- * Dismissed questions are absent, not dimmed — §7-C rules out an archive view,
- * and this list is the lighter surface, not the RecoveredSetAside pattern.
- */
-export async function getReturnListForUser(userId: string): Promise<ReturnListItem[]> {
-  const candidates = await getEligibleReturnCandidates(userId);
-  if (candidates.length === 0) return [];
-
-  const ranked = rankReturnCandidates(candidates);
-  const rows = await loadReturnQuestions(ranked);
-  // Keyed by kind AND id — the two tables' ids are different namespaces and must
-  // never be looked up interchangeably.
-  const byKey = new Map(rows.map((r) => [`${r.kind}:${r.id}`, r]));
-  const authorNames = await resolveCreatorNames(
-    rows.map((r) => r.creatorId).filter((id): id is string => Boolean(id)),
-  );
-
-  return ranked.flatMap((candidate) => {
-    const question = byKey.get(`${candidate.kind}:${candidate.questionId}`);
-    if (!question) return [];
-    return [
-      {
-        kind: candidate.kind,
-        questionId: candidate.questionId,
-        scope: candidate.scope,
-        questionText: question.questionText,
-        category: question.canonicalSubcategory ?? question.broadCategory ?? null,
-        authorName: question.creatorId ? authorNames.get(question.creatorId) ?? null : null,
-        lastSeenAt: candidate.lastSeenAt,
-        returnCount: candidate.returnCount,
-      },
-    ];
-  });
 }
 
 /**

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -127,7 +127,10 @@ export async function getEligibleReturnCandidates(
         u."lastSeenAt"                     AS "lastSeenAt",
         COALESCE(s."returnCount", 0)       AS "returnCount"
       FROM unioned u
-      JOIN "Question" qq ON qq.id = u."questionId" AND qq."deletedAt" IS NULL
+      -- NOTE: Question is snake_case here ("deleted_at"), unlike the camelCase
+      -- MissedReturn* tables above. Getting this wrong raises 42703, which is
+      -- deliberately NOT swallowed below — see the catch.
+      JOIN "Question" qq ON qq.id = u."questionId" AND qq.deleted_at IS NULL
       LEFT JOIN "MissedReturnState" s
         ON s."userId" = ${userId} AND s."questionId" = u."questionId"
       WHERE u."questionId" NOT IN (SELECT "questionId" FROM ever_correct)
@@ -145,10 +148,19 @@ export async function getEligibleReturnCandidates(
       returnCount: Number(row.returnCount ?? 0),
     }));
   } catch (error) {
-    // A pre-migration database yields no candidates rather than failing the
-    // whole queue build (mirrors getSetAsideQuestionIds' 42P01 handling).
-    const code = pgErrorCode(error);
-    if (code === '42P01' || code === '42703') return [];
+    // A pre-migration database (missing MissedReturnState/MissedReturnDismissed)
+    // yields no candidates rather than failing the whole queue build — mirrors
+    // getSetAsideQuestionIds' 42P01 handling.
+    //
+    // 42703 (undefined_column) is deliberately NOT swallowed. A wrong column name
+    // in the SQL above is a CODING error, not a migration state, and swallowing
+    // it would make this function silently return [] forever — the feature would
+    // ship, the flag would flip, and no return slot would ever appear. That is
+    // exactly the "feature lands dark" failure §8.3 warns about, and it nearly
+    // happened here: Question is snake_case ("deleted_at") while the MissedReturn*
+    // tables are camelCase. The orchestrator's own try/catch still degrades the
+    // build gracefully, but it LOGS instead of failing quietly.
+    if (pgErrorCode(error) === '42P01') return [];
     throw error;
   }
 }

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -3,6 +3,7 @@ import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import {
   dailyPreferences,
   db,
+  generatedQuestions,
   missedReturnState,
   questions,
 } from '@/server/db';
@@ -14,6 +15,7 @@ import {
   MISSED_RETURN_LIFETIME_CAP,
   rankReturnCandidates,
   type ReturnCandidate,
+  type ReturnQuestionKind,
   type ReturnScope,
 } from '@/server/daily/missed-return';
 
@@ -61,14 +63,82 @@ export async function getEligibleReturnCandidates(
     );
 
     const rows = await db.execute<{
+      kind: ReturnQuestionKind;
       questionId: string;
       scope: ReturnScope;
       lastSeenAt: Date;
       returnCount: number;
     }>(sql`
       WITH
+      -- ================= GENERATED (LLM-origin) QUESTIONS =================
+      -- These live in GeneratedQuestion, and MASTERY_EVENTS.question_id is NULL
+      -- for them (the writer only ever stores eventQuestionId, which is
+      -- canonical-only). Their entire answer history exists in DailyQueue.slots
+      -- — which is exactly why catch-up sees them. Measured on prod, they are
+      -- ~96% of the wrong answers inside the Daily Five, so omitting them makes
+      -- the whole feature return almost nothing anyone actually missed.
+      gen_slots AS (
+        SELECT
+          slot->>'generated_question_id'                  AS gid,
+          COALESCE(slot->>'answered', 'false') = 'true'   AS answered,
+          slot->>'answer_state'                           AS answer_state,
+          slot->>'catchup_answer_state'                   AS catchup_answer_state,
+          slot->>'dismissed_at'                           AS dismissed_at,
+          q.queue_date::timestamptz                       AS queue_date
+        FROM "DailyQueue" q, LATERAL jsonb_array_elements(q.slots) AS slot
+        WHERE q.user_id = ${userId}
+          AND slot->>'generated_question_id' IS NOT NULL
+      ),
+      -- R6 for generated questions: a correct answer on EITHER the live round or
+      -- a later catch-up attempt retires it permanently.
+      gen_ever_correct AS (
+        SELECT DISTINCT gid FROM gen_slots
+        WHERE answer_state = 'correct' OR catchup_answer_state = 'correct'
+      ),
+      gen_wrong AS (
+        SELECT gid, max(queue_date) AS last_seen
+        FROM gen_slots
+        WHERE answered AND answer_state = 'incorrect' AND dismissed_at IS NULL
+        GROUP BY gid
+      ),
+      gen_expired AS (
+        SELECT gid, max(queue_date) AS last_seen
+        FROM gen_slots
+        WHERE NOT answered AND dismissed_at IS NULL AND queue_date < ${expiredBefore}
+        GROUP BY gid
+      ),
+      gen_dismissed AS (
+        SELECT "generatedQuestionId" AS gid FROM "MissedReturnDismissed"
+        WHERE "userId" = ${userId} AND "reinstatedAt" IS NULL
+          AND "generatedQuestionId" IS NOT NULL
+      ),
+      gen_unioned AS (
+        SELECT gid, 'wrong'::text AS scope, last_seen FROM gen_wrong
+        UNION ALL
+        SELECT gid, 'expired'::text AS scope, last_seen FROM gen_expired
+        WHERE gid NOT IN (SELECT gid FROM gen_wrong)
+      ),
+      generated_candidates AS (
+        SELECT
+          'generated'::text            AS kind,
+          g.gid                        AS "questionId",
+          g.scope                      AS scope,
+          g.last_seen                  AS "lastSeenAt",
+          COALESCE(s."returnCount", 0) AS "returnCount"
+        FROM gen_unioned g
+        JOIN "GeneratedQuestion" gq ON gq.id = g.gid
+        LEFT JOIN "MissedReturnState" s
+          ON s."userId" = ${userId} AND s."generatedQuestionId" = g.gid
+        WHERE g.gid NOT IN (SELECT gid FROM gen_ever_correct)
+          AND g.gid NOT IN (SELECT gid FROM gen_dismissed)
+          AND (s."lastReturnedAt" IS NULL OR s."lastReturnedAt" <= ${cooldownCutoff})
+          AND (g.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
+      ),
+      -- ================= CANONICAL (friend / curated) QUESTIONS =================
       -- (1a) WRONG scope: the player's most recent answer on the question was
-      -- incorrect. answered_by_user_id = user_id keeps this to answers THEY gave.
+      -- incorrect. Read from MASTERY_EVENTS rather than the slots, because a
+      -- canonical question can also be answered on the feed and milestone
+      -- surfaces, and a wrong answer there deserves to come back too.
       wrong AS (
         SELECT DISTINCT ON (me.question_id)
           me.question_id AS "questionId",
@@ -114,6 +184,7 @@ export async function getEligibleReturnCandidates(
       dismissed AS (
         SELECT "questionId" FROM "MissedReturnDismissed"
         WHERE "userId" = ${userId} AND "reinstatedAt" IS NULL
+          AND "questionId" IS NOT NULL
       ),
       -- Wrong takes precedence when a question qualifies under both: it HAS been
       -- seen, so it must carry the return framing and the 3-return cap.
@@ -122,36 +193,49 @@ export async function getEligibleReturnCandidates(
         UNION ALL
         SELECT "questionId", 'expired'::text AS scope, "lastSeenAt" FROM expired_scope
         WHERE "questionId" NOT IN (SELECT "questionId" FROM wrong_scope)
+      ),
+      canonical_candidates AS (
+        SELECT
+          'canonical'::text                  AS kind,
+          u."questionId"                     AS "questionId",
+          u.scope                            AS scope,
+          u."lastSeenAt"                     AS "lastSeenAt",
+          COALESCE(s."returnCount", 0)       AS "returnCount"
+        FROM unioned u
+        -- NOTE: Question is snake_case here ("deleted_at"), unlike the camelCase
+        -- MissedReturn* tables above. Getting this wrong raises 42703, which is
+        -- deliberately NOT swallowed below — see the catch.
+        JOIN "Question" qq ON qq.id = u."questionId" AND qq.deleted_at IS NULL
+        LEFT JOIN "MissedReturnState" s
+          ON s."userId" = ${userId} AND s."questionId" = u."questionId"
+        WHERE u."questionId" NOT IN (SELECT "questionId" FROM ever_correct)
+          AND u."questionId" NOT IN (SELECT "questionId" FROM dismissed)
+          -- (4) 7-day floor between sightings.
+          AND (s."lastReturnedAt" IS NULL OR s."lastReturnedAt" <= ${cooldownCutoff})
+          -- (3) lifetime cap, wrong scope only.
+          AND (u.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
       )
-      SELECT
-        u."questionId"                     AS "questionId",
-        u.scope                            AS scope,
-        u."lastSeenAt"                     AS "lastSeenAt",
-        COALESCE(s."returnCount", 0)       AS "returnCount"
-      FROM unioned u
-      -- NOTE: Question is snake_case here ("deleted_at"), unlike the camelCase
-      -- MissedReturn* tables above. Getting this wrong raises 42703, which is
-      -- deliberately NOT swallowed below — see the catch.
-      JOIN "Question" qq ON qq.id = u."questionId" AND qq.deleted_at IS NULL
-      LEFT JOIN "MissedReturnState" s
-        ON s."userId" = ${userId} AND s."questionId" = u."questionId"
-      WHERE u."questionId" NOT IN (SELECT "questionId" FROM ever_correct)
-        AND u."questionId" NOT IN (SELECT "questionId" FROM dismissed)
-        -- (4) 7-day floor between sightings.
-        AND (s."lastReturnedAt" IS NULL OR s."lastReturnedAt" <= ${cooldownCutoff})
-        -- (3) lifetime cap, wrong scope only.
-        AND (u.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
+      SELECT kind, "questionId", scope, "lastSeenAt", "returnCount" FROM canonical_candidates
+      UNION ALL
+      SELECT kind, "questionId", scope, "lastSeenAt", "returnCount" FROM generated_candidates
       ${limit ? sql`LIMIT ${limit}` : sql``}
     `);
 
     // db.execute returns a driver result ({ rows }) on node-postgres and a bare
     // array on some paths — read both shapes, per the house pattern in
     // domain-fragmentation.ts. Assuming either one alone throws at runtime.
-    type Row = { questionId: string; scope: ReturnScope; lastSeenAt: string | Date; returnCount: number };
+    type Row = {
+      kind: ReturnQuestionKind;
+      questionId: string;
+      scope: ReturnScope;
+      lastSeenAt: string | Date;
+      returnCount: number;
+    };
     const list =
       (rows as unknown as { rows?: Row[] }).rows ?? (rows as unknown as Row[]);
 
     return list.map((row) => ({
+      kind: row.kind,
       questionId: row.questionId,
       scope: row.scope,
       lastSeenAt: new Date(row.lastSeenAt),
@@ -226,17 +310,32 @@ export async function isMissedReturnEnabledForUser(userId: string): Promise<bool
  */
 export async function recordReturnServed(
   userId: string,
-  questionId: string,
+  target: { kind: ReturnQuestionKind; questionId: string },
   scope: ReturnScope,
   { now = new Date() }: { now?: Date } = {},
 ): Promise<void> {
   const increment = scope === 'wrong' ? 1 : 0;
+  const isCanonical = target.kind === 'canonical';
   try {
     await db
       .insert(missedReturnState)
-      .values({ userId, questionId, lastReturnedAt: now, returnCount: increment })
+      .values({
+        userId,
+        questionId: isCanonical ? target.questionId : null,
+        generatedQuestionId: isCanonical ? null : target.questionId,
+        lastReturnedAt: now,
+        returnCount: increment,
+      })
+      // The two kinds have separate partial unique indexes (migration 0130), so
+      // the conflict target has to name the matching one — a single target
+      // covering both columns would never match either index.
       .onConflictDoUpdate({
-        target: [missedReturnState.userId, missedReturnState.questionId],
+        target: isCanonical
+          ? [missedReturnState.userId, missedReturnState.questionId]
+          : [missedReturnState.userId, missedReturnState.generatedQuestionId],
+        targetWhere: isCanonical
+          ? sql`${missedReturnState.questionId} IS NOT NULL`
+          : sql`${missedReturnState.generatedQuestionId} IS NOT NULL`,
         set: {
           lastReturnedAt: now,
           returnCount: sql`${missedReturnState.returnCount} + ${increment}`,
@@ -274,6 +373,7 @@ export async function setMissedReturnEnabled(userId: string, enabled: boolean): 
 }
 
 export type ReturnListItem = {
+  kind: ReturnQuestionKind;
   questionId: string;
   scope: ReturnScope;
   questionText: string;
@@ -296,17 +396,20 @@ export async function getReturnListForUser(userId: string): Promise<ReturnListIt
   if (candidates.length === 0) return [];
 
   const ranked = rankReturnCandidates(candidates);
-  const rows = await loadReturnQuestions(ranked.map((c) => c.questionId));
-  const byId = new Map(rows.map((r) => [r.id, r]));
+  const rows = await loadReturnQuestions(ranked);
+  // Keyed by kind AND id — the two tables' ids are different namespaces and must
+  // never be looked up interchangeably.
+  const byKey = new Map(rows.map((r) => [`${r.kind}:${r.id}`, r]));
   const authorNames = await resolveCreatorNames(
     rows.map((r) => r.creatorId).filter((id): id is string => Boolean(id)),
   );
 
   return ranked.flatMap((candidate) => {
-    const question = byId.get(candidate.questionId);
+    const question = byKey.get(`${candidate.kind}:${candidate.questionId}`);
     if (!question) return [];
     return [
       {
+        kind: candidate.kind,
         questionId: candidate.questionId,
         scope: candidate.scope,
         questionText: question.questionText,
@@ -319,25 +422,77 @@ export async function getReturnListForUser(userId: string): Promise<ReturnListIt
   });
 }
 
-/** Live question text/answer for the candidates the builder decided to serve. */
-export async function loadReturnQuestions(questionIds: readonly string[]) {
-  if (questionIds.length === 0) return [];
-  return db
-    .select({
-      id: questions.id,
-      questionText: questions.questionText,
-      answerText: questions.answerText,
-      creatorId: questions.creatorId,
-      canonicalSubcategory: questions.canonicalSubcategory,
-      broadCategory: questions.broadCategory,
-      category: questions.category,
-      questionType: questions.questionType,
-      difficultyEstimate: questions.difficultyEstimate,
-      creatorNote: questions.creatorNote,
-      source: questions.source,
-    })
-    .from(questions)
-    // inArray, not `= ANY(...)`: drizzle renders a JS array in a sql template as
-    // a tuple, which Postgres rejects with 42809 against ANY().
-    .where(and(inArray(questions.id, [...questionIds]), isNull(questions.deletedAt)));
+/**
+ * Live text for the candidates the builder decided to serve, from BOTH tables.
+ *
+ * Returns one shape regardless of kind so the slot builder and the Customize
+ * list don't each re-branch. Generated questions have no author (LLM origin) and
+ * no creator note, which is why those come back null for them rather than being
+ * faked — the UI must not imply a person wrote them.
+ */
+export type LoadedReturnQuestion = {
+  kind: ReturnQuestionKind;
+  id: string;
+  questionText: string;
+  creatorId: string | null;
+  creatorNote: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+  category: string | null;
+  difficultyEstimate: string | null;
+};
+
+export async function loadReturnQuestions(
+  targets: readonly { kind: ReturnQuestionKind; questionId: string }[],
+): Promise<LoadedReturnQuestion[]> {
+  const canonicalIds = targets.filter((t) => t.kind === 'canonical').map((t) => t.questionId);
+  const generatedIds = targets.filter((t) => t.kind === 'generated').map((t) => t.questionId);
+
+  const [canonicalRows, generatedRows] = await Promise.all([
+    canonicalIds.length
+      ? db
+          .select({
+            id: questions.id,
+            questionText: questions.questionText,
+            creatorId: questions.creatorId,
+            creatorNote: questions.creatorNote,
+            canonicalSubcategory: questions.canonicalSubcategory,
+            broadCategory: questions.broadCategory,
+            category: questions.category,
+            difficultyEstimate: questions.difficultyEstimate,
+          })
+          .from(questions)
+          // inArray, not `= ANY(...)`: drizzle renders a JS array in a sql
+          // template as a tuple, which Postgres rejects with 42809 against ANY().
+          .where(and(inArray(questions.id, canonicalIds), isNull(questions.deletedAt)))
+      : Promise.resolve([]),
+    generatedIds.length
+      ? db
+          .select({
+            id: generatedQuestions.id,
+            questionText: generatedQuestions.questionText,
+            canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+            broadCategory: generatedQuestions.broadCategory,
+            difficultyEstimate: generatedQuestions.difficultyEstimate,
+          })
+          .from(generatedQuestions)
+          .where(inArray(generatedQuestions.id, generatedIds))
+      : Promise.resolve([]),
+  ]);
+
+  return [
+    ...canonicalRows.map((row) => ({ kind: 'canonical' as const, ...row, category: row.category ?? null })),
+    ...generatedRows.map((row) => ({
+      kind: 'generated' as const,
+      id: row.id,
+      questionText: row.questionText,
+      // LLM origin: no human author, no creator note. Never invent either.
+      creatorId: null,
+      creatorNote: null,
+      canonicalSubcategory: row.canonicalSubcategory,
+      broadCategory: row.broadCategory,
+      category: null,
+      difficultyEstimate: row.difficultyEstimate,
+    })),
+  ];
 }

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -1,0 +1,227 @@
+import { and, eq, sql } from 'drizzle-orm';
+
+import {
+  dailyPreferences,
+  db,
+  missedReturnState,
+  questions,
+} from '@/server/db';
+import { pgErrorCode } from '@/server/db/pg-error';
+import { CATCHUP_LOOKBACK_DAYS } from '@/server/daily/catchup';
+import {
+  MISSED_RETURN_COOLDOWN_DAYS,
+  MISSED_RETURN_LIFETIME_CAP,
+  type ReturnCandidate,
+  type ReturnScope,
+} from '@/server/daily/missed-return';
+
+/**
+ * D-MISSED-RETURN-01 §4 — return eligibility, in one query.
+ *
+ * A question is eligible to return to player P when ALL of these hold:
+ *
+ *   1. P's last answer on it was `incorrect`, OR it expired unanswered on P's
+ *      queue
+ *   2. No correct answer from P has ever been recorded on it (R6 — stop on first
+ *      correct; the question retires permanently and becomes a Recovered card)
+ *   3. returnCount < 3 (R7), counted for the WRONG scope only — an expired
+ *      question's first appearance has never been seen, so it is a first ask
+ *      arriving late, not a return (§2)
+ *   4. lastReturnedAt is null or >= 7 days ago (R5 — a FLOOR, not a schedule)
+ *   5. No active MissedReturnDismissed row for (P, question)
+ *   6. P's return toggle is on (§7-B1; absent DailyPreference row reads as ON)
+ *   7. The question is still live (not soft-deleted)
+ *
+ * SCOPE — canonical questions only. Both scopes key on `Question.id`:
+ * MASTERY_EVENTS.question_id is null for LLM-origin generated questions and a
+ * generated daily slot carries `generated_question_id` instead, so neither can
+ * produce a candidate. This matches the Recovered deck, which excludes them for
+ * the same reason, and is why the return loop's exit (§3.1) needs no new code.
+ *
+ * Ranking is NOT done here — see `rankReturnCandidates`. This returns the whole
+ * eligible set because the Customize list (Phase 3) needs it too; the queue
+ * builder takes 1 (R2).
+ */
+
+/** Rows come back pre-shaped for both consumers: the queue builder and Customize. */
+export async function getEligibleReturnCandidates(
+  userId: string,
+  { now = new Date() }: { now?: Date } = {},
+): Promise<ReturnCandidate[]> {
+  try {
+    const cooldownCutoff = new Date(
+      now.getTime() - MISSED_RETURN_COOLDOWN_DAYS * 24 * 60 * 60 * 1000,
+    );
+    // A question only counts as "expired" once it has aged out of catch-up —
+    // before that it is still reachable there and returning it would double-serve.
+    const expiredBefore = new Date(
+      now.getTime() - CATCHUP_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
+    );
+
+    const rows = await db.execute<{
+      questionId: string;
+      scope: ReturnScope;
+      lastSeenAt: Date;
+      returnCount: number;
+    }>(sql`
+      WITH
+      -- (1a) WRONG scope: the player's most recent answer on the question was
+      -- incorrect. answered_by_user_id = user_id keeps this to answers THEY gave.
+      wrong AS (
+        SELECT DISTINCT ON (me.question_id)
+          me.question_id AS "questionId",
+          me.created_at  AS "lastSeenAt"
+        FROM "MASTERY_EVENTS" me
+        WHERE me.user_id = ${userId}
+          AND me.question_id IS NOT NULL
+          AND me.answer_state IS NOT NULL
+        ORDER BY me.question_id, me.created_at DESC
+      ),
+      wrong_scope AS (
+        SELECT "questionId", "lastSeenAt" FROM wrong
+        WHERE "questionId" IN (
+          SELECT me.question_id FROM "MASTERY_EVENTS" me
+          WHERE me.user_id = ${userId}
+            AND me.question_id IS NOT NULL
+            AND me.answer_state = 'incorrect'
+        )
+      ),
+      -- (1b) EXPIRED scope: an unanswered, undismissed daily slot on a queue old
+      -- enough to have fallen out of catch-up. Canonical slots only.
+      expired_scope AS (
+        SELECT DISTINCT
+          slot->>'question_id' AS "questionId",
+          max(q.queue_date::timestamptz) OVER (PARTITION BY slot->>'question_id') AS "lastSeenAt"
+        FROM "DailyQueue" q, LATERAL jsonb_array_elements(q.slots) AS slot
+        WHERE q.user_id = ${userId}
+          AND q.queue_date::timestamptz < ${expiredBefore}
+          AND slot->>'question_id' IS NOT NULL
+          AND slot->>'generated_question_id' IS NULL
+          AND COALESCE(slot->>'answered', 'false') = 'false'
+          AND slot->>'dismissed_at' IS NULL
+      ),
+      -- (2) R6: any correct answer ever retires the question permanently.
+      ever_correct AS (
+        SELECT DISTINCT me.question_id AS "questionId"
+        FROM "MASTERY_EVENTS" me
+        WHERE me.user_id = ${userId}
+          AND me.question_id IS NOT NULL
+          AND me.answer_state IN ('first_correct', 'first_correct_after_wrong', 'repeat_correct')
+      ),
+      -- (5) An ACTIVE dismiss suppresses the question outright.
+      dismissed AS (
+        SELECT "questionId" FROM "MissedReturnDismissed"
+        WHERE "userId" = ${userId} AND "reinstatedAt" IS NULL
+      ),
+      -- Wrong takes precedence when a question qualifies under both: it HAS been
+      -- seen, so it must carry the return framing and the 3-return cap.
+      unioned AS (
+        SELECT "questionId", 'wrong'::text AS scope, "lastSeenAt" FROM wrong_scope
+        UNION ALL
+        SELECT "questionId", 'expired'::text AS scope, "lastSeenAt" FROM expired_scope
+        WHERE "questionId" NOT IN (SELECT "questionId" FROM wrong_scope)
+      )
+      SELECT
+        u."questionId"                     AS "questionId",
+        u.scope                            AS scope,
+        u."lastSeenAt"                     AS "lastSeenAt",
+        COALESCE(s."returnCount", 0)       AS "returnCount"
+      FROM unioned u
+      JOIN "Question" qq ON qq.id = u."questionId" AND qq."deletedAt" IS NULL
+      LEFT JOIN "MissedReturnState" s
+        ON s."userId" = ${userId} AND s."questionId" = u."questionId"
+      WHERE u."questionId" NOT IN (SELECT "questionId" FROM ever_correct)
+        AND u."questionId" NOT IN (SELECT "questionId" FROM dismissed)
+        -- (4) 7-day floor between sightings.
+        AND (s."lastReturnedAt" IS NULL OR s."lastReturnedAt" <= ${cooldownCutoff})
+        -- (3) lifetime cap, wrong scope only.
+        AND (u.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
+    `);
+
+    return (rows as unknown as ReturnCandidate[]).map((row) => ({
+      questionId: row.questionId,
+      scope: row.scope,
+      lastSeenAt: new Date(row.lastSeenAt),
+      returnCount: Number(row.returnCount ?? 0),
+    }));
+  } catch (error) {
+    // A pre-migration database yields no candidates rather than failing the
+    // whole queue build (mirrors getSetAsideQuestionIds' 42P01 handling).
+    const code = pgErrorCode(error);
+    if (code === '42P01' || code === '42703') return [];
+    throw error;
+  }
+}
+
+/**
+ * §7-B1/§7-F1 — the Customize toggle, default ON.
+ *
+ * A user with NO DailyPreference row reads as ENABLED. Reading the column
+ * through a plain join would make "never opened Customize" mean "opted out",
+ * silently withholding the feature from exactly the least-engaged players it is
+ * meant to reach.
+ */
+export async function isMissedReturnEnabledForUser(userId: string): Promise<boolean> {
+  try {
+    const [row] = await db
+      .select({ enabled: dailyPreferences.missedReturnEnabled })
+      .from(dailyPreferences)
+      .where(eq(dailyPreferences.userId, userId))
+      .limit(1);
+    return row ? row.enabled : true;
+  } catch (error) {
+    if (pgErrorCode(error) === '42703') return true; // column not yet migrated
+    throw error;
+  }
+}
+
+/**
+ * Record that a question was served as a return. Upserts the (user, question)
+ * row, always stamping `lastReturnedAt` (which drives the 7-day floor) and
+ * incrementing `returnCount` for the WRONG scope only (§2 — an expired
+ * question's first appearance is a first ask arriving late, not a return).
+ */
+export async function recordReturnServed(
+  userId: string,
+  questionId: string,
+  scope: ReturnScope,
+  { now = new Date() }: { now?: Date } = {},
+): Promise<void> {
+  const increment = scope === 'wrong' ? 1 : 0;
+  try {
+    await db
+      .insert(missedReturnState)
+      .values({ userId, questionId, lastReturnedAt: now, returnCount: increment })
+      .onConflictDoUpdate({
+        target: [missedReturnState.userId, missedReturnState.questionId],
+        set: {
+          lastReturnedAt: now,
+          returnCount: sql`${missedReturnState.returnCount} + ${increment}`,
+        },
+      });
+  } catch (error) {
+    if (pgErrorCode(error) === '42P01') return; // table not yet migrated
+    throw error;
+  }
+}
+
+/** Live question text/answer for the candidates the builder decided to serve. */
+export async function loadReturnQuestions(questionIds: readonly string[]) {
+  if (questionIds.length === 0) return [];
+  return db
+    .select({
+      id: questions.id,
+      questionText: questions.questionText,
+      answerText: questions.answerText,
+      creatorId: questions.creatorId,
+      canonicalSubcategory: questions.canonicalSubcategory,
+      broadCategory: questions.broadCategory,
+      category: questions.category,
+      questionType: questions.questionType,
+      difficultyEstimate: questions.difficultyEstimate,
+      creatorNote: questions.creatorNote,
+      source: questions.source,
+    })
+    .from(questions)
+    .where(and(sql`${questions.id} = ANY(${[...questionIds]})`, sql`${questions.deletedAt} IS NULL`));
+}

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -8,9 +8,11 @@ import {
 } from '@/server/db';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { CATCHUP_LOOKBACK_DAYS } from '@/server/daily/catchup';
+import { resolveCreatorNames } from '@/server/db/queries/daily';
 import {
   MISSED_RETURN_COOLDOWN_DAYS,
   MISSED_RETURN_LIFETIME_CAP,
+  rankReturnCandidates,
   type ReturnCandidate,
   type ReturnScope,
 } from '@/server/daily/missed-return';
@@ -222,6 +224,77 @@ export async function recordReturnServed(
     if (pgErrorCode(error) === '42P01') return; // table not yet migrated
     throw error;
   }
+}
+
+/**
+ * Set the Customize toggle (§7-B1). Upserts so a user who has never opened
+ * Customize (and therefore has no DailyPreference row) can still turn the
+ * feature off. Deliberately narrow — it touches ONLY this column, so it can
+ * never clobber topics, frequency, or difficulty the way a full
+ * updateDailyPreferences round-trip could.
+ *
+ * Materializing a row for a user who had none is safe, and was verified against
+ * production: the DB column defaults (difficulty 'adaptive', domain_mode
+ * 'random', empty selected_domains / domain_preference_frequency) are exactly
+ * what defaultDailyPreferences() synthesizes for a missing row, so
+ * getDailyPreferences returns the same values either way. Keep that true — if
+ * the two default sets ever diverge, this upsert silently changes behavior for
+ * anyone who touches the toggle.
+ */
+export async function setMissedReturnEnabled(userId: string, enabled: boolean): Promise<void> {
+  await db
+    .insert(dailyPreferences)
+    .values({ userId, missedReturnEnabled: enabled })
+    .onConflictDoUpdate({
+      target: dailyPreferences.userId,
+      set: { missedReturnEnabled: enabled, updatedAt: new Date() },
+    });
+}
+
+export type ReturnListItem = {
+  questionId: string;
+  scope: ReturnScope;
+  questionText: string;
+  category: string | null;
+  authorName: string | null;
+  lastSeenAt: Date;
+  returnCount: number;
+};
+
+/**
+ * The Customize list (§7-D): every question currently eligible to return, in the
+ * order they would actually be served, so what the player sees matches what the
+ * queue would pick. Both scopes, since one toggle governs both (§7-B1).
+ *
+ * Dismissed questions are absent, not dimmed — §7-C rules out an archive view,
+ * and this list is the lighter surface, not the RecoveredSetAside pattern.
+ */
+export async function getReturnListForUser(userId: string): Promise<ReturnListItem[]> {
+  const candidates = await getEligibleReturnCandidates(userId);
+  if (candidates.length === 0) return [];
+
+  const ranked = rankReturnCandidates(candidates);
+  const rows = await loadReturnQuestions(ranked.map((c) => c.questionId));
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  const authorNames = await resolveCreatorNames(
+    rows.map((r) => r.creatorId).filter((id): id is string => Boolean(id)),
+  );
+
+  return ranked.flatMap((candidate) => {
+    const question = byId.get(candidate.questionId);
+    if (!question) return [];
+    return [
+      {
+        questionId: candidate.questionId,
+        scope: candidate.scope,
+        questionText: question.questionText,
+        category: question.canonicalSubcategory ?? question.broadCategory ?? null,
+        authorName: question.creatorId ? authorNames.get(question.creatorId) ?? null : null,
+        lastSeenAt: candidate.lastSeenAt,
+        returnCount: candidate.returnCount,
+      },
+    ];
+  });
 }
 
 /** Live question text/answer for the candidates the builder decided to serve. */

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 
 import {
   dailyPreferences,
@@ -141,7 +141,14 @@ export async function getEligibleReturnCandidates(
         AND (u.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
     `);
 
-    return (rows as unknown as ReturnCandidate[]).map((row) => ({
+    // db.execute returns a driver result ({ rows }) on node-postgres and a bare
+    // array on some paths — read both shapes, per the house pattern in
+    // domain-fragmentation.ts. Assuming either one alone throws at runtime.
+    type Row = { questionId: string; scope: ReturnScope; lastSeenAt: string | Date; returnCount: number };
+    const list =
+      (rows as unknown as { rows?: Row[] }).rows ?? (rows as unknown as Row[]);
+
+    return list.map((row) => ({
       questionId: row.questionId,
       scope: row.scope,
       lastSeenAt: new Date(row.lastSeenAt),
@@ -235,5 +242,7 @@ export async function loadReturnQuestions(questionIds: readonly string[]) {
       source: questions.source,
     })
     .from(questions)
-    .where(and(sql`${questions.id} = ANY(${[...questionIds]})`, sql`${questions.deletedAt} IS NULL`));
+    // inArray, not `= ANY(...)`: drizzle renders a JS array in a sql template as
+    // a tuple, which Postgres rejects with 42809 against ANY().
+    .where(and(inArray(questions.id, [...questionIds]), isNull(questions.deletedAt)));
 }

--- a/src/server/db/queries/missed-return.ts
+++ b/src/server/db/queries/missed-return.ts
@@ -48,7 +48,7 @@ import {
 /** Rows come back pre-shaped for both consumers: the queue builder and Customize. */
 export async function getEligibleReturnCandidates(
   userId: string,
-  { now = new Date() }: { now?: Date } = {},
+  { now = new Date(), limit }: { now?: Date; limit?: number } = {},
 ): Promise<ReturnCandidate[]> {
   try {
     const cooldownCutoff = new Date(
@@ -141,6 +141,7 @@ export async function getEligibleReturnCandidates(
         AND (s."lastReturnedAt" IS NULL OR s."lastReturnedAt" <= ${cooldownCutoff})
         -- (3) lifetime cap, wrong scope only.
         AND (u.scope <> 'wrong' OR COALESCE(s."returnCount", 0) < ${MISSED_RETURN_LIFETIME_CAP})
+      ${limit ? sql`LIMIT ${limit}` : sql``}
     `);
 
     // db.execute returns a driver result ({ rows }) on node-postgres and a bare
@@ -172,6 +173,27 @@ export async function getEligibleReturnCandidates(
     if (pgErrorCode(error) === '42P01') return [];
     throw error;
   }
+}
+
+/**
+ * "Does this viewer have anything waiting to come back?" — the Home surface's
+ * question (§7-E), which needs presence, not the list.
+ *
+ * Runs the SAME eligibility query with LIMIT 1 rather than a second copy of the
+ * rule: duplicating seven conditions into a bespoke EXISTS query would guarantee
+ * the two drift apart.
+ *
+ * Measured on prod, the LIMIT is NOT much of a speed-up — the CTEs materialize
+ * before it applies, so it costs ~85-170ms either way (177-candidate account:
+ * 170ms full, and agreeing with the full query on every account tested). What it
+ * buys is bounded row transfer, and it runs inside Home's existing Promise.all,
+ * so it adds parallel time rather than serial. If Home's budget (§12.6, < 1.5s)
+ * ever gets tight, this is a real line item — cache it or fold it into an
+ * existing query rather than assuming the LIMIT makes it free.
+ */
+export async function hasEligibleReturnCandidates(userId: string): Promise<boolean> {
+  const [first] = await getEligibleReturnCandidates(userId, { limit: 1 });
+  return Boolean(first);
 }
 
 /**

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1665,15 +1665,26 @@ export const missedReturnDismissed = pgTable(
   {
     id: id(),
     userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    // Exactly ONE of these is set (DB CHECK, migration 0130), mirroring
+    // CatchupQueueItem.reportTarget and DailyQueue.slots — the two other places
+    // that carry "a question" that may live in either table.
+    questionId: text('questionId').references(() => questions.id, { onDelete: 'cascade' }),
+    generatedQuestionId: text('generatedQuestionId').references(() => generatedQuestions.id, {
+      onDelete: 'cascade',
+    }),
     dismissedAt: timestamp('dismissedAt', { withTimezone: true }).notNull().defaultNow(),
     reinstatedAt: timestamp('reinstatedAt', { withTimezone: true }),
   },
   (table) => [
     index('MissedReturnDismissed_userId_idx').on(table.userId),
+    // One ACTIVE row per (user, question) per kind. The IS NOT NULL guards
+    // matter: without them the other kind's NULL column would collide.
     uniqueIndex('missed_return_dismissed_active_unique')
       .on(table.userId, table.questionId)
-      .where(sql`${table.reinstatedAt} IS NULL`),
+      .where(sql`${table.reinstatedAt} IS NULL AND ${table.questionId} IS NOT NULL`),
+    uniqueIndex('missed_return_dismissed_generated_active_unique')
+      .on(table.userId, table.generatedQuestionId)
+      .where(sql`${table.reinstatedAt} IS NULL AND ${table.generatedQuestionId} IS NOT NULL`),
   ],
 );
 
@@ -1703,14 +1714,24 @@ export const missedReturnState = pgTable(
   {
     id: id(),
     userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    // Exactly ONE of these is set (DB CHECK, migration 0130) — see the note on
+    // MissedReturnDismissed above.
+    questionId: text('questionId').references(() => questions.id, { onDelete: 'cascade' }),
+    generatedQuestionId: text('generatedQuestionId').references(() => generatedQuestions.id, {
+      onDelete: 'cascade',
+    }),
     lastReturnedAt: timestamp('lastReturnedAt', { withTimezone: true }).notNull().defaultNow(),
     returnCount: integer('returnCount').notNull().default(0),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     index('MissedReturnState_userId_idx').on(table.userId),
-    uniqueIndex('missed_return_state_user_question_unique').on(table.userId, table.questionId),
+    uniqueIndex('missed_return_state_user_question_unique')
+      .on(table.userId, table.questionId)
+      .where(sql`${table.questionId} IS NOT NULL`),
+    uniqueIndex('missed_return_state_user_generated_unique')
+      .on(table.userId, table.generatedQuestionId)
+      .where(sql`${table.generatedQuestionId} IS NOT NULL`),
   ],
 );
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -173,6 +173,11 @@ export const smsMessageTypeEnum = pgEnum('SmsMessageType', [
   'joshing_game_progress',
   'joshing_game_complete',
   'friend_answered_question',
+  // D-MISSED-RETURN-01 §7-A1 — the author push when a question they wrote comes
+  // back to a player who once missed it and this time lands correct. The
+  // wrong→right moment is the strongest positive signal the product makes and
+  // nothing carried it back to the author before.
+  'missed_return_recovered',
 ]);
 export const answerStateEnum = pgEnum('AnswerState', [
   'first_correct',
@@ -1027,6 +1032,16 @@ export const dailyPreferences = pgTable(
       .notNull()
       .default({}),
     difficultyPreference: text('difficulty_preference').notNull().default('normal'),
+    /**
+     * D-MISSED-RETURN-01 §7-B1/§7-F1 — the single on/off toggle governing BOTH
+     * return scopes (expired + wrong) together. Default TRUE: on for everyone,
+     * existing and new alike.
+     *
+     * Read it through `isMissedReturnEnabledForUser`, never directly: a user with
+     * no DailyPreference row at all must also read as ON, and a raw join would
+     * silently make "never opened Customize" mean "opted out".
+     */
+    missedReturnEnabled: boolean('missed_return_enabled').notNull().default(true),
     updatedAt: updatedAt(),
   },
   (table) => [
@@ -1659,6 +1674,43 @@ export const missedReturnDismissed = pgTable(
     uniqueIndex('missed_return_dismissed_active_unique')
       .on(table.userId, table.questionId)
       .where(sql`${table.reinstatedAt} IS NULL`),
+  ],
+);
+
+// Per-(user, question) return state for the missed-question return system
+// (D-MISSED-RETURN-01 §4). Exactly two facts, both of which the eligibility rule
+// needs and neither of which is derivable cheaply from anything else:
+//
+//   lastReturnedAt — enforces the 7-day floor between sightings (R5). A floor,
+//                    not a schedule: nothing promises a return on day 8.
+//   returnCount    — enforces the lifetime cap of 3 (R7). A question missed four
+//                    times isn't teaching anything, so it is let go.
+//
+// One row per (userId, questionId), created on first return and updated in place
+// — this is CURRENT STATE, not an event log (MASTERY_EVENTS already keeps the
+// event history, and deriving these two values from it would mean scanning the
+// whole log per candidate on every queue build).
+//
+// Deliberately NOT tracking retirement: R6's "stop on first correct" is already
+// queryable as "has a first_correct_after_wrong event", which is the same
+// predicate the shipped Recovered deck uses. No retiredAt column (§3.1).
+//
+// Per §2, the count is incremented for the WRONG scope only — an expired
+// question's first appearance has never been seen, so it is a first ask arriving
+// late, not a return.
+export const missedReturnState = pgTable(
+  'MissedReturnState',
+  {
+    id: id(),
+    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    lastReturnedAt: timestamp('lastReturnedAt', { withTimezone: true }).notNull().defaultNow(),
+    returnCount: integer('returnCount').notNull().default(0),
+    createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('MissedReturnState_userId_idx').on(table.userId),
+    uniqueIndex('missed_return_state_user_question_unique').on(table.userId, table.questionId),
   ],
 );
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1617,6 +1617,51 @@ export const milestoneDismissed = pgTable(
   ],
 );
 
+// Per-user "don't ask me this again" for the missed-question return system
+// (D-MISSED-RETURN-01 §3.3). A reversible soft-dismiss at the QUESTION level:
+// an active row (reinstatedAt IS NULL) makes the question permanently
+// ineligible to return to the Daily Five as a return slot.
+//
+// WHY THIS EXISTS SEPARATELY from the catch-up dismiss it dual-writes with:
+// catch-up's dismiss is SLOT-scoped — it stamps `dismissed_at` into that day's
+// DailyQueue.slots JSONB, or feedItems.catchupResolvedAt. A return is by
+// definition a NEW slot in a DIFFERENT queue, so a slot-level dismiss is
+// invisible to it and a waved-off question would resurface days later. This
+// table is the (userId, questionId) state that survives across queue instances.
+//
+// WHY IT IS NOT RecoveredSetAside: same shape, OPPOSITE meaning, and the rows
+// must never be conflated (D-MISSED-RETURN-01 §3.1). RecoveredSetAside means
+// "stop showing me this in the review deck" — a question I now KNOW. This means
+// "stop asking me this" — a question I do NOT know and don't want back.
+//
+// Like MilestoneDismissed, a dismiss here is deliberately NEUTRAL: it writes
+// ONLY this row and touches nothing in mastery/points, so it never reads as a
+// wrong answer (D-MISSED-RETURN-01 §5). Undo sets reinstatedAt = now();
+// dismissing again inserts a fresh active row. Mirrors RecoveredSetAside /
+// MilestoneDismissed exactly (the partial unique index keeps at most one active
+// row per (userId, questionId)).
+//
+// Note `questionId` FKs to Question — canonical questions only. LLM-origin
+// daily questions live in GeneratedQuestion and are out of this feature's scope
+// by construction (MASTERY_EVENTS.question_id is likewise null for them, so the
+// Recovered pool excludes them too).
+export const missedReturnDismissed = pgTable(
+  'MissedReturnDismissed',
+  {
+    id: id(),
+    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    dismissedAt: timestamp('dismissedAt', { withTimezone: true }).notNull().defaultNow(),
+    reinstatedAt: timestamp('reinstatedAt', { withTimezone: true }),
+  },
+  (table) => [
+    index('MissedReturnDismissed_userId_idx').on(table.userId),
+    uniqueIndex('missed_return_dismissed_active_unique')
+      .on(table.userId, table.questionId)
+      .where(sql`${table.reinstatedAt} IS NULL`),
+  ],
+);
+
 export const friendInvitations = pgTable(
   'FriendInvitation',
   {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -246,6 +246,12 @@ export const users = pgTable(
     // the interstitial is "not now", not "never" — it must not retire the
     // standing inline RoundReminderCard, so it cannot share that column.
     reminderInterstitialSeenAt: timestamp('reminder_interstitial_seen_at', { withTimezone: true }),
+    // B-BONUS-OFFER-01: stamped the first time the friend-bonus interstitial is
+    // resolved — on BOTH "Keep going" and "No thanks" — so it fires at most once
+    // per account. The interstitial is a first-run explainer for what the +2
+    // additive slots are; after it has been seen, bonus slots simply flow inline
+    // as before. Mirrors reminderInterstitialSeenAt above (same one-shot shape).
+    bonusOfferSeenAt: timestamp('bonus_offer_seen_at', { withTimezone: true }),
     areaTopUpPromptDismissedAt: timestamp('area_top_up_prompt_dismissed_at', { withTimezone: true }),
     lastActivityBellOpenedAt: timestamp('last_activity_bell_opened_at', { withTimezone: true }),
     knowledgeCardShareToken: text('knowledge_card_share_token'),


### PR DESCRIPTION
## Summary

The +2 friend-bonus slots had no "continue" affordance — the action row offered only "Show me the answer", "Dismiss", and the durable category opt-out. New players read the opt-out as the way forward.

Measured on prod (2026-08-24/25): of the 7 players who ever met a bonus slot on their first session, 3 tapped the opt-out immediately (two of them on **both** bonus slots the same round), permanently resting a friend's category. No established player has ever done this on day one — Robyn's first rest landed ~day 30 of 40, Josh's ~day 60 of 98. Across all time, 18 of 221 bonus slots served (8.1%, 8 users) ended in a permanent domain rest.

- **Wires the previously-dead `BonusOfferRow`** as a one-time interstitial standing in place of the first bonus question: *"N more questions from friends' categories. Untimed. They earn points, but they're not part of your five."* `Keep going` / `No thanks`. Declining closes the round's bonus slots **without** resting anything — that separation is the point.
- **Gated once-ever** via new `User.bonus_offer_seen_at`, stamped on either resolution, resolved server-side so a second device can't re-show it.
- **Demoted the opt-out** out of the peer action row into the `⋯` overflow (extended `AnsweredRowActions` to carry non-report items), recopied category-first — `Stop showing me this category` — instead of leading with the friend's name.
- **Made the rest reversible**: the "Resting {category}" notice now carries an inline Undo, matching the reversibility the plain-skip path already promises.

## Migration

`drizzle/0131_bonus_offer_seen_at.sql` adds a nullable `bonus_offer_seen_at` timestamptz to `User`. Journaled, guarded in `instrumentation.ts` for cold-boot safety. **Not yet run** — needs `npm run db:migrate`.

Separately, and not part of this PR: 5 of the 18 historical rests (Neil ×2, Carolyn ×2, Todderick ×1, all first-session) look like accidental clicks from this exact bug and are candidates for a data cleanup — that's prod DML pending a separate go-ahead.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` — clean
- [x] `npm run lint` — 0 errors (4 pre-existing warnings, unrelated files)
- [x] `npx vitest run` — 305 files / 2361 tests passed, 0 failures
- [x] All six design ratchets (`check:fonts/colors/spacing/radius/zindex/typesize`) pass
- [x] New coverage: `GameplayChat.bonusOffer.test.tsx` — interstitial copy, opt-out no longer in the peer row, opt-out lives in the `⋯` overflow, rest-notice undo vs. plain-skip distinction
- [ ] Run `npm run db:migrate` before/at deploy
- [ ] Manual click-through of the interstitial + undo in a running app (not done this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Naghs1f15BBLS5ZHx8iJiQ