### PR TITLE
Add LLM cost baseline: Step 0 measurement + Step 1 runbook

### DIFF
--- a/_docs/LLM-COST-BASELINE-01.md
+++ b/_docs/LLM-COST-BASELINE-01.md
@@ -1,0 +1,230 @@
+# LLM Cost Baseline 01 — Step 0 measurement + Step 1 backstop runbook
+
+**Status:** Step 0 measured (2026-08-27). Step 1 authorized, not yet executed — Console actions pending.
+**Scope:** LLM question-supply cost only. SMS, hosting, database, monetization out of scope.
+**Reproduce:** `npx tsx -r dotenv/config scripts/llm-cost-baseline.ts --start 2026-08-10 --end 2026-08-24`
+(read-only; every query is a SELECT against prod).
+
+---
+
+## Step 0 — Baseline, 2026-08-10 → 2026-08-24
+
+### By raw scope
+
+The weekly digest folds these into seven plain-English surfaces; this is the underlying scope
+detail the cost plan asked for. Costs are ledger-derived (`estimateCostUsd` over `LlmUsageEvent`).
+
+| scope | class | calls | web searches | USD | model |
+|---|---|---:|---:|---:|---|
+| `batch-verify` | recurring | 267 | 76 | $4.8055 | Sonnet 5 |
+| `generate-questions` | recurring | 48 | 0 | $3.3763 | Sonnet 5 |
+| `domain-reference` | recurring | 4 | 9 | $0.7272 | Sonnet 5 |
+| `backfill-supply-generate` | **refill** | 3 | 0 | $0.3647 | Sonnet 5 |
+| `vet-question` | recurring | 265 | 0 | $0.3242 | Haiku 4.5 |
+| `factual-gate` | recurring | 40 | 0 | $0.3052 | Sonnet 5 |
+| `quality-gate` | recurring | 40 | 0 | $0.1487 | Haiku 4.5 |
+| `history-dedupe` | recurring | 39 | 0 | $0.0879 | Haiku 4.5 |
+| `grade` | **gameplay** | 58 | 0 | $0.0802 | Haiku 4.5 |
+| `enrich-variants` | user-triggered | 20 | 0 | $0.0698 | Sonnet 5 |
+| `salvage-propose` | user-triggered | 7 | 0 | $0.0539 | Sonnet 5 |
+| `ceremony-narrative` | commentary | 4 | 0 | $0.0513 | Sonnet 5 |
+| `ask-to-answer-judge` | recurring | 20 | 0 | $0.0222 | Haiku 4.5 |
+| `ask-to-answer-cold` | recurring | 87 | 0 | $0.0199 | Haiku 4.5 |
+| `recheck` | user-triggered | 4 | 0 | $0.0197 | Sonnet 5 |
+| `inside-joke` | commentary | 29 | 0 | $0.0186 | Haiku 4.5 |
+| `batch-dedupe` | recurring | 14 | 0 | $0.0175 | Haiku 4.5 |
+| **TOTAL** | | **949** | **85** | **$10.4928** | |
+
+By class: recurring $9.83 (93.7%) · refill $0.36 (3.5%) · user-triggered $0.14 (1.4%) ·
+gameplay $0.08 (0.8%) · commentary $0.07 (0.7%). No unclassified scopes, no unpriced models.
+
+**Why this is $10.49 and the digest said $8.86 for "the same" window.** It is not a method
+difference. `inWindow()` (`llm-cost-report.ts:213`) measures rolling hours from `now()`, so
+`readSurfaceCost(17, 3)` is a 14-day span ending at the current time of day; this table is 15
+calendar days, Aug 10 00:00 through Aug 24 23:59 UTC. Two partial days account for the gap. Future
+reports should state which convention they use.
+
+### Which background paths are actually running (60-day view)
+
+The cost plan's Step 0 asked us to name "the exact module responsible for ungrounded speculative
+refill." Answered empirically — a flag that is off produces zero ledger rows:
+
+| scope | calls | active days | first → last |
+|---|---:|---:|---|
+| `batch-verify` | 3345 | 59 | 2026-06-30 → 2026-08-27 |
+| `vet-question` | 1300 | 59 | 2026-06-29 → 2026-08-27 |
+| `generate-questions` | 468 | 57 | 2026-06-29 → 2026-08-27 |
+| `self-containment` | 4697 | **1** | 2026-07-12 (21:05 → 23:09) |
+| `backfill-supply-generate` | 74 | 15 | 2026-07-10 → **2026-08-14** |
+| `domain-reference` | 40 | 19 | 2026-07-10 → 2026-08-26 |
+| `pool-refill-generate` | 33 | 3 | 2026-06-29 → **2026-07-01** |
+
+Three findings here:
+
+1. **`SUPPLY_BACKFILL_ENABLED` is ON in prod.** The nightly demand-weighted backfill has been
+   running since 2026-07-10 (74 calls, 15 active days, last fired 2026-08-14). The
+   `supply-refill-status` note that says backfill is "OFF" is stale. It is, however, only 3.5% of
+   window spend — it is the one truly speculative path alive, and it is small.
+2. **The grounded pool-refill is dead.** `pool-refill-generate` last fired 2026-07-01.
+   `RETRIEVAL_GROUNDING_ENABLED` is effectively not on. Any Step-2 change aimed at
+   `runPoolRefill` would target a path that costs nothing today.
+3. **`self-containment` is the textbook case for the audit/steady-state split.** 4,697 calls in a
+   single two-hour window on 2026-07-12 — the name-the-source healing sweep. Blended into a
+   monthly average it would dominate and mean nothing.
+
+### Supply funnel
+
+124 GeneratedQuestion rows created in the window: 1 suppressed as duplicate, 98 verdict `ok`,
+0 demoted, 1 unverifiable, 1 not yet swept. **Reject rate 1.6%.**
+
+At an all-in $10.49 over 121 trusted questions that is **$0.087 per trusted question** — roughly
+2–3× the $0.03–0.04 figure the plan deferred. The reject rate is now low enough that cost per
+trusted question is a usable metric, which the plan assumed it was not yet.
+
+### Inventory and just-in-time generation
+
+- **976 unused, non-duplicate bank rows across 101 domains.** 56 of those 101 domains sit below
+  the stocked floor of 10 (`SUPPLY_STOCKED_FLOOR`).
+- **94% of served generated slots were generated live.** Of 83 generated slots served in the
+  window, 78 had their `GeneratedQuestion` row created within five minutes of the queue that
+  served them. All 14 queues needed at least one live generation.
+
+Those two facts sit badly together: there is inventory and the serving path is barely drawing on
+it. `pickBankSource` (`daily.ts:1976`) does reuse other users' rows, so cross-user reuse is not
+structurally blocked — the cause is not yet identified and is the thing a Step 2 would need to
+diagnose before changing anything about refill.
+
+### Denominators — the finding that reframes the plan
+
+| | |
+|---|---:|
+| Onboarded accounts | 23 |
+| Accounts that received a queue in the window | **1** |
+| Queues built | 14 |
+| Core slots answered | 70 / 70 |
+| Completed Daily Fives | 14 |
+| All-in cost per completed Daily Five | $0.75 |
+
+Weekly history confirms it is a trend, not a fluke: distinct users with a queue ran 4 → 8 → 7 → 4
+→ 2 → 4 → 1 → 1 → 3 across the last nine weeks, while total calls fell 6,282/wk (early July) to
+~420/wk now.
+
+**The plan's central premise needs restating.** It says spending "risks scaling with the number of
+topics rather than the number of players receiving value," and offers the principle that spend
+should be a function of players served. The measurement supports the principle and refutes the
+mechanism. Spend is not scaling with the taxonomy — 93.7% of it is *demand-shaped* work
+(just-in-time generation for a played queue, and the verification tail behind it). It is scaling
+with a supply pipeline calibrated for a playerbase that isn't showing up. One player received
+every Daily Five in this window, and the pipeline spent $9.83 of recurring cost around them.
+
+That also refutes a hypothesis raised in the earlier review of the plan: the daily-assignments
+cron pre-builds for all onboarded accounts in code, but it is producing ~1 queue/day in practice,
+not 23. Spend is not scaling with accounts-ever-created either.
+
+### Ledger caveats — the ledger is not a floor
+
+The plan describes the application ledger as "a known floor." It errs in both directions:
+
+- **Under-counts:** `recordLlmUsage` fires only on a successful response (`src/lib/llm.ts:335`).
+  Provider-billed timeouts and failures are invisible. This has bitten before — the 2026-07-01
+  $7.56 spike was largely unlogged timeouts.
+- **Over-counts:** `claude-sonnet-5` is priced at sticker $3/$15 in `pricing.ts:41` while Anthropic
+  bills an introductory $2/$10 through **2026-08-31**. Generation-side figures in this window read
+  roughly a third high. This corrects itself on 2026-09-01, when sticker becomes true.
+- Web-search spend **is** ledgered ($10/1k, `pricing.ts:107`) and batch runs already apply the 50%
+  token discount — neither is part of the variance.
+- Cost is derived at read time, so editing `pricing.ts` reprices all history.
+
+**Not measurable from this database:** reconciliation against Anthropic's own billing. That needs
+Console or Admin API access — see Step 1.
+
+---
+
+## Step 1 — Operational backstop (runbook)
+
+Decisions taken 2026-08-27: **$100/mo organization ceiling, $50/mo on the Joshing workspace**,
+executed by hand in Console.
+
+### The reporting-split problem
+
+Joshing and Questionable currently share one Anthropic organization **and one Default workspace**.
+That is exactly why their spend can't be separated: the Cost API reports the Default workspace as
+`workspace_id: null`, so there is no dimension to group on. Splitting requires one workspace per
+app — which also gives each its own spend limit, so Questionable can never starve Joshing's live
+grading.
+
+### Ordered checklist
+
+Do these in order. Steps 3–4 are the only ones that can break a running app; the sequence below
+keeps both apps on a valid key at all times.
+
+1. **Create two workspaces.** Console → Settings → Workspaces → Create.
+   Name them `joshing-prod` and `questionable-prod`. Record both `wrkspc_…` IDs.
+2. **Mint one API key per workspace.** Console → Settings → API keys → Create, selecting the
+   workspace as the key's scope. Do *not* delete the existing Default-workspace key yet.
+3. **Swap Joshing's key.** Set `ANTHROPIC_API_KEY` to the `joshing-prod` key in the Vercel
+   **production** environment, then redeploy. Verify with a real request — hit the app
+   cache-busted (`/login?cb=$(date +%s)`) and confirm a new `LlmUsageEvent` row lands.
+4. **Swap Questionable's key** the same way.
+5. **Revoke the old Default-workspace key** only after both apps are confirmed working. Until it
+   is revoked, anything still using it lands in the unsplittable `null` bucket.
+6. **Set spend limits.** Console → Settings → Limits.
+   - Organization: **$100/month**.
+   - `joshing-prod` workspace: **$50/month**.
+   - Leave `questionable-prod` unset (inherits the org limit) unless you want it capped tighter.
+7. **Set email notifications** at 50% and 80% of each limit. These are the actual early warning;
+   the hard limit is the backstop of last resort.
+8. **Create an Admin API key** (Console → Settings → Admin keys, `sk-ant-admin01-…`) if you want
+   the reconciliation in step 9 scripted rather than read off the Cost page.
+
+### Reconciliation query (closes the last Step 0 gap)
+
+Once the workspaces exist and an admin key is available, this is the per-app provider-side truth
+to diff against the application ledger:
+
+```bash
+curl "https://api.anthropic.com/v1/organizations/cost_report?\
+starting_at=2026-09-01T00:00:00Z&\
+ending_at=2026-09-15T00:00:00Z&\
+group_by[]=workspace_id&\
+group_by[]=description" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "x-api-key: $ANTHROPIC_ADMIN_KEY"
+```
+
+Notes that matter for reading the result: costs come back as **decimal strings in cents**; the Cost
+API is **daily granularity only**; Priority Tier spend is excluded from it (use
+`/v1/organizations/usage_report/messages` for that); and `1d` buckets are capped at **31 per
+request**, so a monthly pull is one page but a quarterly one needs pagination.
+
+The difference between that figure and `scripts/llm-cost-baseline.ts` for the same span is the
+plan's "unledgered variance." Expect it to be non-zero in both directions until 2026-09-01, when
+the Sonnet 5 introductory price ends and the ledger's sticker pricing becomes correct.
+
+### What Step 1 deliberately does not do
+
+The ceiling is a safety net, not the cost-control mechanism. It cannot distinguish background
+supply from live grading — if it trips, gameplay stops too. That is the argument for the
+application-level background budget the plan defers to Step 2, and the reason the org ceiling is
+set at ~5× measured spend rather than close to it.
+
+---
+
+## What Step 2 should reconsider
+
+Not authorized here; recorded so the measurement isn't re-derived later.
+
+1. **The refill target is small and partly already dead.** Speculative background refill is 3.5%
+   of spend, and the grounded path hasn't run since July. A Step 2 scoped to "make refill obey the
+   finite-set target" would address ~$0.36 per two weeks.
+2. **The real question is the 94% JIT rate against 976 unused bank rows.** If serving drew on
+   existing stock, generation and its verification tail — 78% of window spend between them —
+   would both fall. That is a serving-path question, not a refill-policy question.
+3. **`batch-verify` is the single largest line at 46%**, and it runs daily on everything generated.
+   Its cost is a function of generation volume, so it moves with (2) rather than needing its own
+   intervention.
+4. **Cost per trusted question is now available** ($0.087, 1.6% reject rate) — the plan deferred
+   this metric on the assumption reject-rate data didn't exist. It does.
+5. **Demand, not supply, is the denominator problem.** At one active player, no supply-side
+   optimization changes the shape of the cost curve much. This is a product observation, not a
+   cost one, but it is what the numbers say.

