### PR TITLE
One "Not for me" control, with the scope as an explicit choice

### DIFF
--- a/drizzle/0131_hidden_question.sql
+++ b/drizzle/0131_hidden_question.sql
@@ -1,0 +1,67 @@
+-- HiddenQuestion: a player's permanent "never show me this question again".
+--
+-- The Not-for-me sheet (one control replacing the old adjacent "Dismiss" and
+-- "This is {Name}'s bag but not mine" links) offers three scopes: skip for now,
+-- hide this question, rest this category. The first two already had homes --
+-- SkippedDailyQuestion for the temporary skip, DailyPreference.domain_preference_frequency
+-- = 'resting' for the category -- but there was nowhere to record a durable
+-- per-question refusal. This table is that home.
+--
+-- It deliberately does NOT carry a queue_id. SkippedDailyQuestion is scoped to
+-- the round it happened in and cascades away with its queue; a hide is a
+-- standing preference that must survive every queue it was ever served in.
+--
+-- Hiding is reversible: "Hidden questions" in settings lists these rows and
+-- restoring one DELETES it. That reversibility is the condition under which
+-- permanent hiding is safe against a finite question pool
+-- (D-SUPPLY-FINITE-SET-01) -- an accidental hide is always recoverable, so no
+-- question is ever burned out of the corpus for good.
+--
+-- Rollback: DROP TABLE "HiddenQuestion"; -- it is additive and nothing outside
+-- the hide/restore path reads it, so dropping it restores prior behavior
+-- exactly (every hidden question simply becomes servable again).
+
+CREATE TABLE IF NOT EXISTS "HiddenQuestion" (
+  "id" text PRIMARY KEY NOT NULL,
+  "user_id" text NOT NULL,
+  "question_id" text,
+  "generated_question_id" text,
+  "canonical_subcategory" text NOT NULL,
+  "hidden_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "HiddenQuestion" ADD CONSTRAINT "HiddenQuestion_user_id_User_id_fk"
+    FOREIGN KEY ("user_id") REFERENCES "public"."User"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "HiddenQuestion" ADD CONSTRAINT "HiddenQuestion_question_id_Question_id_fk"
+    FOREIGN KEY ("question_id") REFERENCES "public"."Question"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "HiddenQuestion" ADD CONSTRAINT "HiddenQuestion_generated_question_id_GeneratedQuestion_id_fk"
+    FOREIGN KEY ("generated_question_id") REFERENCES "public"."GeneratedQuestion"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_idx" ON "HiddenQuestion" ("user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_question_id_idx" ON "HiddenQuestion" ("user_id","question_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_generated_question_id_idx" ON "HiddenQuestion" ("user_id","generated_question_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "HiddenQuestion_question_id_idx" ON "HiddenQuestion" ("question_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "HiddenQuestion_generated_question_id_idx" ON "HiddenQuestion" ("generated_question_id");
+--> statement-breakpoint
+-- B-SECURITY-RLS-01 (precedent: 0081_enable_rls_public_tables). A new public
+-- table is reachable over the Supabase Data API by anon/authenticated the moment
+-- it exists. No policies: the app connects as owner `postgres`, which bypasses RLS.
+ALTER TABLE "HiddenQuestion" ENABLE ROW LEVEL SECURITY;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -918,6 +918,13 @@
       "when": 1787788800000,
       "tag": "0130_missed_return_generated",
       "breakpoints": true
+    },
+    {
+      "idx": 131,
+      "version": "7",
+      "when": 1787875200000,
+      "tag": "0131_hidden_question",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/questions/hide/route.ts
+++ b/src/app/api/questions/hide/route.ts
@@ -1,0 +1,77 @@
+/**
+ * Permanent per-question hide + its undo — the "Never show this question again"
+ * scope of the Not-for-me sheet.
+ *
+ * POST   { question_id? , generated_question_id?, domain }  → hide
+ * DELETE { hidden_id }                                      → restore (undo)
+ *
+ * The other two scopes behind that same sheet already had endpoints and are NOT
+ * duplicated here: "Skip for now" is POST /api/daily/skip, and "Rest this
+ * category" is POST /api/daily/preferences/domain-frequency. This route owns
+ * only the durable per-question refusal.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { hideQuestion, restoreHiddenQuestion } from '@/server/db/queries/hidden-questions';
+
+export const dynamic = 'force-dynamic';
+
+const hideSchema = z
+  .object({
+    question_id: z.string().min(1).optional(),
+    generated_question_id: z.string().min(1).optional(),
+    domain: z.string().min(1),
+  })
+  // A hide has to name exactly one question in exactly one id space; accepting
+  // both would write a row that two different lookups could claim.
+  .refine(
+    (value) => Boolean(value.question_id) !== Boolean(value.generated_question_id),
+    { message: 'exactly one of question_id or generated_question_id is required' },
+  );
+
+const restoreSchema = z.object({ hidden_id: z.string().min(1) });
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = hideSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'validation', message: parsed.error.issues[0]?.message ?? 'invalid body' },
+      { status: 400 },
+    );
+  }
+
+  await hideQuestion({
+    userId: session.userId,
+    questionId: parsed.data.question_id ?? null,
+    generatedQuestionId: parsed.data.generated_question_id ?? null,
+    canonicalSubcategory: parsed.data.domain,
+  });
+
+  return NextResponse.json({ hidden: true });
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = restoreSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'validation', message: 'hidden_id is required' },
+      { status: 400 },
+    );
+  }
+
+  // Scoped to the session user inside the query, so an id belonging to someone
+  // else simply reports not-found rather than clearing their row.
+  const restored = await restoreHiddenQuestion(session.userId, parsed.data.hidden_id);
+  if (!restored) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  return NextResponse.json({ restored: true });
+}

--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { X } from 'lucide-react';
@@ -13,6 +13,7 @@ import { AuthorName } from '@/components/AuthorName';
 import { EditorialBadge } from '@/components/EditorialBadge';
 import { CreatorNote, pickCreatorNote } from '@/components/CreatorNote';
 import { AnsweredRowActions } from '@/components/questions/AnsweredRowActions';
+import { NotForMeSheet } from '@/components/daily/NotForMeSheet';
 import { CATCH_UP_EMPTY_COPY } from '@/server/play/catch-up-copy';
 
 export default function DailyCatchupPage() {
@@ -38,6 +39,42 @@ export default function DailyCatchupPage() {
     dismissCurrent,
   } = useCatchupFlow();
   const [answer, setAnswer] = useState('');
+  const [notForMeOpen, setNotForMeOpen] = useState(false);
+
+  // Catch-up gets the SAME sheet as the Daily Five rather than its own
+  // differently-behaving button — a control that looks identical across surfaces
+  // must also mean the same thing. "Skip for now" maps to catch-up's existing
+  // dismiss (the item returns on a later day); the two durable scopes call the
+  // same endpoints the Daily Five does.
+  const catchupNotForMe = useCallback(
+    async (scope: 'skip' | 'hide_question' | 'rest_category') => {
+      if (!currentItem) return;
+      if (scope === 'rest_category') {
+        await fetch('/api/daily/preferences/domain-frequency', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ domain: currentItem.domain, frequency: 'resting' }),
+        });
+      }
+      if (scope === 'hide_question') {
+        // reportTarget already discriminates the two id spaces (curated/bank rows
+        // carry questionId, LLM-origin rows carry generatedQuestionId); fall back
+        // to the item's own questionId when a stale payload omits it.
+        const target = currentItem.reportTarget?.generatedQuestionId
+          ? { generated_question_id: currentItem.reportTarget.generatedQuestionId }
+          : { question_id: currentItem.reportTarget?.questionId ?? currentItem.questionId };
+        await fetch('/api/questions/hide', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ ...target, domain: currentItem.domain }),
+        });
+      }
+      await dismissCurrent();
+    },
+    [currentItem, dismissCurrent],
+  );
 
   const hasItems = initialTotal > 0;
   const showSummary = phase === 'summary';
@@ -139,8 +176,8 @@ export default function DailyCatchupPage() {
               messages={messages}
               onGiveUp={() => skipCurrent()}
               giveUpDisabled={submitting || isResolvingTurn}
-              onDismiss={() => void dismissCurrent()}
-              dismissDisabled={submitting || isResolvingTurn}
+              onNotForMe={() => setNotForMeOpen(true)}
+              notForMeDisabled={submitting || isResolvingTurn}
             />
             {roundComplete ? (
               <RoundCloseCard
@@ -154,6 +191,19 @@ export default function DailyCatchupPage() {
           </>
         )}
       </section>
+
+      {notForMeOpen && currentItem ? (
+        <NotForMeSheet
+          domain={currentItem.domain}
+          categoryLabel={currentItem.domainDisplayName}
+          skipDisabled={submitting || isResolvingTurn}
+          onChoose={async (scope) => {
+            await catchupNotForMe(scope);
+            setNotForMeOpen(false);
+          }}
+          onClose={() => setNotForMeOpen(false)}
+        />
+      ) : null}
 
       {currentItem && !loading && phase === 'playing' ? (
         <AnswerInputBar

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/answer-submit';
 import { GeometricProgress } from '@/components/play/GeometricProgress';
 import { AnswerInputBar } from '@/components/play/AnswerInputBar';
+import { NotForMeSheet } from '@/components/daily/NotForMeSheet';
 import LoadingScreen from '@/components/LoadingScreen';
 import { useLoadingMoments } from '@/components/loading-moment/useLoadingMoment';
 import { categoryLabel, type InsideJokeKind } from '@/lib/questions-types';
@@ -865,64 +866,90 @@ export default function DailyPage() {
     }
   }, [postAnswer]);
 
-  // Bonus slots only (D-4 §B): "This is {Name}'s bag but not mine". Rests the
-  // slot's domain so the category stops surfacing in future rounds, and closes
-  // this bonus question (a skip — bonus slots are additive, so closing one never
-  // drops the round below the core five). Optimistic: the slot is marked skipped
-  // immediately, then reverted if either request fails.
-  const muteBonusDomain = useCallback(async () => {
-    if (!queue || !currentSlot || submitting) return;
-    const slotIndex = currentSlot.slot_index;
-    const { domain } = currentSlot;
-    setError(null);
-    setQueue((existing) =>
-      existing
-        ? {
-            ...existing,
-            slots: existing.slots.map((slot) =>
-              slot.slot_index === slotIndex ? { ...slot, skipped: true } : slot,
-            ),
-          }
-        : existing,
-    );
-    try {
-      // Rest the category (durable preference). Best-effort, but the skip below
-      // is what actually closes this question, so a failure here still throws.
-      const restResponse = await fetch('/api/daily/preferences/domain-frequency', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ domain, frequency: 'resting' }),
-      });
-      if (!restResponse.ok) throw new Error('Could not update that category.');
+  // The Not-for-me sheet's three scopes, all closing the current slot.
+  //
+  // These used to be two adjacent links that looked identical: "Dismiss" (a
+  // temporary skip) and "This is {Name}'s bag but not mine" (a DURABLE category
+  // rest, bonus slots only). Same styling, very different permanence, no
+  // confirmation on either. Now the scope is an explicit choice in a sheet, and
+  // it is available on EVERY question rather than only the +2.
+  //
+  // All three are optimistic: the slot is marked skipped immediately and
+  // reverted if any request fails. The skip call is what actually closes the
+  // slot in every case, so the durable writes run first and throw on failure —
+  // we never want a closed slot with the preference silently not recorded.
+  const [notForMeOpen, setNotForMeOpen] = useState(false);
 
-      const skipResponse = await fetch('/api/daily/skip', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ queue_id: queue.queue_id, slot_index: slotIndex }),
-      });
-      if (!skipResponse.ok) throw new Error('Could not close that question.');
-      const body = (await skipResponse.json().catch(() => null)) as { slots?: QueueSlot[] } | null;
-      if (Array.isArray(body?.slots)) {
-        const nextSlots = body.slots;
-        setQueue((existing) => (existing ? { ...existing, slots: nextSlots } : existing));
-      }
-    } catch (caught) {
-      // Revert the optimistic skip so the question stays answerable.
+  const notForMe = useCallback(
+    async (scope: 'skip' | 'hide_question' | 'rest_category') => {
+      if (!queue || !currentSlot || submitting) return;
+      const slotIndex = currentSlot.slot_index;
+      const { domain } = currentSlot;
+      setError(null);
       setQueue((existing) =>
         existing
           ? {
               ...existing,
               slots: existing.slots.map((slot) =>
-                slot.slot_index === slotIndex ? { ...slot, skipped: false } : slot,
+                slot.slot_index === slotIndex ? { ...slot, skipped: true } : slot,
               ),
             }
           : existing,
       );
-      setError(caught instanceof Error ? caught.message : 'Could not update that category.');
-    }
-  }, [queue, currentSlot, submitting]);
+      try {
+        if (scope === 'rest_category') {
+          const restResponse = await fetch('/api/daily/preferences/domain-frequency', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ domain, frequency: 'resting' }),
+          });
+          if (!restResponse.ok) throw new Error('Could not update that category.');
+        }
+
+        if (scope === 'hide_question') {
+          // Exactly one id space, matching how the slot addresses its question.
+          const target = currentSlot.generated_question_id
+            ? { generated_question_id: currentSlot.generated_question_id }
+            : { question_id: currentSlot.question_id };
+          const hideResponse = await fetch('/api/questions/hide', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ ...target, domain }),
+          });
+          if (!hideResponse.ok) throw new Error('Could not hide that question.');
+        }
+
+        const skipResponse = await fetch('/api/daily/skip', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ queue_id: queue.queue_id, slot_index: slotIndex }),
+        });
+        if (!skipResponse.ok) throw new Error('Could not close that question.');
+        const body = (await skipResponse.json().catch(() => null)) as { slots?: QueueSlot[] } | null;
+        if (Array.isArray(body?.slots)) {
+          const nextSlots = body.slots;
+          setQueue((existing) => (existing ? { ...existing, slots: nextSlots } : existing));
+        }
+      } catch (caught) {
+        // Revert the optimistic close so the question stays answerable.
+        setQueue((existing) =>
+          existing
+            ? {
+                ...existing,
+                slots: existing.slots.map((slot) =>
+                  slot.slot_index === slotIndex ? { ...slot, skipped: false } : slot,
+                ),
+              }
+            : existing,
+        );
+        setError(caught instanceof Error ? caught.message : 'Could not update that question.');
+      }
+    },
+    [queue, currentSlot, submitting],
+  );
 
   return (
     <main className="relative mx-auto flex min-h-dvh max-w-lg flex-col overflow-hidden bg-[var(--surface)] bg-[url('/images/Variant4.png')] bg-repeat px-0">
@@ -1005,11 +1032,29 @@ export default function DailyPage() {
             messages={messages}
             onGiveUp={() => void giveUpCurrent()}
             giveUpDisabled={submitting}
-            onMutePresence={() => void muteBonusDomain()}
-            muteDisabled={submitting}
+            onNotForMe={() => setNotForMeOpen(true)}
+            notForMeDisabled={submitting}
           />
         )}
       </section>
+
+      {notForMeOpen && currentSlot ? (
+        <NotForMeSheet
+          domain={currentSlot.domain}
+          categoryLabel={
+            (currentSlot.broad_category && currentSlot.broad_category.trim()) ||
+            (currentSlot.category ? categoryLabel(currentSlot.category) : null) ||
+            currentSlot.domain
+          }
+          presenceSourceName={currentSlot.presence_source_name ?? null}
+          skipDisabled={submitting}
+          onChoose={async (scope) => {
+            await notForMe(scope);
+            setNotForMeOpen(false);
+          }}
+          onClose={() => setNotForMeOpen(false)}
+        />
+      ) : null}
 
       {currentSlot && !loading ? (
         <AnswerInputBar

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -15,6 +15,8 @@ import { ProfileFriendsSection } from '@/components/profile/ProfileFriendsSectio
 import { SectionVisibilityToggle } from '@/components/profile/SectionVisibilityToggle';
 import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow';
 import { AccountActions } from '@/components/profile/settings/AccountActions';
+import { HiddenQuestions } from '@/components/profile/settings/HiddenQuestions';
+import { getHiddenQuestionsForUser } from '@/server/db/queries/hidden-questions';
 import { getExistingDevToolHrefs } from '@/server/dev/tool-availability';
 import { NotificationsForm } from '@/components/profile/settings/NotificationsForm';
 import { PrivacyForm } from '@/components/profile/settings/PrivacyForm';
@@ -218,6 +220,18 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
     // dropdowns reflect the DB; skip the read entirely for non-owners.
     const isOwner = isAdminUser(session.userId);
     const llmProviders = isOwner ? await getProviderSettings() : null;
+    // Hidden questions — the undo for the Not-for-me sheet's durable per-question
+    // scope. Owner-only surface, so the read lives inside this branch.
+    // Fail-open: this is one section of a large settings page, so a failed read
+    // renders an empty Hidden questions list rather than 500-ing the whole page.
+    const hiddenQuestionItems = (
+      await getHiddenQuestionsForUser(session.userId).catch(() => [])
+    ).map((row) => ({
+      id: row.id,
+      questionText: row.questionText,
+      domain: row.domain,
+      hiddenAt: row.hiddenAt.toISOString(),
+    }));
     // B-LLM-PROVIDER-AB-METRICS: load the experiment readout data here (the page
     // is already awaited) and pass it into the sync presentational component.
     const llmExperimentData = isOwner ? await loadLlmExperimentData() : null;
@@ -335,6 +349,10 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
         {llmProviders ? <LlmProviderPanel initial={llmProviders} /> : null}
         {llmExperimentData ? <LlmExperimentReadout data={llmExperimentData} /> : null}
         {costReportData ? <LlmCostReportReadout data={costReportData} /> : null}
+
+        <HiddenQuestions
+          initial={hiddenQuestionItems}
+        />
 
         <AccountActions
           isAdmin={isAdminUser(session.userId)}

--- a/src/components/daily/NotForMeSheet.tsx
+++ b/src/components/daily/NotForMeSheet.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Clock, EyeOff, Moon, X } from 'lucide-react'
+
+// The single "Not for me" control's sheet.
+//
+// It replaces two adjacent, identically-styled links that did drastically
+// different things: "Dismiss" (a temporary, capped skip) and "This is {Name}'s
+// bag but not mine" (a DURABLE category opt-out that wrote a preference on one
+// tap, and only ever appeared on +2 bonus slots). Same look, one reversible and
+// one not, no confirmation on either.
+//
+// Now there is one control everywhere, and the scope is an explicit choice:
+//   - Skip for now        → temporary, comes back
+//   - Never this question → durable, undoable from Settings
+//   - Rest this category  → durable, undoable from Manage your topics
+//
+// Person-scope hiding deliberately stays in the feed's ⋯ menu; it is a different
+// axis (who, not what) and mixing it in here would make the sheet a grab bag.
+
+export type NotForMeScope = 'skip' | 'hide_question' | 'rest_category'
+
+export function NotForMeSheet({
+  domain,
+  categoryLabel,
+  presenceSourceName,
+  skipDisabled,
+  skipDisabledReason,
+  onChoose,
+  onClose,
+}: {
+  /** Canonical subcategory — what "rest this category" actually rests. */
+  domain: string
+  /** Human label for the category, when it differs from the raw domain key. */
+  categoryLabel?: string | null
+  /**
+   * Set only on a +2 bonus slot, where the question came from a friend's world.
+   * Swaps the category row's copy to the product's own phrasing for it.
+   */
+  presenceSourceName?: string | null
+  /** True once the round's skip cap is spent — the row stays visible but inert. */
+  skipDisabled?: boolean
+  skipDisabledReason?: string
+  onChoose: (scope: NotForMeScope) => void | Promise<void>
+  onClose: () => void
+}) {
+  const [busy, setBusy] = useState<NotForMeScope | null>(null)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const label = (categoryLabel && categoryLabel.trim()) || domain
+  const firstName = presenceSourceName ? presenceSourceName.trim().split(/\s+/)[0] : null
+
+  async function choose(scope: NotForMeScope) {
+    if (busy) return
+    setBusy(scope)
+    try {
+      await onChoose(scope)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[var(--z-modal)] flex items-end justify-center">
+      <button
+        type="button"
+        className="absolute inset-0"
+        style={{ background: 'var(--scrim)' }}
+        onClick={onClose}
+        aria-label="Dismiss"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Not for me"
+        className="relative flex max-h-[90dvh] w-full max-w-lg flex-col rounded-t-3xl bg-[var(--brand-card)] shadow-[var(--shadow-overlay)]"
+      >
+        <div className="flex items-center justify-between px-5 pt-4 pb-1">
+          <p className="text-xs font-semibold tracking-[0.18em] uppercase text-[var(--brand-ink-400)]">
+            Not for me
+          </p>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex size-11 items-center justify-center rounded-full text-[var(--brand-ink-400)] transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-2 overflow-y-auto px-5 pt-2 pb-6">
+          <Choice
+            icon={<Clock className="size-5" />}
+            title="Skip for now"
+            subtitle={
+              skipDisabled
+                ? (skipDisabledReason ?? 'No skips left in this round.')
+                : "It'll come back another day."
+            }
+            disabled={Boolean(skipDisabled) || busy !== null}
+            busy={busy === 'skip'}
+            onClick={() => void choose('skip')}
+          />
+
+          <Choice
+            icon={<EyeOff className="size-5" />}
+            title="Never show this question"
+            subtitle="You can bring it back from Settings › Hidden questions."
+            disabled={busy !== null}
+            busy={busy === 'hide_question'}
+            onClick={() => void choose('hide_question')}
+          />
+
+          <Choice
+            icon={<Moon className="size-5" />}
+            title={firstName ? `This is ${firstName}’s bag but not mine` : `Rest ${label}`}
+            subtitle={`${label} stops appearing in your five. Undo it in Manage your topics.`}
+            disabled={busy !== null}
+            busy={busy === 'rest_category'}
+            onClick={() => void choose('rest_category')}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Choice({
+  icon,
+  title,
+  subtitle,
+  disabled,
+  busy,
+  onClick,
+}: {
+  icon: React.ReactNode
+  title: string
+  subtitle: string
+  disabled?: boolean
+  busy?: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="flex w-full items-start gap-3 rounded-2xl border border-[var(--brand-rule)] bg-[var(--brand-card)] px-4 py-3 text-left transition hover:bg-muted disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    >
+      <span className="mt-0.5 shrink-0 text-[var(--brand-ink-400)]">{icon}</span>
+      <span className="flex flex-col gap-0.5">
+        <span className="text-sm font-semibold text-foreground">
+          {title}
+          {busy ? '…' : ''}
+        </span>
+        <span className="text-quiet text-[var(--brand-ink-400)]">{subtitle}</span>
+      </span>
+    </button>
+  )
+}

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -430,10 +430,8 @@ function QuestionRow({
   dismissing = false,
   onGiveUp,
   giveUpDisabled = false,
-  onDismiss,
-  dismissDisabled = false,
-  onMutePresence,
-  muteDisabled = false,
+  onNotForMe,
+  notForMeDisabled = false,
   reportTarget = null,
   onReportedInappropriate,
 }: {
@@ -450,12 +448,13 @@ function QuestionRow({
   isNew?: boolean;
   onGiveUp?: () => void;
   giveUpDisabled?: boolean;
-  onDismiss?: () => void;
-  dismissDisabled?: boolean;
+  // One control, three scopes (see NotForMeSheet). Replaces the old adjacent
+  // onDismiss (temporary skip) and onMutePresence (durable category rest), which
+  // looked identical but were not equally reversible.
+  onNotForMe?: () => void;
+  notForMeDisabled?: boolean;
   // Bonus slots only (D-4 §B): "This is {Name}'s bag but not mine" — rests the
   // slot's domain so the category stops surfacing, and closes this question.
-  onMutePresence?: () => void;
-  muteDisabled?: boolean;
   reportTarget?: ReportReasonTarget | null;
   // Reporting the ACTIVE question as inappropriate also removes it from the
   // round (the card vanishing is the feedback, matching the recap surfaces).
@@ -799,7 +798,7 @@ function QuestionRow({
           ) : null}
         </div>
       </div>
-      {onGiveUp || onDismiss || onMutePresence ? (
+      {onGiveUp || onNotForMe ? (
         <div
           style={{
             display: 'flex',
@@ -819,24 +818,14 @@ function QuestionRow({
               Show me the answer
             </button>
           ) : null}
-          {onMutePresence && presenceSourceName ? (
+          {onNotForMe ? (
             <button
               type="button"
-              onClick={onMutePresence}
-              disabled={muteDisabled}
+              onClick={onNotForMe}
+              disabled={notForMeDisabled}
               style={questionActionLinkStyle}
             >
-              This is {firstNameFrom(presenceSourceName)}&rsquo;s bag but not mine
-            </button>
-          ) : null}
-          {onDismiss ? (
-            <button
-              type="button"
-              onClick={onDismiss}
-              disabled={dismissDisabled}
-              style={questionActionLinkStyle}
-            >
-              Dismiss
+              Not for me
             </button>
           ) : null}
         </div>
@@ -1696,19 +1685,22 @@ export function GameplayChatThread({
   messages,
   onGiveUp,
   giveUpDisabled,
-  onDismiss,
-  dismissDisabled,
-  onMutePresence,
-  muteDisabled,
+  onNotForMe,
+  notForMeDisabled,
+  onSlotClosed,
 }: {
   messages: ChatMessage[];
   onGiveUp?: () => void;
   giveUpDisabled?: boolean;
-  onDismiss?: () => void;
-  dismissDisabled?: boolean;
+  // One control, three scopes (see NotForMeSheet). Replaces the old adjacent
+  // onDismiss (temporary skip) and onMutePresence (durable category rest), which
+  // looked identical but were not equally reversible.
+  onNotForMe?: () => void;
+  notForMeDisabled?: boolean;
+  /** Closes the active slot without opening the sheet — used after an
+   *  inappropriate report, where the card vanishing IS the feedback. */
+  onSlotClosed?: () => void;
   // Bonus-slot opt-out (D-4 §B). Wired only to the active bonus question.
-  onMutePresence?: () => void;
-  muteDisabled?: boolean;
 }) {
   // "Show me the answer" and "Dismiss" belong only under the active (still-
   // unanswered) question — the last question message with no result after it.
@@ -1750,17 +1742,11 @@ export function GameplayChatThread({
                 badges={m.badges}
                 onGiveUp={onGiveUp && m.id === activeQuestionId ? onGiveUp : undefined}
                 giveUpDisabled={giveUpDisabled}
-                onDismiss={onDismiss && m.id === activeQuestionId ? onDismiss : undefined}
-                dismissDisabled={dismissDisabled}
-                onMutePresence={
-                  onMutePresence && m.id === activeQuestionId && m.presenceSourceName
-                    ? onMutePresence
-                    : undefined
-                }
-                muteDisabled={muteDisabled}
+                onNotForMe={onNotForMe && m.id === activeQuestionId ? onNotForMe : undefined}
+                notForMeDisabled={notForMeDisabled}
                 reportTarget={m.reportTarget}
                 onReportedInappropriate={
-                  onDismiss && m.id === activeQuestionId ? onDismiss : undefined
+                  onSlotClosed && m.id === activeQuestionId ? onSlotClosed : undefined
                 }
               />
             );

--- a/src/components/profile/settings/HiddenQuestions.tsx
+++ b/src/components/profile/settings/HiddenQuestions.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import { RotateCcw } from 'lucide-react';
+
+// The undo behind "Never show this question again".
+//
+// Permanent hiding is only safe against a finite question pool
+// (D-SUPPLY-FINITE-SET-01) because this list exists: nothing is burned out of
+// the corpus, and a mis-tap costs one trip here rather than a lost question.
+// If this surface is ever removed, the durable per-question scope in
+// NotForMeSheet has to go with it.
+
+export type HiddenQuestionItem = {
+  id: string;
+  questionText: string;
+  domain: string;
+  hiddenAt: string;
+};
+
+export function HiddenQuestions({ initial }: { initial: HiddenQuestionItem[] }) {
+  const [items, setItems] = useState(initial);
+  const [restoring, setRestoring] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function restore(id: string) {
+    if (restoring) return;
+    setRestoring(id);
+    setError(null);
+    // Optimistic: the row leaves immediately, and comes back if the call fails.
+    const previous = items;
+    setItems((current) => current.filter((item) => item.id !== id));
+    try {
+      const res = await fetch('/api/questions/hide', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ hidden_id: id }),
+      });
+      if (!res.ok) throw new Error('Could not bring that question back.');
+    } catch (caught) {
+      setItems(previous);
+      setError(caught instanceof Error ? caught.message : 'Could not bring that question back.');
+    } finally {
+      setRestoring(null);
+    }
+  }
+
+  return (
+    <section className="mb-8" id="hidden-questions">
+      <h2 className="mb-3 font-serif text-2xl font-semibold">Hidden questions</h2>
+      <p className="text-muted-foreground mb-3 text-sm">
+        {items.length === 0
+          ? "You haven't hidden any questions. When you do, they'll be here to bring back."
+          : 'Questions you asked us never to show again. Bring one back and it can appear in your five.'}
+      </p>
+
+      {error ? (
+        <p className="mb-3 text-sm text-[var(--brand-alert)]" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {items.length > 0 ? (
+        <ul className="flex flex-col gap-2">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="flex items-start justify-between gap-3 rounded-2xl border border-[var(--brand-rule)] px-4 py-3"
+            >
+              <div className="flex min-w-0 flex-col gap-1">
+                <p className="text-sm text-foreground">{item.questionText}</p>
+                <p className="text-quiet text-[var(--brand-ink-400)]">{item.domain}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => void restore(item.id)}
+                disabled={restoring === item.id}
+                className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-[var(--brand-rule)] px-3 py-1.5 text-sm font-medium transition hover:bg-muted disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <RotateCcw className="size-4" />
+                {restoring === item.id ? 'Bringing back…' : 'Bring back'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2349,6 +2349,32 @@ export async function register() {
     } catch {
       // Tables arrive with 0127/0128 in normal migration order.
     }
+    // Migration 0131 adds HiddenQuestion, the durable per-question opt-out behind
+    // the Not-for-me sheet. Both the queue builder (which excludes hidden rows on
+    // every build) and the hide/restore routes touch it, so a recorded-but-absent
+    // migration would 42P01 on the next Daily Five build.
+    // Self-contained; precedent: 0127's MissedReturnDismissed guard above.
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "HiddenQuestion" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "user_id" text NOT NULL REFERENCES "User"("id"),
+          "question_id" text REFERENCES "Question"("id"),
+          "generated_question_id" text REFERENCES "GeneratedQuestion"("id"),
+          "canonical_subcategory" text NOT NULL,
+          "hidden_at" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "HiddenQuestion" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_idx" ON "HiddenQuestion" ("user_id")`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_question_id_idx" ON "HiddenQuestion" ("user_id","question_id")`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_generated_question_id_idx" ON "HiddenQuestion" ("user_id","generated_question_id")`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_question_id_idx" ON "HiddenQuestion" ("question_id")`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_generated_question_id_idx" ON "HiddenQuestion" ("generated_question_id")`);
+    } catch {
+      // Fresh databases may not have User/Question/GeneratedQuestion yet —
+      // migrate() creates them all in normal migration order.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -34,6 +34,7 @@ import {
 import { SUBJECT_COOLDOWN_DAYS, makeSubjectCooldownGate } from '@/server/daily/subject-cooldown';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { getFriendAndFoFUserIds } from '@/server/db/queries/friends';
+import { EMPTY_HIDDEN_IDS, getHiddenQuestionIds } from '@/server/db/queries/hidden-questions';
 import {
   getFriendDomainsForBonus,
   type FriendDomainCandidate,
@@ -530,13 +531,28 @@ async function buildDailyQueueForUser(
   const subjectCooldownGate = makeSubjectCooldownGate(recentEntities);
   let deflectedForSubjectCooldown = 0;
 
+  // Permanently hidden questions ("Never show this question again", the durable
+  // scope of the Not-for-me sheet).
+  //
+  // *** THIS IS AN ABSOLUTE DROP, NOT A DEFLECTION. ***
+  // Every other gate in this builder (answer cooldown, subject cooldown,
+  // diversity) pushes a rejected pick into a reserve so a tapped-out knowledge
+  // base can restore it rather than serve a short queue. A hidden question must
+  // never come back by ANY path — not the reserve, not the top-up rounds, not
+  // the short-core backfill. The player said never. Serving a four-question
+  // Daily Five is the correct outcome if the alternative is re-serving something
+  // they explicitly hid.
+  //
+  // Fail-open on error: a lookup failure yields empty sets, so a transient DB
+  // blip degrades to "hides not applied this build" rather than losing the build.
+  const hiddenIds = await getHiddenQuestionIds(userId).catch(() => EMPTY_HIDDEN_IDS);
+  const notHiddenCanonical = <T extends { id: string }>(pick: T): boolean =>
+    !hiddenIds.questionIds.has(pick.id);
+
   const socialGraph = await getFriendAndFoFUserIds(userId);
-  const authoredAll = await pickEligibleAuthoredQuestions(
-    userId,
-    socialGraph,
-    DAILY_QUEUE_SIZE,
-    allowedSubcategories,
-  );
+  const authoredAll = (
+    await pickEligibleAuthoredQuestions(userId, socialGraph, DAILY_QUEUE_SIZE, allowedSubcategories)
+  ).filter(notHiddenCanonical);
   // Cap authored picks first (highest trust → first claim on each subcategory's
   // slots); deflected picks go to a reserve the backfill can draw on if the cap
   // would otherwise leave the queue short.
@@ -567,11 +583,10 @@ async function buildDailyQueueForUser(
   // House content does not enter the Feed and never occupies a +2 bonus slot.
   // Request against the CAPPED authored count so house can fill any slot the cap
   // freed, then run house through the same shared diversity gate.
-  const housePicksAll = await pickHouseQuestions(
-    userId,
-    DAILY_QUEUE_SIZE - authored.length,
-    allowedSubcategories,
-  );
+  // Hidden house picks are dropped outright, same absolute rule as authored above.
+  const housePicksAll = (
+    await pickHouseQuestions(userId, DAILY_QUEUE_SIZE - authored.length, allowedSubcategories)
+  ).filter(notHiddenCanonical);
   const houseReserve: typeof housePicksAll = [];
   const housePicks = housePicksAll.filter((pick) => {
     if (answerCooldownGate.blocks(pick.answerText)) {
@@ -629,6 +644,8 @@ async function buildDailyQueueForUser(
   const generatedReserve: typeof generated = [];
   let droppedDuplicates = 0;
   let droppedGeneric = 0;
+  // Picks dropped because the player permanently hid them (Not-for-me sheet).
+  let droppedHidden = 0;
   let deflectedForDiversity = 0;
   for (const question of generated) {
     // Drop bucket-level domains ("general"/"trivia"/short labels) BEFORE the
@@ -637,6 +654,13 @@ async function buildDailyQueueForUser(
     // (api/daily/queue) silently filter it out, leaving the user one short.
     if (isGenericSubcategory(question.canonicalSubcategory)) {
       droppedGeneric += 1;
+      continue;
+    }
+    // Permanently hidden generated question — absolute drop, no reserve (see the
+    // hiddenIds comment above). A regenerated row reaching the same id the player
+    // hid is still the question they refused.
+    if (hiddenIds.generatedQuestionIds.has(question.id)) {
+      droppedHidden += 1;
       continue;
     }
     const key = normalize(question.questionText);
@@ -892,6 +916,7 @@ async function buildDailyQueueForUser(
       topUpRounds,
       droppedDuplicates,
       droppedGeneric,
+      droppedHidden,
       baseDiversityCap,
       oftenDomains: oftenDomains.size,
       deflectedForDiversity,
@@ -938,6 +963,7 @@ async function buildDailyQueueForUser(
       topUpRounds,
       droppedDuplicates,
       droppedGeneric,
+      droppedHidden,
       baseDiversityCap,
       oftenDomains: oftenDomains.size,
       deflectedForDiversity,

--- a/src/server/db/queries/__tests__/hidden-questions.test.ts
+++ b/src/server/db/queries/__tests__/hidden-questions.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The durable per-question opt-out behind the Not-for-me sheet. These tests pin
+// the two properties the feature's safety rests on:
+//   1. A hide is addressed in exactly ONE id space (canonical vs generated), so
+//      the queue builder's two exclusion sets never disagree about a question.
+//   2. A hide is REVERSIBLE and user-scoped — restore deletes the row, and only
+//      for the owning user. Reversibility is the condition under which permanent
+//      hiding is acceptable against a finite pool (D-SUPPLY-FINITE-SET-01).
+
+const { selectMock, insertMock, deleteMock, state } = vi.hoisted(() => {
+  const state = {
+    /** Rows getHiddenQuestionIds should see. */
+    rows: [] as Array<{ questionId: string | null; generatedQuestionId: string | null }>,
+    /** Rows the idempotency pre-check should see. */
+    existing: [] as Array<{ id: string }>,
+    inserted: [] as unknown[],
+    deletedWhere: [] as unknown[],
+    deleteReturns: [] as Array<{ id: string }>,
+  };
+  return {
+    selectMock: vi.fn(),
+    insertMock: vi.fn(),
+    deleteMock: vi.fn(),
+    state,
+  };
+});
+
+vi.mock('@/server/db', () => ({
+  db: {
+    select: selectMock,
+    insert: insertMock,
+    delete: deleteMock,
+  },
+  hiddenQuestions: {
+    id: 'id',
+    userId: 'user_id',
+    questionId: 'question_id',
+    generatedQuestionId: 'generated_question_id',
+    canonicalSubcategory: 'canonical_subcategory',
+    hiddenAt: 'hidden_at',
+  },
+  questions: { id: 'id', questionText: 'question_text' },
+  generatedQuestions: { id: 'id', questionText: 'question_text' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  desc: (col: unknown) => ({ op: 'desc', col }),
+  eq: (col: unknown, value: unknown) => ({ op: 'eq', col, value }),
+  inArray: (col: unknown, values: unknown) => ({ op: 'inArray', col, values }),
+}));
+
+import {
+  getHiddenQuestionIds,
+  hideQuestion,
+  restoreHiddenQuestion,
+} from '@/server/db/queries/hidden-questions';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.rows = [];
+  state.existing = [];
+  state.inserted = [];
+  state.deletedWhere = [];
+  state.deleteReturns = [];
+
+  // Two different select shapes are used: the id sweep (.from().where()) and the
+  // idempotency pre-check (.from().where().limit()). Both resolve from state.
+  selectMock.mockImplementation((columns: Record<string, unknown>) => ({
+    from: () => ({
+      where: (whereArg: unknown) => {
+        const result = Object.keys(columns).includes('id') ? state.existing : state.rows;
+        return Object.assign(Promise.resolve(result), {
+          limit: () => Promise.resolve(state.existing),
+          orderBy: () => Promise.resolve(state.rows),
+          _where: whereArg,
+        });
+      },
+    }),
+  }));
+
+  insertMock.mockImplementation(() => ({
+    values: (row: unknown) => {
+      state.inserted.push(row);
+      return Promise.resolve();
+    },
+  }));
+
+  deleteMock.mockImplementation(() => ({
+    where: (whereArg: unknown) => {
+      state.deletedWhere.push(whereArg);
+      return { returning: () => Promise.resolve(state.deleteReturns) };
+    },
+  }));
+});
+
+describe('getHiddenQuestionIds — two id spaces, kept separate', () => {
+  it('sorts canonical and generated ids into their own sets', async () => {
+    state.rows = [
+      { questionId: 'q1', generatedQuestionId: null },
+      { questionId: null, generatedQuestionId: 'g1' },
+      { questionId: 'q2', generatedQuestionId: null },
+    ];
+
+    const result = await getHiddenQuestionIds('viewer');
+
+    expect([...result.questionIds].sort()).toEqual(['q1', 'q2']);
+    expect([...result.generatedQuestionIds]).toEqual(['g1']);
+  });
+
+  it('returns empty sets when nothing is hidden', async () => {
+    const result = await getHiddenQuestionIds('viewer');
+    expect(result.questionIds.size).toBe(0);
+    expect(result.generatedQuestionIds.size).toBe(0);
+  });
+});
+
+describe('hideQuestion', () => {
+  it('writes a canonical hide', async () => {
+    await hideQuestion({ userId: 'u1', questionId: 'q1', canonicalSubcategory: 'Beethoven' });
+    expect(state.inserted).toHaveLength(1);
+    expect(state.inserted[0]).toMatchObject({
+      userId: 'u1',
+      questionId: 'q1',
+      generatedQuestionId: null,
+      canonicalSubcategory: 'Beethoven',
+    });
+  });
+
+  it('writes a generated hide', async () => {
+    await hideQuestion({ userId: 'u1', generatedQuestionId: 'g1', canonicalSubcategory: 'Jazz' });
+    expect(state.inserted[0]).toMatchObject({ questionId: null, generatedQuestionId: 'g1' });
+  });
+
+  it('is idempotent — a second hide of the same question writes nothing', async () => {
+    // The pre-check finds an existing row, so a double-tap on a slow connection
+    // can't produce two entries in the Settings list.
+    state.existing = [{ id: 'existing' }];
+    await hideQuestion({ userId: 'u1', questionId: 'q1', canonicalSubcategory: 'Beethoven' });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it('refuses a hide that names no question at all', async () => {
+    await hideQuestion({ userId: 'u1', canonicalSubcategory: 'Beethoven' });
+    expect(state.inserted).toHaveLength(0);
+  });
+});
+
+describe('restoreHiddenQuestion — the undo', () => {
+  it('reports true when a row was deleted', async () => {
+    state.deleteReturns = [{ id: 'h1' }];
+    await expect(restoreHiddenQuestion('u1', 'h1')).resolves.toBe(true);
+  });
+
+  it("reports false when the id isn't the caller's", async () => {
+    // The user scoping lives in the WHERE clause, so someone else's id simply
+    // deletes nothing rather than clearing their row.
+    state.deleteReturns = [];
+    await expect(restoreHiddenQuestion('u1', 'someone-elses')).resolves.toBe(false);
+  });
+});

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -585,6 +585,10 @@ export async function deleteUserAccount(userId: string): Promise<void> {
     await tx.execute(sql`update "DailyPreference" set "friend_ids" = array_remove("friend_ids", ${userId}) where ${userId} = any("friend_ids")`);
 
     await tx.execute(sql`delete from "SkippedDailyQuestion" where "user_id" = ${userId} or "question_id" in ${orphanList} or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`);
+    // HiddenQuestion (0131) has no ON DELETE CASCADE on its user/question FKs, so
+    // it must be cleared explicitly here or account deletion fails on the FK —
+    // same shape and same reason as the SkippedDailyQuestion sweep above.
+    await tx.execute(sql`delete from "HiddenQuestion" where "user_id" = ${userId} or "question_id" in ${orphanList} or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`);
     await tx.execute(sql`delete from "DailyQueue" where "user_id" = ${userId}`);
     await tx.execute(sql`delete from "DailyPreference" where "user_id" = ${userId}`);
 

--- a/src/server/db/queries/hidden-questions.ts
+++ b/src/server/db/queries/hidden-questions.ts
@@ -1,0 +1,183 @@
+/**
+ * Permanent per-question hiding — the "Never show this question again" scope of
+ * the Not-for-me sheet.
+ *
+ * Three scopes sit behind that one control, and they live in three different
+ * places on purpose:
+ *  - "Skip for now"        → SkippedDailyQuestion (queue-scoped, temporary)
+ *  - "Never this question" → HERE (durable, reversible)
+ *  - "Rest this category"  → DailyPreference.domainPreferenceFrequency = 'resting'
+ *
+ * Hiding is reversible by design: restoreQuestion DELETES the row. That is the
+ * condition under which permanent hiding is safe against a finite pool
+ * (D-SUPPLY-FINITE-SET-01) — nothing is burned out of the corpus for good, so a
+ * mis-tap costs the player one trip to Settings rather than a lost question.
+ */
+
+import { and, desc, eq, inArray } from 'drizzle-orm';
+
+import { db, generatedQuestions, hiddenQuestions, questions } from '@/server/db';
+
+/** The two id spaces a hidden question can live in. Both are looked up per build. */
+export type HiddenQuestionIds = {
+  /** Canonical `Question.id` values the player has hidden. */
+  questionIds: Set<string>;
+  /** `GeneratedQuestion.id` values the player has hidden. */
+  generatedQuestionIds: Set<string>;
+};
+
+export const EMPTY_HIDDEN_IDS: HiddenQuestionIds = {
+  questionIds: new Set(),
+  generatedQuestionIds: new Set(),
+};
+
+/**
+ * Every question this player has hidden, as two id sets.
+ *
+ * Read on every Daily Five build. Unlike the cooldown/diversity gates, a hit
+ * here is an ABSOLUTE drop — a hidden question is never reserved, never used as
+ * backfill, and never promoted to fill a short core. The player said never.
+ */
+export async function getHiddenQuestionIds(userId: string): Promise<HiddenQuestionIds> {
+  const rows = await db
+    .select({
+      questionId: hiddenQuestions.questionId,
+      generatedQuestionId: hiddenQuestions.generatedQuestionId,
+    })
+    .from(hiddenQuestions)
+    .where(eq(hiddenQuestions.userId, userId));
+
+  const result: HiddenQuestionIds = {
+    questionIds: new Set<string>(),
+    generatedQuestionIds: new Set<string>(),
+  };
+  for (const row of rows) {
+    if (row.questionId) result.questionIds.add(row.questionId);
+    if (row.generatedQuestionId) result.generatedQuestionIds.add(row.generatedQuestionId);
+  }
+  return result;
+}
+
+/**
+ * Hide one question for one player. Idempotent: hiding an already-hidden
+ * question is a no-op rather than a duplicate row, so a double-tap on a slow
+ * connection can't produce two entries in the Settings list.
+ *
+ * Exactly one of questionId / generatedQuestionId should be set, mirroring how
+ * a queue slot addresses its question.
+ */
+export async function hideQuestion(input: {
+  userId: string;
+  questionId?: string | null;
+  generatedQuestionId?: string | null;
+  canonicalSubcategory: string;
+}): Promise<void> {
+  const { userId, questionId = null, generatedQuestionId = null, canonicalSubcategory } = input;
+  if (!questionId && !generatedQuestionId) return;
+
+  const existing = await db
+    .select({ id: hiddenQuestions.id })
+    .from(hiddenQuestions)
+    .where(
+      and(
+        eq(hiddenQuestions.userId, userId),
+        questionId
+          ? eq(hiddenQuestions.questionId, questionId)
+          : eq(hiddenQuestions.generatedQuestionId, generatedQuestionId as string),
+      ),
+    )
+    .limit(1);
+  if (existing.length > 0) return;
+
+  await db.insert(hiddenQuestions).values({
+    userId,
+    questionId,
+    generatedQuestionId,
+    canonicalSubcategory,
+    hiddenAt: new Date(),
+  });
+}
+
+/**
+ * Un-hide — the undo behind "Hidden questions" in settings. Deletes the row
+ * outright rather than tombstoning it, so the question returns to the pool and
+ * can be hidden again later without special-casing a restored state.
+ *
+ * Scoped to the owning user, so a stray id can't clear someone else's row.
+ */
+export async function restoreHiddenQuestion(userId: string, hiddenId: string): Promise<boolean> {
+  const deleted = await db
+    .delete(hiddenQuestions)
+    .where(and(eq(hiddenQuestions.id, hiddenId), eq(hiddenQuestions.userId, userId)))
+    .returning({ id: hiddenQuestions.id });
+  return deleted.length > 0;
+}
+
+export type HiddenQuestionRow = {
+  id: string;
+  questionText: string;
+  domain: string;
+  hiddenAt: Date;
+};
+
+/**
+ * The player's hidden questions, newest first, with enough text to recognize
+ * what they're restoring. Question text is resolved from whichever source the
+ * row points at; a row whose question has since been deleted is skipped rather
+ * than rendered as a blank line.
+ */
+export async function getHiddenQuestionsForUser(userId: string): Promise<HiddenQuestionRow[]> {
+  const rows = await db
+    .select({
+      id: hiddenQuestions.id,
+      questionId: hiddenQuestions.questionId,
+      generatedQuestionId: hiddenQuestions.generatedQuestionId,
+      domain: hiddenQuestions.canonicalSubcategory,
+      hiddenAt: hiddenQuestions.hiddenAt,
+    })
+    .from(hiddenQuestions)
+    .where(eq(hiddenQuestions.userId, userId))
+    .orderBy(desc(hiddenQuestions.hiddenAt));
+
+  if (rows.length === 0) return [];
+
+  // Two batched lookups rather than a join per source — the row count here is
+  // player-scale (tens), and this keeps the query count flat at two.
+  const canonicalIds = rows.map((r) => r.questionId).filter((v): v is string => Boolean(v));
+  const generatedIds = rows.map((r) => r.generatedQuestionId).filter((v): v is string => Boolean(v));
+
+  const [canonicalRows, generatedRows] = await Promise.all([
+    canonicalIds.length > 0
+      ? db
+          .select({ id: questions.id, text: questions.questionText })
+          .from(questions)
+          .where(inArray(questions.id, canonicalIds))
+      : Promise.resolve([] as Array<{ id: string; text: string }>),
+    generatedIds.length > 0
+      ? db
+          .select({ id: generatedQuestions.id, text: generatedQuestions.questionText })
+          .from(generatedQuestions)
+          .where(inArray(generatedQuestions.id, generatedIds))
+      : Promise.resolve([] as Array<{ id: string; text: string }>),
+  ]);
+
+  const textById = new Map<string, string>();
+  for (const row of canonicalRows) textById.set(row.id, row.text);
+  for (const row of generatedRows) textById.set(row.id, row.text);
+
+  const result: HiddenQuestionRow[] = [];
+  for (const row of rows) {
+    const key = row.questionId ?? row.generatedQuestionId;
+    const questionText = key ? textById.get(key) : undefined;
+    // A hidden question whose source row is gone has nothing to show and nothing
+    // meaningful to restore — leave it out of the list.
+    if (!questionText) continue;
+    result.push({
+      id: row.id,
+      questionText,
+      domain: row.domain,
+      hiddenAt: row.hiddenAt,
+    });
+  }
+  return result;
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1074,6 +1074,48 @@ export const skippedDailyQuestions = pgTable(
   ],
 );
 
+/**
+ * A question the player has permanently hidden ("Never show this question
+ * again" in the Not-for-me sheet). Distinct from SkippedDailyQuestion in two
+ * ways that matter:
+ *
+ *  - No `queue_id`. A skip is scoped to the round it happened in and cascades
+ *    away with its queue; a hide is a durable preference that must outlive
+ *    every queue it was ever served in.
+ *  - It is REVERSIBLE by design. "Hidden questions" in settings lists these
+ *    rows and restoring one deletes it, so nothing is burned irrecoverably.
+ *    That reversibility is what makes permanent hiding acceptable against a
+ *    finite question pool (D-SUPPLY-FINITE-SET-01) -- a player who hides a
+ *    question by accident can always get it back.
+ *
+ * Exactly one of question_id / generated_question_id is set, mirroring how
+ * SkippedDailyQuestion addresses the two question sources.
+ */
+export const hiddenQuestions = pgTable(
+  'HiddenQuestion',
+  {
+    id: id(),
+    userId: text('user_id').notNull().references(() => users.id),
+    questionId: text('question_id').references(() => questions.id),
+    generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id),
+    canonicalSubcategory: text('canonical_subcategory').notNull(),
+    hiddenAt: timestamp('hidden_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('HiddenQuestion_user_id_idx').on(table.userId),
+    index('HiddenQuestion_user_id_question_id_idx').on(table.userId, table.questionId),
+    index('HiddenQuestion_user_id_generated_question_id_idx').on(
+      table.userId,
+      table.generatedQuestionId,
+    ),
+    // Standalone covering indexes for the two FKs, same rationale as
+    // SkippedDailyQuestion's (0083 / advisor 0001): the composites lead with
+    // user_id and can't serve an FK check on the question columns alone.
+    index('HiddenQuestion_question_id_idx').on(table.questionId),
+    index('HiddenQuestion_generated_question_id_idx').on(table.generatedQuestionId),
+  ],
+);
+
 export const userDomainDifficulties = pgTable(
   'USER_DOMAIN_DIFFICULTY',
   {


### PR DESCRIPTION
## The problem

Two links sat under every question, sharing one style (`questionActionLinkStyle`) and doing drastically different things:

| Control | What it actually did | When it appeared |
|---|---|---|
| `Dismiss` | temporary skip, capped 5/round | always |
| `This is {Name}'s bag but not mine` | **durable category rest**, written on one tap | **bonus slots only** |

Same look, same weight, no confirmation on either — and one of them wrote a standing preference immediately.

Worse, the durable opt-out was gated to +2 bonus slots (`onMutePresence && presenceSourceName`). If a **core** question wasn't your bag, there was no way to say so. You could only skip it, temporarily, five times a round.

## Now

One control — **"Not for me"** — on every question, with the scope chosen explicitly:

- **Skip for now** — temporary, comes back
- **Never show this question** — durable, undoable
- **Rest {category}** — durable; keeps the `"{Name}'s bag but not mine"` phrasing on bonus slots, where it reads right

Catch-up gets the **same sheet** rather than keeping its own separate dismiss button. A control that looks identical across surfaces has to mean the same thing — that was the whole complaint.

## Data

New `HiddenQuestion` table (migration `0131`), deliberately **without a `queue_id`**. `SkippedDailyQuestion` is scoped to its round and cascades away with its queue; a standing refusal has to outlive every queue it was ever served in.

**Hiding is reversible, and that's load-bearing rather than a nicety.** Permanent hiding is only defensible against this app's finite pool (`D-SUPPLY-FINITE-SET-01`) because **Settings › Hidden questions** can undo it. That reasoning is written into the schema, the migration header and the component, so the undo doesn't get removed later without seeing why it exists.

## Serving

Hidden questions are an **absolute drop** in the queue builder, not a deflection.

Every other gate there (answer cooldown, subject cooldown, diversity) pushes rejects into a reserve so a thin knowledge base can restore them. Hidden ones bypass that entirely — no reserve, no top-up, no short-core backfill. Serving four is the correct outcome if the alternative is re-serving something the player explicitly said never to.

## Deliberately not included

**The feed's ⋯ menu.** It currently offers *"See questions about {category} less often"* — a soft blue-moon down-weight — and the code states this replaced a hard category hide *"per owner direction"*.

Dropping this sheet in there would reverse that decision, so it wants a call first:

- Replace the down-weight with the sheet (fully uniform, reverses the earlier direction)
- Keep both — down-weight for browsing, sheet for question surfaces
- Add the sheet alongside it

The answered-list ⋯ (report-only today) is untouched pending the same call.

## Migration is NOT applied

`reconcile-drizzle --apply` was avoided on purpose: **0126–0130 are journaled but still absent from `__drizzle_migrations`**, and `--apply` would mark them applied *without running them*. Journal entry hand-written instead.

Those five are pending in prod independently of this PR. `npm run db:migrate` applies all six.

## Verification

`tsc` 0 errors · 2,383 tests pass (307 files) · lint unchanged (4 pre-existing warnings in untouched files) · all six design ratchets green — including fixing a `text-[0.68rem]` I'd introduced rather than raising the type-size ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A
