### PR TITLE
Extend friend-invite TTL to 30 days and remind inviters of stale sends

### DIFF
--- a/src/app/api/cron/friend-invitation-reminders/route.ts
+++ b/src/app/api/cron/friend-invitation-reminders/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { isCronAuthorized } from '@/server/auth/cron';
+import { getInvitationsNeedingReminder } from '@/server/friends/invitations';
+import { writeActivity } from '@/server/activity/write-activity';
+
+export const dynamic = 'force-dynamic';
+
+// Daily nudge for the inviter: a FriendInvitation sent >= 30 days ago (the
+// same TTL the invite itself lapses at) with no acceptance and no cancellation
+// gets one 'friend_invitation_reminder' ActivityItem written to the inviter,
+// surfaced on /activities as "{name} hasn't accepted your invite yet — Resend".
+// getInvitationsNeedingReminder() already excludes invitations that have a
+// prior reminder, so this is safe to run daily without re-notifying.
+export async function GET(request: NextRequest) {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const candidates = await getInvitationsNeedingReminder();
+
+  await Promise.all(
+    candidates.map((invitation) =>
+      writeActivity({
+        userId: invitation.inviterUserId,
+        type: 'friend_invitation_reminder',
+        referenceId: invitation.id,
+        referenceType: 'friend_invitation',
+      }),
+    ),
+  );
+
+  return NextResponse.json({ ok: true, reminded: candidates.length });
+}

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -750,6 +750,21 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         expand: null,
       };
 
+    case 'friend_invitation_reminder': {
+      const reminder = item.reference.friendInvitationReminder;
+      // The invitee has no account yet, so there is no profile to link — render
+      // the name (or the masked phone as a fallback) as plain text, never as an
+      // actor link.
+      const inviteeName = reminder?.inviteeDisplayName?.trim() || reminder?.maskedPhone || 'Your invite';
+      return {
+        ...base,
+        line: [txt(inviteeName), txt(" hasn't accepted your invite yet")],
+        secondLine: null,
+        action: { kind: 'link', href: '/friends', label: 'Resend' },
+        expand: null,
+      };
+    }
+
     default:
       return {
         ...base,

--- a/src/lib/activity-types.ts
+++ b/src/lib/activity-types.ts
@@ -65,7 +65,13 @@ export type ActivityItemType =
   // positive signal the product makes, and nothing carried it back before. Fires
   // for the WRONG return scope only (an expired-scope return has never been seen,
   // so there is no "it stuck" story to tell).
-  | 'missed_return_recovered';
+  | 'missed_return_recovered'
+  // Written to the INVITER (not the invitee, who has no account yet) by the
+  // friend-invitation-reminders cron once a sent FriendInvitation has sat
+  // unaccepted for 30 days — the same mark at which the invite itself expires.
+  // One-shot: the cron checks for an existing row against the same referenceId
+  // before writing again, so this never repeats for the same invitation.
+  | 'friend_invitation_reminder';
 
 // Events surfaced in Home's top-3 RecentActivity and counted by the bell
 // badge. Light type filtering only — chronological within this set. Single

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -5,6 +5,7 @@ import {
   db,
   feedItems,
   follows,
+  friendInvitations,
   friendships,
   gradeDisputes,
   joshingGameQuestions,
@@ -17,6 +18,7 @@ import {
   questions,
   users,
 } from '@/server/db';
+import { maskPhoneE164 } from '@/lib/phone-e164';
 import { getCannedReaction } from '@/lib/reactions';
 import { resolveAuthorDisplay } from '@/lib/questions-types';
 import { HOME_TOP3_ELIGIBLE_TYPES, type ActivityItemType } from '@/server/activity/write-activity';
@@ -125,6 +127,15 @@ export type ActivityItemView = Pick<
       reviewReason: string | null;
       acceptedAlternative: string | null;
     };
+    // friend_invitation_reminder. inviteeDisplayName mirrors what the inviter
+    // typed at send time (the invitee has no account, so there is no `users`
+    // row to join against). maskedPhone matches the masking PeopleYouInvited
+    // already uses for pending invites.
+    friendInvitationReminder?: {
+      invitationId: string;
+      inviteeDisplayName: string | null;
+      maskedPhone: string;
+    };
   };
 };
 