--- a/_docs/LLM-COST-BASELINE-01.md
+++ b/_docs/LLM-COST-BASELINE-01.md
@@ -158,24 +158,23 @@ grading.
 Do these in order. Steps 3–4 are the only ones that can break a running app; the sequence below
 keeps both apps on a valid key at all times.
 
-1. **Create two workspaces.** Console → Settings → Workspaces → Create.
-   Name them `joshing-prod` and `questionable-prod`. Record both `wrkspc_…` IDs.
-2. **Mint one API key per workspace.** Console → Settings → API keys → Create, selecting the
-   workspace as the key's scope. Do *not* delete the existing Default-workspace key yet.
-3. **Swap Joshing's key.** Set `ANTHROPIC_API_KEY` to the `joshing-prod` key in the Vercel
-   **production** environment, then redeploy. Verify with a real request — hit the app
-   cache-busted (`/login?cb=$(date +%s)`) and confirm a new `LlmUsageEvent` row lands.
-4. **Swap Questionable's key** the same way.
-5. **Revoke the old Default-workspace key** only after both apps are confirmed working. Until it
-   is revoked, anything still using it lands in the unsplittable `null` bucket.
-6. **Set spend limits.** Console → Settings → Limits.
-   - Organization: **$100/month**.
-   - `joshing-prod` workspace: **$50/month**.
-   - Leave `questionable-prod` unset (inherits the org limit) unless you want it capped tighter.
-7. **Set email notifications** at 50% and 80% of each limit. These are the actual early warning;
-   the hard limit is the backstop of last resort.
-8. **Create an Admin API key** (Console → Settings → Admin keys, `sk-ant-admin01-…`) if you want
-   the reconciliation in step 9 scripted rather than read off the Cost page.
+**Status as of 2026-08-27: steps 1–7 DONE (Josh, in Console). Step 8 OUTSTANDING** — it blocks
+nothing today, but it's a hard prerequisite for the 2026-09-16 reconciliation (a scheduled cloud
+agent will prompt for it then; see that section below). Do it anytime before then.
+
+1. ✅ **Create two workspaces.** Console → Settings → Workspaces → Create.
+   Named `joshing-prod` and `questionable-prod`.
+2. ✅ **Mint one API key per workspace.** Console → Settings → API keys → Create, selecting the
+   workspace as the key's scope.
+3. ✅ **Swap Joshing's key.** `ANTHROPIC_API_KEY` set to the `joshing-prod` key in Vercel
+   production, redeployed. Confirmed working: `LlmUsageEvent` rows keep landing post-swap with no
+   gap (checked 2026-08-27, most recent call 19:27 UTC that day).
+4. ✅ **Swap Questionable's key** the same way.
+5. ✅ **Revoke the old Default-workspace key.**
+6. ✅ **Set spend limits.** Organization $100/month; `joshing-prod` workspace $50/month.
+7. ✅ **Set email notifications** at 50% and 80% of each limit.
+8. ⬜ **Create an Admin API key** (Console → Settings → Admin keys, `sk-ant-admin01-…`) — needed
+   for the reconciliation query below. Not yet done.
 
 ### Reconciliation query (closes the last Step 0 gap)
 

