### PR TITLE
Stop the +2 handing you your own domains back under a friend's name

### DIFF
--- a/src/server/daily/__tests__/friend-presence-domains.visibility.test.ts
+++ b/src/server/daily/__tests__/friend-presence-domains.visibility.test.ts
@@ -219,7 +219,10 @@ describe('getFriendDomainsForBonus — bounded query count (N+1 fan-out removed)
     expect(getMutualFollowsMock).toHaveBeenCalledTimes(1);
     // Both bulk calls receive the whole surviving set in a single invocation.
     expect(getSectionVisibilitiesBulkMock.mock.calls[0][0]).toHaveLength(30);
-    expect(getKnowledgePageDataForUsersMock.mock.calls[0][0]).toHaveLength(30);
+    // 30 followees + the VIEWER, who rides along in the same batch so their own
+    // domains can be subtracted from the pool. Still one call, still constant.
+    expect(getKnowledgePageDataForUsersMock.mock.calls[0][0]).toHaveLength(31);
+    expect(getKnowledgePageDataForUsersMock.mock.calls[0][0]).toContain('viewer');
   });
 });
 
@@ -253,5 +256,108 @@ describe('getFriendDomainsForBonus — batched output equals per-friend behavior
     expect(jazz?.signal).toBe('both');
     expect(jazz?.presenceSources.map((s) => s.userId).sort()).toEqual(['robyn', 'sam']);
     expect(result.some((c) => c.domain === 'Film')).toBe(false);
+  });
+});
+
+describe("getFriendDomainsForBonus — the viewer's own domains never come back as a friend's", () => {
+  // Regression: the +2 pool was handing players their OWN territory back under a
+  // follower's name. A followee who answers a question in the viewer's domain
+  // picks that domain up (as territory, or as bare activity) and it round-tripped
+  // to the viewer as "from {Name}'s world". Observed in prod with a 781-point
+  // declared domain of the viewer's being attributed to a followee who had zero
+  // points in it. Both the module docstring and the queue orchestrator claimed
+  // this subtraction existed; neither implemented it.
+  it("drops a friend's territory domain that is already the viewer's own", async () => {
+    getFollowingMock.mockResolvedValue([{ id: 'neil', displayName: 'Neil' }]);
+    state.sectionByFriend.set('neil', 'public');
+    state.domainsByFriend = new Map([
+      ['neil', [territoryDomain('Beethoven'), territoryDomain('Pirates')]],
+      ['viewer', [territoryDomain('Beethoven')]],
+    ]);
+
+    const result = await getFriendDomainsForBonus('viewer', 5);
+
+    // "Beethoven" is the viewer's own; only the genuinely new domain survives.
+    expect(result.map((c) => c.domain)).toEqual(['Pirates']);
+  });
+
+  it('matches the viewer\'s own domains case-insensitively', async () => {
+    getFollowingMock.mockResolvedValue([{ id: 'neil', displayName: 'Neil' }]);
+    state.sectionByFriend.set('neil', 'public');
+    state.domainsByFriend = new Map([
+      ['neil', [territoryDomain('UX Design')]],
+      ['viewer', [territoryDomain('ux design')]],
+    ]);
+
+    expect(await getFriendDomainsForBonus('viewer', 5)).toEqual([]);
+  });
+
+  it("still excludes a viewer's own domain that the viewer has HIDDEN", async () => {
+    // Hiding a domain on your own profile doesn't make it someone else's world.
+    getFollowingMock.mockResolvedValue([{ id: 'neil', displayName: 'Neil' }]);
+    state.sectionByFriend.set('neil', 'public');
+    state.domainsByFriend = new Map([
+      ['neil', [territoryDomain('Beethoven')]],
+      ['viewer', [territoryDomain('Beethoven', { isHidden: true })]],
+    ]);
+
+    expect(await getFriendDomainsForBonus('viewer', 5)).toEqual([]);
+  });
+
+  it('leaves the pool untouched when the viewer and friend share nothing', async () => {
+    getFollowingMock.mockResolvedValue([{ id: 'neil', displayName: 'Neil' }]);
+    state.sectionByFriend.set('neil', 'public');
+    state.domainsByFriend = new Map([
+      ['neil', [territoryDomain('Pirates')]],
+      ['viewer', [territoryDomain('Beethoven')]],
+    ]);
+
+    expect((await getFriendDomainsForBonus('viewer', 5)).map((c) => c.domain)).toEqual(['Pirates']);
+  });
+});
+
+describe('getFriendDomainsForBonus — activity needs a correct answer, not just an answer', () => {
+  // `selectRecentlyExploring` gates only on recency + !isHidden, which is right
+  // for the profile's own "Recently exploring" section but too loose to promote a
+  // domain into someone ELSE's Daily Five. In prod a followee answered three
+  // questions, got all three WRONG (0 points, no mastery row), and those domains
+  // became "{Name}'s world" for everyone following them.
+  it('drops an activity-only domain the friend has never answered correctly', async () => {
+    getFollowingMock.mockResolvedValue([{ id: 'neil', displayName: 'Neil' }]);
+    state.sectionByFriend.set('neil', 'public');
+    state.domainsByFriend = new Map([
+      ['neil', [activityDomain('Beethoven', { questionsAnswered: 1, questionsCorrect: 0, correctRate: 0 })]],
+      ['viewer', []],
+    ]);
+
+    expect(await getFriendDomainsForBonus('viewer', 5)).toEqual([]);
+  });
+
+  it('keeps an activity-only domain once the friend has one correct answer', async () => {
+    getFollowingMock.mockResolvedValue([{ id: 'neil', displayName: 'Neil' }]);
+    state.sectionByFriend.set('neil', 'public');
+    state.domainsByFriend = new Map([
+      ['neil', [activityDomain('Beethoven', { questionsAnswered: 2, questionsCorrect: 1, correctRate: 0.5 })]],
+      ['viewer', []],
+    ]);
+
+    const result = await getFriendDomainsForBonus('viewer', 5);
+    expect(result.map((c) => c.domain)).toEqual(['Beethoven']);
+    expect(result[0]?.signal).toBe('activity');
+  });
+
+  it('does NOT apply the correctness floor to territory — a declared domain stands on its own', async () => {
+    // Declaring a domain is a first-party claim; it does not need a correct
+    // answer behind it. Only the activity path gets the floor.
+    getFollowingMock.mockResolvedValue([{ id: 'neil', displayName: 'Neil' }]);
+    state.sectionByFriend.set('neil', 'public');
+    state.domainsByFriend = new Map([
+      ['neil', [territoryDomain('Opera', { questionsAnswered: 1, questionsCorrect: 0, correctRate: 0 })]],
+      ['viewer', []],
+    ]);
+
+    const result = await getFriendDomainsForBonus('viewer', 5);
+    expect(result.map((c) => c.domain)).toEqual(['Opera']);
+    expect(result[0]?.signal).toBe('territory');
   });
 });

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -998,8 +998,10 @@ async function buildDailyQueueForUser(
   // We therefore request coreShortfall + DAILY_BONUS_SLOT_MAX domains so the bonus
   // isn't cannibalized by the backfill. When the core is already full coreShortfall
   // is 0 and this is byte-for-byte the old +2 behavior. Friend-sourced only (never
-  // pads with the viewer's own domains); resting domains are excluded from BOTH the
-  // core backfill and the bonus, so "This is {Name}'s bag but not mine" holds. The
+  // pads with the viewer's own domains — enforced by the `ownDomains` subtraction
+  // inside getFriendDomainsForBonus, NOT by anything here; don't re-assert it as an
+  // invariant at this layer); resting domains are excluded from BOTH the core
+  // backfill and the bonus, so "This is {Name}'s bag but not mine" holds. The
   // pool serves only fresh questions — never a friend's literal answered question
   // (those live behind the Lately milestone click-through, D-4 §A).
   //

--- a/src/server/db/queries/friend-presence-domains.ts
+++ b/src/server/db/queries/friend-presence-domains.ts
@@ -183,6 +183,26 @@ function isTerritoryDomain(domain: DomainMastery): boolean {
   return domain.isDeclared || domain.isDeclaredInterest || domain.isDemonstrated;
 }
 
+/**
+ * The activity signal additionally requires at least one CORRECT answer.
+ *
+ * `selectRecentlyExploring` gates only on recency + `!isHidden`, which is right
+ * for the profile's "Recently exploring" section — answering wrong IS exploring,
+ * and that section describes you to yourself. It is NOT enough to put a domain
+ * into someone ELSE's Daily Five: without this floor a single wrong answer
+ * promotes a domain to "{Name}'s world" and broadcasts it to everyone who
+ * follows them. Mirrors the `demonstrated` aggregate in `loadDomainAggregatesBulk`,
+ * which likewise requires `answerState <> 'incorrect'`; the territory path
+ * already inherits that gate via `isDemonstrated`, so only activity was open.
+ *
+ * Lifetime-correct rather than correct-in-window: the point is to establish that
+ * the friend has real purchase on the domain at all, not to re-litigate recency
+ * (`selectRecentlyExploring` already applied the 30-day window).
+ */
+function hasEarnedActivity(domain: DomainMastery): boolean {
+  return domain.questionsCorrect > 0;
+}
+
 function activityMs(lastActivityAt: string | null): number | null {
   if (!lastActivityAt) return null;
   const ms = new Date(lastActivityAt).getTime();
@@ -194,7 +214,10 @@ function activityMs(lastActivityAt: string | null): number | null {
  * viewer follows. Returns at most `limit` candidates (DAILY_BONUS_SLOT_MAX). The
  * pool is friend-sourced only — it never includes the viewer's own domains, so a
  * viewer who follows no one (or no one with eligible domains) gets an empty pool
- * (clean 5).
+ * (clean 5). That own-domain subtraction is ENFORCED below (`ownDomains`), not
+ * merely assumed: it was documented here and in the orchestrator for a long time
+ * while nothing implemented it, which let a friend's answer in the viewer's own
+ * domain round-trip back as "from {Name}'s world".
  *
  * Privacy: the presence signal honors the same `knowledge_base` SECTION
  * visibility the profile enforces (`canViewSection`). Following is one-way, so
@@ -242,21 +265,40 @@ export async function getFriendDomainsForBonus(
   // consumes `allDomains`). Bounded query count regardless of followee count.
   // A batch failure degrades to an empty pool — the same best-effort posture the
   // old per-friend `.catch(() => ({ allDomains: [] }))` gave each fetch.
-  const domainsByFriend = await getKnowledgePageDataForUsers(
-    visibleFriends.map((f) => f.id),
-  ).catch(() => new Map<string, DomainMastery[]>());
+  // The viewer rides along in the SAME batched query as the friends (one extra
+  // row, no extra round-trip) so their own map can be subtracted below.
+  const domainsByUser = await getKnowledgePageDataForUsers([
+    ...visibleFriends.map((f) => f.id),
+    viewerUserId,
+  ]).catch(() => new Map<string, DomainMastery[]>());
+
+  // *** The viewer's OWN domains — subtracted from the pool. ***
+  // This is what makes the "friend-sourced only" invariant above real; it was
+  // documented here and in the orchestrator but never enforced. Without it the
+  // +2 hands a player their own territory back under a friend's name: a followee
+  // who answers a question in the viewer's domain picks that domain up as
+  // territory (or, before the correctness floor below, as bare activity) and it
+  // returns to the viewer as "from {Name}'s world".
+  // Every domain in the viewer's own knowledge map is theirs — declared,
+  // demonstrated, or merely played — so the whole map is excluded, hidden
+  // domains included (hiding a domain doesn't make it someone else's).
+  const ownDomains = new Set(
+    (domainsByUser.get(viewerUserId) ?? []).map((d) => d.domain.toLowerCase()),
+  );
 
   const contributions: FriendDomainContribution[] = [];
   for (const friend of visibleFriends) {
-    const allDomains = domainsByFriend.get(friend.id) ?? [];
+    const allDomains = domainsByUser.get(friend.id) ?? [];
     const activityDomains = new Set(
       selectRecentlyExploring(allDomains).map((d) => d.domain.toLowerCase()),
     );
 
     for (const domain of allDomains) {
-      if (excludeDomains.has(domain.domain.toLowerCase())) continue;
+      const key = domain.domain.toLowerCase();
+      if (excludeDomains.has(key)) continue;
+      if (ownDomains.has(key)) continue;
       const inTerritory = isTerritoryDomain(domain);
-      const inActivity = !domain.isHidden && activityDomains.has(domain.domain.toLowerCase());
+      const inActivity = !domain.isHidden && hasEarnedActivity(domain) && activityDomains.has(key);
       if (!inTerritory && !inActivity) continue;
       contributions.push({
         friendId: friend.id,


### PR DESCRIPTION
## The bug

Josh noticed his Daily Five +2 was serving him questions "from hazelvision's world" in domains that were unmistakably *his*. He was right, and the mechanism is worse than it looks.

The +2 pool is meant to be friend-sourced only. Both `friend-presence-domains.ts` and `queue-orchestrator.ts` say so in prose:

> *"The pool is friend-sourced only — it never includes the viewer's own domains"*
> *"Friend-sourced only (never pads with the viewer's own domains)"*

Nothing implemented it. `getFriendDomainsForBonus` takes exactly one exclusion set, built at `queue-orchestrator.ts:440` purely from `frequency === 'resting'`. The viewer's own territory was never subtracted. The unit tests mock the whole module, so nothing caught it.

## What that produced in prod

Every presence slot Josh received after 2026-08-24 was one of **his own domains** attributed to a new player:

| Domain | Josh | hazelvision |
|---|---|---|
| 20th Century Composers | 781 pts, declared | none |
| Beethoven | 280 pts, declared | none |
| UX Design | 195 pts, demonstrated | none |
| NBA Basketball History | 20 pts, demonstrated | 10 pts |

And hazelvision's entire claim to the first three was this:

```
20th Century Composers   session_context: feed   answer_state: incorrect   0 pts
Beethoven                session_context: feed   answer_state: incorrect   0 pts
UX Design                session_context: feed   answer_state: incorrect   0 pts
```

He saw questions from Josh's domains in his feed, got all three **wrong**, and that alone flagged them as his territory — which then round-tripped to Josh as *"from hazelvision's world."*

## Two independent holes, both closed

**1. Own-domain subtraction.** The viewer now rides along in the existing `getKnowledgePageDataForUsers` batch (one extra row, no extra round-trip) and every domain in their own knowledge map is dropped — hidden ones included, since hiding a domain doesn't make it someone else's.

**2. Activity needs a correct answer.** `selectRecentlyExploring` gates only on recency + `!isHidden`. The new `hasEarnedActivity` floor requires `questionsCorrect > 0`, mirroring the `demonstrated` aggregate in `loadDomainAggregatesBulk` (`answerState <> 'incorrect'`) — the territory path already inherited that gate via `isDemonstrated`, so only activity was open.

Deliberately scoped to the bonus pool rather than `selectRecentlyExploring`: on your *own* profile, answering wrong genuinely is exploring. The bug was that it also broadcast. Territory is untouched — declaring a domain is a first-party claim that needs no correct answer behind it.

Either fix alone leaves a hole: #1 alone still lets a followee's wrong-answer-only domains reach you; #2 alone still sells you Beethoven the moment they get one right.

## Effect on real data

- **hazelvision goes nearly silent as a +2 source, correctly.** Five of his six domains are also Josh's. His only genuinely-own territory is Space Travel, which survives because he *declared* it (territory path, no floor) even though both his answers there were wrong.
- **Robyn is unaffected** — 6 domains that aren't Josh's (Manual Therapies at 90 pts, Trojan War Mythology, WNBA, 80s Pop Culture, Human Anatomy, 20th Century Poetry). The +2 keeps working; it just stops recycling your own shelf.

Worth flagging separately: 37 of Robyn's 43 domains overlap Josh's. Pool depth gets thin fast when everyone's map is a subset of the most active player's. Not addressed here.

## Tests

7 new cases. Verified load-bearing by disabling both guards — **exactly 4 fail**. The other 3 (non-overlapping domains still flow, one correct answer restores activity, territory isn't floored) pass either way as over-correction guards. One existing assertion updated 30 → 31 for the viewer now in the batch.

`tsc` clean, 670 tests pass across `src/server/daily` + query suites, lint warnings unchanged (4 pre-existing, in untouched files).

## Not included

Today's queue (2026-08-29) is already persisted and still carries a bad slot; the fix only affects future builds, so it clears on the next one. No prod DML here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A
