### PR TITLE
Vertically center question action button labels

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -860,6 +860,12 @@ const reportMenuFontResetStyle: CSSProperties = {
 
 const questionActionLinkStyle: CSSProperties = {
   alignSelf: 'flex-start',
+  // Buttons default to inline layout with baseline-aligned content; the mono
+  // font's line-height then leaves the label sitting off-center inside the
+  // fixed padding box. Centering it explicitly keeps the pill balanced.
+  display: 'inline-flex',
+  alignItems: 'center',
+  lineHeight: 1,
   background: 'var(--surface)',
   // B-10.2 follow-up (2026-08-30): border now matches the label color
   // instead of the generic --border hairline, which sat a full step


### PR DESCRIPTION
## Summary
- `questionActionLinkStyle` (the shared pill style for "Show me the answer" / "Not for me" in `GameplayChat.tsx`) had no `display`/`alignItems`/`lineHeight`, so the mono font's default line-height left the label sitting off-center inside the padded box.
- Added `display: 'inline-flex'`, `alignItems: 'center'`, `lineHeight: 1` to center the text vertically. Pill shape, padding, size, and position are unchanged.

## Test plan
- [ ] Visual check on `/daily` and catch-up: confirm "SHOW ME THE ANSWER" / "NOT FOR ME" labels sit centered in their pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A