### PR TITLE
Stop the nightly verify gate from Sonnet-billing admin bulk uploads

### DIFF
--- a/src/app/api/cron/batch-verify-questions/route.ts
+++ b/src/app/api/cron/batch-verify-questions/route.ts
@@ -132,6 +132,15 @@ function selectPending(limit: number): Promise<[PendingRow[], PendingRow[]]> {
         isNull(questions.verifiedAt),
         ne(questions.visibility, 'blocked'),
         isNull(questions.deletedAt),
+        // House-authored rows (admin bulk-upload / crafter-keep) are
+        // creator-written and admin-trusted at insert time (bulk-upload's own
+        // comment: "Admin-uploaded questions are trusted: verified +
+        // creator-written") — they still get the free deterministic leak
+        // check and the cheap Haiku vet scorer, just never this Sonnet
+        // (+ occasional web search) pass. Excluded so a large admin upload
+        // can't camp the daily 25-row cap and rack up sync-rate Sonnet spend
+        // on content nobody asked to machine-verify (2026-08-31).
+        ne(questions.source, 'house_authored'),
       ))
       .limit(limit),
     db
@@ -202,7 +211,10 @@ async function stampGenerated(rowId: string, verdict: VerificationVerdict, now: 
  * batch-only — NEVER a write-time gate, NEVER overwrites an author's answer.
  *
  * Sweeps both question stores for rows not yet stamped (verified_at IS NULL):
- *   - Question        — eligible, not blocked, not deleted; a demote sets
+ *   - Question        — eligible, not blocked, not deleted, not house-authored
+ *                       (admin bulk-upload / crafter-keep — already trusted at
+ *                       insert time, permanently left unswept here to avoid
+ *                       sync-rate Sonnet spend on it); a demote sets
  *                       publicStatus = 'needs_review'.
  *   - GeneratedQuestion — not already suppressed, not expired; a demote sets
  *                       is_duplicate = true (the only suppress flag the bank honors).


### PR DESCRIPTION
## Summary
- `batch-verify-questions` (the nightly Sonnet fact-check cron, sync-rate since `BATCH_VERIFY_ASYNC_ENABLED` is unset) selects any `Question` row with `verified_at IS NULL` with no `source` filter — an admin bulk upload competes for the same 25-row/day cap as everything else, at full sync pricing, including occasional web-search calls.
- Excludes `source = 'house_authored'` from that query. These rows are admin-trusted at insert time already (bulk-upload's own comment: *"Admin-uploaded questions are trusted: verified + creator-written"*) — they still get the free deterministic answer-leak check and the cheap Haiku vet scorer, just never this Sonnet pass.

## Context
Discovered while investigating cost for an 80-question admin-uploaded batch. Checked the live backlog: 107 `Question` rows pending verification, **80 of them (75%) were that one bulk upload** — at 25/day it would have taken ~4-5 daily cron runs of real, uncached Sonnet spend to clear a batch that was already manually fact-checked before upload.

## Test plan
- [x] `npx tsc -p tsconfig.typecheck.json` clean
- [x] `npx eslint src/app/api/cron/batch-verify-questions/route.ts` clean
- [ ] Confirm the daily cron's `question.scanned` count drops accordingly on the next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A