### PR TITLE
Cap the diversity backfill so one reserve can't eat a whole shortfall

### DIFF
--- a/src/server/daily/__tests__/diversity-cap.test.ts
+++ b/src/server/daily/__tests__/diversity-cap.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DAILY_QUEUE_MAX_PER_SUBCATEGORY, DAILY_QUEUE_SIZE } from '@/server/daily/types';
+import { DAILY_QUEUE_MAX_PER_SUBCATEGORY, DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE } from '@/server/daily/types';
 
 // Same wholesale-mock strategy as queue-floor.test.ts: fillDailyQueueForUser
 // orchestrates DB pickers + LLM generation, all of which touch @/server/db (which
@@ -103,6 +103,24 @@ function authoredPick(id: string, subcategory: string) {
     category: '',
     authorName: null,
     authorNote: null,
+  } as never;
+}
+
+// Minimal stand-in for a house pick (pickHouseQuestions) — distinct answerText
+// per id so the (empty by default) answer-cooldown gate never collides across
+// picks, matching authoredPick's shape plus the fields the answer/subject
+// cooldown gates read.
+function houseQuestion(id: string, subcategory: string) {
+  return {
+    id,
+    questionText: `House ${id}`,
+    answerText: `Answer ${id}`,
+    canonicalSubcategory: subcategory,
+    broadCategory: null,
+    category: '',
+    subjectEntity: null,
+    difficultyEstimate: null,
+    creatorNote: null,
   } as never;
 }
 
@@ -348,5 +366,35 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
 
     // A full five-question queue still builds — the cap degraded gracefully.
     expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
+  });
+
+  it('caps the soft-cap backfill at one slot past the normal cap (prod incident 2026-08-30)', async () => {
+    // Reproduces the incident directly: a house bank with only ONE covered
+    // subcategory (5 Botany picks, mirroring the 10-question "Beethoven" house
+    // bank) and generation that comes back empty every round. Before the
+    // B-DIVERSITY-BACKFILL-CAP-01 fix, the soft-cap backfill drained the whole
+    // house reserve to keep the queue full — 5/5 Botany. The backfill must now
+    // stop at ONE slot past the normal cap (3, not 5) and let the queue serve
+    // short rather than repeat the same subcategory past that ceiling.
+    mocks.pickHouseQuestions.mockResolvedValue([
+      houseQuestion('h1', 'Botany'),
+      houseQuestion('h2', 'Botany'),
+      houseQuestion('h3', 'Botany'),
+      houseQuestion('h4', 'Botany'),
+      houseQuestion('h5', 'Botany'),
+    ]);
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([]);
+
+    await fillDailyQueueForUser(USER);
+
+    const houseSlots = persistedSlots().filter(
+      (slot) => slot.source === 'house' && slot.domain === 'Botany',
+    );
+    // Normal cap (2) + exactly one extra slot from the backfill relaxation = 3.
+    expect(houseSlots).toHaveLength(DAILY_QUEUE_MAX_PER_SUBCATEGORY + 1);
+    // With nothing else available to diversify with, the queue serves short —
+    // exactly the floor — rather than padding out to five with more Botany.
+    const core = persistedSlots().filter((slot) => !slot.presence_source_id);
+    expect(core).toHaveLength(DAILY_QUEUE_MIN_SIZE);
   });
 });

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -811,6 +811,29 @@ async function buildDailyQueueForUser(
   // knowledge base too narrow to field five distinct subcategories degrades to
   // exactly the queue it would have built without the cap — never shorter, and never
   // a spurious generation_failed below the floor.
+  //
+  // A SECOND, higher cap still applies during backfill (B-DIVERSITY-BACKFILL-CAP-01,
+  // 2026-08-30): capForSubcategory(key) + 1 — one more than the normal cap, never
+  // unbounded. Without this, one reserve fully absorbing a shortfall before another
+  // ever gets drawn from could relax a whole Five back down to a single subcategory —
+  // seen in prod: 5/5 "Beethoven" house questions, even though a genuinely diverse
+  // batch of fresh questions had generated successfully that same build and was
+  // sitting in generatedReserve. It never got drawn from because the house reserve
+  // (3 cap-deflected Beethoven house questions) alone fully covered the shortfall
+  // first, per the authored → house → generated draw order above. "often" domains
+  // stay exempt — that's still an explicit player request, not a fallback artifact —
+  // but every other subcategory can take at most one extra slot during relaxation. A
+  // queue that still can't reach five under this stays short rather than repetitive;
+  // DAILY_QUEUE_MIN_SIZE is the floor.
+  const backfillCapForSubcategory = (normalizedSubcategory: string): number => {
+    if (oftenDomains.has(normalizedSubcategory)) return DAILY_QUEUE_SIZE;
+    return capForSubcategory(normalizedSubcategory) + 1;
+  };
+  const backfillGate = makeSubcategoryDiversityGate(backfillCapForSubcategory);
+  for (const pick of authored) backfillGate.admit(pick.canonicalSubcategory);
+  for (const pick of housePicks) backfillGate.admit(pick.canonicalSubcategory);
+  for (const question of generatedForQueue) backfillGate.admit(question.canonicalSubcategory);
+
   const authoredBackfill: typeof authored = [];
   const houseBackfill: typeof housePicks = [];
   const generatedBackfill: typeof generatedForQueue = [];
@@ -818,16 +841,19 @@ async function buildDailyQueueForUser(
     DAILY_QUEUE_SIZE - (authored.length + housePicks.length + generatedForQueue.length);
   for (const pick of authoredReserve) {
     if (backfillShortfall <= 0) break;
+    if (!backfillGate.admit(pick.canonicalSubcategory)) continue;
     authoredBackfill.push(pick);
     backfillShortfall -= 1;
   }
   for (const pick of houseReserve) {
     if (backfillShortfall <= 0) break;
+    if (!backfillGate.admit(pick.canonicalSubcategory)) continue;
     houseBackfill.push(pick);
     backfillShortfall -= 1;
   }
   for (const question of generatedReserve) {
     if (backfillShortfall <= 0) break;
+    if (!backfillGate.admit(question.canonicalSubcategory)) continue;
     generatedBackfill.push(question);
     backfillShortfall -= 1;
   }


### PR DESCRIPTION
## Summary
- Prod incident 2026-08-30: a Daily Five served 5/5 "Beethoven" house questions. Generation had actually succeeded that build — a diverse batch across 11 domains landed in `generatedReserve` — but the soft-cap backfill drains reserves in a fixed `authored -> house -> generated` order, and the house reserve alone (3 cap-deflected Beethoven questions) fully covered the 3-slot shortfall before the generated reserve was ever touched.
- Adds a second, slightly higher cap during backfill (`capForSubcategory(key) + 1`, "often" domains still exempt) so no single reserve can relax a subcategory past one extra slot. A shortfall one reserve can't fully cover under this cap now spills to the next reserve in line instead of repeating.
- Adds a regression test reproducing the incident shape directly (house bank covering only one subcategory, generation returning empty every round). Verified locally against the pre-fix code that it fails there (5/5 Botany) and passes with the fix (capped at 3, queue served short).

## Test plan
- [x] `npx vitest run src/server/daily/__tests__/diversity-cap.test.ts` — 8/8 pass
- [x] Confirmed the new test fails without the fix (reverted locally, not committed) and passes with it
- [ ] `npx tsc -p tsconfig.typecheck.json` — clean on the modified file at time of the original commit; worth a full re-run before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A