@@ -161,6 +172,7 @@ function isActivityType(value: string): value is ActivityItemType {
     'grade_dispute_filed',
     'niche_match_answered_your_question',
     'niche_match_you_answered',
+    'friend_invitation_reminder',
   ].includes(value);
 }
 
@@ -815,6 +827,34 @@ async function hydrateDeclaredPromoted(items: ActivityItemRow[]) {
   );
 }
 
+async function hydrateFriendInvitationReminders(items: ActivityItemRow[]) {
+  const relevant = items.filter(
+    (item) => item.type === 'friend_invitation_reminder' && item.referenceType === 'friend_invitation' && item.referenceId,
+  );
+  if (relevant.length === 0) {
+    return new Map<string, NonNullable<ActivityItemView['reference']['friendInvitationReminder']>>();
+  }
+
+  const invitationIds = [...new Set(relevant.map((item) => item.referenceId!))];
+  const rows = await db
+    .select({
+      id: friendInvitations.id,
+      inviteeDisplayName: friendInvitations.inviteeDisplayName,
+      inviteePhone: friendInvitations.inviteePhone,
+    })
+    .from(friendInvitations)
+    .where(inArray(friendInvitations.id, invitationIds));
+
+  return new Map(rows.map((row) => [
+    row.id,
+    {
+      invitationId: row.id,
+      inviteeDisplayName: row.inviteeDisplayName,
+      maskedPhone: maskPhoneE164(row.inviteePhone),
+    },
+  ] as const));
+}
+
 async function hydrateActivityRows(
   rows: ActivityItemRow[],
   userId: string,
@@ -832,6 +872,7 @@ async function hydrateActivityRows(
     authoredSharedQuestionsById,
     declaredPromotedById,
     gradeDisputesById,
+    friendInvitationRemindersById,
   ] = await Promise.all([
     hydrateActors(rows),
     hydrateFriendshipRequests(rows),
@@ -845,6 +886,7 @@ async function hydrateActivityRows(
     hydrateAuthoredSharedQuestions(rows),
     hydrateDeclaredPromoted(rows),
     hydrateGradeDisputes(rows),
+    hydrateFriendInvitationReminders(rows),
   ]);
 
   return rows
@@ -893,6 +935,9 @@ async function hydrateActivityRows(
           : undefined,
         gradeDispute: row.referenceType === 'grade_dispute' && row.referenceId
           ? gradeDisputesById.get(row.referenceId)
+          : undefined,
+        friendInvitationReminder: row.type === 'friend_invitation_reminder' && row.referenceId
+          ? friendInvitationRemindersById.get(row.referenceId)
           : undefined,
       },
     }));

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -1,9 +1,9 @@
 import { randomBytes } from 'crypto'
 
-import { and, desc, eq, gt, isNotNull, isNull, or } from 'drizzle-orm'
+import { and, desc, eq, gt, inArray, isNotNull, isNull, lte, or } from 'drizzle-orm'
 
 import { maskPhoneE164 } from '@/lib/phone-e164'
-import { db, friendInvitations, users } from '@/server/db'
+import { activityItems, db, friendInvitations, users } from '@/server/db'
 import { backfillInviterFeedItems } from '@/server/feed/backfill-inviter-feed'
 import { upsertInvitationFriendship } from '@/server/friends/friendships'
 import { hashTelemetryValue, logTelemetry } from '@/server/telemetry'
@@ -14,7 +14,13 @@ export const INVITATION_ACCEPTANCE_ERROR_MESSAGE =
 export const INVITE_REQUIRED_MESSAGE =
   "Joshing is invite-only. Ask a friend who's already on Joshing to send you an invite."
 
-const DEFAULT_INVITATION_TTL_MS = 1000 * 60 * 60 * 24 * 14
+// 30 days (was 14). Kept well inside the ~90-day window US carriers wait
+// before recycling an unused phone number — the risk a perpetual invite would
+// carry is a stranger who later inherits the invitee's old number accepting
+// on their behalf. The friend-invitation-reminders cron fires at this same
+// 30-day mark for still-unaccepted invites, so expiry and "nudge the inviter"
+// land together.
+const DEFAULT_INVITATION_TTL_MS = 1000 * 60 * 60 * 24 * 30
 
 export type FriendInvitation = typeof friendInvitations.$inferSelect
 