--- a/scripts/llm-cost-baseline.ts
+++ b/scripts/llm-cost-baseline.ts
@@ -1,0 +1,429 @@
+// Step 0 baseline for the LLM cost transition — READ-ONLY.
+//
+// The weekly digest (src/server/db/queries/llm-cost-report.ts) rolls raw
+// LlmUsageEvent.scope strings up into seven plain-English surfaces. That is the
+// right shape for a human skim and the wrong shape for a cost decision: the
+// "Fact-checking questions" surface alone folds seven scopes spanning new-question
+// verification, post-hoc rechecks, audits, and ask-to-answer. This script reports
+// the RAW scopes, classifies each as recurring / gameplay / non-recurring, and
+// prints the supply-side denominators the classification needs to mean anything.
+//
+// It answers Step 0 of the cost plan except the one part no query can reach:
+// reconciliation against Anthropic's own billing. See "ledger caveats" in the
+// output for the two known directions of drift.
+//
+// Usage (DATABASE_URL in .env is prod — every query here is a SELECT):
+//   npx tsx -r dotenv/config scripts/llm-cost-baseline.ts
+//   npx tsx -r dotenv/config scripts/llm-cost-baseline.ts --start 2026-08-10 --end 2026-08-24
+//   ...add --json for machine-readable output.
+import 'dotenv/config';
+
+import { pool } from '../src/server/db';
+import { MODEL_PRICING, estimateCostUsd } from '../src/server/llm/pricing';
+
+const argv = process.argv.slice(2);
+const flag = (name: string): string | undefined => {
+  const i = argv.indexOf(name);
+  return i === -1 || i + 1 >= argv.length ? undefined : argv[i + 1];
+};
+const asJson = argv.includes('--json');
+
+// Default window: the trailing 14 days, which is what the digest reports on.
+const end = flag('--end') ?? new Date().toISOString().slice(0, 10);
+const start =
+  flag('--start') ??
+  new Date(Date.parse(`${end}T00:00:00Z`) - 13 * 86_400_000).toISOString().slice(0, 10);
+
+/**
+ * Decision A of the plan: every dollar must land in exactly one of these, and
+ * "recurring" must not silently absorb work that only happens once.
+ *
+ * `recurring`     — steady-state cost of maintaining supply for the players we have.
+ * `gameplay`      — the marginal cost of serving/grading a question already made.
+ * `onboarding`    — per-new-player cost; recurring only while we are adding players.
+ * `commentary`    — per-answer prose (asides, explainers, breadcrumbs).
+ * `non-recurring` — audits, healing sweeps, migrations, backfills. Reported apart.
+ * `user-triggered`— a human pressed something (recheck, salvage, ask-to-answer).
+ * `admin`         — internal tooling: dashboards, proposals, diagnostics.
+ *
+ * A scope missing from this map falls into `UNCLASSIFIED` and is printed loudly
+ * rather than folded into a bucket — the same fail-loud posture as the digest's
+ * "Other / unmapped".
+ */
+const SCOPE_CLASS: Record<string, string> = {
+  // Steady-state supply.
+  'generate-questions': 'recurring',
+  'quality-gate': 'recurring',
+  'factual-gate': 'recurring',
+  critique: 'recurring',
+  difficulty: 'recurring',
+  'batch-dedupe': 'recurring',
+  'history-dedupe': 'recurring',
+  'vet-question': 'recurring',
+  'batch-verify': 'recurring',
+  'domain-reference': 'recurring',
+  'ask-to-answer-cold': 'recurring',
+  'ask-to-answer-judge': 'recurring',
+
+  // Background refill — recurring IF the flags are on. Broken out separately in
+  // the report because whether these fired at all is the plan's open question.
+  'pool-refill-generate': 'refill',
+  'backfill-supply-generate': 'refill',
+
+  // Player-facing.
+  grade: 'gameplay',
+  explainer: 'commentary',
+  'reflection-explainer': 'commentary',
+  'inside-joke': 'commentary',
+  breadcrumb: 'commentary',
+  'ceremony-narrative': 'commentary',
+
+  // Per-new-player.
+  'interests-answerability': 'onboarding',
+  'interests-canonicalize': 'onboarding',
+  'interests-categorize-domain': 'onboarding',
+  'interests-expand': 'onboarding',
+  'interests-proofread': 'onboarding',
+  'interests-suggest': 'onboarding',
+  'interests-suggest-adjacent': 'onboarding',
+  'interests-suggest-broader': 'onboarding',
+
+  // Deliberate, non-steady-state work.
+  'self-containment': 'non-recurring',
+  'audit:gate': 'non-recurring',
+  'fill-rich-generate': 'non-recurring',
+  'hamlet-ab-generate': 'non-recurring',
+  'node-weight-depth': 'non-recurring',
+  'mastery-threshold-points': 'non-recurring',
+
+  // Someone pressed a button.
+  recheck: 'user-triggered',
+  'salvage-propose': 'user-triggered',
+  'enrich-variants': 'user-triggered',
+  'questions-suggest-verify': 'user-triggered',
+  'crafter-draft': 'user-triggered',
+  multitudes: 'user-triggered',
+
+  // Internal tooling.
+  'prompt-proposal': 'admin',
+};
+const UNCLASSIFIED = 'UNCLASSIFIED';
+
+type ScopeRow = {
+  scope: string;
+  model: string;
+  is_batch: boolean;
+  calls: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_create_tokens: number;
+  web_search_requests: number;
+};
+
+const usd = (n: number) => `$${n.toFixed(4)}`;
+const pad = (s: string | number, w: number) => String(s).padEnd(w);
+const lpad = (s: string | number, w: number) => String(s).padStart(w);
+
+async function main() {
+  const out: Record<string, unknown> = { window: { start, end } };
+
+  // ── 1. Raw scope × model rollup ───────────────────────────────────────────
+  const { rows: scopeRows } = await pool.query<ScopeRow>(
+    `SELECT scope, model, is_batch,
+            count(*)::int                       AS calls,
+            sum(input_tokens)::bigint           AS input_tokens,
+            sum(output_tokens)::bigint          AS output_tokens,
+            sum(cache_read_tokens)::bigint      AS cache_read_tokens,
+            sum(cache_create_tokens)::bigint    AS cache_create_tokens,
+            sum(web_search_requests)::bigint    AS web_search_requests
+       FROM "LlmUsageEvent"
+      WHERE created_at >= $1::date AND created_at < ($2::date + 1)
+      GROUP BY scope, model, is_batch
+      ORDER BY scope, model`,
+    [start, end],
+  );
+
+  type Priced = ScopeRow & { usd: number; unpriced: boolean; klass: string };
+  const priced: Priced[] = scopeRows.map((r) => {
+    const est = estimateCostUsd(r.model, {
+      inputTokens: Number(r.input_tokens),
+      outputTokens: Number(r.output_tokens),
+      cacheReadTokens: Number(r.cache_read_tokens),
+      cacheCreateTokens: Number(r.cache_create_tokens),
+      webSearchRequests: Number(r.web_search_requests),
+      isBatch: r.is_batch,
+    });
+    return {
+      ...r,
+      usd: est.usd ?? 0,
+      unpriced: est.unpriced,
+      klass: SCOPE_CLASS[r.scope] ?? UNCLASSIFIED,
+    };
+  });
+
+  const byScope = new Map<string, Priced[]>();
+  for (const p of priced) {
+    const list = byScope.get(p.scope) ?? [];
+    list.push(p);
+    byScope.set(p.scope, list);
+  }
+
+  const scopeTotals = [...byScope.entries()]
+    .map(([scope, rows]) => ({
+      scope,
+      klass: rows[0].klass,
+      calls: rows.reduce((a, r) => a + r.calls, 0),
+      usd: rows.reduce((a, r) => a + r.usd, 0),
+      searches: rows.reduce((a, r) => a + Number(r.web_search_requests), 0),
+      models: [...new Set(rows.map((r) => r.model))],
+      unpriced: rows.some((r) => r.unpriced),
+    }))
+    .sort((a, b) => b.usd - a.usd);
+
+  const grandTotal = scopeTotals.reduce((a, s) => a + s.usd, 0);
+  const classTotals = new Map<string, { usd: number; calls: number }>();
+  for (const s of scopeTotals) {
+    const acc = classTotals.get(s.klass) ?? { usd: 0, calls: 0 };
+    acc.usd += s.usd;
+    acc.calls += s.calls;
+    classTotals.set(s.klass, acc);
+  }
+
+  out.scopes = scopeTotals;
+  out.classes = Object.fromEntries(classTotals);
+  out.totalUsd = grandTotal;
+
+  if (!asJson) {
+    console.log(`\n═══ LLM cost baseline — ${start} → ${end} ═══\n`);
+    console.log('── By raw scope (the digest folds these into 7 surfaces) ──');
+    console.log(
+      `${pad('scope', 30)}${pad('class', 16)}${lpad('calls', 7)}${lpad('searches', 10)}${lpad('usd', 11)}   models`,
+    );
+    for (const s of scopeTotals) {
+      console.log(
+        `${pad(s.scope, 30)}${pad(s.klass, 16)}${lpad(s.calls, 7)}${lpad(s.searches, 10)}${lpad(usd(s.usd), 11)}   ${s.models.join(', ')}${s.unpriced ? '  ⚠ UNPRICED' : ''}`,
+      );
+    }
+    console.log(`${pad('TOTAL', 46)}${lpad(scopeTotals.reduce((a, s) => a + s.calls, 0), 7)}${lpad(scopeTotals.reduce((a, s) => a + s.searches, 0), 10)}${lpad(usd(grandTotal), 11)}`);
+
+    console.log('\n── By cost class ──');
+    for (const [klass, v] of [...classTotals.entries()].sort((a, b) => b[1].usd - a[1].usd)) {
+      const pct = grandTotal > 0 ? ((v.usd / grandTotal) * 100).toFixed(1) : '0.0';
+      console.log(`${pad(klass, 16)}${lpad(usd(v.usd), 11)}${lpad(`${pct}%`, 8)}${lpad(v.calls, 8)} calls`);
+    }
+  }
+
+  // ── 2. Unpriced models (ledger reads $0 for these) ────────────────────────
+  const unpricedModels = [...new Set(priced.filter((p) => p.unpriced).map((p) => p.model))];
+  out.unpricedModels = unpricedModels;
+  if (!asJson && unpricedModels.length > 0) {
+    console.log(`\n⚠  Unpriced models (counted as $0 in every ledger figure): ${unpricedModels.join(', ')}`);
+  }
+
+  // ── 3. Which background paths actually ran (60-day view) ──────────────────
+  const { rows: activity } = await pool.query<{
+    scope: string;
+    first_seen: string;
+    last_seen: string;
+    active_days: number;
+    calls: number;
+  }>(
+    `SELECT scope,
+            min(created_at)::text                     AS first_seen,
+            max(created_at)::text                     AS last_seen,
+            count(DISTINCT created_at::date)::int     AS active_days,
+            count(*)::int                             AS calls
+       FROM "LlmUsageEvent"
+      WHERE created_at >= now() - interval '60 days'
+        AND scope IN ('pool-refill-generate','backfill-supply-generate','generate-questions',
+                      'domain-reference','batch-verify','vet-question','self-containment')
+      GROUP BY scope
+      ORDER BY scope`,
+  );
+  out.backgroundPathActivity = activity;
+  if (!asJson) {
+    console.log('\n── Background supply paths, last 60 days (absence ⇒ flag is off) ──');
+    if (activity.length === 0) console.log('   (no rows for any tracked background scope)');
+    for (const a of activity) {
+      console.log(
+        `${pad(a.scope, 30)}${lpad(a.calls, 7)} calls  ${lpad(a.active_days, 3)} active days   ${a.first_seen.slice(0, 16)} → ${a.last_seen.slice(0, 16)}`,
+      );
+    }
+    for (const s of ['pool-refill-generate', 'backfill-supply-generate']) {
+      if (!activity.some((a) => a.scope === s)) {
+        console.log(`   ✔ ${s}: ZERO calls in 60 days — that refill path is not running.`);
+      }
+    }
+  }
+
+  // ── 4. Supply funnel in the window ────────────────────────────────────────
+  const { rows: funnel } = await pool.query<{
+    generated: number;
+    suppressed: number;
+    ok: number;
+    demoted: number;
+    unverifiable: number;
+    unverified: number;
+  }>(
+    `SELECT count(*)::int                                                              AS generated,
+            count(*) FILTER (WHERE is_duplicate)::int                                  AS suppressed,
+            count(*) FILTER (WHERE verification_verdict = 'ok')::int                   AS ok,
+            count(*) FILTER (WHERE verification_verdict = 'demoted')::int              AS demoted,
+            count(*) FILTER (WHERE verification_verdict = 'unverifiable')::int         AS unverifiable,
+            count(*) FILTER (WHERE verified_at IS NULL)::int                           AS unverified
+       FROM "GeneratedQuestion"
+      WHERE created_at >= $1::date AND created_at < ($2::date + 1)`,
+    [start, end],
+  );
+  out.supplyFunnel = funnel[0];
+  if (!asJson) {
+    const f = funnel[0];
+    console.log('\n── Supply funnel (GeneratedQuestion rows created in window) ──');
+    console.log(`   generated ${f.generated}   suppressed-as-duplicate ${f.suppressed}   verdict ok ${f.ok}   demoted ${f.demoted}   unverifiable ${f.unverifiable}   not-yet-swept ${f.unverified}`);
+    // Trusted = survived both the dedup suppression and the verifier. Rows the
+    // verifier has not reached yet are NOT counted as trusted.
+    const rejected = f.suppressed + f.demoted + f.unverifiable;
+    const trusted = f.generated - rejected - f.unverified;
+    if (f.generated > 0) {
+      console.log(`   reject rate ${((rejected / f.generated) * 100).toFixed(1)}%   trusted ${trusted}   all-in cost per trusted question ${trusted > 0 ? usd(grandTotal / trusted) : 'n/a'} (incl. non-recurring — see caveats)`);
+    }
+  }
+
+  // ── 5. Bank inventory ─────────────────────────────────────────────────────
+  const { rows: stock } = await pool.query<{
+    domains: number;
+    rows_servable: number;
+    below_floor: number;
+    dry: number;
+  }>(
+    `WITH per_domain AS (
+       SELECT canonical_subcategory AS domain, count(*)::int AS n
+         FROM "GeneratedQuestion"
+        WHERE used_in_queue = false
+          AND is_duplicate = false
+          AND fact_key IS NOT NULL
+        GROUP BY canonical_subcategory
+     )
+     SELECT count(*)::int                                  AS domains,
+            coalesce(sum(n), 0)::int                       AS rows_servable,
+            count(*) FILTER (WHERE n < 10)::int            AS below_floor,
+            count(*) FILTER (WHERE n = 0)::int             AS dry
+       FROM per_domain`,
+  );
+  out.bankStock = stock[0];
+  if (!asJson) {
+    const s = stock[0];
+    console.log('\n── Unused bank stock (org-wide; serving is per-user, so this is an upper bound) ──');
+    console.log(`   ${s.rows_servable} unused non-duplicate rows across ${s.domains} domains; ${s.below_floor} domains below the stocked floor of 10`);
+  }
+
+  // ── 6. "Emergency" (just-in-time) generation share ────────────────────────
+  // A bot slot is JIT when its GeneratedQuestion was created within 5 minutes of
+  // the queue that serves it — i.e. the build generated it live instead of
+  // drawing pre-existing stock.
+  const { rows: jit } = await pool.query<{
+    queues: number;
+    bot_slots: number;
+    jit_slots: number;
+    queues_with_jit: number;
+  }>(
+    `WITH slot AS (
+       SELECT q.id AS queue_id, q.created_at AS queue_at,
+              (s->>'generated_question_id') AS gq_id
+         FROM "DailyQueue" q,
+              LATERAL jsonb_array_elements(q.slots) s
+        WHERE q.created_at >= $1::date AND q.created_at < ($2::date + 1)
+          AND s->>'generated_question_id' IS NOT NULL
+     ),
+     marked AS (
+       SELECT slot.queue_id,
+              (gq.created_at >= slot.queue_at - interval '5 minutes') AS is_jit
+         FROM slot
+         JOIN "GeneratedQuestion" gq ON gq.id = slot.gq_id
+     )
+     SELECT (SELECT count(*)::int FROM "DailyQueue"
+              WHERE created_at >= $1::date AND created_at < ($2::date + 1))    AS queues,
+            count(*)::int                                                      AS bot_slots,
+            count(*) FILTER (WHERE is_jit)::int                                AS jit_slots,
+            count(DISTINCT queue_id) FILTER (WHERE is_jit)::int                AS queues_with_jit
+       FROM marked`,
+    [start, end],
+  );
+  out.jitGeneration = jit[0];
+  if (!asJson) {
+    const j = jit[0];
+    const pct = j.bot_slots > 0 ? ((j.jit_slots / j.bot_slots) * 100).toFixed(1) : '0.0';
+    console.log('\n── Just-in-time ("emergency") generation ──');
+    console.log(`   ${j.queues} queues built; ${j.bot_slots} generated slots served, ${j.jit_slots} of them generated live (${pct}%)`);
+    console.log(`   ${j.queues_with_jit} queues needed at least one live generation`);
+  }
+
+  // ── 7. Denominators ───────────────────────────────────────────────────────
+  const { rows: denom } = await pool.query<{
+    queues: number;
+    users_with_queue: number;
+    onboarded_users: number;
+    core_slots: number;
+    answered_core: number;
+    complete_fives: number;
+  }>(
+    `WITH core AS (
+       SELECT q.id AS queue_id,
+              count(*)::int                                        AS core_slots,
+              count(*) FILTER (WHERE (s->>'answered')::boolean)::int AS answered
+         FROM "DailyQueue" q,
+              LATERAL jsonb_array_elements(q.slots) s
+        WHERE q.created_at >= $1::date AND q.created_at < ($2::date + 1)
+          AND s->>'presence_source_id' IS NULL
+          AND s->>'return_scope' IS NULL
+        GROUP BY q.id
+     )
+     SELECT (SELECT count(*)::int FROM "DailyQueue"
+              WHERE created_at >= $1::date AND created_at < ($2::date + 1))          AS queues,
+            (SELECT count(DISTINCT user_id)::int FROM "DailyQueue"
+              WHERE created_at >= $1::date AND created_at < ($2::date + 1))          AS users_with_queue,
+            -- "User" is one of the camelCase tables; "DailyQueue" is snake_case.
+            (SELECT count(*)::int FROM "User" WHERE "onboardingComplete" = true)      AS onboarded_users,
+            coalesce(sum(core_slots), 0)::int                                        AS core_slots,
+            coalesce(sum(answered), 0)::int                                          AS answered_core,
+            count(*) FILTER (WHERE answered >= core_slots AND core_slots > 0)::int   AS complete_fives
+       FROM core`,
+    [start, end],
+  );
+  out.denominators = denom[0];
+  if (!asJson) {
+    const d = denom[0];
+    console.log('\n── Denominators ──');
+    console.log(`   ${d.onboarded_users} onboarded accounts; ${d.users_with_queue} received a queue; ${d.queues} queues built`);
+    console.log(`   ${d.answered_core}/${d.core_slots} core slots answered; ${d.complete_fives} completed Daily Fives`);
+    if (d.complete_fives > 0) {
+      console.log(`   all-in cost per completed Daily Five: ${usd(grandTotal / d.complete_fives)} (denominator is small — do not gate on this yet)`);
+    }
+    if (d.queues > 0 && d.onboarded_users > 0) {
+      console.log(`   queues built per onboarded account: ${(d.queues / d.onboarded_users).toFixed(1)} over ${Math.round((Date.parse(`${end}T00:00:00Z`) - Date.parse(`${start}T00:00:00Z`)) / 86_400_000) + 1} days`);
+    }
+  }
+
+  if (!asJson) {
+    console.log('\n── Ledger caveats (both directions — the ledger is NOT a floor) ──');
+    console.log('   ・ UNDER-counts: recordLlmUsage only fires on a successful response, so provider-billed');
+    console.log('     timeouts and failures are invisible (src/lib/llm.ts).');
+    const sonnet5 = MODEL_PRICING['claude-sonnet-5'];
+    if (sonnet5) {
+      console.log(`   ・ OVER-counts: claude-sonnet-5 is priced at sticker $${sonnet5.inputPerMtok}/$${sonnet5.outputPerMtok} while Anthropic bills`);
+      console.log('     an introductory $2/$10 through 2026-08-31 — generation reads ~33% high in this window.');
+    }
+    console.log('   ・ Cost is derived at read time, so editing pricing.ts reprices all history.');
+    console.log('   ・ Reconciliation against Anthropic billing needs Console/Admin-API access — not in this DB.\n');
+  }
+
+  if (asJson) console.log(JSON.stringify(out, null, 2));
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => pool.end());


