### PR TITLE
Fix false-suppression of human-authored dedup collisions

### DIFF
--- a/src/server/pool/__tests__/dedup.test.ts
+++ b/src/server/pool/__tests__/dedup.test.ts
@@ -106,8 +106,10 @@ describe('resolveCollision — fact_key-aware threshold (false-suppression fix)'
     expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-m' });
   });
 
-  it('falls back to the base threshold when one fact_key is absent', () => {
-    // Human survivors carry no fact_key → the high bar must NOT apply.
+  it('falls back to the base threshold when one fact_key is absent (machine incoming)', () => {
+    // Human survivors carry no fact_key → the high bar must NOT apply here:
+    // this branch only ever suppresses the incoming MACHINE row, so there is
+    // no false-suppression risk to a human row to guard against.
     const d = resolveCollision(
       { id: 'new-m', origin: 'machine', factKey: 'pl-mulciber-pandaemonium' },
       near({ id: 'old-h', origin: 'human', similarity: 0.95, factKey: null }),
@@ -115,5 +117,51 @@ describe('resolveCollision — fact_key-aware threshold (false-suppression fix)'
       DT,
     );
     expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-h' });
+  });
+});
+
+describe('resolveCollision — human-vs-human never gets fact_key protection (engine bug fix)', () => {
+  // Human-authored Question rows never carry a fact_key (it's an LLM-generation
+  // artifact — see src/server/questions/fact-key.ts), so two human rows about
+  // the same subject could never reach the factKeysDiffer branch and always
+  // fell back to the lenient 0.92 bar — even though human-vs-human is the ONLY
+  // branch where the suppressed row is ever human-authored (every other branch
+  // either suppresses a machine row outright or always keeps the human row).
+  // Observed in production: "how many piano sonatas did Beethoven write" vs.
+  // "how many symphonies did Beethoven write" collided at ~0.95 purely on
+  // shared phrasing, despite being unrelated facts.
+  it('does NOT suppress two distinct human facts that merely share a subject’s vocabulary', () => {
+    const d = resolveCollision(
+      { id: 'new-h', origin: 'human' },
+      near({ id: 'old-h', origin: 'human', similarity: 0.95 }),
+      T,
+      DT,
+    );
+    expect(d).toEqual({ action: 'none' });
+  });
+
+  it('STILL suppresses near-identical human text with no fact_key on either side', () => {
+    const d = resolveCollision(
+      { id: 'new-h', origin: 'human' },
+      near({ id: 'old-h', origin: 'human', similarity: 0.999 }),
+      T,
+      DT,
+    );
+    expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-h' });
+  });
+
+  it('does not raise the bar for human vs machine (only human-vs-human is protected)', () => {
+    const d = resolveCollision(
+      { id: 'new-h', origin: 'human' },
+      near({ id: 'old-m', origin: 'machine', similarity: 0.95 }),
+      T,
+      DT,
+    );
+    expect(d).toEqual({
+      action: 'suppress_existing',
+      existingId: 'old-m',
+      existingOrigin: 'machine',
+      survivorId: 'new-h',
+    });
   });
 });

--- a/src/server/pool/dedup.ts
+++ b/src/server/pool/dedup.ts
@@ -85,7 +85,23 @@ export function resolveCollision(
     incoming.factKey != null &&
     nearest.factKey != null &&
     incoming.factKey !== nearest.factKey;
-  const effectiveThreshold = factKeysDiffer
+  // fact_key is an LLM-generation artifact — a human-authored Question row
+  // never carries one (src/server/questions/fact-key.ts), so a human-vs-human
+  // collision can NEVER reach the factKeysDiffer branch above and always fell
+  // back to the base 0.92 threshold. That's exactly the false-suppression
+  // failure mode fact_key was built to catch (2026-06-27 audit: ~46% of
+  // distinct facts about one subject falsely suppressed at 0.92, because
+  // questions about one subject share enough vocabulary to embed close
+  // together even when the facts differ), just left unprotected for the one
+  // branch below where the row actually LOST is human-authored — every other
+  // branch either only ever suppresses a machine row or always keeps the
+  // human row (see the matrix below). Apply the same raised bar here, on the
+  // same "be conservative absent same-fact evidence" principle, scoped to
+  // human-vs-human so the machine-involving branches (already covered by
+  // fact_key when present, and deliberately left lenient when a machine row's
+  // near-neighbor is an older fact_key-less human row) are untouched.
+  const bothHuman = incoming.origin === 'human' && nearest.origin === 'human';
+  const effectiveThreshold = factKeysDiffer || bothHuman
     ? Math.max(threshold, differentFactThreshold)
     : threshold;
   if (nearest.similarity < effectiveThreshold) return { action: 'none' };


### PR DESCRIPTION
## Summary
- Human-authored `Question` rows never carry a `fact_key` (it's an LLM-generation artifact), so a human-vs-human embedding collision could never reach the `factKeysDiffer` escape hatch built by the 2026-06-27 audit fix and always fell back to the lenient 0.92 threshold.
- Human-vs-human is the *only* branch in the collision matrix where the suppressed row is ever human-authored — every other branch (machine-vs-machine, machine-vs-human, human-vs-machine) either only suppresses a machine row or always keeps the human one. So this was the one unprotected case, and it's the one where a false suppression actually costs irreplaceable content.
- Raises the effective threshold to the existing `DEFAULT_DIFFERENT_FACT_COSINE_THRESHOLD` (0.99) specifically for human-vs-human collisions. Every fact_key-bearing and machine-involving path is untouched.

## Context
Found while reviewing 80 questions Josh hand-authored (RBG, philosophy, Wallace Stevens, Ulysses, Rams, Beethoven, etc.). 7 were flagged `is_duplicate` and silently suppressed from serving; on inspection none were actually duplicate facts — e.g. "how many piano sonatas did Beethoven write" (32) vs. "how many symphonies did Beethoven write" (9) collided at ~0.95 similarity purely on shared phrasing ("How many X did Beethoven compose?"), despite being unrelated facts. All 7 have been manually unsuppressed in prod; this PR fixes the underlying engine bug so it doesn't recur on the next multi-question batch about one subject.

No API cost impact — this is a pure comparison-logic change to an already-computed cosine similarity, no new embedding or LLM calls.

## Test plan
- [x] `npx vitest run src/server/pool/__tests__/dedup.test.ts` — 14/14 pass (10 existing + 4 new covering the human-vs-human fix)
- [x] `npx tsc -p tsconfig.typecheck.json` clean on both touched files
- [ ] Confirm no regression in the nightly dedup pass on the next generation batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A