@@ -354,6 +360,55 @@ export async function getValidPendingInvitationForPhone(
     .limit(1)
 
   return invitation ?? null
+}
+
+// Reuses the invitation TTL: the reminder fires at the same 30-day mark the
+// invite itself lapses at, so "nudge the inviter" and "this link stopped
+// working" land together instead of the inviter finding out only when Stan
+// tells them the link is dead.
+const REMINDER_THRESHOLD_MS = DEFAULT_INVITATION_TTL_MS
+
+// Candidates for the friend-invitation-reminders cron: sent >= 30 days ago,
+// still neither accepted nor cancelled, and not already reminded (a prior
+// reminder is any non-deleted ActivityItem of type friend_invitation_reminder
+// referencing this invitation — checked here rather than adding a dedicated
+// column, since the ActivityItem row itself is the durable "already reminded"
+// marker). One-shot per invitation: resending creates a fresh row (see
+// createFriendInvitation), so a resent invite gets its own 30-day clock.
+export async function getInvitationsNeedingReminder(
+  now: Date = new Date()
+): Promise<FriendInvitation[]> {
+  const cutoff = new Date(now.getTime() - REMINDER_THRESHOLD_MS)
+
+  const candidates = await db
+    .select()
+    .from(friendInvitations)
+    .where(
+      and(
+        isNull(friendInvitations.acceptedAt),
+        isNull(friendInvitations.cancelledAt),
+        lte(friendInvitations.sentAt, cutoff)
+      )
+    )
+
+  if (candidates.length === 0) return []
+
+  const alreadyReminded = await db
+    .select({ referenceId: activityItems.referenceId })
+    .from(activityItems)
+    .where(
+      and(
+        eq(activityItems.type, 'friend_invitation_reminder'),
+        isNull(activityItems.deletedAt),
+        inArray(
+          activityItems.referenceId,
+          candidates.map((c) => c.id)
+        )
+      )
+    )
+  const remindedIds = new Set(alreadyReminded.map((r) => r.referenceId))
+
+  return candidates.filter((c) => !remindedIds.has(c.id))
 }
 
 export async function hasValidPendingInvitationForPhone(

--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,10 @@
       "schedule": "30 6 * * *"
     },
     {
+      "path": "/api/cron/friend-invitation-reminders",
+      "schedule": "45 6 * * *"
+    },
+    {
       "path": "/api/cron/pool-refill",
       "schedule": "0 9 * * *"
     },


### PR DESCRIPTION
## Summary
- Bumps `FriendInvitation` expiry from 14 to 30 days — stays well inside the window carriers recycle an unused phone number, so a lapsed link can't later be accepted by a stranger who inherits Stan's (or anyone's) old number.
- Adds a daily cron (`friend-invitation-reminders`, 6:45am) that writes an inviter-facing activity nudge once an invitation hits that same 30-day mark still unaccepted: *"{name} hasn't accepted your invite yet — Resend"*. One-shot per invitation (checks for an existing reminder before writing); a resend creates a fresh invitation row and gets its own clean 30-day clock.
- New `friend_invitation_reminder` activity type wired through `activity-types.ts`, `queries/activity.ts` (hydrates the invitee's name/masked phone off `FriendInvitation`, since they have no account to join against), and `activity-stream.ts` (renders with a `Resend` link action to `/friends`).

## Test plan
- [x] `npx tsc -p tsconfig.typecheck.json` — no new errors (pre-existing unrelated `.next/types` errors only)
- [x] `npx eslint` on all touched files — clean
- [x] `npx vitest run` on `src/server/friends`, `src/server/activity`, and `src/lib/__tests__/activity-stream-*` — 231 tests pass
- [x] Dry-ran the reminder query (read-only) against prod — correctly surfaces the 4 currently-stale unaccepted invitations
- [ ] Confirm the cron fires and writes the expected activity row after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A