### PR DESCRIPTION
## Summary
- Step 0 measurement of the LLM cost transition (2026-08-10→24 window): read-only, re-runnable script (`scripts/llm-cost-baseline.ts`) that classifies raw `LlmUsageEvent` scopes by cost class, plus the funnel/inventory/JIT/denominator queries the earlier plan needed.
- Findings + Step 1 backstop runbook written up in `_docs/LLM-COST-BASELINE-01.md`. Key result: spend is demand-shaped (93.7% recurring, dominated by `batch-verify` + `generate-questions`), not taxonomy-shaped — one player received every Daily Five in the measured window. Step 2 (the refill-policy change originally proposed) is not authorized on this evidence; the grounded refill path has been dead since 2026-07-01 and the demand-weighted backfill is only ~3.5% of spend.
- Step 1 (org/workspace spend-limit backstop) checklist is recorded as 7/8 done — Josh split Joshing/Questionable into separate Anthropic workspaces, swapped keys, revoked the old Default key, and set $100/mo org + $50/mo Joshing limits with alerts, all in Console on 2026-08-27. Only the Admin API key (needed for the Sept reconciliation) remains.
- A one-time scheduled cloud agent (`trig_01KVDvE5SyqPMvJKjvoNQLLK`, fires 2026-09-16) reads this doc from `main` and hands Josh the reconciliation commands once the Sonnet 5 introductory pricing window closes.

## Test plan
- [x] Script runs read-only against prod DB (`npx tsx -r dotenv/config scripts/llm-cost-baseline.ts --start 2026-08-10 --end 2026-08-24`) — verified live, output matches the doc.
- [x] No app code touched; nothing in this PR runs on any request path.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Naghs1f15BBLS5ZHx8iJiQ