### PR TITLE
Prepare Twilio Sole Proprietor A2P campaign

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,10 +137,14 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # See src/server/auth/admin.ts and src/env-check.ts.
 # ADMIN_USER_IDS="f5ed1c59-3eaa-48d0-b789-2896bc447750"
 
-# ── Phase 5+ only (Twilio — do not add until Phase 5) ────────
-# TWILIO_ACCOUNT_SID=""
-# TWILIO_AUTH_TOKEN=""
-# TWILIO_MESSAGING_SERVICE_SID=""
+# ── SMS (Twilio Programmable Messaging) ─────────────────────
+# Required in production for requested OTPs and opted-in daily reminders.
+# Configure these in the deployment environment; never commit real values.
+# The Messaging Service must be the A2P-registered Joshing service. A phone
+# number SID is intentionally not supported here.
+TWILIO_ACCOUNT_SID=""
+TWILIO_AUTH_TOKEN=""
+TWILIO_MESSAGING_SERVICE_SID=""
 
 # ── Email (Resend) ────────────────────────────────────────────
 # Used by src/server/email/client.ts to send the email-verification

--- a/drizzle/0132_sms_consent_and_daily_idempotency.sql
+++ b/drizzle/0132_sms_consent_and_daily_idempotency.sql
@@ -1,0 +1,27 @@
+-- Auditable SMS reminder consent plus per-day delivery idempotency.
+--
+-- The User columns record the latest opt-in and opt-out timestamps together
+-- with the web-form source and policy version that accompanied the current
+-- preference change. Existing users remain unchanged/null and therefore are
+-- not treated as opted in.
+--
+-- sms_reminder_sent_at is an atomic claim on the one DailyQueue row per
+-- user/day. The cron sets it before delivery and clears it only when delivery
+-- fails, preventing retry/concurrency duplicates.
+--
+-- Rollback:
+--   ALTER TABLE "User" DROP COLUMN IF EXISTS "sms_opt_in_at";
+--   ALTER TABLE "User" DROP COLUMN IF EXISTS "sms_opt_out_at";
+--   ALTER TABLE "User" DROP COLUMN IF EXISTS "sms_consent_source";
+--   ALTER TABLE "User" DROP COLUMN IF EXISTS "sms_consent_policy_version";
+--   ALTER TABLE "DailyQueue" DROP COLUMN IF EXISTS "sms_reminder_sent_at";
+
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "sms_opt_in_at" timestamptz;
+--> statement-breakpoint
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "sms_opt_out_at" timestamptz;
+--> statement-breakpoint
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "sms_consent_source" text;
+--> statement-breakpoint
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "sms_consent_policy_version" text;
+--> statement-breakpoint
+ALTER TABLE "DailyQueue" ADD COLUMN IF NOT EXISTS "sms_reminder_sent_at" timestamptz;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -925,6 +925,13 @@
       "when": 1787875200000,
       "tag": "0131_hidden_question",
       "breakpoints": true
+    },
+    {
+      "idx": 132,
+      "version": "7",
+      "when": 1787961600000,
+      "tag": "0132_sms_consent_and_daily_idempotency",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,55 +1,65 @@
-import { NextRequest } from 'next/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { readSessionClaimsMock } = vi.hoisted(() => ({
   readSessionClaimsMock: vi.fn(),
-}))
+}));
 
 vi.mock('@/server/auth/session', () => ({
   readSessionClaims: readSessionClaimsMock,
-}))
+}));
 
-import { proxy } from '@/proxy'
+import { proxy } from '@/proxy';
 
 function makeRequest(path: string) {
-  return new NextRequest(new URL(path, 'https://joshing.test'))
+  return new NextRequest(new URL(path, 'https://joshing.test'));
 }
 
 describe('proxy unauthenticated route preservation', () => {
   beforeEach(() => {
-    vi.restoreAllMocks()
-    readSessionClaimsMock.mockReset()
-  })
+    vi.restoreAllMocks();
+    readSessionClaimsMock.mockReset();
+  });
 
   it('passes invite pages through without clearing or rewriting the invite token', async () => {
-    readSessionClaimsMock.mockResolvedValueOnce(null)
+    readSessionClaimsMock.mockResolvedValueOnce(null);
 
-    const response = await proxy(makeRequest('/invite/keep-this-token'))
+    const response = await proxy(makeRequest('/invite/keep-this-token'));
 
-    expect(response.status).toBe(200)
-    expect(response.headers.get('x-middleware-next')).toBe('1')
-    expect(response.headers.get('location')).toBeNull()
-  })
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+    expect(response.headers.get('location')).toBeNull();
+  });
 
   it('passes the per-user invite landing (/u/<handle>/<token>) through logged-out so the invite params survive to /login', async () => {
-    readSessionClaimsMock.mockResolvedValueOnce(null)
+    readSessionClaimsMock.mockResolvedValueOnce(null);
 
-    const response = await proxy(makeRequest('/u/josh/keep-this-token'))
+    const response = await proxy(makeRequest('/u/josh/keep-this-token'));
 
-    expect(response.status).toBe(200)
-    expect(response.headers.get('x-middleware-next')).toBe('1')
-    expect(response.headers.get('location')).toBeNull()
-  })
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+    expect(response.headers.get('location')).toBeNull();
+  });
 
   it('passes the public /terms page through logged-out instead of looping it back to login', async () => {
-    readSessionClaimsMock.mockResolvedValueOnce(null)
+    readSessionClaimsMock.mockResolvedValueOnce(null);
 
-    const response = await proxy(makeRequest('/terms'))
+    const response = await proxy(makeRequest('/terms'));
 
-    expect(response.status).toBe(200)
-    expect(response.headers.get('x-middleware-next')).toBe('1')
-    expect(response.headers.get('location')).toBeNull()
-  })
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+    expect(response.headers.get('location')).toBeNull();
+  });
+
+  it('passes the public /privacy page through logged-out instead of redirecting to login', async () => {
+    readSessionClaimsMock.mockResolvedValueOnce(null);
+
+    const response = await proxy(makeRequest('/privacy'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+    expect(response.headers.get('location')).toBeNull();
+  });
 
   it('lets authenticated readers reach /terms without onboarding/login redirects', async () => {
     readSessionClaimsMock.mockResolvedValueOnce({
@@ -57,25 +67,38 @@ describe('proxy unauthenticated route preservation', () => {
       sessionId: 's1',
       invitationAccepted: true,
       onboardingComplete: true,
-    })
+    });
 
-    const response = await proxy(makeRequest('/terms'))
+    const response = await proxy(makeRequest('/terms'));
 
-    expect(response.status).toBe(200)
-    expect(response.headers.get('x-middleware-next')).toBe('1')
-    expect(response.headers.get('location')).toBeNull()
-  })
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+    expect(response.headers.get('location')).toBeNull();
+  });
+
+  it('lets authenticated readers reach /privacy without onboarding/login redirects', async () => {
+    readSessionClaimsMock.mockResolvedValueOnce({
+      userId: 'u1',
+      sessionId: 's1',
+      invitationAccepted: true,
+      onboardingComplete: true,
+    });
+
+    const response = await proxy(makeRequest('/privacy'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+    expect(response.headers.get('location')).toBeNull();
+  });
 
   it('redirects other unauthenticated pages to login, preserving the original path via next', async () => {
-    readSessionClaimsMock.mockResolvedValueOnce(null)
+    readSessionClaimsMock.mockResolvedValueOnce(null);
 
-    const response = await proxy(
-      makeRequest('/dashboard?invitationToken=drop-me'),
-    )
+    const response = await proxy(makeRequest('/dashboard?invitationToken=drop-me'));
 
-    expect(response.status).toBe(307)
-    const location = response.headers.get('location')
-    expect(location).toContain('https://joshing.test/login')
-    expect(location).toContain('next=')
-  })
-})
+    expect(response.status).toBe(307);
+    const location = response.headers.get('location');
+    expect(location).toContain('https://joshing.test/login');
+    expect(location).toContain('next=');
+  });
+});

--- a/src/app/__tests__/legal-pages.test.tsx
+++ b/src/app/__tests__/legal-pages.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getSessionMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+}));
+
+import PrivacyPage from '@/app/privacy/page';
+import TermsPage from '@/app/terms/page';
+
+describe('public legal pages', () => {
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    getSessionMock.mockResolvedValue(null);
+  });
+
+  it('renders the Privacy Policy for a signed-out visitor', async () => {
+    const html = renderToStaticMarkup(await PrivacyPage());
+    expect(html).toContain('Privacy Policy');
+    expect(html).toContain('Reply STOP to opt out or HELP for assistance');
+    expect(html).toContain('href="/terms"');
+    expect(html).toContain('href="/login"');
+  });
+
+  it('renders Terms and SMS Terms for a signed-out visitor', async () => {
+    const html = renderToStaticMarkup(await TermsPage());
+    expect(html).toContain('Terms &amp; Disclaimer');
+    expect(html).toContain('SMS Terms');
+    expect(html).toContain('Consent to receive reminder texts is not a condition of purchase');
+    expect(html).toContain('href="/privacy"');
+    expect(html).toContain('href="/login"');
+  });
+});

--- a/src/app/api/auth/request-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/request-otp/__tests__/route.test.ts
@@ -1,4 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 const {
   findUserSelectMock,
@@ -6,24 +10,24 @@ const {
   getInvitePrefillByTokenMock,
   requestOtpMock,
   resolveInviteLinkMock,
+  sendSmsMock,
 } = vi.hoisted(() => {
-  const findUserSelectMock = vi.fn(
-    async () => [] as Array<Record<string, unknown>>,
-  )
+  const findUserSelectMock = vi.fn(async () => [] as Array<Record<string, unknown>>);
   return {
     findUserSelectMock,
     hasValidPendingInvitationForPhoneMock: vi.fn(async () => false),
     getInvitePrefillByTokenMock: vi.fn(async () => null as unknown),
     requestOtpMock: vi.fn(async () => ({ code: '424242' })),
     resolveInviteLinkMock: vi.fn(async () => null as unknown),
-  }
-})
+    sendSmsMock: vi.fn(async () => ({ ok: true as const })),
+  };
+});
 
 vi.mock('@/server/auth', () => ({
   isUsPhoneNumber: (value: string) => /^\+1\d{10}$/.test(value),
   normalizePhone: (value: string) => value,
   requestOtp: requestOtpMock,
-}))
+}));
 
 vi.mock('@/server/db', () => ({
   db: {
@@ -36,52 +40,58 @@ vi.mock('@/server/db', () => ({
     })),
   },
   users: { id: 'users.id', phoneNumber: 'users.phoneNumber' },
-}))
+}));
 
 vi.mock('@/server/friends/invitations', () => ({
   hasValidPendingInvitationForPhone: hasValidPendingInvitationForPhoneMock,
   getInvitePrefillByToken: getInvitePrefillByTokenMock,
   INVITE_REQUIRED_MESSAGE:
     "Joshing is invite-only. Ask a friend who's already on Joshing to send you an invite.",
-  INVITATION_ACCEPTANCE_ERROR_MESSAGE:
-    'This invitation could not be accepted.',
-}))
+  INVITATION_ACCEPTANCE_ERROR_MESSAGE: 'This invitation could not be accepted.',
+}));
 
 vi.mock('@/server/friends/user-invite-token', () => ({
   resolveInviteLink: resolveInviteLinkMock,
-}))
+}));
 
-import { POST } from '@/app/api/auth/request-otp/route'
+vi.mock('@/server/sms', () => ({
+  buildOtpMessage: (code: string) =>
+    `Joshing verification code: ${code}. Expires in 10 minutes. Do not share this code.`,
+  sendSms: sendSmsMock,
+}));
+
+import { POST } from '@/app/api/auth/request-otp/route';
 
 function jsonRequest(body: unknown) {
   return new Request('http://localhost/api/auth/request-otp', {
     method: 'POST',
     body: JSON.stringify(body),
-  })
+  });
 }
 
-const NEW_PHONE = '+15551230001'
-const USER_INVITE = { handle: 'jpalay', token: 'real-token' }
+const NEW_PHONE = '+15551230001';
+const USER_INVITE = { handle: 'jpalay', token: 'real-token' };
 
 describe('/api/auth/request-otp invite gate', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    findUserSelectMock.mockReset()
+    vi.clearAllMocks();
+    findUserSelectMock.mockReset();
     // Default: phone belongs to no existing user (new-signup path).
-    findUserSelectMock.mockResolvedValue([])
-    hasValidPendingInvitationForPhoneMock.mockResolvedValue(false)
-    getInvitePrefillByTokenMock.mockResolvedValue(null)
-    resolveInviteLinkMock.mockResolvedValue(null)
-    requestOtpMock.mockResolvedValue({ code: '424242' })
-  })
+    findUserSelectMock.mockResolvedValue([]);
+    hasValidPendingInvitationForPhoneMock.mockResolvedValue(false);
+    getInvitePrefillByTokenMock.mockResolvedValue(null);
+    resolveInviteLinkMock.mockResolvedValue(null);
+    requestOtpMock.mockResolvedValue({ code: '424242' });
+    sendSmsMock.mockResolvedValue({ ok: true });
+  });
 
   it('blocks a brand-new phone with no invitation (403, no OTP sent)', async () => {
-    const response = await POST(jsonRequest({ phone: NEW_PHONE }))
+    const response = await POST(jsonRequest({ phone: NEW_PHONE }));
 
-    expect(response.status).toBe(403)
-    expect(await response.json()).toMatchObject({ error: 'invite_required' })
-    expect(requestOtpMock).not.toHaveBeenCalled()
-  })
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: 'invite_required' });
+    expect(requestOtpMock).not.toHaveBeenCalled();
+  });
 
   it('lets a brand-new phone through when a valid per-user invite link is supplied', async () => {
     resolveInviteLinkMock.mockResolvedValue({
@@ -89,110 +99,142 @@ describe('/api/auth/request-otp invite gate', () => {
       inviterHandle: 'jpalay',
       inviterDisplayName: 'Joshua P',
       inviterAvatarColor: null,
-    })
+    });
 
-    const response = await POST(
-      jsonRequest({ phone: NEW_PHONE, userInvite: USER_INVITE }),
-    )
+    const response = await POST(jsonRequest({ phone: NEW_PHONE, userInvite: USER_INVITE }));
 
-    expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject({ ok: true })
-    expect(resolveInviteLinkMock).toHaveBeenCalledWith('jpalay', 'real-token')
-    expect(requestOtpMock).toHaveBeenCalledTimes(1)
-  })
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ ok: true });
+    expect(resolveInviteLinkMock).toHaveBeenCalledWith('jpalay', 'real-token');
+    expect(requestOtpMock).toHaveBeenCalledTimes(1);
+    expect(sendSmsMock).toHaveBeenCalledWith(
+      NEW_PHONE,
+      'Joshing verification code: 424242. Expires in 10 minutes. Do not share this code.',
+      'otp',
+      undefined,
+    );
+  });
 
   it('still blocks a brand-new phone when the invite link does not resolve', async () => {
-    resolveInviteLinkMock.mockResolvedValue(null)
+    resolveInviteLinkMock.mockResolvedValue(null);
 
     const response = await POST(
       jsonRequest({
         phone: NEW_PHONE,
         userInvite: { handle: 'jpalay', token: 'bogus' },
       }),
-    )
+    );
 
-    expect(response.status).toBe(403)
-    expect(requestOtpMock).not.toHaveBeenCalled()
-  })
+    expect(response.status).toBe(403);
+    expect(requestOtpMock).not.toHaveBeenCalled();
+  });
 
   it('returns the warm invite_phone_unclaimed signal when a token rides along but the (edited) phone has no claim', async () => {
     // Phone-first invite path: the invitee edited the pre-filled number to one
     // with no claim of its own. The gate still rejects (no OTP), but with a
     // distinguishable label so the client can render the warm dead-end.
-    const response = await POST(
-      jsonRequest({ phone: NEW_PHONE, invitationToken: 'tok-1' }),
-    )
+    const response = await POST(jsonRequest({ phone: NEW_PHONE, invitationToken: 'tok-1' }));
 
-    expect(response.status).toBe(403)
+    expect(response.status).toBe(403);
     expect(await response.json()).toMatchObject({
       error: 'invite_phone_unclaimed',
-    })
-    expect(requestOtpMock).not.toHaveBeenCalled()
-  })
+    });
+    expect(requestOtpMock).not.toHaveBeenCalled();
+  });
 
   it('does not require an invitation for an existing user', async () => {
-    findUserSelectMock.mockResolvedValue([{ id: 'user-1' }])
+    findUserSelectMock.mockResolvedValue([{ id: 'user-1' }]);
 
-    const response = await POST(jsonRequest({ phone: NEW_PHONE }))
+    const response = await POST(jsonRequest({ phone: NEW_PHONE }));
 
-    expect(response.status).toBe(200)
-    expect(resolveInviteLinkMock).not.toHaveBeenCalled()
-    expect(requestOtpMock).toHaveBeenCalledTimes(1)
-  })
-})
+    expect(response.status).toBe(200);
+    expect(resolveInviteLinkMock).not.toHaveBeenCalled();
+    expect(requestOtpMock).toHaveBeenCalledTimes(1);
+    expect(sendSmsMock).toHaveBeenCalledWith(
+      NEW_PHONE,
+      'Joshing verification code: 424242. Expires in 10 minutes. Do not share this code.',
+      'otp',
+      'user-1',
+    );
+  });
+});
 
 describe('/api/auth/request-otp invite-phone prefill', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    findUserSelectMock.mockReset()
-    findUserSelectMock.mockResolvedValue([])
-    hasValidPendingInvitationForPhoneMock.mockResolvedValue(false)
-    getInvitePrefillByTokenMock.mockResolvedValue(null)
-    resolveInviteLinkMock.mockResolvedValue(null)
-    requestOtpMock.mockResolvedValue({ code: '424242' })
-  })
+    vi.clearAllMocks();
+    findUserSelectMock.mockReset();
+    findUserSelectMock.mockResolvedValue([]);
+    hasValidPendingInvitationForPhoneMock.mockResolvedValue(false);
+    getInvitePrefillByTokenMock.mockResolvedValue(null);
+    resolveInviteLinkMock.mockResolvedValue(null);
+    requestOtpMock.mockResolvedValue({ code: '424242' });
+    sendSmsMock.mockResolvedValue({ ok: true });
+  });
 
   it('sends the OTP to the invite phone and returns only the masked form', async () => {
     getInvitePrefillByTokenMock.mockResolvedValue({
       inviterName: 'Alex',
       inviteePhone: '+17345556819',
       maskedPhone: '•••-•••-6819',
-    })
+    });
 
-    const response = await POST(
-      jsonRequest({ invitationToken: 'tok-1', useInvitePhone: true }),
-    )
+    const response = await POST(jsonRequest({ invitationToken: 'tok-1', useInvitePhone: true }));
 
-    expect(response.status).toBe(200)
-    const body = await response.json()
-    expect(body).toMatchObject({ ok: true, maskedPhone: '•••-•••-6819' })
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({ ok: true, maskedPhone: '•••-•••-6819' });
     // The raw phone must never cross to the client.
-    expect(JSON.stringify(body)).not.toContain('+17345556819')
-    expect(getInvitePrefillByTokenMock).toHaveBeenCalledWith('tok-1')
-    expect(requestOtpMock).toHaveBeenCalledWith('+17345556819')
-  })
+    expect(JSON.stringify(body)).not.toContain('+17345556819');
+    expect(getInvitePrefillByTokenMock).toHaveBeenCalledWith('tok-1');
+    expect(requestOtpMock).toHaveBeenCalledWith('+17345556819');
+    expect(sendSmsMock).toHaveBeenCalledWith(
+      '+17345556819',
+      'Joshing verification code: 424242. Expires in 10 minutes. Do not share this code.',
+      'otp',
+    );
+  });
 
   it('rejects when the invite token does not resolve to a sendable phone (no OTP sent)', async () => {
-    getInvitePrefillByTokenMock.mockResolvedValue(null)
+    getInvitePrefillByTokenMock.mockResolvedValue(null);
 
-    const response = await POST(
-      jsonRequest({ invitationToken: 'bogus', useInvitePhone: true }),
-    )
+    const response = await POST(jsonRequest({ invitationToken: 'bogus', useInvitePhone: true }));
 
-    expect(response.status).toBe(400)
-    expect(await response.json()).toMatchObject({ error: 'invalid_invitation' })
-    expect(requestOtpMock).not.toHaveBeenCalled()
-  })
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: 'invalid_invitation' });
+    expect(requestOtpMock).not.toHaveBeenCalled();
+  });
 
   it('falls back to the phone gate when useInvitePhone is not set', async () => {
     // invitationToken present but useInvitePhone absent → manual path; the
     // brand-new phone has no invitation, so the gate blocks it.
-    const response = await POST(
-      jsonRequest({ phone: NEW_PHONE, invitationToken: 'tok-1' }),
-    )
+    const response = await POST(jsonRequest({ phone: NEW_PHONE, invitationToken: 'tok-1' }));
 
-    expect(response.status).toBe(403)
-    expect(getInvitePrefillByTokenMock).not.toHaveBeenCalled()
-    expect(requestOtpMock).not.toHaveBeenCalled()
-  })
-})
+    expect(response.status).toBe(403);
+    expect(getInvitePrefillByTokenMock).not.toHaveBeenCalled();
+    expect(requestOtpMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('/api/auth/request-otp production delivery safety', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('NODE_ENV', 'production');
+    findUserSelectMock.mockReset();
+    findUserSelectMock.mockResolvedValue([{ id: 'user-1' }]);
+    requestOtpMock.mockResolvedValue({ code: '424242' });
+    sendSmsMock.mockResolvedValue({ ok: true });
+  });
+
+  it('never exposes debugCode in production', async () => {
+    const response = await POST(jsonRequest({ phone: NEW_PHONE }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, phone: NEW_PHONE });
+  });
+
+  it('does not claim success when Twilio delivery fails', async () => {
+    sendSmsMock.mockResolvedValue({ ok: false, reason: 'provider_error' });
+    const response = await POST(jsonRequest({ phone: NEW_PHONE }));
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({ error: 'sms_delivery_failed' });
+  });
+});

--- a/src/app/api/auth/request-otp/route.ts
+++ b/src/app/api/auth/request-otp/route.ts
@@ -11,6 +11,7 @@ import {
   INVITE_REQUIRED_MESSAGE,
 } from '@/server/friends/invitations';
 import { resolveInviteLink } from '@/server/friends/user-invite-token';
+import { buildOtpMessage, sendSms } from '@/server/sms';
 
 const bodySchema = z.object({
   // Optional: in the invite-prefill flow (useInvitePhone) the client sends no
@@ -59,6 +60,14 @@ export async function POST(request: Request) {
       }
 
       const { code } = await requestOtp(prefill.inviteePhone);
+      const delivery = await sendSms(prefill.inviteePhone, buildOtpMessage(code), 'otp');
+
+      if (process.env.NODE_ENV === 'production' && !delivery.ok) {
+        return NextResponse.json(
+          { error: 'sms_delivery_failed', message: 'Unable to send code. Please try again.' },
+          { status: 502 },
+        );
+      }
 
       return NextResponse.json({
         ok: true,
@@ -118,11 +127,15 @@ export async function POST(request: Request) {
       }
     }
 
-    // TODO: when OTP goes live, send the code via SMS here
-    // (sendSms(phone, ...) from '@/server/sms'). Today requestOtp() only
-    // generates + stores the code; nothing texts it. In non-prod the code is
-    // returned as debugCode below so the flow can be completed manually.
     const { code } = await requestOtp(phone);
+    const delivery = await sendSms(phone, buildOtpMessage(code), 'otp', existingUser?.id);
+
+    if (process.env.NODE_ENV === 'production' && !delivery.ok) {
+      return NextResponse.json(
+        { error: 'sms_delivery_failed', message: 'Unable to send code. Please try again.' },
+        { status: 502 },
+      );
+    }
 
     return NextResponse.json({
       ok: true,

--- a/src/app/api/cron/daily-assignments/route.ts
+++ b/src/app/api/cron/daily-assignments/route.ts
@@ -3,15 +3,17 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import {
   claimDailyEmailReminder,
+  claimDailySmsReminder,
   getTodaysDailyQueue,
   releaseDailyEmailReminder,
+  releaseDailySmsReminder,
 } from '@/server/db/queries/daily';
 import { db, users } from '@/server/db';
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
 import { type QueueSlot } from '@/server/daily/types';
 import { runWithConcurrency } from '@/server/lib/concurrency';
 import { isCronAuthorized } from '@/server/auth/cron';
-import { sendSms } from '@/server/sms';
+import { buildDailyReminderSmsBody, isEligibleForDailyReminder, sendSms } from '@/server/sms';
 import { sendEmail } from '@/server/email/client';
 import { buildDailyReminderTemplate } from '@/server/email/templates/daily-reminder';
 import { formatActivityForEmail, topicsForReminder } from '@/server/email/daily-reminder-data';
@@ -55,9 +57,10 @@ const USER_CONCURRENCY = 4;
 // `deferred` and picked up by the idempotent catch-up passes scheduled a few
 // minutes later in vercel.json (the route already skips users whose queue exists,
 // and SMS/email are replay-safe). See D-NARROW-KB-FABRICATION-01.
-const USER_BUDGET_MS = Number(process.env.DAILY_ASSIGNMENTS_BUDGET_MS) > 0
-  ? Number(process.env.DAILY_ASSIGNMENTS_BUDGET_MS)
-  : 250_000;
+const USER_BUDGET_MS =
+  Number(process.env.DAILY_ASSIGNMENTS_BUDGET_MS) > 0
+    ? Number(process.env.DAILY_ASSIGNMENTS_BUDGET_MS)
+    : 250_000;
 
 function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
@@ -82,6 +85,7 @@ export async function GET(request: NextRequest) {
     .select({
       id: users.id,
       phoneNumber: users.phoneNumber,
+      phoneVerified: users.phoneVerified,
       smsOptIn: users.smsOptIn,
       email: users.email,
       emailOptIn: users.emailOptIn,
@@ -121,15 +125,9 @@ export async function GET(request: NextRequest) {
       let queue = await getTodaysDailyQueue(user.id);
       const existingSlots = queue ? asQueueSlots(queue.slots) : [];
 
-      // Nudges below are gated on THIS invocation having built the queue.
-      // The workflow curls this route with retries and a timeout equal to
-      // maxDuration, so a client-side timeout (function still running) replays
-      // the whole run; skipping users whose queue already exists makes the
-      // route idempotent for SMS/email — a retry can never re-text someone the
-      // previous attempt already nudged. Side effect (accepted): a user who
-      // built their own queue between the 17:00 reset and this cron gets no
-      // reminder — they're already playing today.
-      let freshlyGenerated = false;
+      // Queue generation and reminder delivery have independent idempotency.
+      // Each channel atomically claims its per-user/day marker below, so retries
+      // can safely revisit both newly generated and already-existing queues.
       if (!queue || existingSlots.length === 0) {
         // Background build: use the longer top-up budget this 300s cron route
         // allows, so a struggling build reaches DAILY_QUEUE_SIZE instead of
@@ -137,19 +135,30 @@ export async function GET(request: NextRequest) {
         await fillDailyQueueForUser(user.id, { background: true });
         queue = await getTodaysDailyQueue(user.id);
         results.generated += 1;
-        freshlyGenerated = true;
       } else {
         results.existing += 1;
       }
 
-      if (freshlyGenerated && queue && user.smsOptIn === 'opted_in' && user.phoneNumber) {
-        await sendSms(
-          user.phoneNumber,
-          `Your five for today. ${baseUrl}/daily`,
-          'daily_questions',
-          user.id,
-        );
-        results.smsSent += 1;
+      if (queue && isEligibleForDailyReminder(user)) {
+        const slots = asQueueSlots(queue.slots);
+        const hasQuestionsReady = slots.some((slot) => !slot.answered && !slot.skipped);
+        if (hasQuestionsReady && (await claimDailySmsReminder(queue.id))) {
+          const smsResult = await sendSms(
+            user.phoneNumber,
+            buildDailyReminderSmsBody(baseUrl),
+            'daily_questions',
+            user.id,
+          );
+          if (smsResult.ok) {
+            results.smsSent += 1;
+          } else {
+            await releaseDailySmsReminder(queue.id);
+            console.warn('[cron/daily-assignments] reminder SMS failed', {
+              userId: user.id,
+              reason: smsResult.reason,
+            });
+          }
+        }
       }
 
       // Email reminder — previews today's first question as a no-spoiler teaser.

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { clearCachedLoadingMomentPayload } from '@/components/loading-moment/client-cache';
@@ -167,11 +168,7 @@ function LoadingLabel({ verb }: { verb: string }) {
       {verb}
       <span aria-hidden="true">
         {[0, 1, 2].map((i) => (
-          <span
-            key={i}
-            className="loading-ellipsis-dot"
-            style={{ animationDelay: `${i * 0.16}s` }}
-          >
+          <span key={i} className="loading-ellipsis-dot" style={{ animationDelay: `${i * 0.16}s` }}>
             .
           </span>
         ))}
@@ -188,6 +185,22 @@ function InviteContextCard({ invite }: { invite: InviteContext }) {
         need to verify your phone number and then you can start playing.
       </p>
     </div>
+  );
+}
+
+export function OtpRequestDisclosure() {
+  return (
+    <p className="mt-2 text-center text-xs leading-5 text-black/60">
+      Continuing requests a one-time Joshing verification code. Message and data rates may apply.{' '}
+      <Link href="/terms" className="underline underline-offset-2">
+        Terms
+      </Link>{' '}
+      and{' '}
+      <Link href="/privacy" className="underline underline-offset-2">
+        Privacy
+      </Link>
+      .
+    </p>
   );
 }
 
@@ -631,6 +644,7 @@ export default function LoginPanel({
                 <button type="submit" className={SUBMIT_CLASS} disabled={loading}>
                   {loading ? 'Sending…' : 'Send text'}
                 </button>
+                <OtpRequestDisclosure />
 
                 {/* Divider sets the secondary action apart from the primary:
                     small, muted "or" with more room below it than above. */}
@@ -700,6 +714,7 @@ export default function LoginPanel({
               <button type="submit" className={SUBMIT_CLASS} disabled={loading}>
                 {loading ? <LoadingLabel verb="Continuing" /> : 'Continue'}
               </button>
+              <OtpRequestDisclosure />
             </>
           )}
         </form>

--- a/src/app/login/__tests__/LoginPanel.sms.test.tsx
+++ b/src/app/login/__tests__/LoginPanel.sms.test.tsx
@@ -1,0 +1,48 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { searchParamsMock } = vi.hoisted(() => ({
+  searchParamsMock: new URLSearchParams(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => searchParamsMock,
+}));
+
+import LoginPanel from '@/app/login/LoginPanel';
+
+function expectOneOtpDisclosure(html: string) {
+  expect(html.match(/Continuing requests a one-time Joshing verification code/g)).toHaveLength(1);
+  expect(html).toContain('Message and data rates may apply');
+  expect(html).toContain('href="/terms"');
+  expect(html).toContain('href="/privacy"');
+}
+
+describe('LoginPanel OTP request disclosure', () => {
+  beforeEach(() => {
+    searchParamsMock.delete('invitationToken');
+  });
+
+  it('places the disclosure beside the manual phone-entry action', () => {
+    const html = renderToStaticMarkup(<LoginPanel />);
+    expect(html).toContain('What is your phone number?');
+    expectOneOtpDisclosure(html);
+  });
+
+  it('places the disclosure beside the invitation-prefilled Send text action', () => {
+    searchParamsMock.set('invitationToken', 'invite-token');
+    const html = renderToStaticMarkup(
+      <LoginPanel
+        invitePrefill={{
+          inviterName: 'Alex',
+          inviterUserId: 'inviter-1',
+          inviterAvatarColor: null,
+          inviteePhone: '+17345550123',
+        }}
+      />,
+    );
+    expect(html).toContain('Send text');
+    expectOneOtpDisclosure(html);
+  });
+});

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,130 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { getSession } from '@/server/auth/session';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy · Joshing',
+  description: 'How Joshing collects, uses, and protects information.',
+};
+
+const CONTACT_EMAIL = 'Joshuapalay+joshingsupport@gmail.com';
+
+export default async function PrivacyPage() {
+  const session = await getSession();
+  const backHref = session ? '/users/me' : '/login';
+  const backLabel = session ? '← Back to profile' : '← Back to sign in';
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-10 pb-28">
+      <div className="mb-6">
+        <Link
+          href={backHref}
+          className="text-muted-foreground text-sm font-medium underline-offset-4 hover:underline"
+        >
+          {backLabel}
+        </Link>
+      </div>
+
+      <h1 className="font-serif text-3xl font-semibold">Privacy Policy</h1>
+      <p className="text-muted-foreground mt-2 text-xs">Last updated September 1, 2026</p>
+
+      <div className="text-foreground mt-6 space-y-8 text-sm leading-6">
+        <section>
+          <h2 className="font-serif text-xl font-semibold">Information we collect</h2>
+          <p className="mt-2">
+            Joshing collects account and profile information such as your phone number, phone
+            verification status, display name, call sign, optional email address, interests, and
+            privacy preferences. We also store the questions, answers, game activity, connections,
+            and feedback you create while using the service. We collect basic request, device, and
+            product-usage information needed to operate, secure, and improve Joshing.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="font-serif text-xl font-semibold">How we use information</h2>
+          <p className="mt-2">
+            We use information to verify accounts, provide and personalize the daily game, show
+            content and activity to the people allowed by your settings, maintain safety and
+            reliability, answer support requests, and improve the service. We do not sell your
+            personal information.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="font-serif text-xl font-semibold">Service providers</h2>
+          <p className="mt-2">
+            We use service providers to host the app, store data, deliver text messages and email,
+            monitor performance, and help generate or evaluate game content. They receive only the
+            information needed to perform those services for Joshing and are not authorized by us to
+            use it for their own marketing.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="font-serif text-xl font-semibold">SMS and mobile information</h2>
+          <div className="mt-2 space-y-3">
+            <p>
+              Joshing sends a one-time verification code when you request one and, only after your
+              explicit opt-in, up to one daily reminder that your questions are ready. Message and
+              data rates may apply. Reply STOP to opt out or HELP for assistance.
+            </p>
+            <p>
+              Mobile information is not shared with third parties or affiliates for marketing or
+              promotional purposes. Text-message opt-in data and consent are not shared except with
+              providers necessary to deliver the messaging service.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="font-serif text-xl font-semibold">Retention</h2>
+          <p className="mt-2">
+            We keep account and game information while your account is active and as needed to
+            operate Joshing. If you delete your account, we delete or de-identify account data
+            except where limited retention is needed for security, fraud prevention, legal
+            obligations, or reliable backups.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="font-serif text-xl font-semibold">Security</h2>
+          <p className="mt-2">
+            We use reasonable technical and organizational safeguards designed to protect your
+            information. No online service can guarantee absolute security.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="font-serif text-xl font-semibold">Your choices</h2>
+          <p className="mt-2">
+            You can update profile and discoverability settings, turn daily SMS or email reminders
+            on or off, hide questions, and delete your account from your profile. You may also reply
+            STOP to reminder texts. See the{' '}
+            <Link
+              href="/terms"
+              className="font-medium text-[var(--brand-orange)] underline underline-offset-4"
+            >
+              Terms &amp; Disclaimer
+            </Link>{' '}
+            for the SMS program terms.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="font-serif text-xl font-semibold">Contact</h2>
+          <p className="mt-2">
+            Questions or privacy requests can be sent to{' '}
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
+              className="font-medium text-[var(--brand-orange)] underline underline-offset-4"
+            >
+              {CONTACT_EMAIL}
+            </a>
+            .
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -34,10 +34,6 @@ const CLAUSES: { lead: string; body: string }[] = [
     body: 'When you create questions or content, you’re letting us use, display, and share it within the game so it works the way it’s meant to.',
   },
   {
-    lead: 'Privacy, briefly.',
-    body: 'We collect what we need to run the game and don’t sell your data. (A fuller privacy policy is coming.)',
-  },
-  {
     lead: 'Changes.',
     body: 'We may update these terms as Joshing grows. Continuing to play means you’re cool with the current version.',
   },
@@ -57,7 +53,7 @@ export default async function TermsPage() {
       <div className="mb-6">
         <Link
           href={backHref}
-          className="text-sm font-medium text-muted-foreground underline-offset-4 hover:underline"
+          className="text-muted-foreground text-sm font-medium underline-offset-4 hover:underline"
         >
           {backLabel}
         </Link>
@@ -65,20 +61,65 @@ export default async function TermsPage() {
 
       <h1 className="font-serif text-3xl font-semibold">Terms &amp; Disclaimer</h1>
 
-      <p className="mt-4 text-sm leading-6 text-muted-foreground">
+      <p className="text-muted-foreground mt-4 text-sm leading-6">
         Joshing is a game we’re building and improving as we go. By using it, you agree to a few
         common-sense things:
       </p>
 
       <div className="mt-6 space-y-4">
         {CLAUSES.map((clause) => (
-          <p key={clause.lead} className="text-sm leading-6 text-foreground">
+          <p key={clause.lead} className="text-foreground text-sm leading-6">
             <span className="font-semibold">{clause.lead}</span> {clause.body}
           </p>
         ))}
+        <p className="text-foreground text-sm leading-6">
+          <span className="font-semibold">Privacy.</span> We collect what we need to run the game
+          and don&apos;t sell your data. Read the full{' '}
+          <Link
+            href="/privacy"
+            className="font-medium text-[var(--brand-orange)] underline underline-offset-4"
+          >
+            Privacy Policy
+          </Link>
+          .
+        </p>
       </div>
 
-      <p className="mt-8 text-sm leading-6 text-muted-foreground">
+      <section className="mt-10 border-t pt-8">
+        <h2 className="font-serif text-2xl font-semibold">SMS Terms</h2>
+        <div className="text-foreground mt-4 space-y-4 text-sm leading-6">
+          <p>
+            <span className="font-semibold">Program name and purpose.</span> Joshing SMS sends a
+            one-time verification code when you request one. If you separately opt in on your
+            profile, Joshing may also send one daily reminder when your five questions are ready.
+          </p>
+          <p>
+            <span className="font-semibold">Frequency and charges.</span> Verification messages are
+            sent only when requested. Reminder frequency is up to one message per day. Message and
+            data rates may apply. Consent to receive reminder texts is not a condition of purchase.
+          </p>
+          <p>
+            <span className="font-semibold">Your choices.</span> Reply STOP to opt out of reminder
+            texts. Reply HELP for help, or email{' '}
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
+              className="font-medium text-[var(--brand-orange)] underline underline-offset-4"
+            >
+              {CONTACT_EMAIL}
+            </a>
+            . See our{' '}
+            <Link
+              href="/privacy"
+              className="font-medium text-[var(--brand-orange)] underline underline-offset-4"
+            >
+              Privacy Policy
+            </Link>{' '}
+            for how we handle mobile information and consent records.
+          </p>
+        </div>
+      </section>
+
+      <p className="text-muted-foreground mt-8 text-sm leading-6">
         Questions? Reach out to us at{' '}
         <a
           href={`mailto:${CONTACT_EMAIL}`}

--- a/src/components/profile/settings/NotificationsForm.tsx
+++ b/src/components/profile/settings/NotificationsForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 
 import { Switch } from '@/components/ui/Switch';
 import type { ReminderState } from '@/server/db/queries/account';
@@ -11,6 +12,10 @@ type Props = {
 };
 
 const RESEND_COOLDOWN_SECONDS = 60;
+
+export function smsOptInForChecked(checked: boolean): 'opted_in' | 'opted_out' {
+  return checked ? 'opted_in' : 'opted_out';
+}
 
 async function patchReminders(body: Record<string, unknown>): Promise<{
   ok: boolean;
@@ -78,6 +83,9 @@ export function NotificationsForm({ initialState, phone }: Props) {
   const [resendNotice, setResendNotice] = useState<string | null>(null);
   const [resendCooldown, setResendCooldown] = useState(0);
   const [editingEmail, setEditingEmail] = useState(false);
+  const [savingSms, setSavingSms] = useState(false);
+  const [smsNotice, setSmsNotice] = useState<string | null>(null);
+  const [smsError, setSmsError] = useState<string | null>(null);
 
   const smsOn = state.smsOptIn === 'opted_in';
   const emailOn = state.emailOptIn === 'opted_in';
@@ -148,6 +156,21 @@ export function NotificationsForm({ initialState, phone }: Props) {
     setState(result.state);
   }
 
+  async function toggleSms(checked: boolean) {
+    setSavingSms(true);
+    setSmsError(null);
+    setSmsNotice(null);
+    const next = smsOptInForChecked(checked);
+    const result = await patchReminders({ smsOptIn: next });
+    setSavingSms(false);
+    if (!result.ok || !result.state) {
+      setSmsError(result.errorMessage ?? 'Could not save SMS reminder preference.');
+      return;
+    }
+    setState(result.state);
+    setSmsNotice(checked ? 'Daily SMS reminders are on.' : 'Daily SMS reminders are off.');
+  }
+
   async function resendEmail() {
     setResending(true);
     setEmailError(null);
@@ -167,36 +190,56 @@ export function NotificationsForm({ initialState, phone }: Props) {
 
   return (
     <div className="space-y-4">
-      <section className="rounded-xl border bg-card p-5 text-card-foreground">
+      <section className="bg-card text-card-foreground rounded-xl border p-5">
         <div className="flex items-start justify-between gap-3">
           <div className="flex min-w-0 flex-1 flex-col">
-            <div className="flex flex-wrap items-center gap-2">
-              <h3 className="font-serif text-lg font-semibold">SMS reminders</h3>
-              <span className="inline-flex items-center rounded-full border border-[var(--warning-border)] bg-[var(--warning-surface)] px-2 py-0.5 text-xs font-medium text-[var(--warning)]">
-                Coming soon
-              </span>
-            </div>
-            <p className="mt-1 text-sm text-muted-foreground">
-              SMS notifications are coming soon — this functionality isn&apos;t
-              available yet. Once it&apos;s ready, we&apos;ll text {phone}{' '}
-              when a new round opens.
+            <h3 className="font-serif text-lg font-semibold">SMS reminders</h3>
+            <p id="sms-reminder-consent" className="text-muted-foreground mt-1 text-sm">
+              Get one Joshing reminder each day when your questions are ready. Message and data
+              rates may apply. Reply STOP to opt out or HELP for help.
+            </p>
+            <p className="text-muted-foreground mt-2 text-xs leading-5">
+              If enabled, reminders are sent to {phone}. Consent is not a condition of purchase.{' '}
+              <Link href="/terms" className="font-medium underline underline-offset-2">
+                Terms
+              </Link>{' '}
+              and{' '}
+              <Link href="/privacy" className="font-medium underline underline-offset-2">
+                Privacy
+              </Link>
+              .
             </p>
           </div>
           <Switch
             checked={smsOn}
-            onCheckedChange={() => {}}
+            onCheckedChange={(checked) => void toggleSms(checked)}
             label="SMS reminders"
-            disabled
-            title="SMS notifications are coming soon"
+            aria-describedby="sms-reminder-consent"
+            disabled={savingSms}
           />
         </div>
+        {savingSms ? (
+          <p className="text-muted-foreground mt-3 text-xs" role="status" aria-live="polite">
+            Saving SMS reminder preference…
+          </p>
+        ) : null}
+        {smsNotice ? (
+          <p className="mt-3 text-xs text-[var(--success)]" role="status" aria-live="polite">
+            {smsNotice}
+          </p>
+        ) : null}
+        {smsError ? (
+          <p className="text-destructive mt-3 text-xs" role="alert">
+            {smsError}
+          </p>
+        ) : null}
       </section>
 
-      <section className="rounded-xl border bg-card p-5 text-card-foreground">
+      <section className="bg-card text-card-foreground rounded-xl border p-5">
         <div className="flex items-start justify-between gap-3">
           <div className="flex min-w-0 flex-1 flex-col">
             <h3 className="font-serif text-lg font-semibold">Email reminders</h3>
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="text-muted-foreground mt-1 text-sm">
               {hasVerifiedEmail
                 ? `Email ${state.email} when a new round opens.`
                 : 'Add an email address to enable email reminders.'}
@@ -234,7 +277,7 @@ export function NotificationsForm({ initialState, phone }: Props) {
                 setEmailDraft(event.target.value);
                 setEmailError(null);
               }}
-              className="bg-[var(--brand-field)] flex-1 rounded-lg border border-[var(--accent-gold)] px-3 py-2 text-sm focus:border-[var(--brand-navy)]"
+              className="flex-1 rounded-lg border border-[var(--accent-gold)] bg-[var(--brand-field)] px-3 py-2 text-sm focus:border-[var(--brand-navy)]"
             />
             <button
               type="button"
@@ -253,7 +296,7 @@ export function NotificationsForm({ initialState, phone }: Props) {
             {editingEmail ? (
               <button
                 type="button"
-                className="text-sm text-muted-foreground underline-offset-2 hover:underline disabled:opacity-50"
+                className="text-muted-foreground text-sm underline-offset-2 hover:underline disabled:opacity-50"
                 onClick={cancelEditingEmail}
                 disabled={savingEmail}
               >
@@ -265,7 +308,7 @@ export function NotificationsForm({ initialState, phone }: Props) {
 
         {hasPendingEmail ? (
           <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs text-muted-foreground">
+            <p className="text-muted-foreground text-xs">
               {pendingIsChange
                 ? `Confirm ${state.pendingEmail} to switch your reminder address. Until then, we’ll keep emailing ${state.email}.`
                 : `Check ${state.pendingEmail} for a confirmation link. It expires in 24 hours.`}
@@ -285,21 +328,17 @@ export function NotificationsForm({ initialState, phone }: Props) {
           </div>
         ) : null}
         {hasVerifiedEmail && emailOn ? (
-          <p className="mt-3 text-xs text-muted-foreground">
+          <p className="text-muted-foreground mt-3 text-xs">
             On. We&apos;ll email you each day when your five are ready.
           </p>
         ) : null}
-        {resendNotice ? (
-          <p className="mt-2 text-xs text-[var(--success)]">{resendNotice}</p>
-        ) : null}
-        {emailError ? (
-          <p className="mt-2 text-xs text-destructive">{emailError}</p>
-        ) : null}
+        {resendNotice ? <p className="mt-2 text-xs text-[var(--success)]">{resendNotice}</p> : null}
+        {emailError ? <p className="text-destructive mt-2 text-xs">{emailError}</p> : null}
       </section>
 
-      <p className="text-xs text-muted-foreground">
-        Once your email is confirmed and reminders are on, we&apos;ll send a daily
-        nudge when your five are ready — with a no-spoiler peek at the first question.
+      <p className="text-muted-foreground text-xs">
+        Once your email is confirmed and reminders are on, we&apos;ll send a daily nudge when your
+        five are ready — with a no-spoiler peek at the first question.
       </p>
     </div>
   );

--- a/src/components/profile/settings/__tests__/NotificationsForm.sms.test.tsx
+++ b/src/components/profile/settings/__tests__/NotificationsForm.sms.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import {
+  NotificationsForm,
+  smsOptInForChecked,
+} from '@/components/profile/settings/NotificationsForm';
+import type { ReminderState } from '@/server/db/queries/account';
+
+const initialState: ReminderState = {
+  smsOptIn: 'not_asked',
+  emailOptIn: 'not_asked',
+  emailVerified: false,
+  email: null,
+  pendingEmail: null,
+  phoneNumber: '+17345550123',
+  smsOptInAt: null,
+  smsOptOutAt: null,
+  smsConsentSource: null,
+  smsConsentPolicyVersion: null,
+  reminderPromptDismissedAt: null,
+  reminderInterstitialSeenAt: null,
+};
+
+describe('NotificationsForm SMS consent', () => {
+  it('defaults an unasked user off and shows the complete disclosure and policy links', () => {
+    const html = renderToStaticMarkup(
+      <NotificationsForm initialState={initialState} phone="(734) 555-0123" />,
+    );
+
+    expect(html).toContain('role="switch"');
+    expect(html).toContain('aria-checked="false"');
+    expect(html).toContain(
+      'Get one Joshing reminder each day when your questions are ready. Message and data rates may apply. Reply STOP to opt out or HELP for help.',
+    );
+    expect(html).toContain('href="/terms"');
+    expect(html).toContain('href="/privacy"');
+    expect(html).not.toContain('Coming soon');
+  });
+
+  it('maps switch changes to the exact API values', () => {
+    expect(smsOptInForChecked(true)).toBe('opted_in');
+    expect(smsOptInForChecked(false)).toBe('opted_out');
+  });
+});

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -57,9 +57,10 @@ export async function register() {
     // connectionTimeoutMillis makes a hung connect fail in seconds instead of
     // minutes; it has no effect on a healthy connection. Override via
     // BOOT_DB_CONNECT_TIMEOUT_MS (0/unset → 10s default).
-    const bootConnectTimeoutMs = Number(process.env.BOOT_DB_CONNECT_TIMEOUT_MS) > 0
-      ? Number(process.env.BOOT_DB_CONNECT_TIMEOUT_MS)
-      : 10_000;
+    const bootConnectTimeoutMs =
+      Number(process.env.BOOT_DB_CONNECT_TIMEOUT_MS) > 0
+        ? Number(process.env.BOOT_DB_CONNECT_TIMEOUT_MS)
+        : 10_000;
     const pool = new Pool({
       connectionString: process.env.DATABASE_URL,
       connectionTimeoutMillis: bootConnectTimeoutMs,
@@ -76,9 +77,10 @@ export async function register() {
     // Fail-open: if every attempt fails we still proceed — the guards are each
     // try/caught and migrate() is timeout-bounded, so boot never hard-blocks on a
     // flaky DB. Override the count via BOOT_DB_CONNECT_RETRIES (0/unset → 3).
-    const bootConnectRetries = Number(process.env.BOOT_DB_CONNECT_RETRIES) > 0
-      ? Number(process.env.BOOT_DB_CONNECT_RETRIES)
-      : 3;
+    const bootConnectRetries =
+      Number(process.env.BOOT_DB_CONNECT_RETRIES) > 0
+        ? Number(process.env.BOOT_DB_CONNECT_RETRIES)
+        : 3;
     for (let attempt = 1; attempt <= bootConnectRetries; attempt += 1) {
       try {
         await db.execute(sql`select 1`);
@@ -126,74 +128,74 @@ export async function register() {
     // the SKIP_BOOT_DB_GUARDS trade-off can be judged on real data.
     const guardChainStartedAt = Date.now();
     if (runBootGuards) {
-    // Migration 0006 sets NOT NULL on senderUserId/recipientUserId after adding them
-    // as nullable columns. If any rows have NULL values (from a partial migration or
-    // data predating those columns), the SET NOT NULL fails and blocks all subsequent
-    // migrations. Delete those structurally-invalid rows first so 0006 can succeed.
-    try {
-      await db.execute(sql`
+      // Migration 0006 sets NOT NULL on senderUserId/recipientUserId after adding them
+      // as nullable columns. If any rows have NULL values (from a partial migration or
+      // data predating those columns), the SET NOT NULL fails and blocks all subsequent
+      // migrations. Delete those structurally-invalid rows first so 0006 can succeed.
+      try {
+        await db.execute(sql`
         DELETE FROM "QuestionReaction"
         WHERE "senderUserId" IS NULL OR "recipientUserId" IS NULL
       `);
-    } catch {
-      // Table or columns may not exist yet — that's fine, migrate() will create them
-    }
+      } catch {
+        // Table or columns may not exist yet — that's fine, migrate() will create them
+      }
 
-    // Domain-merge mastery events were introduced after the base table in
-    // drizzle/0009_domain_merge_events.sql. Some preview/production databases
-    // can have that migration recorded without the enum value or metadata column
-    // present, which makes the domain cleanup audit insert in ceremony.ts fail.
-    // Add both pieces idempotently before migrate() so the backfill can proceed.
-    try {
-      await db.execute(sql`
+      // Domain-merge mastery events were introduced after the base table in
+      // drizzle/0009_domain_merge_events.sql. Some preview/production databases
+      // can have that migration recorded without the enum value or metadata column
+      // present, which makes the domain cleanup audit insert in ceremony.ts fail.
+      // Add both pieces idempotently before migrate() so the backfill can proceed.
+      try {
+        await db.execute(sql`
         ALTER TYPE "public"."MasterySourceType" ADD VALUE IF NOT EXISTS 'curator_credit'
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TYPE "public"."MasterySourceType" ADD VALUE IF NOT EXISTS 'domain_merged'
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TYPE "public"."MasterySourceType" ADD VALUE IF NOT EXISTS 'declared_promoted'
       `);
-      // Area Expansion (0094): the expansion write records a zero-point
-      // MASTERY_EVENTS row with this source type. Pre-add it so a
-      // recorded-but-not-fully-applied 0094 can't 22P02 the insert.
-      await db.execute(sql`
+        // Area Expansion (0094): the expansion write records a zero-point
+        // MASTERY_EVENTS row with this source type. Pre-add it so a
+        // recorded-but-not-fully-applied 0094 can't 22P02 the insert.
+        await db.execute(sql`
         ALTER TYPE "public"."MasterySourceType" ADD VALUE IF NOT EXISTS 'expansion'
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "MASTERY_EVENTS"
           ADD COLUMN IF NOT EXISTS "metadata" jsonb
       `);
-    } catch {
-      // MASTERY_EVENTS or MasterySourceType may not exist yet — migrate() handles
-      // initial creation and the additive migration will add these schema pieces.
-    }
+      } catch {
+        // MASTERY_EVENTS or MasterySourceType may not exist yet — migrate() handles
+        // initial creation and the additive migration will add these schema pieces.
+      }
 
-    // PlayerMastery.territory_type was introduced after the base table and later
-    // (migration 0034) converted from text to a TerritoryType enum. Preview
-    // databases can have either migration recorded without its schema actually
-    // landing, which makes Drizzle selects fail with Postgres 42703 or 22P02
-    // before app code can recover. Mirror 0034's idempotent shape here: create
-    // the enum, ensure the column exists (as enum if fresh, converted if text).
-    try {
-      await db.execute(sql`
+      // PlayerMastery.territory_type was introduced after the base table and later
+      // (migration 0034) converted from text to a TerritoryType enum. Preview
+      // databases can have either migration recorded without its schema actually
+      // landing, which makes Drizzle selects fail with Postgres 42703 or 22P02
+      // before app code can recover. Mirror 0034's idempotent shape here: create
+      // the enum, ensure the column exists (as enum if fresh, converted if text).
+      try {
+        await db.execute(sql`
         DO $$ BEGIN
           CREATE TYPE "public"."TerritoryType" AS ENUM('declared', 'demonstrated');
         EXCEPTION WHEN duplicate_object THEN NULL;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "PLAYER_MASTERY"
           ADD COLUMN IF NOT EXISTS "territory_type" "public"."TerritoryType" DEFAULT 'demonstrated' NOT NULL
       `);
-      // B-DOMAIN-BONUS-ROTATION-01 (migration 0094): gate +2 bonus domains out of
-      // the core rotation until adopted. Additive, default true → no behaviour
-      // change for existing rows.
-      await db.execute(sql`
+        // B-DOMAIN-BONUS-ROTATION-01 (migration 0094): gate +2 bonus domains out of
+        // the core rotation until adopted. Additive, default true → no behaviour
+        // change for existing rows.
+        await db.execute(sql`
         ALTER TABLE "PLAYER_MASTERY"
           ADD COLUMN IF NOT EXISTS "rotation_eligible" boolean NOT NULL DEFAULT true
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$ BEGIN
           IF EXISTS (
             SELECT 1 FROM information_schema.columns
@@ -213,55 +215,55 @@ export async function register() {
           END IF;
         END $$
       `);
-    } catch {
-      // PLAYER_MASTERY may not exist yet — migrate() handles initial creation.
-    }
+      } catch {
+        // PLAYER_MASTERY may not exist yet — migrate() handles initial creation.
+      }
 
-    // B-QUESTION-QUALITY-AGENTS-01 (migration 0096): batch-verification stamp on
-    // both question stores + the needs_review demote status. All additive and
-    // nullable, so pre-applying is a no-op on a fully-migrated DB and repairs a
-    // partially-recorded one before migrate() / app reads touch the columns
-    // (precedent: the territory_type + DomainExclusionScope guards above/below).
-    try {
-      await db.execute(sql`
+      // B-QUESTION-QUALITY-AGENTS-01 (migration 0096): batch-verification stamp on
+      // both question stores + the needs_review demote status. All additive and
+      // nullable, so pre-applying is a no-op on a fully-migrated DB and repairs a
+      // partially-recorded one before migrate() / app reads touch the columns
+      // (precedent: the territory_type + DomainExclusionScope guards above/below).
+      try {
+        await db.execute(sql`
         DO $$ BEGIN
           CREATE TYPE "public"."QuestionVerificationVerdict" AS ENUM('ok', 'demoted', 'unverifiable', 'skipped');
         EXCEPTION WHEN duplicate_object THEN NULL;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TYPE "public"."PublicStatus" ADD VALUE IF NOT EXISTS 'needs_review'
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "Question"
           ADD COLUMN IF NOT EXISTS "verified_at" timestamptz,
           ADD COLUMN IF NOT EXISTS "verification_verdict" "public"."QuestionVerificationVerdict"
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "GeneratedQuestion"
           ADD COLUMN IF NOT EXISTS "verified_at" timestamptz,
           ADD COLUMN IF NOT EXISTS "verification_verdict" "public"."QuestionVerificationVerdict"
       `);
-      // B-CRAFTER-LIFECYCLE-01 (migration 0100): the verifier's verdict reason,
-      // shown on the admin review queue's machine-demotion cards. Additive +
-      // nullable — same repair rationale as the 0096 columns above.
-      await db.execute(sql`
+        // B-CRAFTER-LIFECYCLE-01 (migration 0100): the verifier's verdict reason,
+        // shown on the admin review queue's machine-demotion cards. Additive +
+        // nullable — same repair rationale as the 0096 columns above.
+        await db.execute(sql`
         ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "verification_reason" text
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "verification_reason" text
       `);
-    } catch {
-      // Question / GeneratedQuestion / PublicStatus may not exist yet on a fresh
-      // DB — migrate() creates them and 0096 adds these pieces.
-    }
+      } catch {
+        // Question / GeneratedQuestion / PublicStatus may not exist yet on a fresh
+        // DB — migrate() creates them and 0096 adds these pieces.
+      }
 
-    // B-QUESTION-QUALITY-AGENTS-01 (migration 0097): the stored quality-aggregation
-    // digest table. New + isolated; RLS-enabled with no policies (owner role
-    // bypasses RLS) per B-SECURITY-RLS-01. Idempotent so a partially-recorded DB
-    // still boots before the weekly cron's insert (precedent: 0092 LlmCostReport).
-    try {
-      await db.execute(sql`
+      // B-QUESTION-QUALITY-AGENTS-01 (migration 0097): the stored quality-aggregation
+      // digest table. New + isolated; RLS-enabled with no policies (owner role
+      // bypasses RLS) per B-SECURITY-RLS-01. Idempotent so a partially-recorded DB
+      // still boots before the weekly cron's insert (precedent: 0092 LlmCostReport).
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "QualityReport" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "period_start" timestamp with time zone NOT NULL,
@@ -271,20 +273,20 @@ export async function register() {
           "created_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "QualityReport" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "QualityReport" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "QualityReport_created_at_idx" ON "QualityReport" ("created_at")
       `);
-    } catch {
-      // Best-effort pre-create; migrate() creates it on a fresh DB.
-    }
+      } catch {
+        // Best-effort pre-create; migrate() creates it on a fresh DB.
+      }
 
-    // B-CRAFTER-LIFECYCLE-01 (migration 0101): the per-(player, domain) manual
-    // author-invitation table. New + isolated; RLS-enabled with no policies
-    // (owner role bypasses RLS) per B-SECURITY-RLS-01. Idempotent (precedent:
-    // the 0097 QualityReport guard above).
-    try {
-      await db.execute(sql`
+      // B-CRAFTER-LIFECYCLE-01 (migration 0101): the per-(player, domain) manual
+      // author-invitation table. New + isolated; RLS-enabled with no policies
+      // (owner role bypasses RLS) per B-SECURITY-RLS-01. Idempotent (precedent:
+      // the 0097 QualityReport guard above).
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "AuthorInvitation" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "user_id" text NOT NULL REFERENCES "User"("id"),
@@ -297,24 +299,24 @@ export async function register() {
           "resolved_at" timestamp with time zone
         )
       `);
-      await db.execute(sql`ALTER TABLE "AuthorInvitation" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "AuthorInvitation" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "AuthorInvitation_active_user_domain_key"
           ON "AuthorInvitation" ("user_id", "domain") WHERE "resolved_at" IS NULL
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "AuthorInvitation_user_id_idx" ON "AuthorInvitation" ("user_id")
       `);
-    } catch {
-      // Best-effort pre-create; migrate() creates it on a fresh DB.
-    }
+      } catch {
+        // Best-effort pre-create; migrate() creates it on a fresh DB.
+      }
 
-    // B-CRAFTER-DECISION-LEDGER-01 (migration 0103): the keep/kill teaching
-    // ledger for machine draft candidates. New + isolated; RLS-enabled with no
-    // policies (owner role bypasses RLS) per B-SECURITY-RLS-01. Idempotent
-    // (precedent: the 0101 AuthorInvitation guard above).
-    try {
-      await db.execute(sql`
+      // B-CRAFTER-DECISION-LEDGER-01 (migration 0103): the keep/kill teaching
+      // ledger for machine draft candidates. New + isolated; RLS-enabled with no
+      // policies (owner role bypasses RLS) per B-SECURITY-RLS-01. Idempotent
+      // (precedent: the 0101 AuthorInvitation guard above).
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "CrafterDraftDecision" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "decider_id" text NOT NULL REFERENCES "User"("id"),
@@ -329,24 +331,24 @@ export async function register() {
           "created_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "CrafterDraftDecision" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "CrafterDraftDecision" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "CrafterDraftDecision_domain_idx" ON "CrafterDraftDecision" ("domain")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "CrafterDraftDecision_decider_id_idx" ON "CrafterDraftDecision" ("decider_id")
       `);
-    } catch {
-      // Best-effort pre-create; migrate() creates it on a fresh DB.
-    }
+      } catch {
+        // Best-effort pre-create; migrate() creates it on a fresh DB.
+      }
 
-    // B-KNOWLEDGE-TAXONOMY-01 P1 (migration 0102_knowledge_graph): the
-    // leaf/parent knowledge-graph tables (KnowledgeNode + KnowledgeEdge). New +
-    // isolated; RLS-enabled with no policies (owner role bypasses RLS) per
-    // B-SECURITY-RLS-01. Idempotent (precedent: 0097/0101 guards above).
-    // Structure only — dark until KNOWLEDGE_GRAPH_* flags flip.
-    try {
-      await db.execute(sql`
+      // B-KNOWLEDGE-TAXONOMY-01 P1 (migration 0102_knowledge_graph): the
+      // leaf/parent knowledge-graph tables (KnowledgeNode + KnowledgeEdge). New +
+      // isolated; RLS-enabled with no policies (owner role bypasses RLS) per
+      // B-SECURITY-RLS-01. Idempotent (precedent: 0097/0101 guards above).
+      // Structure only — dark until KNOWLEDGE_GRAPH_* flags flip.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "KnowledgeNode" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "label" text NOT NULL,
@@ -358,17 +360,17 @@ export async function register() {
           "created_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "KnowledgeNode" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "KnowledgeNode" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "KnowledgeNode_domain_key_key" ON "KnowledgeNode" ("domain_key")
       `);
-      // B-KNOWLEDGE-ADMIN-01 P3 (migration 0107): Wikidata provenance on
-      // ratified nodes. Additive nullable column — same repair rationale as
-      // the 0105 web_search_requests guard.
-      await db.execute(sql`
+        // B-KNOWLEDGE-ADMIN-01 P3 (migration 0107): Wikidata provenance on
+        // ratified nodes. Additive nullable column — same repair rationale as
+        // the 0105 web_search_requests guard.
+        await db.execute(sql`
         ALTER TABLE "KnowledgeNode" ADD COLUMN IF NOT EXISTS "wikidata_qid" text
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "KnowledgeEdge" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "child_domain_key" text NOT NULL,
@@ -376,20 +378,20 @@ export async function register() {
           "created_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "KnowledgeEdge" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "KnowledgeEdge" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "KnowledgeEdge_child_parent_key"
           ON "KnowledgeEdge" ("child_domain_key", "parent_domain_key")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "KnowledgeEdge_parent_domain_key_idx" ON "KnowledgeEdge" ("parent_domain_key")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "KnowledgeEdge_child_domain_key_idx" ON "KnowledgeEdge" ("child_domain_key")
       `);
-      // B-KNOWLEDGE-TAXONOMY-01 P4 (migration 0104): the parent-mastery freeze
-      // ledger — same idempotent shape.
-      await db.execute(sql`
+        // B-KNOWLEDGE-TAXONOMY-01 P4 (migration 0104): the parent-mastery freeze
+        // ledger — same idempotent shape.
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "KnowledgeParentMastery" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "user_id" text NOT NULL REFERENCES "User"("id"),
@@ -397,17 +399,17 @@ export async function register() {
           "mastered_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "KnowledgeParentMastery" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "KnowledgeParentMastery" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "KnowledgeParentMastery_user_parent_key"
           ON "KnowledgeParentMastery" ("user_id", "parent_domain_key")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "KnowledgeParentMastery_user_id_idx" ON "KnowledgeParentMastery" ("user_id")
       `);
-      // Mastery v2 (migration 0111): the leaf-mastery freeze ledger — same
-      // idempotent shape as the parent ledger above.
-      await db.execute(sql`
+        // Mastery v2 (migration 0111): the leaf-mastery freeze ledger — same
+        // idempotent shape as the parent ledger above.
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "KnowledgeLeafMastery" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "user_id" text NOT NULL REFERENCES "User"("id"),
@@ -415,24 +417,24 @@ export async function register() {
           "mastered_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "KnowledgeLeafMastery" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "KnowledgeLeafMastery" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "KnowledgeLeafMastery_user_leaf_key"
           ON "KnowledgeLeafMastery" ("user_id", "leaf_domain_key")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "KnowledgeLeafMastery_user_id_idx" ON "KnowledgeLeafMastery" ("user_id")
       `);
-    } catch {
-      // Best-effort pre-create; migrate() creates them on a fresh DB.
-    }
+      } catch {
+        // Best-effort pre-create; migrate() creates them on a fresh DB.
+      }
 
-    // B-SUPPLY-REFILL-THROUGHPUT-01 follow-up (migration 0098): per-domain refill
-    // health for adaptive timeout exclusion. New + isolated; RLS-enabled with no
-    // policies (owner role bypasses RLS). Idempotent so a partially-recorded DB
-    // still boots before runPoolRefill's first upsert (precedent: 0097).
-    try {
-      await db.execute(sql`
+      // B-SUPPLY-REFILL-THROUGHPUT-01 follow-up (migration 0098): per-domain refill
+      // health for adaptive timeout exclusion. New + isolated; RLS-enabled with no
+      // policies (owner role bypasses RLS). Idempotent so a partially-recorded DB
+      // still boots before runPoolRefill's first upsert (precedent: 0097).
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "RetrievalDomainHealth" (
           "domain" text PRIMARY KEY,
           "consecutive_timeouts" integer NOT NULL DEFAULT 0,
@@ -441,19 +443,19 @@ export async function register() {
           "updated_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "RetrievalDomainHealth" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "RetrievalDomainHealth" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "RetrievalDomainHealth_cooldown_idx" ON "RetrievalDomainHealth" ("consecutive_timeouts", "last_timeout_at")
       `);
-    } catch {
-      // Best-effort pre-create; migrate() creates it on a fresh DB.
-    }
+      } catch {
+        // Best-effort pre-create; migrate() creates it on a fresh DB.
+      }
 
-    // D-NEARNESS-LADDER-HYBRID-01 (migration 0099): the global near-ness tree cache.
-    // New + isolated; RLS-enabled with no policies (owner role bypasses RLS).
-    // Idempotent so a partially-recorded DB boots before the first tree write.
-    try {
-      await db.execute(sql`
+      // D-NEARNESS-LADDER-HYBRID-01 (migration 0099): the global near-ness tree cache.
+      // New + isolated; RLS-enabled with no policies (owner role bypasses RLS).
+      // Idempotent so a partially-recorded DB boots before the first tree write.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "DomainRelation" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "child_domain" text NOT NULL,
@@ -464,25 +466,25 @@ export async function register() {
           "created_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "DomainRelation" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "DomainRelation" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "DomainRelation_child_related_key" ON "DomainRelation" ("child_domain", "related_domain")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "DomainRelation_child_domain_idx" ON "DomainRelation" ("child_domain")
       `);
-    } catch {
-      // Best-effort pre-create; migrate() creates it on a fresh DB.
-    }
+      } catch {
+        // Best-effort pre-create; migrate() creates it on a fresh DB.
+      }
 
-    // Migration 0043 renames PlayerMastery.season_points_start to
-    // lifetime_points_baseline. If a preview/production database has 0043
-    // recorded without the rename actually applied, Drizzle selects against
-    // the new column name fail with Postgres 42703. Apply the rename
-    // idempotently before migrate() so app code referencing the new column
-    // name keeps working.
-    try {
-      await db.execute(sql`
+      // Migration 0043 renames PlayerMastery.season_points_start to
+      // lifetime_points_baseline. If a preview/production database has 0043
+      // recorded without the rename actually applied, Drizzle selects against
+      // the new column name fail with Postgres 42703. Apply the rename
+      // idempotently before migrate() so app code referencing the new column
+      // name keeps working.
+      try {
+        await db.execute(sql`
         DO $$
         BEGIN
           IF EXISTS (
@@ -495,43 +497,43 @@ export async function register() {
           END IF;
         END $$
       `);
-    } catch {
-      // PLAYER_MASTERY may not exist yet — migrate() handles initial creation.
-    }
+      } catch {
+        // PLAYER_MASTERY may not exist yet — migrate() handles initial creation.
+      }
 
-    // UserQuestionBank provenance columns were added after the original table. If
-    // a preview/production database has the migration marked as applied without
-    // these additive columns present, Drizzle selects fail with Postgres 42703.
-    // Add them idempotently before migrate() so question-bank reads stay safe.
-    try {
-      await db.execute(sql`
+      // UserQuestionBank provenance columns were added after the original table. If
+      // a preview/production database has the migration marked as applied without
+      // these additive columns present, Drizzle selects fail with Postgres 42703.
+      // Add them idempotently before migrate() so question-bank reads stay safe.
+      try {
+        await db.execute(sql`
         ALTER TABLE "UserQuestionBank"
           ADD COLUMN IF NOT EXISTS "added_from_context_type" text,
           ADD COLUMN IF NOT EXISTS "added_from_context_id" text
       `);
-    } catch {
-      // UserQuestionBank may not exist yet — migrate() handles initial creation.
-    }
+      } catch {
+        // UserQuestionBank may not exist yet — migrate() handles initial creation.
+      }
 
-    // Question generated-question provenance columns and constraints were added
-    // in migration 0018. If that migration is recorded without these additive
-    // pieces present, "my questions" reads can fail before migrate() repairs them.
-    // Add the columns, foreign key, and unique index idempotently before migrate().
-    try {
-      // 0018 also drops NOT NULL on creator_id so daily_generated questions
-      // (which have no human author) can be persisted with creator_id=null.
-      // If that statement didn't take effect on a partially-recorded migration,
-      // every persistGeneratedQuestion call fails with 23502 and friend-feed
-      // propagation silently drops for the rest of time. Re-apply it idempotently.
-      await db.execute(sql`
+      // Question generated-question provenance columns and constraints were added
+      // in migration 0018. If that migration is recorded without these additive
+      // pieces present, "my questions" reads can fail before migrate() repairs them.
+      // Add the columns, foreign key, and unique index idempotently before migrate().
+      try {
+        // 0018 also drops NOT NULL on creator_id so daily_generated questions
+        // (which have no human author) can be persisted with creator_id=null.
+        // If that statement didn't take effect on a partially-recorded migration,
+        // every persistGeneratedQuestion call fails with 23502 and friend-feed
+        // propagation silently drops for the rest of time. Re-apply it idempotently.
+        await db.execute(sql`
         ALTER TABLE "Question" ALTER COLUMN "creator_id" DROP NOT NULL
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "Question"
           ADD COLUMN IF NOT EXISTS "generated_question_id" text,
           ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'authored' NOT NULL
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$
         DECLARE
           question_table regclass := to_regclass('public."Question"');
@@ -554,177 +556,177 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "Question_generated_question_id_key"
         ON "Question" USING btree ("generated_question_id")
       `);
-      // Question.surface_priority_score (migration 0024's runtime hotfix,
-      // journaled later): some preview databases have the feed migrations
-      // recorded without this column actually present. This guard replaces
-      // the lazy ALTER-on-first-query shim that used to live in
-      // src/server/db/queries/questions.ts — boot guards belong here, not in
-      // the query layer.
-      await db.execute(sql`
+        // Question.surface_priority_score (migration 0024's runtime hotfix,
+        // journaled later): some preview databases have the feed migrations
+        // recorded without this column actually present. This guard replaces
+        // the lazy ALTER-on-first-query shim that used to live in
+        // src/server/db/queries/questions.ts — boot guards belong here, not in
+        // the query layer.
+        await db.execute(sql`
         ALTER TABLE "Question"
           ADD COLUMN IF NOT EXISTS "surface_priority_score" DOUBLE PRECISION NOT NULL DEFAULT 0
       `);
-    } catch {
-      // Question or GeneratedQuestion may not exist yet — migrate() handles
-      // initial creation and the 0018 migration will add these schema pieces.
-    }
+      } catch {
+        // Question or GeneratedQuestion may not exist yet — migrate() handles
+        // initial creation and the 0018 migration will add these schema pieces.
+      }
 
-    // Several FeedItem columns were introduced after the original table. In preview
-    // databases with partially-recorded migrations, Drizzle can believe these
-    // migrations already ran while the nullable columns are still absent, causing
-    // feed reads to fail before migrate() gets another chance to reconcile them.
-    // Pre-apply these additive columns idempotently so GET /api/feed remains safe.
-    try {
-      await db.execute(sql`
+      // Several FeedItem columns were introduced after the original table. In preview
+      // databases with partially-recorded migrations, Drizzle can believe these
+      // migrations already ran while the nullable columns are still absent, causing
+      // feed reads to fail before migrate() gets another chance to reconcile them.
+      // Pre-apply these additive columns idempotently so GET /api/feed remains safe.
+      try {
+        await db.execute(sql`
         ALTER TABLE "FeedItem"
           ADD COLUMN IF NOT EXISTS "personalMessage" text,
           ADD COLUMN IF NOT EXISTS "sourceResult" text,
           ADD COLUMN IF NOT EXISTS "submittedAnswer" text,
           ADD COLUMN IF NOT EXISTS "catchupResolvedAt" timestamptz
       `);
-    } catch {
-      // FeedItem table may not exist yet — migrate() handles initial creation.
-    }
+      } catch {
+        // FeedItem table may not exist yet — migrate() handles initial creation.
+      }
 
-    // Migration 0075 adds DailyQueue.email_reminder_sent_at, the per-queue
-    // idempotency marker the daily-assignments cron claims before sending a
-    // reminder email. A preview/production DB that records 0075 without the
-    // column present would make the cron's claim UPDATE fail; pre-apply it
-    // idempotently (precedent: 0074's domain_key guard above).
-    try {
-      await db.execute(sql`
+      // Migration 0075 adds DailyQueue.email_reminder_sent_at, the per-queue
+      // idempotency marker the daily-assignments cron claims before sending a
+      // reminder email. A preview/production DB that records 0075 without the
+      // column present would make the cron's claim UPDATE fail; pre-apply it
+      // idempotently (precedent: 0074's domain_key guard above).
+      try {
+        await db.execute(sql`
         ALTER TABLE "DailyQueue"
           ADD COLUMN IF NOT EXISTS "email_reminder_sent_at" timestamptz
       `);
-    } catch {
-      // DailyQueue table may not exist yet — migrate() handles initial creation.
-    }
+      } catch {
+        // DailyQueue table may not exist yet — migrate() handles initial creation.
+      }
 
-    // Migration 0077 adds EmailVerificationToken.opt_in_on_confirm — the
-    // "turn reminders on when this link is confirmed" intent the onboarding
-    // beat sets and consumeVerificationToken reads. A preview/production DB
-    // that records 0077 without the column present would break token consume;
-    // pre-apply it idempotently (precedent: 0075's guard above).
-    try {
-      await db.execute(sql`
+      // Migration 0077 adds EmailVerificationToken.opt_in_on_confirm — the
+      // "turn reminders on when this link is confirmed" intent the onboarding
+      // beat sets and consumeVerificationToken reads. A preview/production DB
+      // that records 0077 without the column present would break token consume;
+      // pre-apply it idempotently (precedent: 0075's guard above).
+      try {
+        await db.execute(sql`
         ALTER TABLE "EmailVerificationToken"
           ADD COLUMN IF NOT EXISTS "opt_in_on_confirm" boolean NOT NULL DEFAULT false
       `);
-    } catch {
-      // EmailVerificationToken may not exist yet — migrate() handles initial creation.
-    }
+      } catch {
+        // EmailVerificationToken may not exist yet — migrate() handles initial creation.
+      }
 
-    // Migration 0080 adds Question.author_deleted — the account-deletion
-    // tombstone marker (D-ACCOUNT-DELETION-TERRITORY-01). A preview/production DB
-    // that records 0080 without the column present would break the deletion path
-    // (deleteUserAccount sets author_deleted = true when tombstoning an author's
-    // questions) and any tombstone-aware read; pre-apply it idempotently
-    // (precedent: 0077's opt_in_on_confirm guard above).
-    try {
-      await db.execute(sql`
+      // Migration 0080 adds Question.author_deleted — the account-deletion
+      // tombstone marker (D-ACCOUNT-DELETION-TERRITORY-01). A preview/production DB
+      // that records 0080 without the column present would break the deletion path
+      // (deleteUserAccount sets author_deleted = true when tombstoning an author's
+      // questions) and any tombstone-aware read; pre-apply it idempotently
+      // (precedent: 0077's opt_in_on_confirm guard above).
+      try {
+        await db.execute(sql`
         ALTER TABLE "Question"
           ADD COLUMN IF NOT EXISTS "author_deleted" boolean NOT NULL DEFAULT false
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "Question_author_deleted_idx"
           ON "Question" ("author_deleted")
           WHERE "author_deleted" = true
       `);
-    } catch {
-      // Question table may not exist yet — migrate() handles initial creation.
-    }
+      } catch {
+        // Question table may not exist yet — migrate() handles initial creation.
+      }
 
-    // Migration 0084 adds FeedItem.viaUserId (the two-hop forward-relay source,
-    // D-4 via-attribution) and User.discoverable_by_forward (its consent gate).
-    // A preview/production DB that records 0084 without these columns present
-    // would break feed reads that select viaUserId and the discoverability gate;
-    // pre-apply them idempotently (precedent: 0080's author_deleted guard above).
-    // The FK constraint is not re-added here — migrate() adds it on fresh DBs and
-    // it is not needed for read safety.
-    try {
-      await db.execute(sql`
+      // Migration 0084 adds FeedItem.viaUserId (the two-hop forward-relay source,
+      // D-4 via-attribution) and User.discoverable_by_forward (its consent gate).
+      // A preview/production DB that records 0084 without these columns present
+      // would break feed reads that select viaUserId and the discoverability gate;
+      // pre-apply them idempotently (precedent: 0080's author_deleted guard above).
+      // The FK constraint is not re-added here — migrate() adds it on fresh DBs and
+      // it is not needed for read safety.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "discoverable_by_forward" boolean NOT NULL DEFAULT true
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "FeedItem"
           ADD COLUMN IF NOT EXISTS "viaUserId" text
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "FeedItem_viaUserId_idx" ON "FeedItem" ("viaUserId")
       `);
-    } catch {
-      // User / FeedItem may not exist yet — migrate() handles initial creation.
-    }
+      } catch {
+        // User / FeedItem may not exist yet — migrate() handles initial creation.
+      }
 
-    // Migration 0085 adds FeedItem.answeredAt — the true answer time the Answered
-    // archive (readFeedItems) sorts on, replacing the sourceEventAt (send-time)
-    // fallback that buried recently-answered cards below the first page. A
-    // preview/production DB that records 0085 without the column present would
-    // break the answer writes (feed/answer, lately/milestone/answer set it) and
-    // the archive read; pre-apply it idempotently (precedent: 0084's viaUserId
-    // guard above). The historical backfill is left to migrate() — it is not
-    // needed for read safety.
-    try {
-      await db.execute(sql`
+      // Migration 0085 adds FeedItem.answeredAt — the true answer time the Answered
+      // archive (readFeedItems) sorts on, replacing the sourceEventAt (send-time)
+      // fallback that buried recently-answered cards below the first page. A
+      // preview/production DB that records 0085 without the column present would
+      // break the answer writes (feed/answer, lately/milestone/answer set it) and
+      // the archive read; pre-apply it idempotently (precedent: 0084's viaUserId
+      // guard above). The historical backfill is left to migrate() — it is not
+      // needed for read safety.
+      try {
+        await db.execute(sql`
         ALTER TABLE "FeedItem"
           ADD COLUMN IF NOT EXISTS "answeredAt" timestamptz
       `);
-    } catch {
-      // FeedItem table may not exist yet — migrate() handles initial creation.
-    }
+      } catch {
+        // FeedItem table may not exist yet — migrate() handles initial creation.
+      }
 
-    // Migration 0086 adds GeneratedQuestion.subject_entity + Question.subject_entity
-    // — the primary subject feeding the Tier 2 subject-cooldown gate. The generator
-    // writes it and persistGeneratedQuestion carries it onto the canonical row; a
-    // preview/production DB that records 0086 without the columns present would
-    // break those writes. Pre-apply idempotently (precedent: 0085 above). The
-    // historical backfill (scripts/backfill-subject-entity.ts) is separate and not
-    // needed for read/write safety — a NULL subject_entity just means "no signal".
-    try {
-      await db.execute(sql`
+      // Migration 0086 adds GeneratedQuestion.subject_entity + Question.subject_entity
+      // — the primary subject feeding the Tier 2 subject-cooldown gate. The generator
+      // writes it and persistGeneratedQuestion carries it onto the canonical row; a
+      // preview/production DB that records 0086 without the columns present would
+      // break those writes. Pre-apply idempotently (precedent: 0085 above). The
+      // historical backfill (scripts/backfill-subject-entity.ts) is separate and not
+      // needed for read/write safety — a NULL subject_entity just means "no signal".
+      try {
+        await db.execute(sql`
         ALTER TABLE "GeneratedQuestion"
           ADD COLUMN IF NOT EXISTS "subject_entity" text
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "Question"
           ADD COLUMN IF NOT EXISTS "subject_entity" text
       `);
-    } catch {
-      // Tables may not exist yet — migrate() handles initial creation.
-    }
+      } catch {
+        // Tables may not exist yet — migrate() handles initial creation.
+      }
 
-    // Migration 0028 adds the Category.general_knowledge enum value and migration
-    // 0030 uses it as a default/backfill value. Drizzle wraps all pending Postgres
-    // migrations in one transaction, but Postgres requires a newly-added enum value
-    // to be committed before it can be used. Pre-apply the enum addition and data
-    // change outside the migrator transaction so production startup cannot get
-    // stuck on `unsafe use of new value "general_knowledge"`.
-    try {
-      await db.execute(sql`
+      // Migration 0028 adds the Category.general_knowledge enum value and migration
+      // 0030 uses it as a default/backfill value. Drizzle wraps all pending Postgres
+      // migrations in one transaction, but Postgres requires a newly-added enum value
+      // to be committed before it can be used. Pre-apply the enum addition and data
+      // change outside the migrator transaction so production startup cannot get
+      // stuck on `unsafe use of new value "general_knowledge"`.
+      try {
+        await db.execute(sql`
         ALTER TYPE "public"."Category" ADD VALUE IF NOT EXISTS 'general_knowledge'
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "Question" ALTER COLUMN "category" SET DEFAULT 'general_knowledge'
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         UPDATE "Question" SET "category" = 'general_knowledge' WHERE "category" = 'other'
       `);
-    } catch {
-      // Fresh databases may not have Category or Question yet. In that case the
-      // normal migration sequence will create the base schema first.
-    }
+      } catch {
+        // Fresh databases may not have Category or Question yet. In that case the
+        // normal migration sequence will create the base schema first.
+      }
 
-    // If the Category enum type already exists but migration 0000 isn't recorded,
-    // the migrator fails at the very first CREATE TYPE statement and aborts — leaving
-    // all subsequent migrations (0006 recipientUserId, 0014 territory_type, etc.)
-    // unapplied. Detect this and manually insert the 0000 record so Drizzle skips it.
-    try {
-      const typeResult = await db.execute(sql`
+      // If the Category enum type already exists but migration 0000 isn't recorded,
+      // the migrator fails at the very first CREATE TYPE statement and aborts — leaving
+      // all subsequent migrations (0006 recipientUserId, 0014 territory_type, etc.)
+      // unapplied. Detect this and manually insert the 0000 record so Drizzle skips it.
+      try {
+        const typeResult = await db.execute(sql`
         SELECT EXISTS (
           SELECT 1 FROM pg_type t
           JOIN pg_namespace n ON n.oid = t.typnamespace
@@ -732,15 +734,19 @@ export async function register() {
         ) AS exists
       `);
 
-      const categoryExists = typeResult.rows[0]?.exists === true || typeResult.rows[0]?.exists === 'true';
-      if (categoryExists) {
-        const migrationsFolder = path.join(process.cwd(), 'drizzle');
-        const migrationSql = fs.readFileSync(path.join(migrationsFolder, '0000_material_lyja.sql'), 'utf8');
-        const hash = crypto.createHash('sha256').update(migrationSql).digest('hex');
+        const categoryExists =
+          typeResult.rows[0]?.exists === true || typeResult.rows[0]?.exists === 'true';
+        if (categoryExists) {
+          const migrationsFolder = path.join(process.cwd(), 'drizzle');
+          const migrationSql = fs.readFileSync(
+            path.join(migrationsFolder, '0000_material_lyja.sql'),
+            'utf8',
+          );
+          const hash = crypto.createHash('sha256').update(migrationSql).digest('hex');
 
-        // Ensure Drizzle's internal migration tracking schema and table exist
-        await db.execute(sql`CREATE SCHEMA IF NOT EXISTS "drizzle"`);
-        await db.execute(sql`
+          // Ensure Drizzle's internal migration tracking schema and table exist
+          await db.execute(sql`CREATE SCHEMA IF NOT EXISTS "drizzle"`);
+          await db.execute(sql`
           CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
             id serial PRIMARY KEY,
             hash text NOT NULL,
@@ -748,26 +754,26 @@ export async function register() {
           )
         `);
 
-        // Record 0000 as applied if it isn't already, so migrate() skips it
-        await db.execute(sql`
+          // Record 0000 as applied if it isn't already, so migrate() skips it
+          await db.execute(sql`
           INSERT INTO "drizzle"."__drizzle_migrations" (hash, created_at)
           SELECT ${hash}::text, ${Date.now()}::bigint
           WHERE NOT EXISTS (
             SELECT 1 FROM "drizzle"."__drizzle_migrations" WHERE hash = ${hash}
           )
         `);
+        }
+      } catch {
+        // If this check fails, proceed — migrate() will attempt all migrations and
+        // log the error itself
       }
-    } catch {
-      // If this check fails, proceed — migrate() will attempt all migrations and
-      // log the error itself
-    }
 
-    // Migration 0021 adds a partial unique index on FeedDismissedDomain. Some
-    // deployments may still execute an index-only copy of that migration, or may
-    // have migration 0012 recorded without the table actually present. Create the
-    // table and its non-unique indexes first so either migration shape can finish.
-    try {
-      await db.execute(sql`
+      // Migration 0021 adds a partial unique index on FeedDismissedDomain. Some
+      // deployments may still execute an index-only copy of that migration, or may
+      // have migration 0012 recorded without the table actually present. Create the
+      // table and its non-unique indexes first so either migration shape can finish.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "FeedDismissedDomain" (
           "id" TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
           "userId" TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
@@ -776,15 +782,15 @@ export async function register() {
           "reinstatedAt" TIMESTAMPTZ
         )
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "FeedDismissedDomain_userId_idx"
         ON "FeedDismissedDomain" ("userId")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "FeedDismissedDomain_userId_sub_idx"
         ON "FeedDismissedDomain" ("userId", "canonicalSubcategory")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DELETE FROM "FeedDismissedDomain" existing
         USING "FeedDismissedDomain" newest
         WHERE existing."userId" = newest."userId"
@@ -796,19 +802,19 @@ export async function register() {
             OR (existing."dismissedAt" = newest."dismissedAt" AND existing."id" < newest."id")
           )
       `);
-    } catch {
-      // Fresh databases may not have the User table yet. In that case migrate()
-      // will create both User and FeedDismissedDomain in normal migration order.
-    }
+      } catch {
+        // Fresh databases may not have the User table yet. In that case migrate()
+        // will create both User and FeedDismissedDomain in normal migration order.
+      }
 
-    // Migration 0036 adds a DomainExclusionScope enum, a NOT NULL scope column
-    // with default on USER_DOMAIN_EXCLUSIONS, and replaces the unique constraint
-    // to include scope. If a preview/production database has this migration
-    // recorded without these pieces present, the exclusion writes used by the
-    // daily familiarity slider fail before migrate() can repair them. Apply each
-    // piece idempotently outside the migrator transaction.
-    try {
-      await db.execute(sql`
+      // Migration 0036 adds a DomainExclusionScope enum, a NOT NULL scope column
+      // with default on USER_DOMAIN_EXCLUSIONS, and replaces the unique constraint
+      // to include scope. If a preview/production database has this migration
+      // recorded without these pieces present, the exclusion writes used by the
+      // daily familiarity slider fail before migrate() can repair them. Apply each
+      // piece idempotently outside the migrator transaction.
+      try {
+        await db.execute(sql`
         DO $$
         BEGIN
           IF NOT EXISTS (
@@ -820,15 +826,15 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
           ADD COLUMN IF NOT EXISTS "scope" "public"."DomainExclusionScope" NOT NULL DEFAULT 'subcategory'
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
           DROP CONSTRAINT IF EXISTS "USER_DOMAIN_EXCLUSIONS_user_id_canonical_subcategory_key"
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$
         DECLARE
           exclusions_table regclass := to_regclass('public."USER_DOMAIN_EXCLUSIONS"');
@@ -846,53 +852,72 @@ export async function register() {
           END IF;
         END $$
       `);
-    } catch {
-      // USER_DOMAIN_EXCLUSIONS may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      } catch {
+        // USER_DOMAIN_EXCLUSIONS may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0124 (D-DOMAIN-REST-01) adds a nullable rest_until column to
-    // USER_DOMAIN_EXCLUSIONS: the game-summary "Rest a topic" action writes an
-    // exclusion with an expiry instead of a permanent one. The queue-build read
-    // path (getExcludedKnowledgeDomains) references this column, so a
-    // preview/production database that records the migration without the column
-    // present would fail there before migrate() can repair it. Additive +
-    // nullable — same repair rationale as the 0036 scope guard above.
-    try {
-      await db.execute(sql`
+      // Migration 0124 (D-DOMAIN-REST-01) adds a nullable rest_until column to
+      // USER_DOMAIN_EXCLUSIONS: the game-summary "Rest a topic" action writes an
+      // exclusion with an expiry instead of a permanent one. The queue-build read
+      // path (getExcludedKnowledgeDomains) references this column, so a
+      // preview/production database that records the migration without the column
+      // present would fail there before migrate() can repair it. Additive +
+      // nullable — same repair rationale as the 0036 scope guard above.
+      try {
+        await db.execute(sql`
         ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
           ADD COLUMN IF NOT EXISTS "rest_until" timestamptz
       `);
-    } catch {
-      // USER_DOMAIN_EXCLUSIONS may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      } catch {
+        // USER_DOMAIN_EXCLUSIONS may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0125 (D-REMINDER-INTERSTITIAL-01) adds a nullable
-    // reminder_interstitial_seen_at column to User: the one-time full-screen
-    // reminder interstitial stamps it (on both sign-up and skip) so it fires at
-    // most once. The daily-summary query and PATCH /api/account/reminders read
-    // and write it, so a preview/production database that records the migration
-    // without the column present would fail there before migrate() can repair
-    // it. Additive + nullable — same repair rationale as the 0124 rest_until and
-    // 0037 reminder_prompt_dismissed_at guards.
-    try {
-      await db.execute(sql`
+      // Migration 0125 (D-REMINDER-INTERSTITIAL-01) adds a nullable
+      // reminder_interstitial_seen_at column to User: the one-time full-screen
+      // reminder interstitial stamps it (on both sign-up and skip) so it fires at
+      // most once. The daily-summary query and PATCH /api/account/reminders read
+      // and write it, so a preview/production database that records the migration
+      // without the column present would fail there before migrate() can repair
+      // it. Additive + nullable — same repair rationale as the 0124 rest_until and
+      // 0037 reminder_prompt_dismissed_at guards.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "reminder_interstitial_seen_at" timestamptz
       `);
-    } catch {
-      // User table may not exist yet on a fresh database — migrate() creates
-      // it before this migration runs.
-    }
+      } catch {
+        // User table may not exist yet on a fresh database — migrate() creates
+        // it before this migration runs.
+      }
 
-    // Migration 0037 adds the EmailOptIn enum and four columns on User for the
-    // round-open reminder opt-in (email_opt_in, email_verified, pending_email,
-    // reminder_prompt_dismissed_at). If a preview/production database has this
-    // migration recorded without the pieces present, the daily summary query
-    // and PATCH /api/account/reminders fail before migrate() can repair them.
-    try {
-      await db.execute(sql`
+      // Migration 0132 adds auditable SMS-consent metadata and the independent
+      // daily SMS claim. All columns are additive + nullable, so this guard can
+      // safely repair a partially-recorded preview database.
+      try {
+        await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "sms_opt_in_at" timestamptz,
+          ADD COLUMN IF NOT EXISTS "sms_opt_out_at" timestamptz,
+          ADD COLUMN IF NOT EXISTS "sms_consent_source" text,
+          ADD COLUMN IF NOT EXISTS "sms_consent_policy_version" text
+      `);
+        await db.execute(sql`
+        ALTER TABLE "DailyQueue"
+          ADD COLUMN IF NOT EXISTS "sms_reminder_sent_at" timestamptz
+      `);
+      } catch {
+        // Tables may not exist yet on a fresh database — migrate() creates them.
+      }
+
+      // Migration 0037 adds the EmailOptIn enum and four columns on User for the
+      // round-open reminder opt-in (email_opt_in, email_verified, pending_email,
+      // reminder_prompt_dismissed_at). If a preview/production database has this
+      // migration recorded without the pieces present, the daily summary query
+      // and PATCH /api/account/reminders fail before migrate() can repair them.
+      try {
+        await db.execute(sql`
         DO $$
         BEGIN
           IF NOT EXISTS (
@@ -904,116 +929,142 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "email_opt_in" "public"."EmailOptIn" NOT NULL DEFAULT 'not_asked'
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "email_verified" boolean NOT NULL DEFAULT false
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "pending_email" text
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "reminder_prompt_dismissed_at" timestamptz
       `);
-    } catch {
-      // User table may not exist yet on a fresh database — migrate() creates
-      // it before this migration runs.
-    }
+      } catch {
+        // User table may not exist yet on a fresh database — migrate() creates
+        // it before this migration runs.
+      }
 
-    // Migration 0040 adds includeSubmittedAnswer to QuestionReaction (§8.22
-    // opt-in for surfacing answerer text to the question author). Guard for
-    // preview/production databases that may have this migration recorded
-    // without the column actually present.
-    try {
-      await db.execute(sql`
+      // Migration 0040 adds includeSubmittedAnswer to QuestionReaction (§8.22
+      // opt-in for surfacing answerer text to the question author). Guard for
+      // preview/production databases that may have this migration recorded
+      // without the column actually present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "QuestionReaction"
           ADD COLUMN IF NOT EXISTS "includeSubmittedAnswer" boolean NOT NULL DEFAULT false
       `);
-    } catch {
-      // QuestionReaction table may not exist yet on a fresh database —
-      // migrate() creates it before this migration runs.
-    }
+      } catch {
+        // QuestionReaction table may not exist yet on a fresh database —
+        // migrate() creates it before this migration runs.
+      }
 
-    // Migration 0041 adds the nullable Question.inside_joke column for the
-    // friends-only LLM-generated aside. Apply it idempotently in case the
-    // migration is recorded without the column actually present.
-    try {
-      await db.execute(sql`
+      // Migration 0041 adds the nullable Question.inside_joke column for the
+      // friends-only LLM-generated aside. Apply it idempotently in case the
+      // migration is recorded without the column actually present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "Question"
           ADD COLUMN IF NOT EXISTS "inside_joke" text
       `);
-    } catch {
-      // Question may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // Question may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0060 adds the nullable GeneratedQuestion.inside_joke column,
-    // which holds the precomputed aside copied into Question.inside_joke at
-    // persist time. Apply it idempotently in case the migration is recorded
-    // without the column actually present.
-    try {
-      await db.execute(sql`
+      // Migration 0060 adds the nullable GeneratedQuestion.inside_joke column,
+      // which holds the precomputed aside copied into Question.inside_joke at
+      // persist time. Apply it idempotently in case the migration is recorded
+      // without the column actually present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "GeneratedQuestion"
           ADD COLUMN IF NOT EXISTS "inside_joke" text
       `);
-    } catch {
-      // GeneratedQuestion may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      } catch {
+        // GeneratedQuestion may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0062 (B1 pool substrate) adds the TrustTier/QuestionScope enums
-    // and the pool fields (trust_tier, scope, perishable, source_refs, empirical
-    // stats, embedding-dedup flags) to Question + GeneratedQuestion. App code
-    // (the unified selection layer, suppress-aware bank pick) reads these, so a
-    // preview/production database that records the migration without the pieces
-    // present must still boot. Enums + columns + grandfather backfill are applied
-    // idempotently; the backfills target only rows still at the 'unverified'
-    // default, so they are re-runnable no-ops once corrected.
-    try {
-      await db.execute(sql`
+      // Migration 0062 (B1 pool substrate) adds the TrustTier/QuestionScope enums
+      // and the pool fields (trust_tier, scope, perishable, source_refs, empirical
+      // stats, embedding-dedup flags) to Question + GeneratedQuestion. App code
+      // (the unified selection layer, suppress-aware bank pick) reads these, so a
+      // preview/production database that records the migration without the pieces
+      // present must still boot. Enums + columns + grandfather backfill are applied
+      // idempotently; the backfills target only rows still at the 'unverified'
+      // default, so they are re-runnable no-ops once corrected.
+      try {
+        await db.execute(sql`
         DO $$ BEGIN
           CREATE TYPE "public"."TrustTier" AS ENUM('unverified', 'machine_verified', 'human_validated', 'author_confirmed');
         EXCEPTION WHEN duplicate_object THEN NULL;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$ BEGIN
           CREATE TYPE "public"."QuestionScope" AS ENUM('private', 'friends_only', 'public');
         EXCEPTION WHEN duplicate_object THEN NULL;
         END $$
       `);
-      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified'`);
-      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false`);
-      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb`);
-      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false`);
-      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "suppressed_by" text`);
-      await db.execute(sql`UPDATE "Question" SET "trust_tier" = 'author_confirmed' WHERE "trust_tier" = 'unverified'`);
-    } catch {
-      // Question may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
-    try {
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified'`);
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "scope" "public"."QuestionScope" NOT NULL DEFAULT 'public'`);
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false`);
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb`);
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "n_answered" integer NOT NULL DEFAULT 0`);
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "empirical_correct_rate" double precision`);
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false`);
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "suppressed_by" text`);
-      // Grandfather-promote the pre-existing machine backlog — but ONLY while the
-      // database is still pre-B4. Once migration 0066 adds ask_to_answer_verified,
-      // we are in the B4 world where fresh rows are promoted explicitly by the
-      // ask-to-answer gate (resolveMachineTrustTier); a blanket boot-time promotion
-      // would then wrongly bump rows the gate deliberately left 'unverified'
-      // (failed/skipped ask-to-answer). The one-time grandfather already ran in the
-      // 0062 migration SQL; this guard only re-applies it for a recovering pre-B4 DB.
-      await db.execute(sql`
+        await db.execute(
+          sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified'`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false`,
+        );
+        await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "suppressed_by" text`);
+        await db.execute(
+          sql`UPDATE "Question" SET "trust_tier" = 'author_confirmed' WHERE "trust_tier" = 'unverified'`,
+        );
+      } catch {
+        // Question may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
+      try {
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified'`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "scope" "public"."QuestionScope" NOT NULL DEFAULT 'public'`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "n_answered" integer NOT NULL DEFAULT 0`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "empirical_correct_rate" double precision`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "suppressed_by" text`,
+        );
+        // Grandfather-promote the pre-existing machine backlog — but ONLY while the
+        // database is still pre-B4. Once migration 0066 adds ask_to_answer_verified,
+        // we are in the B4 world where fresh rows are promoted explicitly by the
+        // ask-to-answer gate (resolveMachineTrustTier); a blanket boot-time promotion
+        // would then wrongly bump rows the gate deliberately left 'unverified'
+        // (failed/skipped ask-to-answer). The one-time grandfather already ran in the
+        // 0062 migration SQL; this guard only re-applies it for a recovering pre-B4 DB.
+        await db.execute(sql`
         DO $$ BEGIN
           IF NOT EXISTS (
             SELECT 1 FROM information_schema.columns
@@ -1023,171 +1074,191 @@ export async function register() {
           END IF;
         END $$
       `);
-    } catch {
-      // GeneratedQuestion may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      } catch {
+        // GeneratedQuestion may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0066 (B4 Phase 1) adds GeneratedQuestion.ask_to_answer_verified —
-    // the ask-to-answer corroboration record that (with B3 retrieval) earns the
-    // machine_verified tier. App code reads it via resolveMachineTrustTier, so a
-    // preview/production database that records the migration without the column
-    // present must still boot.
-    try {
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "ask_to_answer_verified" boolean NOT NULL DEFAULT false`);
-    } catch {
-      // GeneratedQuestion may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      // Migration 0066 (B4 Phase 1) adds GeneratedQuestion.ask_to_answer_verified —
+      // the ask-to-answer corroboration record that (with B3 retrieval) earns the
+      // machine_verified tier. App code reads it via resolveMachineTrustTier, so a
+      // preview/production database that records the migration without the column
+      // present must still boot.
+      try {
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "ask_to_answer_verified" boolean NOT NULL DEFAULT false`,
+        );
+      } catch {
+        // GeneratedQuestion may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0067 (B4 Phase 2) adds Question.nobody_correct_flag (the "nobody
-    // got it" review smell) + its partial index. App code (the questions view,
-    // evaluateQuestionTrustOnPlay) reads the column, so a database that records
-    // the migration without it present must still boot. The one-time trust
-    // back-fills (author_confirmed correction + human_validated promotion) are
-    // applied by the migration only — not re-run here — because they are pure data
-    // back-fill (a missing promotion is safe/conservative, never a boot blocker)
-    // and re-aggregating MASTERY_EVENTS on every boot would be wasteful.
-    try {
-      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "nobody_correct_flag" boolean NOT NULL DEFAULT false`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "Question_nobody_correct_flag_idx" ON "Question" ("nobody_correct_flag") WHERE "nobody_correct_flag" = true`);
-    } catch {
-      // Question may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      // Migration 0067 (B4 Phase 2) adds Question.nobody_correct_flag (the "nobody
+      // got it" review smell) + its partial index. App code (the questions view,
+      // evaluateQuestionTrustOnPlay) reads the column, so a database that records
+      // the migration without it present must still boot. The one-time trust
+      // back-fills (author_confirmed correction + human_validated promotion) are
+      // applied by the migration only — not re-run here — because they are pure data
+      // back-fill (a missing promotion is safe/conservative, never a boot blocker)
+      // and re-aggregating MASTERY_EVENTS on every boot would be wasteful.
+      try {
+        await db.execute(
+          sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "nobody_correct_flag" boolean NOT NULL DEFAULT false`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "Question_nobody_correct_flag_idx" ON "Question" ("nobody_correct_flag") WHERE "nobody_correct_flag" = true`,
+        );
+      } catch {
+        // Question may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0068 (B4 Phase 4) adds GeneratedQuestion.acceptable_variants —
-    // equivalent answer phrasings honored in grading. App code (generation persist
-    // + the daily/catchup answer routes) reads it, so a database that records the
-    // migration without the column present must still boot.
-    try {
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "acceptable_variants" text[] NOT NULL DEFAULT '{}'`);
-    } catch {
-      // GeneratedQuestion may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      // Migration 0068 (B4 Phase 4) adds GeneratedQuestion.acceptable_variants —
+      // equivalent answer phrasings honored in grading. App code (generation persist
+      // + the daily/catchup answer routes) reads it, so a database that records the
+      // migration without the column present must still boot.
+      try {
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "acceptable_variants" text[] NOT NULL DEFAULT '{}'`,
+        );
+      } catch {
+        // GeneratedQuestion may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0074 (BP-7 / C5) adds GeneratedQuestion.domain_key — the TS
-    // domainKey() fold of canonical_subcategory, matched by the bank lookup so
-    // spelling variants share stock — plus its lookup index. All pool write
-    // paths set it and pickBankSource reads it, so a database that records the
-    // migration without the column present must still boot (precedent: the
-    // 0068 acceptable_variants guard above).
-    try {
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "domain_key" text`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "GeneratedQuestion_domain_key_difficulty_idx" ON "GeneratedQuestion" ("domain_key", "difficulty_estimate")`);
-    } catch {
-      // GeneratedQuestion may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      // Migration 0074 (BP-7 / C5) adds GeneratedQuestion.domain_key — the TS
+      // domainKey() fold of canonical_subcategory, matched by the bank lookup so
+      // spelling variants share stock — plus its lookup index. All pool write
+      // paths set it and pickBankSource reads it, so a database that records the
+      // migration without the column present must still boot (precedent: the
+      // 0068 acceptable_variants guard above).
+      try {
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "domain_key" text`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "GeneratedQuestion_domain_key_difficulty_idx" ON "GeneratedQuestion" ("domain_key", "difficulty_estimate")`,
+        );
+      } catch {
+        // GeneratedQuestion may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0063 (B1) enables pgvector and adds the nullable 1024-dim
-    // embedding column + HNSW cosine indexes to both pool tables. The dedup
-    // helpers read/write GeneratedQuestion.embedding / Question.embedding, so a
-    // database that records the migration without the pieces present must still
-    // boot. Guard the extension, columns, and indexes idempotently. If pgvector
-    // is unavailable the whole block is skipped — insert-time dedup degrades to
-    // the deterministic guards.
-    try {
-      await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "embedding" vector(1024)`);
-      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "embedding" vector(1024)`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "GeneratedQuestion_embedding_hnsw_idx" ON "GeneratedQuestion" USING hnsw ("embedding" vector_cosine_ops)`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "Question_embedding_hnsw_idx" ON "Question" USING hnsw ("embedding" vector_cosine_ops)`);
-    } catch {
-      // pgvector may be unavailable, or the tables may not exist yet on a fresh
-      // database — migrate() handles creation; dedup is best-effort regardless.
-    }
+      // Migration 0063 (B1) enables pgvector and adds the nullable 1024-dim
+      // embedding column + HNSW cosine indexes to both pool tables. The dedup
+      // helpers read/write GeneratedQuestion.embedding / Question.embedding, so a
+      // database that records the migration without the pieces present must still
+      // boot. Guard the extension, columns, and indexes idempotently. If pgvector
+      // is unavailable the whole block is skipped — insert-time dedup degrades to
+      // the deterministic guards.
+      try {
+        await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "embedding" vector(1024)`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "embedding" vector(1024)`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "GeneratedQuestion_embedding_hnsw_idx" ON "GeneratedQuestion" USING hnsw ("embedding" vector_cosine_ops)`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "Question_embedding_hnsw_idx" ON "Question" USING hnsw ("embedding" vector_cosine_ops)`,
+        );
+      } catch {
+        // pgvector may be unavailable, or the tables may not exist yet on a fresh
+        // database — migrate() handles creation; dedup is best-effort regardless.
+      }
 
-    // Migration 0071 enables pg_trgm, which convergeDomain()'s fuzzy pass calls
-    // via similarity() (the /api/knowledge/converge route + the onboarding seed
-    // pipeline). similarity() needs no index, so none is created — see the
-    // migration header. A database that records the migration without the
-    // extension present must still boot; if pg_trgm is unavailable the whole
-    // block is skipped — convergence degrades to exact-key + "create new".
-    try {
-      await db.execute(sql`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
-    } catch {
-      // pg_trgm may be unavailable on this database — convergence is best-effort.
-    }
+      // Migration 0071 enables pg_trgm, which convergeDomain()'s fuzzy pass calls
+      // via similarity() (the /api/knowledge/converge route + the onboarding seed
+      // pipeline). similarity() needs no index, so none is created — see the
+      // migration header. A database that records the migration without the
+      // extension present must still boot; if pg_trgm is unavailable the whole
+      // block is skipped — convergence degrades to exact-key + "create new".
+      try {
+        await db.execute(sql`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+      } catch {
+        // pg_trgm may be unavailable on this database — convergence is best-effort.
+      }
 
-    // Migration 0044 adds the nullable User.last_activity_bell_opened_at
-    // timestamp used by getBellBadgeCount to compute "rolled-off + unseen"
-    // counts. Apply it idempotently in case the migration is recorded
-    // without the column actually present.
-    try {
-      await db.execute(sql`
+      // Migration 0044 adds the nullable User.last_activity_bell_opened_at
+      // timestamp used by getBellBadgeCount to compute "rolled-off + unseen"
+      // counts. Apply it idempotently in case the migration is recorded
+      // without the column actually present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "last_activity_bell_opened_at" timestamp with time zone
       `);
-    } catch {
-      // User may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // User may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0045 introduces the public-facing User.handle plus the
-    // handle_last_changed_at rate-limit anchor. Guard for preview/production
-    // databases that may have this migration recorded without the column
-    // or unique-lower index actually present.
-    try {
-      await db.execute(sql`
+      // Migration 0045 introduces the public-facing User.handle plus the
+      // handle_last_changed_at rate-limit anchor. Guard for preview/production
+      // databases that may have this migration recorded without the column
+      // or unique-lower index actually present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "handle" text
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "handle_last_changed_at" timestamp with time zone
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_handle_lower"
           ON "User" (LOWER("handle")) WHERE "handle" IS NOT NULL
       `);
-    } catch {
-      // User may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // User may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0046 adds the nullable User.avatar_color column. The value
-    // is computed at signup via colorForUser(id) so the persisted color
-    // matches what the runtime helper already renders. Guard for
-    // preview/production databases that may have the migration recorded
-    // without the column actually present.
-    try {
-      await db.execute(sql`
+      // Migration 0046 adds the nullable User.avatar_color column. The value
+      // is computed at signup via colorForUser(id) so the persisted color
+      // matches what the runtime helper already renders. Guard for
+      // preview/production databases that may have the migration recorded
+      // without the column actually present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "avatar_color" text
       `);
-    } catch {
-      // User may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // User may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0047 added User.bio / .tagline / .location plus length
-    // CHECKs. Migration 0054 drops all three columns + their CHECKs as part
-    // of the profile redesign — no app code references them after 0054.
-    // The 0047 guards have been removed accordingly; 0054 runs IF EXISTS
-    // drops idempotently so a partially-recorded 0054 is still safe.
+      // Migration 0047 added User.bio / .tagline / .location plus length
+      // CHECKs. Migration 0054 drops all three columns + their CHECKs as part
+      // of the profile redesign — no app code references them after 0054.
+      // The 0047 guards have been removed accordingly; 0054 runs IF EXISTS
+      // drops idempotently so a partially-recorded 0054 is still safe.
 
-    // Migration 0048 adds the friends/privacy foundation:
-    //   • User.discoverable_by_contacts / .discoverable_by_mutual_friends
-    //     (default FALSE) — read by B-Friends-3/4 once those land.
-    //   • ContactHash table — stores per-user SHA-256 contact hashes for
-    //     the B-Friends-4 matching channel. Cascades on User delete.
-    //   • Friendship extensions — personalNote (≤160), expiresAt,
-    //     resolvedAt + two CHECKs (length, users distinct) + two partial
-    //     indexes (expiry cron, declined/expired decay GC).
-    // Guard for preview/production databases that may have the migration
-    // recorded without the columns/table/constraints actually present.
-    try {
-      await db.execute(sql`
+      // Migration 0048 adds the friends/privacy foundation:
+      //   • User.discoverable_by_contacts / .discoverable_by_mutual_friends
+      //     (default FALSE) — read by B-Friends-3/4 once those land.
+      //   • ContactHash table — stores per-user SHA-256 contact hashes for
+      //     the B-Friends-4 matching channel. Cascades on User delete.
+      //   • Friendship extensions — personalNote (≤160), expiresAt,
+      //     resolvedAt + two CHECKs (length, users distinct) + two partial
+      //     indexes (expiry cron, declined/expired decay GC).
+      // Guard for preview/production databases that may have the migration
+      // recorded without the columns/table/constraints actually present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "discoverable_by_contacts" boolean NOT NULL DEFAULT false
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "discoverable_by_mutual_friends" boolean NOT NULL DEFAULT false
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "ContactHash" (
           "userId"     text NOT NULL,
           "phoneHash"  text NOT NULL,
@@ -1195,7 +1266,7 @@ export async function register() {
           PRIMARY KEY ("userId", "phoneHash")
         )
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$
         DECLARE
           hash_table regclass := to_regclass('public."ContactHash"');
@@ -1215,23 +1286,23 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "ContactHash_phoneHash_idx"
           ON "ContactHash" ("phoneHash")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "Friendship"
           ADD COLUMN IF NOT EXISTS "personalNote" text
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "Friendship"
           ADD COLUMN IF NOT EXISTS "expiresAt" timestamptz
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "Friendship"
           ADD COLUMN IF NOT EXISTS "resolvedAt" timestamptz
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$
         BEGIN
           IF NOT EXISTS (
@@ -1256,109 +1327,109 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "Friendship_expiresAt_pending_idx"
           ON "Friendship" ("expiresAt") WHERE status = 'pending'
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "Friendship_resolvedAt_decay_idx"
           ON "Friendship" ("resolvedAt") WHERE status IN ('declined', 'expired')
       `);
-    } catch {
-      // User or Friendship may not exist yet on a fresh database — migrate()
-      // creates the base tables before this migration runs.
-    }
+      } catch {
+        // User or Friendship may not exist yet on a fresh database — migrate()
+        // creates the base tables before this migration runs.
+      }
 
-    // Migration 0049 adds the per-user invite token (users.invite_token)
-    // used by /u/<handle>/<token> shareable links. Guard for preview/
-    // production databases that may have the migration recorded without
-    // the column or the unique partial index actually present.
-    try {
-      await db.execute(sql`
+      // Migration 0049 adds the per-user invite token (users.invite_token)
+      // used by /u/<handle>/<token> shareable links. Guard for preview/
+      // production databases that may have the migration recorded without
+      // the column or the unique partial index actually present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "invite_token" text
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_invite_token"
           ON "User" ("invite_token") WHERE "invite_token" IS NOT NULL
       `);
-    } catch {
-      // User may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // User may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0050 adds users.phone_hash (the user's own SHA-256(salt+E.164)
-    // for the contact-hash match query) and users.last_friend_discovery_check_at
-    // (the threshold for the Find Friends discovery dot + passive
-    // Invitations-tab row). Guard for preview/production databases that may
-    // have the migration recorded without the columns or index present.
-    try {
-      await db.execute(sql`
+      // Migration 0050 adds users.phone_hash (the user's own SHA-256(salt+E.164)
+      // for the contact-hash match query) and users.last_friend_discovery_check_at
+      // (the threshold for the Find Friends discovery dot + passive
+      // Invitations-tab row). Guard for preview/production databases that may
+      // have the migration recorded without the columns or index present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "phone_hash" text
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "last_friend_discovery_check_at" timestamptz
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "idx_users_phone_hash"
           ON "User" ("phone_hash")
       `);
-    } catch {
-      // User may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // User may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0051 adds GeneratedQuestion.fact_key (nullable) plus the
-    // (user_id, fact_key) lookup index used by the fact-level dedup in
-    // persistGeneratedQuestion + the recent-fact-keys avoid list in
-    // generateDailyQuestions. Guard for preview/production databases that may
-    // have the migration recorded without the column or index actually present.
-    try {
-      await db.execute(sql`
+      // Migration 0051 adds GeneratedQuestion.fact_key (nullable) plus the
+      // (user_id, fact_key) lookup index used by the fact-level dedup in
+      // persistGeneratedQuestion + the recent-fact-keys avoid list in
+      // generateDailyQuestions. Guard for preview/production databases that may
+      // have the migration recorded without the column or index actually present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "GeneratedQuestion"
           ADD COLUMN IF NOT EXISTS "fact_key" text
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "GeneratedQuestion_user_id_fact_key_idx"
           ON "GeneratedQuestion" ("user_id", "fact_key")
       `);
-    } catch {
-      // GeneratedQuestion may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      } catch {
+        // GeneratedQuestion may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0052 adds a 'friends' value to QuestionVisibility and creates
-    // the PROFILE_SECTION_VISIBILITY table (with backfill from the legacy
-    // User.portrait_visibility and User.authorProfilePublic columns). The
-    // enum addition must be pre-applied here because Postgres forbids
-    // referencing a newly-added enum value inside the same transaction that
-    // adds it — Drizzle wraps the migrator in a transaction, so subsequent
-    // code paths that read 'friends' from a preview database where 0052 is
-    // recorded-but-not-fully-applied would 22P02 without this guard.
-    try {
-      await db.execute(sql`
+      // Migration 0052 adds a 'friends' value to QuestionVisibility and creates
+      // the PROFILE_SECTION_VISIBILITY table (with backfill from the legacy
+      // User.portrait_visibility and User.authorProfilePublic columns). The
+      // enum addition must be pre-applied here because Postgres forbids
+      // referencing a newly-added enum value inside the same transaction that
+      // adds it — Drizzle wraps the migrator in a transaction, so subsequent
+      // code paths that read 'friends' from a preview database where 0052 is
+      // recorded-but-not-fully-applied would 22P02 without this guard.
+      try {
+        await db.execute(sql`
         ALTER TYPE "public"."QuestionVisibility" ADD VALUE IF NOT EXISTS 'friends'
       `);
-    } catch {
-      // QuestionVisibility may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
-    // Migration 0069 adds a 'blocked' value to QuestionVisibility for questions
-    // that fail the safety vet. Pre-applied here for the same reason as 'friends'
-    // above: code paths that read/compare 'blocked' from a preview database where
-    // 0069 is recorded-but-not-fully-applied would 22P02 without this guard.
-    try {
-      await db.execute(sql`
+      } catch {
+        // QuestionVisibility may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
+      // Migration 0069 adds a 'blocked' value to QuestionVisibility for questions
+      // that fail the safety vet. Pre-applied here for the same reason as 'friends'
+      // above: code paths that read/compare 'blocked' from a preview database where
+      // 0069 is recorded-but-not-fully-applied would 22P02 without this guard.
+      try {
+        await db.execute(sql`
         ALTER TYPE "public"."QuestionVisibility" ADD VALUE IF NOT EXISTS 'blocked'
       `);
-    } catch {
-      // QuestionVisibility may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
-    try {
-      await db.execute(sql`
+      } catch {
+        // QuestionVisibility may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
+      try {
+        await db.execute(sql`
         DO $$
         BEGIN
           IF NOT EXISTS (
@@ -1374,7 +1445,7 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "PROFILE_SECTION_VISIBILITY" (
           "id"          text PRIMARY KEY DEFAULT gen_random_uuid()::text,
           "user_id"     text NOT NULL,
@@ -1385,7 +1456,7 @@ export async function register() {
             CHECK ("visibility" IN ('public', 'friends', 'private'))
         )
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$
         BEGIN
           IF NOT EXISTS (
@@ -1399,7 +1470,7 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$
         BEGIN
           IF NOT EXISTS (
@@ -1413,23 +1484,23 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "PROFILE_SECTION_VISIBILITY_user_id_idx"
           ON "PROFILE_SECTION_VISIBILITY" ("user_id")
       `);
-    } catch {
-      // User table may not exist yet on a fresh database — migrate() creates
-      // both User and PROFILE_SECTION_VISIBILITY before this migration runs.
-    }
+      } catch {
+        // User table may not exist yet on a fresh database — migrate() creates
+        // both User and PROFILE_SECTION_VISIBILITY before this migration runs.
+      }
 
-    // Migration 0061 creates the EmailVerificationToken table that backs the
-    // /verify-email confirm-link flow. The send + confirm routes hit this
-    // table on every email-verification request, so a preview/production
-    // database with the migration recorded but the table missing would 42P01
-    // before migrate() could repair it. Pre-create the table, FK, and
-    // indexes idempotently outside the migrator transaction.
-    try {
-      await db.execute(sql`
+      // Migration 0061 creates the EmailVerificationToken table that backs the
+      // /verify-email confirm-link flow. The send + confirm routes hit this
+      // table on every email-verification request, so a preview/production
+      // database with the migration recorded but the table missing would 42P01
+      // before migrate() could repair it. Pre-create the table, FK, and
+      // indexes idempotently outside the migrator transaction.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "EmailVerificationToken" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "user_id" text NOT NULL,
@@ -1440,7 +1511,7 @@ export async function register() {
           "created_at" timestamp with time zone DEFAULT now() NOT NULL
         )
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$
         DECLARE
           token_table regclass := to_regclass('public."EmailVerificationToken"');
@@ -1460,92 +1531,92 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "EmailVerificationToken_token_hash_key"
           ON "EmailVerificationToken" ("token_hash")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "EmailVerificationToken_user_id_idx"
           ON "EmailVerificationToken" ("user_id")
       `);
-    } catch {
-      // User table may not exist yet on a fresh database — migrate() creates
-      // it before this migration runs.
-    }
+      } catch {
+        // User table may not exist yet on a fresh database — migrate() creates
+        // it before this migration runs.
+      }
 
-    // Migration 0054 adds a 'knowledge_base' value to ProfileSection (which
-    // collapses the legacy 'knowledge_map' and 'mind_expanding' sections into
-    // one) and drops User.bio / .tagline / .location plus their CHECKs. The
-    // enum addition must be pre-applied here because Postgres forbids
-    // referencing a newly-added enum value inside the same transaction that
-    // adds it — Drizzle wraps the migrator in a transaction, so the
-    // backfill INSERT inside 0054 would 22P02 without this guard.
-    try {
-      await db.execute(sql`
+      // Migration 0054 adds a 'knowledge_base' value to ProfileSection (which
+      // collapses the legacy 'knowledge_map' and 'mind_expanding' sections into
+      // one) and drops User.bio / .tagline / .location plus their CHECKs. The
+      // enum addition must be pre-applied here because Postgres forbids
+      // referencing a newly-added enum value inside the same transaction that
+      // adds it — Drizzle wraps the migrator in a transaction, so the
+      // backfill INSERT inside 0054 would 22P02 without this guard.
+      try {
+        await db.execute(sql`
         ALTER TYPE "public"."ProfileSection" ADD VALUE IF NOT EXISTS 'knowledge_base'
       `);
-    } catch {
-      // ProfileSection may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      } catch {
+        // ProfileSection may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0055 adds GeneratedQuestion.sub_angles (text[]) for positive
-    // sub-angle guidance in daily question generation. Guard for preview/
-    // production databases that may have the migration recorded without the
-    // column actually present — code paths that select sub_angles would 42703
-    // before app code can recover.
-    try {
-      await db.execute(sql`
+      // Migration 0055 adds GeneratedQuestion.sub_angles (text[]) for positive
+      // sub-angle guidance in daily question generation. Guard for preview/
+      // production databases that may have the migration recorded without the
+      // column actually present — code paths that select sub_angles would 42703
+      // before app code can recover.
+      try {
+        await db.execute(sql`
         ALTER TABLE "GeneratedQuestion"
           ADD COLUMN IF NOT EXISTS "sub_angles" text[] NOT NULL DEFAULT '{}'
       `);
-    } catch {
-      // GeneratedQuestion may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      } catch {
+        // GeneratedQuestion may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0056 adds the nullable User.area_top_up_prompt_dismissed_at
-    // timestamp. It recorded that a user dismissed (or completed) the one-time
-    // "add two more areas" prompt. That prompt was removed (onboarding now lets
-    // a new user pick up to 12 areas directly, so the top-up nudge is no longer
-    // needed), but the column is retained as a harmless orphan to keep schema
-    // parity and avoid a destructive migration on existing databases. The guard
-    // stays so partially-recorded preview/production databases don't 42703.
-    try {
-      await db.execute(sql`
+      // Migration 0056 adds the nullable User.area_top_up_prompt_dismissed_at
+      // timestamp. It recorded that a user dismissed (or completed) the one-time
+      // "add two more areas" prompt. That prompt was removed (onboarding now lets
+      // a new user pick up to 12 areas directly, so the top-up nudge is no longer
+      // needed), but the column is retained as a harmless orphan to keep schema
+      // parity and avoid a destructive migration on existing databases. The guard
+      // stays so partially-recorded preview/production databases don't 42703.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "area_top_up_prompt_dismissed_at" timestamp with time zone
       `);
-    } catch {
-      // User may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // User may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0058 (D-1 Stage 3) introduces the directional Follow model:
-    // the FollowState/FollowPrivacy enums, the User.follow_privacy column, the
-    // Follow table, and a backfill from the frozen Friendship table. Guard for
-    // preview/production databases that may have the migration recorded without
-    // the objects present — relationship reads now go through Follow and would
-    // 42P01/42703/42704 before app code can recover. Backfills are
-    // ON CONFLICT DO NOTHING, so this whole block is safe to re-run.
-    try {
-      await db.execute(sql`
+      // Migration 0058 (D-1 Stage 3) introduces the directional Follow model:
+      // the FollowState/FollowPrivacy enums, the User.follow_privacy column, the
+      // Follow table, and a backfill from the frozen Friendship table. Guard for
+      // preview/production databases that may have the migration recorded without
+      // the objects present — relationship reads now go through Follow and would
+      // 42P01/42703/42704 before app code can recover. Backfills are
+      // ON CONFLICT DO NOTHING, so this whole block is safe to re-run.
+      try {
+        await db.execute(sql`
         DO $$ BEGIN
           CREATE TYPE "public"."FollowState" AS ENUM('pending', 'approved');
         EXCEPTION WHEN duplicate_object THEN NULL;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$ BEGIN
           CREATE TYPE "public"."FollowPrivacy" AS ENUM('public', 'approval_required');
         EXCEPTION WHEN duplicate_object THEN NULL;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "follow_privacy" "public"."FollowPrivacy" NOT NULL DEFAULT 'approval_required'
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "Follow" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "followerId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
@@ -1559,27 +1630,27 @@ export async function register() {
           CONSTRAINT "Follow_distinct_users" CHECK ("followerId" <> "followeeId")
         )
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "Follow_followerId_state_idx" ON "Follow" ("followerId", "state")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "Follow_followeeId_state_idx" ON "Follow" ("followeeId", "state")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         INSERT INTO "Follow" ("id", "followerId", "followeeId", "state", "approvedAt", "created_at")
         SELECT gen_random_uuid()::text, "userAId", "userBId", 'approved'::"public"."FollowState",
                COALESCE("formedAt", now()), "createdAt"
         FROM "Friendship" WHERE "status" = 'active'
         ON CONFLICT ("followerId", "followeeId") DO NOTHING
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         INSERT INTO "Follow" ("id", "followerId", "followeeId", "state", "approvedAt", "created_at")
         SELECT gen_random_uuid()::text, "userBId", "userAId", 'approved'::"public"."FollowState",
                COALESCE("formedAt", now()), "createdAt"
         FROM "Friendship" WHERE "status" = 'active'
         ON CONFLICT ("followerId", "followeeId") DO NOTHING
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         INSERT INTO "Follow" ("id", "followerId", "followeeId", "state", "personalNote", "requestContext", "created_at")
         SELECT gen_random_uuid()::text,
                "requestedByUserId",
@@ -1589,71 +1660,71 @@ export async function register() {
         FROM "Friendship" WHERE "status" = 'pending'
         ON CONFLICT ("followerId", "followeeId") DO NOTHING
       `);
-    } catch {
-      // User or Friendship may not exist yet on a fresh database — migrate()
-      // creates them and applies 0058 in normal order.
-    }
+      } catch {
+        // User or Friendship may not exist yet on a fresh database — migrate()
+        // creates them and applies 0058 in normal order.
+      }
 
-    // Migration 0059 (D-2 WS1) adds User.discoverable_by_niche_match, the third
-    // discoverability flag. Additive boolean with a default — the safe case.
-    // TEST-PHASE default is ON (DEFAULT true): the whole cohort, including
-    // pre-existing users, is enrolled in the niche-match test. The production
-    // default is an OPEN DECISION to revisit after the test; default-ON here is
-    // deliberate for the test cohort only. Guard for preview/production
-    // databases that may have the migration recorded without the column present.
-    try {
-      await db.execute(sql`
+      // Migration 0059 (D-2 WS1) adds User.discoverable_by_niche_match, the third
+      // discoverability flag. Additive boolean with a default — the safe case.
+      // TEST-PHASE default is ON (DEFAULT true): the whole cohort, including
+      // pre-existing users, is enrolled in the niche-match test. The production
+      // default is an OPEN DECISION to revisit after the test; default-ON here is
+      // deliberate for the test cohort only. Guard for preview/production
+      // databases that may have the migration recorded without the column present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "discoverable_by_niche_match" boolean NOT NULL DEFAULT true
       `);
-    } catch {
-      // User may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // User may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0064 (Refine Your Game) adds USER_DOMAIN_DIFFICULTY.freeze_until.
-    // adaptive-difficulty.ts reads it on every answer to decide whether the
-    // served difficulty is pinned, so a preview/production database with the
-    // migration recorded but the column missing would error before migrate()
-    // could repair it. Additive nullable column — pre-apply it idempotently.
-    try {
-      await db.execute(sql`
+      // Migration 0064 (Refine Your Game) adds USER_DOMAIN_DIFFICULTY.freeze_until.
+      // adaptive-difficulty.ts reads it on every answer to decide whether the
+      // served difficulty is pinned, so a preview/production database with the
+      // migration recorded but the column missing would error before migrate()
+      // could repair it. Additive nullable column — pre-apply it idempotently.
+      try {
+        await db.execute(sql`
         ALTER TABLE "USER_DOMAIN_DIFFICULTY"
           ADD COLUMN IF NOT EXISTS "freeze_until" timestamp with time zone
       `);
-    } catch {
-      // USER_DOMAIN_DIFFICULTY may not exist yet on a fresh database —
-      // migrate() creates it before this migration runs.
-    }
+      } catch {
+        // USER_DOMAIN_DIFFICULTY may not exist yet on a fresh database —
+        // migrate() creates it before this migration runs.
+      }
 
-    // Migration 0089 adds USER_DOMAIN_DIFFICULTY.expansion_eligible_since and
-    // .expansion_offered_at for the post-daily-Five expansion offer. The daily
-    // summary reads them to decide whether to surface "you're crushing X — branch
-    // out?", so a preview/production database with the migration recorded but the
-    // columns missing would error. Additive nullable columns — pre-apply
-    // idempotently.
-    try {
-      await db.execute(sql`
+      // Migration 0089 adds USER_DOMAIN_DIFFICULTY.expansion_eligible_since and
+      // .expansion_offered_at for the post-daily-Five expansion offer. The daily
+      // summary reads them to decide whether to surface "you're crushing X — branch
+      // out?", so a preview/production database with the migration recorded but the
+      // columns missing would error. Additive nullable columns — pre-apply
+      // idempotently.
+      try {
+        await db.execute(sql`
         ALTER TABLE "USER_DOMAIN_DIFFICULTY"
           ADD COLUMN IF NOT EXISTS "expansion_eligible_since" timestamp with time zone
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "USER_DOMAIN_DIFFICULTY"
           ADD COLUMN IF NOT EXISTS "expansion_offered_at" timestamp with time zone
       `);
-    } catch {
-      // USER_DOMAIN_DIFFICULTY may not exist yet on a fresh database —
-      // migrate() creates it before this migration runs.
-    }
+      } catch {
+        // USER_DOMAIN_DIFFICULTY may not exist yet on a fresh database —
+        // migrate() creates it before this migration runs.
+      }
 
-    // Migration 0065 (Refine Your Game) creates DAILY_REFINE_DECISION, the
-    // decision + cooldown ledger behind the daily-summary refine section. The
-    // summary builder, the resolve/undo route, and the next-daily commit hook
-    // all read this table, so a preview/production database with the migration
-    // recorded but the table missing would 42P01 before migrate() could repair
-    // it. Pre-create the table, FKs, and indexes idempotently.
-    try {
-      await db.execute(sql`
+      // Migration 0065 (Refine Your Game) creates DAILY_REFINE_DECISION, the
+      // decision + cooldown ledger behind the daily-summary refine section. The
+      // summary builder, the resolve/undo route, and the next-daily commit hook
+      // all read this table, so a preview/production database with the migration
+      // recorded but the table missing would 42P01 before migrate() could repair
+      // it. Pre-create the table, FKs, and indexes idempotently.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "DAILY_REFINE_DECISION" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "user_id" text NOT NULL,
@@ -1668,7 +1739,7 @@ export async function register() {
           "updated_at" timestamp with time zone DEFAULT now() NOT NULL
         )
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$
         DECLARE
           decision_table regclass := to_regclass('public."DAILY_REFINE_DECISION"');
@@ -1702,99 +1773,99 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_unique_item"
           ON "DAILY_REFINE_DECISION" ("user_id", "queue_id", "item_type", "canonical_subcategory", COALESCE("friend_id", ''))
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_cooldown_idx"
           ON "DAILY_REFINE_DECISION" ("user_id", "item_type", "canonical_subcategory", "cooldown_until")
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_uncommitted_idx"
           ON "DAILY_REFINE_DECISION" ("user_id", "committed_at")
       `);
-    } catch {
-      // User or DailyQueue may not exist yet on a fresh database — migrate()
-      // creates them before this migration runs.
-    }
+      } catch {
+        // User or DailyQueue may not exist yet on a fresh database — migrate()
+        // creates them before this migration runs.
+      }
 
-    // Migration 0070 adds DailyPreference.domain_preference_frequency (jsonb,
-    // NOT NULL default '{}'). getDailyPreferences() selects it from the home
-    // server component and the whole daily flow, so a database that records the
-    // migration without the column present would 42703 before migrate() could
-    // repair it (see digest 1273321541). Additive column with a default —
-    // pre-apply it idempotently.
-    try {
-      await db.execute(sql`
+      // Migration 0070 adds DailyPreference.domain_preference_frequency (jsonb,
+      // NOT NULL default '{}'). getDailyPreferences() selects it from the home
+      // server component and the whole daily flow, so a database that records the
+      // migration without the column present would 42703 before migrate() could
+      // repair it (see digest 1273321541). Additive column with a default —
+      // pre-apply it idempotently.
+      try {
+        await db.execute(sql`
         ALTER TABLE "DailyPreference"
           ADD COLUMN IF NOT EXISTS "domain_preference_frequency" jsonb NOT NULL DEFAULT '{}'::jsonb
       `);
-    } catch {
-      // DailyPreference may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      } catch {
+        // DailyPreference may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0072 (B-FirstRecap-1) adds the nullable
-    // User.first_session_recap_seen_at timestamp. The first-session recap
-    // orchestrator (GET /api/daily/first-session-recap) and the seen-marker
-    // (POST .../seen) both read/write it on the post-summary path, so a
-    // preview/production database with the migration recorded but the column
-    // missing would 42703 before migrate() could repair it. Additive nullable
-    // column with no default — pre-apply it idempotently.
-    try {
-      await db.execute(sql`
+      // Migration 0072 (B-FirstRecap-1) adds the nullable
+      // User.first_session_recap_seen_at timestamp. The first-session recap
+      // orchestrator (GET /api/daily/first-session-recap) and the seen-marker
+      // (POST .../seen) both read/write it on the post-summary path, so a
+      // preview/production database with the migration recorded but the column
+      // missing would 42703 before migrate() could repair it. Additive nullable
+      // column with no default — pre-apply it idempotently.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "first_session_recap_seen_at" timestamp with time zone
       `);
-    } catch {
-      // User may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // User may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0076 (B-FirstGameRecap-1) adds the nullable
-    // User.first_game_recap_seen_at timestamp. The first-game recap endpoint
-    // reads it on the game-summary path, so pre-apply this additive nullable
-    // column idempotently for databases whose migration journal got ahead of
-    // the physical column.
-    try {
-      await db.execute(sql`
+      // Migration 0076 (B-FirstGameRecap-1) adds the nullable
+      // User.first_game_recap_seen_at timestamp. The first-game recap endpoint
+      // reads it on the game-summary path, so pre-apply this additive nullable
+      // column idempotently for databases whose migration journal got ahead of
+      // the physical column.
+      try {
+        await db.execute(sql`
         ALTER TABLE "User"
           ADD COLUMN IF NOT EXISTS "first_game_recap_seen_at" timestamp with time zone
       `);
-    } catch {
-      // User may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // User may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0073 (B-Report-1) adds the ContentReport table + its three
-    // enums (ContentReportCategory / ContentReportIncorrectKind /
-    // ContentReportStatus). Purely additive substrate — nothing reads it yet
-    // (B-Report-2 onward wires it up) — but a preview/production database that
-    // records the migration without the objects present must still boot, and a
-    // newly-added enum value/type referenced inside the migrator transaction
-    // can 22P02/42704, so create the enums, table, FKs, CHECKs, and indexes
-    // idempotently outside that transaction. Re-running is a no-op.
-    try {
-      await db.execute(sql`
+      // Migration 0073 (B-Report-1) adds the ContentReport table + its three
+      // enums (ContentReportCategory / ContentReportIncorrectKind /
+      // ContentReportStatus). Purely additive substrate — nothing reads it yet
+      // (B-Report-2 onward wires it up) — but a preview/production database that
+      // records the migration without the objects present must still boot, and a
+      // newly-added enum value/type referenced inside the migrator transaction
+      // can 22P02/42704, so create the enums, table, FKs, CHECKs, and indexes
+      // idempotently outside that transaction. Re-running is a no-op.
+      try {
+        await db.execute(sql`
         DO $$ BEGIN
           CREATE TYPE "public"."ContentReportCategory" AS ENUM('incorrect', 'inappropriate');
         EXCEPTION WHEN duplicate_object THEN NULL;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$ BEGIN
           CREATE TYPE "public"."ContentReportIncorrectKind" AS ENUM('answer_key', 'premise');
         EXCEPTION WHEN duplicate_object THEN NULL;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$ BEGIN
           CREATE TYPE "public"."ContentReportStatus" AS ENUM('open', 'upheld', 'dismissed');
         EXCEPTION WHEN duplicate_object THEN NULL;
         END $$
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "ContentReport" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "reporter_user_id" text NOT NULL,
@@ -1816,7 +1887,7 @@ export async function register() {
             CHECK (incorrect_kind IS NULL OR category = 'incorrect')
         )
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         DO $$
         DECLARE
           report_table regclass := to_regclass('public."ContentReport"');
@@ -1864,109 +1935,141 @@ export async function register() {
           END IF;
         END $$
       `);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "ContentReport_reporter_user_id_idx" ON "ContentReport" ("reporter_user_id")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "ContentReport_question_id_idx" ON "ContentReport" ("question_id")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "ContentReport_generated_question_id_idx" ON "ContentReport" ("generated_question_id")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "ContentReport_status_idx" ON "ContentReport" ("status")`);
-      await db.execute(sql`
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "ContentReport_reporter_user_id_idx" ON "ContentReport" ("reporter_user_id")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "ContentReport_question_id_idx" ON "ContentReport" ("question_id")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "ContentReport_generated_question_id_idx" ON "ContentReport" ("generated_question_id")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "ContentReport_status_idx" ON "ContentReport" ("status")`,
+        );
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "ContentReport_one_open_per_question"
           ON "ContentReport" ("reporter_user_id", "question_id")
           WHERE status = 'open' AND question_id IS NOT NULL
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "ContentReport_one_open_per_generated_question"
           ON "ContentReport" ("reporter_user_id", "generated_question_id")
           WHERE status = 'open' AND generated_question_id IS NOT NULL
       `);
-    } catch {
-      // User, Question, or GeneratedQuestion may not exist yet on a fresh
-      // database — migrate() creates them before this migration runs.
-    }
+      } catch {
+        // User, Question, or GeneratedQuestion may not exist yet on a fresh
+        // database — migrate() creates them before this migration runs.
+      }
 
-    // Migration 0078 adds two composite lookup indexes on hot read paths: the
-    // "Lately" convergence lookback (MASTERY_EVENTS user_id+source_type+
-    // answer_state+created_at) and the friends-visibility EXISTS on the feed
-    // path (Follow followerId+followeeId+state). Pure index additions — a
-    // preview/production database that records the migration without the
-    // indexes present must still get them (precedent: 0074's domain_key index
-    // guard). CREATE INDEX IF NOT EXISTS is idempotent; re-running is a no-op.
-    try {
-      await db.execute(sql`
+      // Migration 0078 adds two composite lookup indexes on hot read paths: the
+      // "Lately" convergence lookback (MASTERY_EVENTS user_id+source_type+
+      // answer_state+created_at) and the friends-visibility EXISTS on the feed
+      // path (Follow followerId+followeeId+state). Pure index additions — a
+      // preview/production database that records the migration without the
+      // indexes present must still get them (precedent: 0074's domain_key index
+      // guard). CREATE INDEX IF NOT EXISTS is idempotent; re-running is a no-op.
+      try {
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "MASTERY_EVENTS_user_id_source_type_answer_state_created_at_idx"
           ON "MASTERY_EVENTS" ("user_id", "source_type", "answer_state", "created_at")
       `);
-    } catch {
-      // MASTERY_EVENTS may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
-    try {
-      await db.execute(sql`
+      } catch {
+        // MASTERY_EVENTS may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
+      try {
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "Follow_followerId_followeeId_state_idx"
           ON "Follow" ("followerId", "followeeId", "state")
       `);
-    } catch {
-      // Follow may not exist yet on a fresh database — migrate() creates it
-      // before this migration runs.
-    }
+      } catch {
+        // Follow may not exist yet on a fresh database — migrate() creates it
+        // before this migration runs.
+      }
 
-    // Migration 0079 adds covering indexes for four hot-path foreign keys
-    // (FeedItem.questionId / sourceUserId / joshingGameId, ActivityItem
-    // .actorUserId) on the Feed-load and From-Friends read paths. Pure index
-    // additions — a preview/production database that records the migration
-    // without the indexes present must still get them (precedent: 0078).
-    // CREATE INDEX IF NOT EXISTS is idempotent; re-running is a no-op.
-    try {
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "FeedItem_questionId_idx" ON "FeedItem" ("questionId")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "FeedItem_sourceUserId_idx" ON "FeedItem" ("sourceUserId")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "FeedItem_joshingGameId_idx" ON "FeedItem" ("joshingGameId")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "ActivityItem_actorUserId_idx" ON "ActivityItem" ("actorUserId")`);
-    } catch {
-      // FeedItem / ActivityItem may not exist yet on a fresh database —
-      // migrate() creates them before this migration runs.
-    }
+      // Migration 0079 adds covering indexes for four hot-path foreign keys
+      // (FeedItem.questionId / sourceUserId / joshingGameId, ActivityItem
+      // .actorUserId) on the Feed-load and From-Friends read paths. Pure index
+      // additions — a preview/production database that records the migration
+      // without the indexes present must still get them (precedent: 0078).
+      // CREATE INDEX IF NOT EXISTS is idempotent; re-running is a no-op.
+      try {
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "FeedItem_questionId_idx" ON "FeedItem" ("questionId")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "FeedItem_sourceUserId_idx" ON "FeedItem" ("sourceUserId")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "FeedItem_joshingGameId_idx" ON "FeedItem" ("joshingGameId")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "ActivityItem_actorUserId_idx" ON "ActivityItem" ("actorUserId")`,
+        );
+      } catch {
+        // FeedItem / ActivityItem may not exist yet on a fresh database —
+        // migrate() creates them before this migration runs.
+      }
 
-    // Migration 0082 adds the composite index backing the Questions-tab list
-    // (getBankedQuestions: filter user_id, ORDER BY added_at DESC). Pure index
-    // addition — a preview/production database that records the migration
-    // without the index present must still get it (precedent: 0079).
-    // CREATE INDEX IF NOT EXISTS is idempotent; re-running is a no-op.
-    try {
-      await db.execute(sql`
+      // Migration 0082 adds the composite index backing the Questions-tab list
+      // (getBankedQuestions: filter user_id, ORDER BY added_at DESC). Pure index
+      // addition — a preview/production database that records the migration
+      // without the index present must still get it (precedent: 0079).
+      // CREATE INDEX IF NOT EXISTS is idempotent; re-running is a no-op.
+      try {
+        await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "UserQuestionBank_user_id_added_at_idx"
           ON "UserQuestionBank" ("user_id", "added_at")
       `);
-    } catch {
-      // UserQuestionBank may not exist yet on a fresh database — migrate()
-      // creates it before this migration runs.
-    }
+      } catch {
+        // UserQuestionBank may not exist yet on a fresh database — migrate()
+        // creates it before this migration runs.
+      }
 
-    // Migration 0083 adds covering indexes for the cold-path foreign keys the
-    // Supabase advisor flags as unindexed (lint 0001). Pure, idempotent index
-    // additions — a preview/production database that records the migration
-    // without them present must still get them (precedent: 0079, 0082). Each
-    // CREATE INDEX IF NOT EXISTS is a no-op when the index already exists.
-    try {
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_queue_id_idx" ON "DAILY_REFINE_DECISION" ("queue_id")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "FriendInvitation_inviteeUserId_idx" ON "FriendInvitation" ("inviteeUserId")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "Friendship_requestedByUserId_idx" ON "Friendship" ("requestedByUserId")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "Friendship_removedByUserId_idx" ON "Friendship" ("removedByUserId")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "JoshingGameQuestion_questionId_idx" ON "JoshingGameQuestion" ("questionId")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "JoshingGameResponse_questionId_idx" ON "JoshingGameResponse" ("questionId")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "SkippedDailyQuestion_question_id_idx" ON "SkippedDailyQuestion" ("question_id")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "SkippedDailyQuestion_generated_question_id_idx" ON "SkippedDailyQuestion" ("generated_question_id")`);
-    } catch {
-      // These tables may not exist yet on a fresh database — migrate() creates
-      // them (and the same indexes) before/at this migration.
-    }
+      // Migration 0083 adds covering indexes for the cold-path foreign keys the
+      // Supabase advisor flags as unindexed (lint 0001). Pure, idempotent index
+      // additions — a preview/production database that records the migration
+      // without them present must still get them (precedent: 0079, 0082). Each
+      // CREATE INDEX IF NOT EXISTS is a no-op when the index already exists.
+      try {
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_queue_id_idx" ON "DAILY_REFINE_DECISION" ("queue_id")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "FriendInvitation_inviteeUserId_idx" ON "FriendInvitation" ("inviteeUserId")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "Friendship_requestedByUserId_idx" ON "Friendship" ("requestedByUserId")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "Friendship_removedByUserId_idx" ON "Friendship" ("removedByUserId")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "JoshingGameQuestion_questionId_idx" ON "JoshingGameQuestion" ("questionId")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "JoshingGameResponse_questionId_idx" ON "JoshingGameResponse" ("questionId")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "SkippedDailyQuestion_question_id_idx" ON "SkippedDailyQuestion" ("question_id")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "SkippedDailyQuestion_generated_question_id_idx" ON "SkippedDailyQuestion" ("generated_question_id")`,
+        );
+      } catch {
+        // These tables may not exist yet on a fresh database — migrate() creates
+        // them (and the same indexes) before/at this migration.
+      }
 
-    // Migration 0087 (B-LLM-PROVIDER-AB-SWITCH B2) creates the AppSettings
-    // single-row global settings table for the provider A/B switch. A
-    // preview/production database that records the migration without the table
-    // present would 42P01 when getProviderSettings() reads it. Create it
-    // idempotently (with RLS + the seed row) so the read always finds a row.
-    // Precedent: 0073 (ContentReport). Self-contained — depends on no other table.
-    try {
-      await db.execute(sql`
+      // Migration 0087 (B-LLM-PROVIDER-AB-SWITCH B2) creates the AppSettings
+      // single-row global settings table for the provider A/B switch. A
+      // preview/production database that records the migration without the table
+      // present would 42P01 when getProviderSettings() reads it. Create it
+      // idempotently (with RLS + the seed row) so the read always finds a row.
+      // Precedent: 0073 (ContentReport). Self-contained — depends on no other table.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "AppSettings" (
           "id" text PRIMARY KEY DEFAULT 'singleton' NOT NULL,
           "gen_provider" text NOT NULL DEFAULT 'anthropic',
@@ -1981,35 +2084,43 @@ export async function register() {
           CONSTRAINT "AppSettings_grade_provider_valid" CHECK (grade_provider IN ('anthropic', 'openai'))
         )
       `);
-      await db.execute(sql`ALTER TABLE "AppSettings" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`INSERT INTO "AppSettings" ("id") VALUES ('singleton') ON CONFLICT ("id") DO NOTHING`);
-    } catch {
-      // Non-fatal — migrate() creates the table from 0087 immediately after.
-    }
+        await db.execute(sql`ALTER TABLE "AppSettings" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`INSERT INTO "AppSettings" ("id") VALUES ('singleton') ON CONFLICT ("id") DO NOTHING`,
+        );
+      } catch {
+        // Non-fatal — migrate() creates the table from 0087 immediately after.
+      }
 
-    // Migration 0088 (B-LLM-PROVIDER-AB-SWITCH B3) adds provider-provenance
-    // columns to three existing tables. A preview/production database that
-    // records the migration without the columns present would 42703 when a
-    // stamped write references them. Add them idempotently (additive, nullable,
-    // no default — precedent: 0085/0086). Each ADD COLUMN IF NOT EXISTS no-ops
-    // when the column already exists.
-    try {
-      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "generated_by_provider" text`);
-      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "categorize_provider" text`);
-      await db.execute(sql`ALTER TABLE "MASTERY_EVENTS" ADD COLUMN IF NOT EXISTS "llm_provider" text`);
-    } catch {
-      // These tables may not exist yet on a fresh database — migrate() creates
-      // them (with these columns) before/at this migration.
-    }
+      // Migration 0088 (B-LLM-PROVIDER-AB-SWITCH B3) adds provider-provenance
+      // columns to three existing tables. A preview/production database that
+      // records the migration without the columns present would 42703 when a
+      // stamped write references them. Add them idempotently (additive, nullable,
+      // no default — precedent: 0085/0086). Each ADD COLUMN IF NOT EXISTS no-ops
+      // when the column already exists.
+      try {
+        await db.execute(
+          sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "generated_by_provider" text`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "categorize_provider" text`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "MASTERY_EVENTS" ADD COLUMN IF NOT EXISTS "llm_provider" text`,
+        );
+      } catch {
+        // These tables may not exist yet on a fresh database — migrate() creates
+        // them (with these columns) before/at this migration.
+      }
 
-    // Migrations 0090 + 0091 (B-LLM-PROVIDER-AB-METRICS) create the provider
-    // flip log and per-call usage tables. A preview/production database that
-    // records the migrations without the tables present would 42P01 when the
-    // PATCH route logs a flip or recordLlmUsage() inserts a row. Create them
-    // idempotently (with RLS + indexes). Both are self-contained — they depend
-    // on no other table. Precedent: 0087.
-    try {
-      await db.execute(sql`
+      // Migrations 0090 + 0091 (B-LLM-PROVIDER-AB-METRICS) create the provider
+      // flip log and per-call usage tables. A preview/production database that
+      // records the migrations without the tables present would 42P01 when the
+      // PATCH route logs a flip or recordLlmUsage() inserts a row. Create them
+      // idempotently (with RLS + indexes). Both are self-contained — they depend
+      // on no other table. Precedent: 0087.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "LlmProviderChangeLog" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "surface" text NOT NULL,
@@ -2022,9 +2133,11 @@ export async function register() {
           CONSTRAINT "LlmProviderChangeLog_to_valid" CHECK (to_provider IN ('anthropic', 'openai'))
         )
       `);
-      await db.execute(sql`ALTER TABLE "LlmProviderChangeLog" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmProviderChangeLog_created_at_idx" ON "LlmProviderChangeLog" ("created_at")`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "LlmProviderChangeLog" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "LlmProviderChangeLog_created_at_idx" ON "LlmProviderChangeLog" ("created_at")`,
+        );
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "LlmUsageEvent" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "scope" text NOT NULL,
@@ -2039,20 +2152,22 @@ export async function register() {
           CONSTRAINT "LlmUsageEvent_provider_valid" CHECK (provider IN ('anthropic', 'openai'))
         )
       `);
-      await db.execute(sql`ALTER TABLE "LlmUsageEvent" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmUsageEvent_provider_created_at_idx" ON "LlmUsageEvent" ("provider", "created_at")`);
-      // Migration 0105: per-call web-search request count, so search spend
-      // (~$0.01/request, a separate Anthropic meter) is ledgered instead of
-      // invisible (ledger-telemetry-gaps.md gap (a)). Additive with a DEFAULT —
-      // same repair rationale as the 0100 verification_reason guard.
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "LlmUsageEvent" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "LlmUsageEvent_provider_created_at_idx" ON "LlmUsageEvent" ("provider", "created_at")`,
+        );
+        // Migration 0105: per-call web-search request count, so search spend
+        // (~$0.01/request, a separate Anthropic meter) is ledgered instead of
+        // invisible (ledger-telemetry-gaps.md gap (a)). Additive with a DEFAULT —
+        // same repair rationale as the 0100 verification_reason guard.
+        await db.execute(sql`
         ALTER TABLE "LlmUsageEvent" ADD COLUMN IF NOT EXISTS "web_search_requests" integer NOT NULL DEFAULT 0
       `);
-      // Migration 0106: batch-verify async mode — the VerifyBatchRun tracking
-      // table (the cron would 42P01 on harvest/submit if the migration recorded
-      // without the table) + the is_batch discount marker on LlmUsageEvent.
-      // Same rationale as the 0090/0091 guards above.
-      await db.execute(sql`
+        // Migration 0106: batch-verify async mode — the VerifyBatchRun tracking
+        // table (the cron would 42P01 on harvest/submit if the migration recorded
+        // without the table) + the is_batch discount marker on LlmUsageEvent.
+        // Same rationale as the 0090/0091 guards above.
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "VerifyBatchRun" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "provider_batch_id" text NOT NULL,
@@ -2063,17 +2178,21 @@ export async function register() {
           CONSTRAINT "VerifyBatchRun_status_valid" CHECK (status IN ('submitted', 'harvested', 'failed'))
         )
       `);
-      await db.execute(sql`ALTER TABLE "VerifyBatchRun" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "VerifyBatchRun_provider_batch_id_key" ON "VerifyBatchRun" ("provider_batch_id")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "VerifyBatchRun_status_idx" ON "VerifyBatchRun" ("status")`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "VerifyBatchRun" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE UNIQUE INDEX IF NOT EXISTS "VerifyBatchRun_provider_batch_id_key" ON "VerifyBatchRun" ("provider_batch_id")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "VerifyBatchRun_status_idx" ON "VerifyBatchRun" ("status")`,
+        );
+        await db.execute(sql`
         ALTER TABLE "LlmUsageEvent" ADD COLUMN IF NOT EXISTS "is_batch" boolean NOT NULL DEFAULT false
       `);
-      // Migration 0108 (D-FANDOM-GROUNDING-01): the per-domain reference-passage
-      // cache. The generation cron would 42P01 on its cache read/upsert if the
-      // migration recorded without the table. Self-contained; same rationale as
-      // the 0090/0091/0106 guards above.
-      await db.execute(sql`
+        // Migration 0108 (D-FANDOM-GROUNDING-01): the per-domain reference-passage
+        // cache. The generation cron would 42P01 on its cache read/upsert if the
+        // migration recorded without the table. Self-contained; same rationale as
+        // the 0090/0091/0106 guards above.
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "DomainReferencePassage" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "canonical_subcategory" text NOT NULL,
@@ -2085,12 +2204,14 @@ export async function register() {
           CONSTRAINT "DomainReferencePassage_source_valid" CHECK (source IN ('wikipedia', 'fandom', 'none'))
         )
       `);
-      await db.execute(sql`ALTER TABLE "DomainReferencePassage" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "DomainReferencePassage_domain_key" ON "DomainReferencePassage" ("canonical_subcategory")`);
-      // Migration 0092 (B-LLM-COST-LATENCY-REPORT-01) stores the weekly cost &
-      // latency digest. The llm-cost-report cron would 42P01 on insert if the
-      // migration recorded without the table present. Self-contained; precedent: 0091.
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "DomainReferencePassage" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE UNIQUE INDEX IF NOT EXISTS "DomainReferencePassage_domain_key" ON "DomainReferencePassage" ("canonical_subcategory")`,
+        );
+        // Migration 0092 (B-LLM-COST-LATENCY-REPORT-01) stores the weekly cost &
+        // latency digest. The llm-cost-report cron would 42P01 on insert if the
+        // migration recorded without the table present. Self-contained; precedent: 0091.
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "LlmCostReport" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "period_start" timestamp with time zone NOT NULL,
@@ -2100,23 +2221,27 @@ export async function register() {
           "created_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "LlmCostReport" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmCostReport_created_at_idx" ON "LlmCostReport" ("created_at")`);
-      // Migration 0114 (D-SUPPLY-FINITE-SET-01 P2): the durable set-completion
-      // designation + system-created (inviterless) author invitations. The daily
-      // summary evaluates completion and would error on the missing column /
-      // NOT NULL constraint if the migration recorded without these. Both
-      // idempotent (ADD COLUMN IF NOT EXISTS / DROP NOT NULL is a no-op if already
-      // relaxed). Same rationale as the 0105/0106 guards above.
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "LlmCostReport" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "LlmCostReport_created_at_idx" ON "LlmCostReport" ("created_at")`,
+        );
+        // Migration 0114 (D-SUPPLY-FINITE-SET-01 P2): the durable set-completion
+        // designation + system-created (inviterless) author invitations. The daily
+        // summary evaluates completion and would error on the missing column /
+        // NOT NULL constraint if the migration recorded without these. Both
+        // idempotent (ADD COLUMN IF NOT EXISTS / DROP NOT NULL is a no-op if already
+        // relaxed). Same rationale as the 0105/0106 guards above.
+        await db.execute(sql`
         ALTER TABLE "PLAYER_MASTERY" ADD COLUMN IF NOT EXISTS "designated_at" timestamp with time zone
       `);
-      await db.execute(sql`ALTER TABLE "AuthorInvitation" ALTER COLUMN "invited_by" DROP NOT NULL`);
-      // Migration 0115 (D-QUALITY-SALVAGE-01): machine-proposed salvage fixes for
-      // demoted questions. The salvage batch + review queue read/insert here and
-      // would 42P01 if the migration recorded without the table. Self-contained;
-      // same rationale as the 0103 CrafterDraftDecision guard.
-      await db.execute(sql`
+        await db.execute(
+          sql`ALTER TABLE "AuthorInvitation" ALTER COLUMN "invited_by" DROP NOT NULL`,
+        );
+        // Migration 0115 (D-QUALITY-SALVAGE-01): machine-proposed salvage fixes for
+        // demoted questions. The salvage batch + review queue read/insert here and
+        // would 42P01 if the migration recorded without the table. Self-contained;
+        // same rationale as the 0103 CrafterDraftDecision guard.
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "QuestionSalvageProposal" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "question_id" text NOT NULL,
@@ -2130,14 +2255,18 @@ export async function register() {
           "created_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "QuestionSalvageProposal" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "QuestionSalvageProposal_question_id_idx" ON "QuestionSalvageProposal" ("question_id")`);
-      await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "QuestionSalvageProposal_active_question_key" ON "QuestionSalvageProposal" ("question_id") WHERE "status" = 'ready'`);
-      // Migration 0116 (D-DIFFICULTY-SIZE-COMPLETION-01): cached topic depth score
-      // that set-completion sizes the completable set from. evaluateSetCompletions
-      // would 42P01 on read if the migration recorded without the table. Self-
-      // contained; same rationale as the 0108 DomainReferencePassage guard.
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "QuestionSalvageProposal" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "QuestionSalvageProposal_question_id_idx" ON "QuestionSalvageProposal" ("question_id")`,
+        );
+        await db.execute(
+          sql`CREATE UNIQUE INDEX IF NOT EXISTS "QuestionSalvageProposal_active_question_key" ON "QuestionSalvageProposal" ("question_id") WHERE "status" = 'ready'`,
+        );
+        // Migration 0116 (D-DIFFICULTY-SIZE-COMPLETION-01): cached topic depth score
+        // that set-completion sizes the completable set from. evaluateSetCompletions
+        // would 42P01 on read if the migration recorded without the table. Self-
+        // contained; same rationale as the 0108 DomainReferencePassage guard.
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "DomainDepthEstimate" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "domain_key" text NOT NULL,
@@ -2148,35 +2277,63 @@ export async function register() {
           "created_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "DomainDepthEstimate_domain_key" ON "DomainDepthEstimate" ("domain_key")`);
-      // Migration 0117 (D-SUPPLY-FINITENESS-01): corpus-grounded size columns on
-      // DomainDepthEstimate. Additive + nullable; getTargetQuestionCountForDomains
-      // reads estimated_questions and would 42703 on an un-migrated DB. Same guard
-      // rationale as the 0116 block above.
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "estimated_questions" integer`);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "corpus_count" integer`);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "shape" text`);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "confidence" text`);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "basis" text`);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "wikipedia_title" text`);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "wikidata_qid" text`);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "fandom_host" text`);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "resolved_at" timestamp with time zone`);
-      // Migration 0118 (D-SUPPLY-FINITENESS-01 #4): dry-round observation
-      // counters for the supply-state machine. Additive + nullable/defaulted.
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "consecutive_dry_rounds" integer NOT NULL DEFAULT 0`);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "last_yield_at" timestamp with time zone`);
-      // Migration 0119: admin manual estimate override + co-calibration stamp.
-      // Additive + nullable; the coverage read selects manual_estimated_questions
-      // and would 42703 on an un-migrated DB. Same guard rationale as 0117/0118.
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "manual_estimated_questions" integer`);
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "calibrated_at" timestamp with time zone`);
-      // Migration 0120: daily gate-drop counters. The write path is fire-and-
-      // forget (a missing table never blocks generation) but the weekly quality
-      // digest reads it and would 42P01 on an un-migrated DB. Same rationale as
-      // the 0116 DomainDepthEstimate guard above.
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE UNIQUE INDEX IF NOT EXISTS "DomainDepthEstimate_domain_key" ON "DomainDepthEstimate" ("domain_key")`,
+        );
+        // Migration 0117 (D-SUPPLY-FINITENESS-01): corpus-grounded size columns on
+        // DomainDepthEstimate. Additive + nullable; getTargetQuestionCountForDomains
+        // reads estimated_questions and would 42703 on an un-migrated DB. Same guard
+        // rationale as the 0116 block above.
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "estimated_questions" integer`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "corpus_count" integer`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "shape" text`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "confidence" text`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "basis" text`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "wikipedia_title" text`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "wikidata_qid" text`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "fandom_host" text`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "resolved_at" timestamp with time zone`,
+        );
+        // Migration 0118 (D-SUPPLY-FINITENESS-01 #4): dry-round observation
+        // counters for the supply-state machine. Additive + nullable/defaulted.
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "consecutive_dry_rounds" integer NOT NULL DEFAULT 0`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "last_yield_at" timestamp with time zone`,
+        );
+        // Migration 0119: admin manual estimate override + co-calibration stamp.
+        // Additive + nullable; the coverage read selects manual_estimated_questions
+        // and would 42703 on an un-migrated DB. Same guard rationale as 0117/0118.
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "manual_estimated_questions" integer`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "calibrated_at" timestamp with time zone`,
+        );
+        // Migration 0120: daily gate-drop counters. The write path is fire-and-
+        // forget (a missing table never blocks generation) but the weekly quality
+        // digest reads it and would 42P01 on an un-migrated DB. Same rationale as
+        // the 0116 DomainDepthEstimate guard above.
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "GateDropStat" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text,
           "day" date NOT NULL,
@@ -2188,16 +2345,18 @@ export async function register() {
           CONSTRAINT "GateDropStat_day_gate_unique" UNIQUE ("day", "gate")
         )
       `);
-      await db.execute(sql`ALTER TABLE "GateDropStat" ENABLE ROW LEVEL SECURITY`);
-      // Migration 0121: admin per-domain generation cap. Additive + nullable; the
-      // coverage read + getCappedDomainKeys select generation_capped_at and would
-      // 42703 on an un-migrated DB. Same guard rationale as 0117/0118/0119.
-      await db.execute(sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "generation_capped_at" timestamp with time zone`);
-      // Migration 0122 (D-DOMAIN-MERGE-REVIEW-REDESIGN-01): permanent Dismiss
-      // records for the domain-merge review surface. getDomainFragmentationCandidates
-      // reads it on every review load and would 42P01 if the migration recorded
-      // without the table. Self-contained; same rationale as the 0116 guard.
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "GateDropStat" ENABLE ROW LEVEL SECURITY`);
+        // Migration 0121: admin per-domain generation cap. Additive + nullable; the
+        // coverage read + getCappedDomainKeys select generation_capped_at and would
+        // 42703 on an un-migrated DB. Same guard rationale as 0117/0118/0119.
+        await db.execute(
+          sql`ALTER TABLE "DomainDepthEstimate" ADD COLUMN IF NOT EXISTS "generation_capped_at" timestamp with time zone`,
+        );
+        // Migration 0122 (D-DOMAIN-MERGE-REVIEW-REDESIGN-01): permanent Dismiss
+        // records for the domain-merge review surface. getDomainFragmentationCandidates
+        // reads it on every review load and would 42P01 if the migration recorded
+        // without the table. Self-contained; same rationale as the 0116 guard.
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "ReviewedDomainPair" (
           "pair_key" text PRIMARY KEY NOT NULL,
           "domain_a" text NOT NULL,
@@ -2205,16 +2364,16 @@ export async function register() {
           "reviewed_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "ReviewedDomainPair" ENABLE ROW LEVEL SECURITY`);
-    } catch {
-      // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
-    }
-    // Migration 0093 (D-REVIEW-RECOVERED-01) adds the per-user "set aside" table
-    // for the recovered-review surface. The recovered page reads it on every load
-    // and would 42P01 if the migration recorded without the table present.
-    // Self-contained; precedent: 0021's FeedDismissedDomain guard above.
-    try {
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "ReviewedDomainPair" ENABLE ROW LEVEL SECURITY`);
+      } catch {
+        // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
+      }
+      // Migration 0093 (D-REVIEW-RECOVERED-01) adds the per-user "set aside" table
+      // for the recovered-review surface. The recovered page reads it on every load
+      // and would 42P01 if the migration recorded without the table present.
+      // Self-contained; precedent: 0021's FeedDismissedDomain guard above.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "RecoveredSetAside" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
@@ -2223,23 +2382,25 @@ export async function register() {
           "reinstatedAt" timestamp with time zone
         )
       `);
-      await db.execute(sql`ALTER TABLE "RecoveredSetAside" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "RecoveredSetAside_userId_idx" ON "RecoveredSetAside" ("userId")`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "RecoveredSetAside" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "RecoveredSetAside_userId_idx" ON "RecoveredSetAside" ("userId")`,
+        );
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "recovered_set_aside_active_unique"
         ON "RecoveredSetAside" ("userId", "questionId")
         WHERE "reinstatedAt" IS NULL
       `);
-    } catch {
-      // Fresh databases may not have User/Question yet — migrate() creates all
-      // three in normal migration order.
-    }
-    // Migration 0113 adds the per-user "dismiss" table for From Friends milestone
-    // questions (dismiss-as-answered). build-stream reads it on every Home load
-    // and would 42P01 if the migration recorded without the table present.
-    // Self-contained; precedent: 0093's RecoveredSetAside guard above.
-    try {
-      await db.execute(sql`
+      } catch {
+        // Fresh databases may not have User/Question yet — migrate() creates all
+        // three in normal migration order.
+      }
+      // Migration 0113 adds the per-user "dismiss" table for From Friends milestone
+      // questions (dismiss-as-answered). build-stream reads it on every Home load
+      // and would 42P01 if the migration recorded without the table present.
+      // Self-contained; precedent: 0093's RecoveredSetAside guard above.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "MilestoneDismissed" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
@@ -2248,24 +2409,26 @@ export async function register() {
           "reinstatedAt" timestamp with time zone
         )
       `);
-      await db.execute(sql`ALTER TABLE "MilestoneDismissed" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "MilestoneDismissed_userId_idx" ON "MilestoneDismissed" ("userId")`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "MilestoneDismissed" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "MilestoneDismissed_userId_idx" ON "MilestoneDismissed" ("userId")`,
+        );
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "milestone_dismissed_active_unique"
         ON "MilestoneDismissed" ("userId", "questionId")
         WHERE "reinstatedAt" IS NULL
       `);
-    } catch {
-      // Fresh databases may not have User/Question yet — migrate() creates all
-      // three in normal migration order.
-    }
-    // Migration 0127 (D-MISSED-RETURN-01 §3.3) adds the per-(user, question)
-    // dismiss table for the missed-question return system. The catch-up
-    // dismiss/undismiss routes dual-write it on every call and would 42P01 if
-    // the migration recorded without the table present.
-    // Self-contained; precedent: 0113's MilestoneDismissed guard above.
-    try {
-      await db.execute(sql`
+      } catch {
+        // Fresh databases may not have User/Question yet — migrate() creates all
+        // three in normal migration order.
+      }
+      // Migration 0127 (D-MISSED-RETURN-01 §3.3) adds the per-(user, question)
+      // dismiss table for the missed-question return system. The catch-up
+      // dismiss/undismiss routes dual-write it on every call and would 42P01 if
+      // the migration recorded without the table present.
+      // Self-contained; precedent: 0113's MilestoneDismissed guard above.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "MissedReturnDismissed" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
@@ -2274,24 +2437,26 @@ export async function register() {
           "reinstatedAt" timestamp with time zone
         )
       `);
-      await db.execute(sql`ALTER TABLE "MissedReturnDismissed" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "MissedReturnDismissed_userId_idx" ON "MissedReturnDismissed" ("userId")`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "MissedReturnDismissed" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "MissedReturnDismissed_userId_idx" ON "MissedReturnDismissed" ("userId")`,
+        );
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_active_unique"
         ON "MissedReturnDismissed" ("userId", "questionId")
         WHERE "reinstatedAt" IS NULL
       `);
-    } catch {
-      // Fresh databases may not have User/Question yet — migrate() creates all
-      // three in normal migration order.
-    }
-    // Migration 0128 (D-MISSED-RETURN-01 §4) adds the per-(user, question) return
-    // state and the Customize toggle. The queue builder reads both on every build
-    // once the flag is on, and the eligibility query would 42P01/42703 if the
-    // migration recorded without them present.
-    // Self-contained; precedent: 0113's MilestoneDismissed guard above.
-    try {
-      await db.execute(sql`
+      } catch {
+        // Fresh databases may not have User/Question yet — migrate() creates all
+        // three in normal migration order.
+      }
+      // Migration 0128 (D-MISSED-RETURN-01 §4) adds the per-(user, question) return
+      // state and the Customize toggle. The queue builder reads both on every build
+      // once the flag is on, and the eligibility query would 42P01/42703 if the
+      // migration recorded without them present.
+      // Self-contained; precedent: 0113's MilestoneDismissed guard above.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "MissedReturnState" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
@@ -2301,61 +2466,67 @@ export async function register() {
           "createdAt" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "MissedReturnState" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "MissedReturnState_userId_idx" ON "MissedReturnState" ("userId")`);
-      await db.execute(sql`
+        await db.execute(sql`ALTER TABLE "MissedReturnState" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "MissedReturnState_userId_idx" ON "MissedReturnState" ("userId")`,
+        );
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_question_unique"
         ON "MissedReturnState" ("userId", "questionId")
       `);
-    } catch {
-      // Fresh databases may not have User/Question yet — migrate() creates all
-      // three in normal migration order.
-    }
-    try {
-      await db.execute(sql`
+      } catch {
+        // Fresh databases may not have User/Question yet — migrate() creates all
+        // three in normal migration order.
+      }
+      try {
+        await db.execute(sql`
         ALTER TABLE "DailyPreference"
         ADD COLUMN IF NOT EXISTS "missed_return_enabled" boolean NOT NULL DEFAULT true
       `);
-    } catch {
-      // DailyPreference may not exist yet on a fresh database.
-    }
-    // Migration 0130 widens the return system to LLM-generated questions, which
-    // are ~96% of the wrong answers inside the Daily Five. The eligibility query
-    // selects "generatedQuestionId" on every queue build once the flag is on and
-    // would 42703 if the migration recorded without the columns present.
-    try {
-      await db.execute(sql`
+      } catch {
+        // DailyPreference may not exist yet on a fresh database.
+      }
+      // Migration 0130 widens the return system to LLM-generated questions, which
+      // are ~96% of the wrong answers inside the Daily Five. The eligibility query
+      // selects "generatedQuestionId" on every queue build once the flag is on and
+      // would 42703 if the migration recorded without the columns present.
+      try {
+        await db.execute(sql`
         ALTER TABLE "MissedReturnDismissed"
         ADD COLUMN IF NOT EXISTS "generatedQuestionId" text
         REFERENCES "GeneratedQuestion"("id") ON DELETE CASCADE
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         ALTER TABLE "MissedReturnState"
         ADD COLUMN IF NOT EXISTS "generatedQuestionId" text
         REFERENCES "GeneratedQuestion"("id") ON DELETE CASCADE
       `);
-      await db.execute(sql`ALTER TABLE "MissedReturnDismissed" ALTER COLUMN "questionId" DROP NOT NULL`);
-      await db.execute(sql`ALTER TABLE "MissedReturnState" ALTER COLUMN "questionId" DROP NOT NULL`);
-      await db.execute(sql`
+        await db.execute(
+          sql`ALTER TABLE "MissedReturnDismissed" ALTER COLUMN "questionId" DROP NOT NULL`,
+        );
+        await db.execute(
+          sql`ALTER TABLE "MissedReturnState" ALTER COLUMN "questionId" DROP NOT NULL`,
+        );
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_dismissed_generated_active_unique"
         ON "MissedReturnDismissed" ("userId", "generatedQuestionId")
         WHERE "reinstatedAt" IS NULL AND "generatedQuestionId" IS NOT NULL
       `);
-      await db.execute(sql`
+        await db.execute(sql`
         CREATE UNIQUE INDEX IF NOT EXISTS "missed_return_state_user_generated_unique"
         ON "MissedReturnState" ("userId", "generatedQuestionId")
         WHERE "generatedQuestionId" IS NOT NULL
       `);
-    } catch {
-      // Tables arrive with 0127/0128 in normal migration order.
-    }
-    // Migration 0131 adds HiddenQuestion, the durable per-question opt-out behind
-    // the Not-for-me sheet. Both the queue builder (which excludes hidden rows on
-    // every build) and the hide/restore routes touch it, so a recorded-but-absent
-    // migration would 42P01 on the next Daily Five build.
-    // Self-contained; precedent: 0127's MissedReturnDismissed guard above.
-    try {
-      await db.execute(sql`
+      } catch {
+        // Tables arrive with 0127/0128 in normal migration order.
+      }
+      // Migration 0131 adds HiddenQuestion, the durable per-question opt-out behind
+      // the Not-for-me sheet. Both the queue builder (which excludes hidden rows on
+      // every build) and the hide/restore routes touch it, so a recorded-but-absent
+      // migration would 42P01 on the next Daily Five build.
+      // Self-contained; precedent: 0127's MissedReturnDismissed guard above.
+      try {
+        await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "HiddenQuestion" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "user_id" text NOT NULL REFERENCES "User"("id"),
@@ -2365,16 +2536,26 @@ export async function register() {
           "hidden_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);
-      await db.execute(sql`ALTER TABLE "HiddenQuestion" ENABLE ROW LEVEL SECURITY`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_idx" ON "HiddenQuestion" ("user_id")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_question_id_idx" ON "HiddenQuestion" ("user_id","question_id")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_generated_question_id_idx" ON "HiddenQuestion" ("user_id","generated_question_id")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_question_id_idx" ON "HiddenQuestion" ("question_id")`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_generated_question_id_idx" ON "HiddenQuestion" ("generated_question_id")`);
-    } catch {
-      // Fresh databases may not have User/Question/GeneratedQuestion yet —
-      // migrate() creates them all in normal migration order.
-    }
+        await db.execute(sql`ALTER TABLE "HiddenQuestion" ENABLE ROW LEVEL SECURITY`);
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_idx" ON "HiddenQuestion" ("user_id")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_question_id_idx" ON "HiddenQuestion" ("user_id","question_id")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_user_id_generated_question_id_idx" ON "HiddenQuestion" ("user_id","generated_question_id")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_question_id_idx" ON "HiddenQuestion" ("question_id")`,
+        );
+        await db.execute(
+          sql`CREATE INDEX IF NOT EXISTS "HiddenQuestion_generated_question_id_idx" ON "HiddenQuestion" ("generated_question_id")`,
+        );
+      } catch {
+        // Fresh databases may not have User/Question/GeneratedQuestion yet —
+        // migrate() creates them all in normal migration order.
+      }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 
@@ -2385,9 +2566,10 @@ export async function register() {
     // healthy later boot (or the deploy step) applies them — a one-off cold-boot
     // stall must not block request work. Override via BOOT_MIGRATE_TIMEOUT_MS
     // (0/unset → 60s default).
-    const bootMigrateTimeoutMs = Number(process.env.BOOT_MIGRATE_TIMEOUT_MS) > 0
-      ? Number(process.env.BOOT_MIGRATE_TIMEOUT_MS)
-      : 60_000;
+    const bootMigrateTimeoutMs =
+      Number(process.env.BOOT_MIGRATE_TIMEOUT_MS) > 0
+        ? Number(process.env.BOOT_MIGRATE_TIMEOUT_MS)
+        : 60_000;
     let migrateTimedOut = false;
     let migrateTimer: ReturnType<typeof setTimeout> | undefined;
     try {
@@ -2412,7 +2594,10 @@ export async function register() {
           err,
         );
       } else {
-        console.error('[instrumentation] DB migration failed — server will start but schema may be out of date:', err);
+        console.error(
+          '[instrumentation] DB migration failed — server will start but schema may be out of date:',
+          err,
+        );
       }
     } finally {
       if (migrateTimer) clearTimeout(migrateTimer);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,12 +1,12 @@
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse, type NextRequest } from 'next/server';
 
-import { readSessionClaims } from '@/server/auth/session'
+import { readSessionClaims } from '@/server/auth/session';
 
-const SESSION_COOKIE_NAME = 'joshing_session'
+const SESSION_COOKIE_NAME = 'joshing_session';
 
 function tagTiming(response: NextResponse, startedAt: number): NextResponse {
-  response.headers.set('Server-Timing', `proxy;dur=${Date.now() - startedAt}`)
-  return response
+  response.headers.set('Server-Timing', `proxy;dur=${Date.now() - startedAt}`);
+  return response;
 }
 
 /**
@@ -24,34 +24,35 @@ function tagTiming(response: NextResponse, startedAt: number): NextResponse {
  * additional fence, not a replacement.
  */
 export async function middleware(request: NextRequest) {
-  const startedAt = Date.now()
+  const startedAt = Date.now();
   if (request.method === 'OPTIONS') {
-    return tagTiming(new NextResponse(null, { status: 200 }), startedAt)
+    return tagTiming(new NextResponse(null, { status: 200 }), startedAt);
   }
 
-  const { pathname, search } = request.nextUrl
-  const isApi = pathname.startsWith('/api/')
+  const { pathname, search } = request.nextUrl;
+  const isApi = pathname.startsWith('/api/');
 
-  // Terms & Disclaimer is a standalone public page: it is linked from the
+  // Terms and Privacy are standalone public pages: they are linked from the
   // logged-out /login card (opened in a new tab), so it must resolve without
   // a session — otherwise the proxy bounces the unauthenticated reader to
   // /login?next=/terms, a loop back into the very screen they came from. It
   // is equally readable when authenticated, so allow it through for everyone
   // before any auth/onboarding routing runs.
-  if (pathname === '/terms') return tagTiming(NextResponse.next(), startedAt)
+  if (pathname === '/terms' || pathname === '/privacy') {
+    return tagTiming(NextResponse.next(), startedAt);
+  }
 
-  const isLoginPage = pathname === '/login'
+  const isLoginPage = pathname === '/login';
   // Both invite landing surfaces must be reachable logged-out so the invitee
   // can carry their invite into /login: /invite/<token> (FriendInvitation,
   // SMS-style) and /u/<handle>/<token> (per-user evergreen invite link,
   // B-Friends-3). Without /u/ here the proxy bounces the invitee to /login
   // and drops the invite params, so brand-new accounts hit the invite-only
   // gate at verify-otp and can never sign up.
-  const isInvitePage =
-    pathname.startsWith('/invite/') || pathname.startsWith('/u/')
+  const isInvitePage = pathname.startsWith('/invite/') || pathname.startsWith('/u/');
 
-  const token = request.cookies.get(SESSION_COOKIE_NAME)?.value
-  const claims = await readSessionClaims(token)
+  const token = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+  const claims = await readSessionClaims(token);
 
   if (!claims) {
     if (isApi) {
@@ -61,12 +62,12 @@ export async function middleware(request: NextRequest) {
           { status: 401 },
         ),
         startedAt,
-      )
+      );
     }
-    if (isLoginPage || isInvitePage) return tagTiming(NextResponse.next(), startedAt)
-    const loginUrl = new URL('/login', request.url)
-    loginUrl.searchParams.set('next', pathname + search)
-    return tagTiming(NextResponse.redirect(loginUrl), startedAt)
+    if (isLoginPage || isInvitePage) return tagTiming(NextResponse.next(), startedAt);
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('next', pathname + search);
+    return tagTiming(NextResponse.redirect(loginUrl), startedAt);
   }
 
   // Legacy session: valid JWT but no `inv` claim. Trigger graceful refresh.
@@ -81,28 +82,28 @@ export async function middleware(request: NextRequest) {
           { status: 401 },
         ),
         startedAt,
-      )
+      );
     }
-    if (isLoginPage || isInvitePage) return tagTiming(NextResponse.next(), startedAt)
-    const refreshUrl = new URL('/api/auth/refresh-session', request.url)
-    refreshUrl.searchParams.set('next', pathname + search)
-    return tagTiming(NextResponse.redirect(refreshUrl), startedAt)
+    if (isLoginPage || isInvitePage) return tagTiming(NextResponse.next(), startedAt);
+    const refreshUrl = new URL('/api/auth/refresh-session', request.url);
+    refreshUrl.searchParams.set('next', pathname + search);
+    return tagTiming(NextResponse.redirect(refreshUrl), startedAt);
   }
 
   // Authenticated with valid invitation. API requests pass through; page
   // requests get the onboarding/login routing pass.
-  if (isApi) return tagTiming(NextResponse.next(), startedAt)
+  if (isApi) return tagTiming(NextResponse.next(), startedAt);
 
-  const isOnboardingPage = pathname === '/onboarding'
+  const isOnboardingPage = pathname === '/onboarding';
   const isAllowedOnboardingPath =
     isOnboardingPage ||
     pathname === '/logout' ||
     pathname.startsWith('/api/onboarding/') ||
-    pathname.startsWith('/api/auth/')
+    pathname.startsWith('/api/auth/');
 
   if (claims.onboardingComplete) {
     if (isOnboardingPage) {
-      return tagTiming(NextResponse.redirect(new URL('/', request.url)), startedAt)
+      return tagTiming(NextResponse.redirect(new URL('/', request.url)), startedAt);
     }
     // /login is intentionally NOT redirected here. These claims are verified
     // from the JWT signature alone (no DB lookup), so they can outlive the DB
@@ -112,7 +113,7 @@ export async function middleware(request: NextRequest) {
     // so the home renders signed-out and /api/feed 401s, yet the proxy bars
     // the one recovery surface. The login page redirects genuinely
     // authenticated users home itself, via a DB-checked getSession().
-    return tagTiming(NextResponse.next(), startedAt)
+    return tagTiming(NextResponse.next(), startedAt);
   }
 
   // claims.onboardingComplete is false: either the user genuinely hasn't
@@ -120,14 +121,11 @@ export async function middleware(request: NextRequest) {
   // their JWT is missing the field. Allow onboarding/auth paths through and
   // route everything else to the refresh endpoint, which does one DB read,
   // re-mints the JWT if needed, and bounces back. Steady-state is JWT-only.
-  if (isAllowedOnboardingPath) return tagTiming(NextResponse.next(), startedAt)
+  if (isAllowedOnboardingPath) return tagTiming(NextResponse.next(), startedAt);
 
-  const refreshUrl = new URL(
-    '/api/auth/refresh-onboarding-claim',
-    request.url,
-  )
-  refreshUrl.searchParams.set('next', pathname + search)
-  return tagTiming(NextResponse.redirect(refreshUrl), startedAt)
+  const refreshUrl = new URL('/api/auth/refresh-onboarding-claim', request.url);
+  refreshUrl.searchParams.set('next', pathname + search);
+  return tagTiming(NextResponse.redirect(refreshUrl), startedAt);
 }
 
 /**
@@ -144,10 +142,10 @@ export async function middleware(request: NextRequest) {
  * handles authenticated users hitting those pages (e.g. redirecting them
  * to /).
  */
-export { middleware as proxy }
+export { middleware as proxy };
 
 export const config = {
   matcher: [
     '/((?!api/auth|api/cron|api/share|api/telemetry|share|images|_next/static|_next/image|favicon\\.ico|__nextjs).*)',
   ],
-}
+};

--- a/src/server/__tests__/sms.test.ts
+++ b/src/server/__tests__/sms.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildDailyReminderSmsBody,
+  buildOtpMessage,
+  isEligibleForDailyReminder,
+  isSmsMessageTypeEnabled,
+} from '@/server/sms';
+
+describe('A2P SMS campaign boundaries and copy', () => {
+  it('allows only OTP and daily-reminder message types', () => {
+    expect(isSmsMessageTypeEnabled('otp')).toBe(true);
+    expect(isSmsMessageTypeEnabled('daily_questions')).toBe(true);
+    expect(isSmsMessageTypeEnabled('daily_questions_batched')).toBe(true);
+
+    for (const messageType of [
+      'invitation',
+      'question_reaction',
+      'correct_answer_notification',
+      'joshing_game_received',
+      'joshing_game_progress',
+      'joshing_game_complete',
+      'ceremony_ready',
+      'friend_answered_question',
+      'missed_return_recovered',
+    ] as const) {
+      expect(isSmsMessageTypeEnabled(messageType)).toBe(false);
+    }
+  });
+
+  it('builds identified OTP and compliant daily reminder copy', () => {
+    expect(buildOtpMessage('123456')).toBe(
+      'Joshing verification code: 123456. Expires in 10 minutes. Do not share this code.',
+    );
+    expect(buildDailyReminderSmsBody('https://joshing.example/')).toBe(
+      'Joshing: Your five for today are ready: https://joshing.example/daily. Reply STOP to opt out, HELP for help. Msg & data rates may apply.',
+    );
+  });
+
+  it('requires verified phone plus explicit opt-in for daily reminders', () => {
+    expect(
+      isEligibleForDailyReminder({
+        phoneNumber: '+17345550123',
+        phoneVerified: true,
+        smsOptIn: 'opted_in',
+      }),
+    ).toBe(true);
+    expect(
+      isEligibleForDailyReminder({
+        phoneNumber: '+17345550123',
+        phoneVerified: false,
+        smsOptIn: 'opted_in',
+      }),
+    ).toBe(false);
+    expect(
+      isEligibleForDailyReminder({
+        phoneNumber: '+17345550123',
+        phoneVerified: true,
+        smsOptIn: 'not_asked',
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/server/db/queries/__tests__/account.sms-consent.test.ts
+++ b/src/server/db/queries/__tests__/account.sms-consent.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildSmsConsentAuditPatch,
+  SMS_CONSENT_POLICY_VERSION,
+  SMS_CONSENT_SOURCE,
+} from '@/server/db/queries/account';
+
+describe('SMS consent audit persistence', () => {
+  const changedAt = new Date('2026-09-01T12:00:00.000Z');
+
+  it('builds one atomic opt-in update with timestamp, source, and policy version', () => {
+    expect(buildSmsConsentAuditPatch('opted_in', changedAt)).toEqual({
+      smsOptIn: 'opted_in',
+      smsOptInAt: changedAt,
+      smsConsentSource: SMS_CONSENT_SOURCE,
+      smsConsentPolicyVersion: SMS_CONSENT_POLICY_VERSION,
+    });
+  });
+
+  it('builds one atomic opt-out update with its own timestamp', () => {
+    expect(buildSmsConsentAuditPatch('opted_out', changedAt)).toEqual({
+      smsOptIn: 'opted_out',
+      smsOptOutAt: changedAt,
+      smsConsentSource: SMS_CONSENT_SOURCE,
+      smsConsentPolicyVersion: SMS_CONSENT_POLICY_VERSION,
+    });
+  });
+});

--- a/src/server/db/queries/__tests__/daily.test.ts
+++ b/src/server/db/queries/__tests__/daily.test.ts
@@ -6,6 +6,7 @@ let selectResults: unknown[][] = [[], []];
 let selectCall = 0;
 const deleteWheres: unknown[] = [];
 const updateSets: unknown[] = [];
+let returningRows: unknown[] = [];
 
 const makeChain = () => {
   const chain = {
@@ -34,12 +35,21 @@ vi.mock('@/server/db', () => ({
       set: (vals: unknown) => ({
         where: () => {
           updateSets.push(vals);
-          return Promise.resolve([]);
+          const result = Promise.resolve([]) as Promise<unknown[]> & {
+            returning: () => Promise<unknown[]>;
+          };
+          result.returning = () => Promise.resolve(returningRows);
+          return result;
         },
       }),
     }),
   },
-  dailyQueues: { id: 'id', userId: 'user_id', queueDate: 'queue_date' },
+  dailyQueues: {
+    id: 'id',
+    userId: 'user_id',
+    queueDate: 'queue_date',
+    smsReminderSentAt: 'sms_reminder_sent_at',
+  },
   generatedQuestions: {},
   dailyPreferences: {},
   declaredInterests: {},
@@ -61,8 +71,10 @@ vi.mock('@/lib/games/timezone', async (importActual) => ({
 }));
 
 import {
+  claimDailySmsReminder,
   clearStaleShortTodayQueue,
   carryForwardUntouchedDailyQueue,
+  releaseDailySmsReminder,
 } from '@/server/db/queries/daily';
 
 // Fixtures must satisfy queueSlotSchema — asQueueSlots zod-validates the JSONB
@@ -87,6 +99,22 @@ beforeEach(() => {
   selectCall = 0;
   deleteWheres.length = 0;
   updateSets.length = 0;
+  returningRows = [];
+});
+
+describe('daily SMS reminder claims', () => {
+  it('returns true only when this caller wins the atomic claim', async () => {
+    returningRows = [{ id: 'queue-1' }];
+    expect(await claimDailySmsReminder('queue-1')).toBe(true);
+
+    returningRows = [];
+    expect(await claimDailySmsReminder('queue-1')).toBe(false);
+  });
+
+  it('releases the claim after a failed provider send', async () => {
+    await releaseDailySmsReminder('queue-1');
+    expect(updateSets.at(-1)).toEqual({ smsReminderSentAt: null });
+  });
 });
 
 describe('clearStaleShortTodayQueue', () => {
@@ -103,7 +131,10 @@ describe('clearStaleShortTodayQueue', () => {
   });
 
   it('keeps a started (answered) short queue', async () => {
-    selectResults = [[{ id: 'started', slots: slots(3, { answered: true }), createdAt: BEFORE_WINDOW }], []];
+    selectResults = [
+      [{ id: 'started', slots: slots(3, { answered: true }), createdAt: BEFORE_WINDOW }],
+      [],
+    ];
     expect(await clearStaleShortTodayQueue('u1')).toBe(false);
     expect(deleteWheres).toHaveLength(0);
   });
@@ -134,7 +165,10 @@ describe('carryForwardUntouchedDailyQueue', () => {
   });
 
   it('does NOT carry a started prior queue forward', async () => {
-    selectResults = [[], [{ id: 'p1', slots: slots(5, { answered: true }), createdAt: BEFORE_WINDOW }]];
+    selectResults = [
+      [],
+      [{ id: 'p1', slots: slots(5, { answered: true }), createdAt: BEFORE_WINDOW }],
+    ];
     expect(await carryForwardUntouchedDailyQueue('u1')).toBe(false);
     expect(updateSets).toHaveLength(0);
   });

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -1,10 +1,6 @@
 import { and, eq, inArray, ne, sql } from 'drizzle-orm';
 
-import {
-  contactHashes,
-  db,
-  users,
-} from '@/server/db';
+import { contactHashes, db, users } from '@/server/db';
 
 export type UserProfile = {
   id: string;
@@ -187,6 +183,22 @@ export async function updateProfileFields(
 }
 
 export type ReminderOptInState = 'opted_in' | 'opted_out' | 'not_asked';
+export const SMS_CONSENT_SOURCE = 'profile_web_form';
+export const SMS_CONSENT_POLICY_VERSION = '2026-09-01';
+
+export function buildSmsConsentAuditPatch(
+  smsOptIn: 'opted_in' | 'opted_out',
+  changedAt = new Date(),
+): Record<string, unknown> {
+  return {
+    smsOptIn,
+    smsConsentSource: SMS_CONSENT_SOURCE,
+    smsConsentPolicyVersion: SMS_CONSENT_POLICY_VERSION,
+    ...(smsOptIn === 'opted_in'
+      ? { smsOptInAt: changedAt }
+      : { smsOptOutAt: changedAt }),
+  };
+}
 
 export type ReminderState = {
   smsOptIn: ReminderOptInState;
@@ -195,6 +207,10 @@ export type ReminderState = {
   email: string | null;
   pendingEmail: string | null;
   phoneNumber: string;
+  smsOptInAt: string | null;
+  smsOptOutAt: string | null;
+  smsConsentSource: string | null;
+  smsConsentPolicyVersion: string | null;
   reminderPromptDismissedAt: string | null;
   // D-REMINDER-INTERSTITIAL-01: when the one-time full-screen interstitial was
   // shown (both sign-up and skip stamp it). Null → never shown → still eligible.
@@ -211,6 +227,10 @@ export async function getReminderState(userId: string): Promise<ReminderState | 
       email: users.email,
       pendingEmail: users.pendingEmail,
       phoneNumber: users.phoneNumber,
+      smsOptInAt: users.smsOptInAt,
+      smsOptOutAt: users.smsOptOutAt,
+      smsConsentSource: users.smsConsentSource,
+      smsConsentPolicyVersion: users.smsConsentPolicyVersion,
       reminderPromptDismissedAt: users.reminderPromptDismissedAt,
       reminderInterstitialSeenAt: users.reminderInterstitialSeenAt,
     })
@@ -227,6 +247,10 @@ export async function getReminderState(userId: string): Promise<ReminderState | 
     email: row.email,
     pendingEmail: row.pendingEmail,
     phoneNumber: row.phoneNumber,
+    smsOptInAt: row.smsOptInAt?.toISOString() ?? null,
+    smsOptOutAt: row.smsOptOutAt?.toISOString() ?? null,
+    smsConsentSource: row.smsConsentSource,
+    smsConsentPolicyVersion: row.smsConsentPolicyVersion,
     reminderPromptDismissedAt: row.reminderPromptDismissedAt?.toISOString() ?? null,
     reminderInterstitialSeenAt: row.reminderInterstitialSeenAt?.toISOString() ?? null,
   };
@@ -271,7 +295,9 @@ export async function updateReminderPreferences(
   }
 
   const set: Record<string, unknown> = { updatedAt: new Date() };
-  if (patch.smsOptIn !== undefined) set.smsOptIn = patch.smsOptIn;
+  if (patch.smsOptIn !== undefined) {
+    Object.assign(set, buildSmsConsentAuditPatch(patch.smsOptIn));
+  }
   if (patch.emailOptIn !== undefined) set.emailOptIn = patch.emailOptIn;
   if (patch.pendingEmail !== undefined) set.pendingEmail = patch.pendingEmail;
   if (patch.dismissed === true) set.reminderPromptDismissedAt = new Date();
@@ -365,10 +391,7 @@ export async function assignInitialHandle(params: {
   const now = new Date();
 
   try {
-    await db
-      .update(users)
-      .set({ handle, updatedAt: now })
-      .where(eq(users.id, params.userId));
+    await db.update(users).set({ handle, updatedAt: now }).where(eq(users.id, params.userId));
   } catch (err) {
     if (err instanceof Error && /unique/i.test(err.message)) {
       return { ok: false };
@@ -384,9 +407,7 @@ export type DiscoverabilityState = {
   discoverableByNicheMatch: boolean;
 };
 
-export async function getDiscoverability(
-  userId: string,
-): Promise<DiscoverabilityState | null> {
+export async function getDiscoverability(userId: string): Promise<DiscoverabilityState | null> {
   const [row] = await db
     .select({
       discoverableByContacts: users.discoverableByContacts,
@@ -440,16 +461,14 @@ export async function updateDiscoverability(
 
     await tx.update(users).set(set).where(eq(users.id, userId));
 
-    const turningContactsOff =
-      patch.contacts === false && current.discoverableByContacts === true;
+    const turningContactsOff = patch.contacts === false && current.discoverableByContacts === true;
     if (turningContactsOff) {
       await tx.delete(contactHashes).where(eq(contactHashes.userId, userId));
     }
 
     return {
       discoverableByContacts: patch.contacts ?? current.discoverableByContacts,
-      discoverableByMutualFriends:
-        patch.mutualFriends ?? current.discoverableByMutualFriends,
+      discoverableByMutualFriends: patch.mutualFriends ?? current.discoverableByMutualFriends,
       discoverableByNicheMatch: patch.nicheMatch ?? current.discoverableByNicheMatch,
     };
   });
@@ -460,17 +479,12 @@ export async function updateDiscoverability(
 // discoverableByNicheMatch is currently true. Used to resolve the asymmetric
 // two-flag gate in notifyNicheMatch with a single query rather than a
 // per-user getDiscoverability round-trip.
-export async function getNicheMatchDiscoverable(
-  userIds: string[],
-): Promise<Set<string>> {
+export async function getNicheMatchDiscoverable(userIds: string[]): Promise<Set<string>> {
   if (userIds.length === 0) return new Set();
   const rows = await db
     .select({ id: users.id })
     .from(users)
-    .where(and(
-      inArray(users.id, userIds),
-      eq(users.discoverableByNicheMatch, true),
-    ));
+    .where(and(inArray(users.id, userIds), eq(users.discoverableByNicheMatch, true)));
   return new Set(rows.map((r) => r.id));
 }
 
@@ -478,17 +492,12 @@ export async function getNicheMatchDiscoverable(
 // Returns the subset of the supplied ids whose discoverableByForward is currently
 // true. Sibling to getNicheMatchDiscoverable — kept separate so the "via {source}"
 // forward-relay exposure can be gated independently of niche-match. Single query.
-export async function getForwardDiscoverable(
-  userIds: string[],
-): Promise<Set<string>> {
+export async function getForwardDiscoverable(userIds: string[]): Promise<Set<string>> {
   if (userIds.length === 0) return new Set();
   const rows = await db
     .select({ id: users.id })
     .from(users)
-    .where(and(
-      inArray(users.id, userIds),
-      eq(users.discoverableByForward, true),
-    ));
+    .where(and(inArray(users.id, userIds), eq(users.discoverableByForward, true)));
   return new Set(rows.map((r) => r.id));
 }
 
@@ -497,7 +506,10 @@ export async function getForwardDiscoverable(
 // unconditionally without a separate empty-set branch.
 function idInList(ids: string[]) {
   if (ids.length === 0) return sql`(null)`;
-  return sql`(${sql.join(ids.map((id) => sql`${id}`), sql.raw(', '))})`;
+  return sql`(${sql.join(
+    ids.map((id) => sql`${id}`),
+    sql.raw(', '),
+  )})`;
 }
 
 // Production account deletion (D-ACCOUNT-DELETION-TERRITORY-01). Honors the
@@ -524,9 +536,13 @@ export async function deleteUserAccount(userId: string): Promise<void> {
     // (the question is tombstoned below and re-sources to house). Stripping
     // source-actor cards first also lets a question whose only retained tie was
     // such a card fall through to hard-delete.
-    await tx.execute(sql`delete from "FeedItem" where "recipientUserId" = ${userId} or "sourceUserId" = ${userId} or "joshingGameId" in (select id from "JoshingGame" where "creatorId" = ${userId})`);
+    await tx.execute(
+      sql`delete from "FeedItem" where "recipientUserId" = ${userId} or "sourceUserId" = ${userId} or "joshingGameId" in (select id from "JoshingGame" where "creatorId" = ${userId})`,
+    );
     await tx.execute(sql`delete from "ActivityItem" where "userId" = ${userId}`);
-    await tx.execute(sql`update "ActivityItem" set "actorUserId" = null where "actorUserId" = ${userId}`);
+    await tx.execute(
+      sql`update "ActivityItem" set "actorUserId" = null where "actorUserId" = ${userId}`,
+    );
 
     // Partition this author's questions: TOMBSTONE (A1) when a RETAINED user still
     // has proven territory or a save tied to it, else hard-delete (Decision B).
@@ -560,45 +576,75 @@ export async function deleteUserAccount(userId: string): Promise<void> {
     );
 
     if (
-      questionReactionColumnNames.has('senderUserId')
-      && questionReactionColumnNames.has('recipientUserId')
-      && questionReactionColumnNames.has('questionId')
+      questionReactionColumnNames.has('senderUserId') &&
+      questionReactionColumnNames.has('recipientUserId') &&
+      questionReactionColumnNames.has('questionId')
     ) {
-      await tx.execute(sql`delete from "QuestionReaction" where "senderUserId" = ${userId} or "recipientUserId" = ${userId} or "questionId" in ${orphanList}`);
+      await tx.execute(
+        sql`delete from "QuestionReaction" where "senderUserId" = ${userId} or "recipientUserId" = ${userId} or "questionId" in ${orphanList}`,
+      );
     } else if (
-      questionReactionColumnNames.has('answerer_id')
-      && questionReactionColumnNames.has('creator_id')
-      && questionReactionColumnNames.has('question_id')
+      questionReactionColumnNames.has('answerer_id') &&
+      questionReactionColumnNames.has('creator_id') &&
+      questionReactionColumnNames.has('question_id')
     ) {
-      await tx.execute(sql`delete from "QuestionReaction" where "answerer_id" = ${userId} or "creator_id" = ${userId} or "question_id" in ${orphanList}`);
+      await tx.execute(
+        sql`delete from "QuestionReaction" where "answerer_id" = ${userId} or "creator_id" = ${userId} or "question_id" in ${orphanList}`,
+      );
     }
-    await tx.execute(sql`delete from "GradeDispute" where "creator_id" = ${userId} or "question_id" in ${orphanList}`);
+    await tx.execute(
+      sql`delete from "GradeDispute" where "creator_id" = ${userId} or "question_id" in ${orphanList}`,
+    );
 
-    await tx.execute(sql`delete from "JoshingGameResponse" where "userId" = ${userId} or "gameId" in (select id from "JoshingGame" where "creatorId" = ${userId}) or "questionId" in ${orphanList}`);
-    await tx.execute(sql`delete from "JoshingGameRecipient" where "userId" = ${userId} or "gameId" in (select id from "JoshingGame" where "creatorId" = ${userId})`);
-    await tx.execute(sql`delete from "JoshingGameQuestion" where "gameId" in (select id from "JoshingGame" where "creatorId" = ${userId}) or "questionId" in ${orphanList}`);
+    await tx.execute(
+      sql`delete from "JoshingGameResponse" where "userId" = ${userId} or "gameId" in (select id from "JoshingGame" where "creatorId" = ${userId}) or "questionId" in ${orphanList}`,
+    );
+    await tx.execute(
+      sql`delete from "JoshingGameRecipient" where "userId" = ${userId} or "gameId" in (select id from "JoshingGame" where "creatorId" = ${userId})`,
+    );
+    await tx.execute(
+      sql`delete from "JoshingGameQuestion" where "gameId" in (select id from "JoshingGame" where "creatorId" = ${userId}) or "questionId" in ${orphanList}`,
+    );
     await tx.execute(sql`delete from "JoshingGame" where "creatorId" = ${userId}`);
 
-    await tx.execute(sql`delete from "Friendship" where "userAId" = ${userId} or "userBId" = ${userId} or "requestedByUserId" = ${userId} or "removedByUserId" = ${userId}`);
+    await tx.execute(
+      sql`delete from "Friendship" where "userAId" = ${userId} or "userBId" = ${userId} or "requestedByUserId" = ${userId} or "removedByUserId" = ${userId}`,
+    );
     await tx.execute(sql`delete from "FriendInvitation" where "inviterUserId" = ${userId}`);
-    await tx.execute(sql`update "FriendInvitation" set "inviteeUserId" = null where "inviteeUserId" = ${userId}`);
-    await tx.execute(sql`update "DailyPreference" set "friend_ids" = array_remove("friend_ids", ${userId}) where ${userId} = any("friend_ids")`);
+    await tx.execute(
+      sql`update "FriendInvitation" set "inviteeUserId" = null where "inviteeUserId" = ${userId}`,
+    );
+    await tx.execute(
+      sql`update "DailyPreference" set "friend_ids" = array_remove("friend_ids", ${userId}) where ${userId} = any("friend_ids")`,
+    );
 
-    await tx.execute(sql`delete from "SkippedDailyQuestion" where "user_id" = ${userId} or "question_id" in ${orphanList} or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`);
+    await tx.execute(
+      sql`delete from "SkippedDailyQuestion" where "user_id" = ${userId} or "question_id" in ${orphanList} or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`,
+    );
     // HiddenQuestion (0131) has no ON DELETE CASCADE on its user/question FKs, so
     // it must be cleared explicitly here or account deletion fails on the FK —
     // same shape and same reason as the SkippedDailyQuestion sweep above.
-    await tx.execute(sql`delete from "HiddenQuestion" where "user_id" = ${userId} or "question_id" in ${orphanList} or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`);
+    await tx.execute(
+      sql`delete from "HiddenQuestion" where "user_id" = ${userId} or "question_id" in ${orphanList} or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`,
+    );
     await tx.execute(sql`delete from "DailyQueue" where "user_id" = ${userId}`);
     await tx.execute(sql`delete from "DailyPreference" where "user_id" = ${userId}`);
 
-    await tx.execute(sql`delete from "QuestionFeedback" where "user_id" = ${userId} or "question_id" in ${orphanList} or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`);
-    await tx.execute(sql`delete from "QuestionRating" where "user_id" = ${userId} or "question_id" in ${orphanList}`);
+    await tx.execute(
+      sql`delete from "QuestionFeedback" where "user_id" = ${userId} or "question_id" in ${orphanList} or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`,
+    );
+    await tx.execute(
+      sql`delete from "QuestionRating" where "user_id" = ${userId} or "question_id" in ${orphanList}`,
+    );
     // Decision B: a friend's bank save IS a retained dependency, so a banked
     // question is a tombstone — only THIS user's own bank rows are removed (their
     // saves of a tombstoned question are preserved by the orphan-only question key).
-    await tx.execute(sql`delete from "UserQuestionBank" where "user_id" = ${userId} or "question_id" in ${orphanList}`);
-    await tx.execute(sql`delete from "QuestionAudienceTag" where "creator_id" = ${userId} or "question_id" in ${orphanList}`);
+    await tx.execute(
+      sql`delete from "UserQuestionBank" where "user_id" = ${userId} or "question_id" in ${orphanList}`,
+    );
+    await tx.execute(
+      sql`delete from "QuestionAudienceTag" where "creator_id" = ${userId} or "question_id" in ${orphanList}`,
+    );
 
     // ContentReport: the `ContentReport_one_target` CHECK
     // ((question_id NOT NULL) + (generated_question_id NOT NULL) = 1) forbids
@@ -609,7 +655,9 @@ export async function deleteUserAccount(userId: string): Promise<void> {
     // TOMBSTONE question keep pointing at the surviving row (moderation record
     // preserved). Runs before the orphan-Question and GeneratedQuestion deletes
     // so their RESTRICT FKs don't block.
-    await tx.execute(sql`delete from "ContentReport" where "reporter_user_id" = ${userId} or "question_id" in ${orphanList} or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`);
+    await tx.execute(
+      sql`delete from "ContentReport" where "reporter_user_id" = ${userId} or "question_id" in ${orphanList} or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`,
+    );
 
     // THE territory-preservation core (#1/#3/#4): delete ONLY this user's own
     // mastery rows (their proven territory + their author-credit). Retained users'
@@ -619,11 +667,15 @@ export async function deleteUserAccount(userId: string): Promise<void> {
     // Decision C — degrade convergence/Lately attribution: a retained user's event
     // that named THIS user as the answerer keeps the fact, loses the name.
     // answered_by_user_id is plain text (not an FK); convergence reads it.
-    await tx.execute(sql`update "MASTERY_EVENTS" set "answered_by_user_id" = null where "answered_by_user_id" = ${userId}`);
+    await tx.execute(
+      sql`update "MASTERY_EVENTS" set "answered_by_user_id" = null where "answered_by_user_id" = ${userId}`,
+    );
 
     // A1 tombstone: retained-dependency questions persist, re-sourced to house.
     if (tombstoneIds.length > 0) {
-      await tx.execute(sql`update "Question" set "creator_id" = null, "source" = 'house_authored', "author_deleted" = true, "updated_at" = now() where id in ${idInList(tombstoneIds)}`);
+      await tx.execute(
+        sql`update "Question" set "creator_id" = null, "source" = 'house_authored', "author_deleted" = true, "updated_at" = now() where id in ${idInList(tombstoneIds)}`,
+      );
     }
     // Decision B: questions with no retained dependency hard-delete with the user.
     // Their FeedItems were stripped above and their other referencers removed by
@@ -632,7 +684,9 @@ export async function deleteUserAccount(userId: string): Promise<void> {
       await tx.execute(sql`delete from "Question" where id in ${idInList(orphanIds)}`);
     }
 
-    await tx.execute(sql`update "Question" set "generated_question_id" = null where "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`);
+    await tx.execute(
+      sql`update "Question" set "generated_question_id" = null where "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`,
+    );
     await tx.execute(sql`delete from "GeneratedQuestion" where "user_id" = ${userId}`);
 
     await tx.execute(sql`delete from "PLAYER_MASTERY" where "user_id" = ${userId}`);

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1,4 +1,19 @@
-import { and, asc, cosineDistance, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, sql } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  cosineDistance,
+  desc,
+  eq,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  lte,
+  ne,
+  or,
+  sql,
+} from 'drizzle-orm';
 
 import {
   dailyPreferences,
@@ -18,11 +33,25 @@ import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import type { GradableQuestionType } from '@/server/grading';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
-import { notBlockedGeneratedByContentReport, notSuppressedByContentReport } from '@/server/db/queries/content-reports';
+import {
+  notBlockedGeneratedByContentReport,
+  notSuppressedByContentReport,
+} from '@/server/db/queries/content-reports';
 import { notBlocked } from '@/server/feed/visibility';
 import { pgErrorCode } from '@/server/db/pg-error';
-import { CATEGORIES, categoryLabel, HOUSE_AUTHOR, resolveAuthorDisplay } from '@/lib/questions-types';
-import { CATCHUP_LOOKBACK_DAYS, asQueueSlots, dailyQueueItemId, feedCatchupItemId, minusUtcDays } from '@/server/daily/catchup';
+import {
+  CATEGORIES,
+  categoryLabel,
+  HOUSE_AUTHOR,
+  resolveAuthorDisplay,
+} from '@/lib/questions-types';
+import {
+  CATCHUP_LOOKBACK_DAYS,
+  asQueueSlots,
+  dailyQueueItemId,
+  feedCatchupItemId,
+  minusUtcDays,
+} from '@/server/daily/catchup';
 import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import { answerCooldownKey } from '@/server/daily/answer-cooldown';
 import {
@@ -38,10 +67,7 @@ import {
   isCatchUpSlotEligible,
   queueAgeInDays,
 } from '@/server/play/catch-up-eligibility';
-import {
-  dedupeCatchUpItems,
-  orderCatchUpItems,
-} from '@/server/play/catch-up-turn-sequencing';
+import { dedupeCatchUpItems, orderCatchUpItems } from '@/server/play/catch-up-turn-sequencing';
 import { getBasePoints } from '@/server/mastery/scoring';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { domainKey } from '@/lib/knowledge/domain-key';
@@ -174,7 +200,8 @@ export async function getExcludedKnowledgeDomains(userId: string): Promise<Scope
       .from(userDomainExclusions)
       .where(activeExclusion);
   } catch (error) {
-    if (pgErrorCode(error) === '42P01') return { subcategories: new Set(), broadCategories: new Set() };
+    if (pgErrorCode(error) === '42P01')
+      return { subcategories: new Set(), broadCategories: new Set() };
     // 42703 = the scope OR rest_until column is missing on a database where the
     // additive migration (0036 / 0124) hasn't landed yet. Fall back to a
     // scope='subcategory', treat-all-as-permanent read so the feature degrades
@@ -210,7 +237,7 @@ export async function getExcludedKnowledgeDomains(userId: string): Promise<Scope
   // broadCategories filter.
   if (categoryEnums.length > 0) {
     try {
-      const knownCategories = categoryEnums.filter((value): value is typeof CATEGORIES[number] =>
+      const knownCategories = categoryEnums.filter((value): value is (typeof CATEGORIES)[number] =>
         (CATEGORIES as readonly string[]).includes(value),
       );
       if (knownCategories.length > 0) {
@@ -237,10 +264,17 @@ async function getCorrectAnswerCountsByDomain(userId: string): Promise<Map<strin
       count: sql<number>`count(*)::int`,
     })
     .from(masteryEvents)
-    .where(and(eq(masteryEvents.userId, userId), inArray(masteryEvents.sourceType, ['live_correct', 'catchup_correct'])))
+    .where(
+      and(
+        eq(masteryEvents.userId, userId),
+        inArray(masteryEvents.sourceType, ['live_correct', 'catchup_correct']),
+      ),
+    )
     .groupBy(masteryEvents.canonicalSubcategory);
 
-  return new Map(rows.map((row) => [normalizeDomain(row.domain).toLowerCase(), Number(row.count ?? 0)]));
+  return new Map(
+    rows.map((row) => [normalizeDomain(row.domain).toLowerCase(), Number(row.count ?? 0)]),
+  );
 }
 
 async function getPlayerMasteryKnowledgeRows(userId: string) {
@@ -283,17 +317,19 @@ async function getPlayerMasteryKnowledgeRows(userId: string) {
 }
 
 export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDomain[]> {
-  const [masteryRows, declaredRows, excludedDomains, correctCountsByDomain, preferences] = await Promise.all([
-    getPlayerMasteryKnowledgeRows(userId),
-    getActiveDeclaredInterests(userId),
-    getExcludedKnowledgeDomains(userId),
-    getCorrectAnswerCountsByDomain(userId),
-    getDailyPreferences(userId),
-  ]);
+  const [masteryRows, declaredRows, excludedDomains, correctCountsByDomain, preferences] =
+    await Promise.all([
+      getPlayerMasteryKnowledgeRows(userId),
+      getActiveDeclaredInterests(userId),
+      getExcludedKnowledgeDomains(userId),
+      getCorrectAnswerCountsByDomain(userId),
+      getDailyPreferences(userId),
+    ]);
 
   const isExcluded = (domain: string, broadCategory: string | null): boolean => {
     if (excludedDomains.subcategories.has(domain.toLowerCase())) return true;
-    if (broadCategory && excludedDomains.broadCategories.has(broadCategory.toLowerCase())) return true;
+    if (broadCategory && excludedDomains.broadCategories.has(broadCategory.toLowerCase()))
+      return true;
     return false;
   };
 
@@ -383,8 +419,19 @@ export async function getTodaysDailyQueue(userId: string): Promise<DailyQueueRow
  * summary, content reports) deliberately stay snapshot-first.
  */
 export async function refreshQueueSlotQuestionTexts(slots: QueueSlot[]): Promise<QueueSlot[]> {
-  const generatedIds = [...new Set(slots.map((slot) => slot.generated_question_id).filter((id): id is string => Boolean(id)))];
-  const canonicalIds = [...new Set(slots.filter((slot) => !slot.generated_question_id).map((slot) => slot.question_id).filter((id): id is string => Boolean(id)))];
+  const generatedIds = [
+    ...new Set(
+      slots.map((slot) => slot.generated_question_id).filter((id): id is string => Boolean(id)),
+    ),
+  ];
+  const canonicalIds = [
+    ...new Set(
+      slots
+        .filter((slot) => !slot.generated_question_id)
+        .map((slot) => slot.question_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ];
   if (generatedIds.length === 0 && canonicalIds.length === 0) return slots;
 
   const [generatedRows, canonicalRows] = await Promise.all([
@@ -444,6 +491,22 @@ export async function releaseDailyEmailReminder(queueId: string): Promise<void> 
     .where(eq(dailyQueues.id, queueId));
 }
 
+/** Atomically claim this queue's one allowed daily SMS reminder. */
+export async function claimDailySmsReminder(queueId: string): Promise<boolean> {
+  const claimed = await db
+    .update(dailyQueues)
+    .set({ smsReminderSentAt: new Date() })
+    .where(and(eq(dailyQueues.id, queueId), isNull(dailyQueues.smsReminderSentAt)))
+    .returning({ id: dailyQueues.id });
+
+  return claimed.length > 0;
+}
+
+/** Release a failed SMS claim so a later cron pass can retry delivery. */
+export async function releaseDailySmsReminder(queueId: string): Promise<void> {
+  await db.update(dailyQueues).set({ smsReminderSentAt: null }).where(eq(dailyQueues.id, queueId));
+}
+
 /**
  * Total number of daily queues ever built for this user, across all dates.
  *
@@ -482,11 +545,13 @@ export async function invalidateUntouchedDailyQueues(userId: string): Promise<nu
   const queues = await db
     .select()
     .from(dailyQueues)
-    .where(and(
-      eq(dailyQueues.userId, userId),
-      lte(dailyQueues.queueDate, assignmentDateStr),
-      gte(dailyQueues.queueDate, oldestEligible),
-    ));
+    .where(
+      and(
+        eq(dailyQueues.userId, userId),
+        lte(dailyQueues.queueDate, assignmentDateStr),
+        gte(dailyQueues.queueDate, oldestEligible),
+      ),
+    );
 
   const untouchedIds = queues
     .filter((queue) => !asQueueSlots(queue.slots).some((slot) => slot.answered || slot.skipped))
@@ -529,11 +594,13 @@ export async function carryForwardUntouchedDailyQueue(userId: string): Promise<b
   const [prior] = await db
     .select()
     .from(dailyQueues)
-    .where(and(
-      eq(dailyQueues.userId, userId),
-      lt(dailyQueues.queueDate, assignmentDateStr),
-      gte(dailyQueues.queueDate, oldestEligible),
-    ))
+    .where(
+      and(
+        eq(dailyQueues.userId, userId),
+        lt(dailyQueues.queueDate, assignmentDateStr),
+        gte(dailyQueues.queueDate, oldestEligible),
+      ),
+    )
     .orderBy(desc(dailyQueues.queueDate))
     .limit(1);
 
@@ -582,11 +649,13 @@ export async function getPriorInWindowDailyQueue(userId: string): Promise<DailyQ
   const [prior] = await db
     .select()
     .from(dailyQueues)
-    .where(and(
-      eq(dailyQueues.userId, userId),
-      lt(dailyQueues.queueDate, assignmentDateStr),
-      gte(dailyQueues.queueDate, oldestEligible),
-    ))
+    .where(
+      and(
+        eq(dailyQueues.userId, userId),
+        lt(dailyQueues.queueDate, assignmentDateStr),
+        gte(dailyQueues.queueDate, oldestEligible),
+      ),
+    )
     .orderBy(desc(dailyQueues.queueDate))
     .limit(1);
   return prior ?? null;
@@ -677,16 +746,15 @@ export async function getGeneratedQuestionsForQueue(queue: DailyQueueRow) {
 
   if (generatedIds.length === 0) return [];
 
-  return db
-    .select()
-    .from(generatedQuestions)
-    .where(inArray(generatedQuestions.id, generatedIds));
+  return db.select().from(generatedQuestions).where(inArray(generatedQuestions.id, generatedIds));
 }
 
 // Resolve creator display names for a set of (possibly null/duplicate) creator
 // ids, returning a id→name map. Null/absent ids are skipped — their questions
 // are LLM-origin and the client labels them non-relationally.
-export async function resolveCreatorNames(creatorIds: Array<string | null>): Promise<Map<string, string | null>> {
+export async function resolveCreatorNames(
+  creatorIds: Array<string | null>,
+): Promise<Map<string, string | null>> {
   const ids = [...new Set(creatorIds.filter((id): id is string => Boolean(id)))];
   if (ids.length === 0) return new Map();
   const nameRows = await db
@@ -715,10 +783,7 @@ async function getDailyCatchupItems(
     db
       .select()
       .from(dailyQueues)
-      .where(and(
-        eq(dailyQueues.userId, userId),
-        lte(dailyQueues.queueDate, assignmentDateStr),
-      ))
+      .where(and(eq(dailyQueues.userId, userId), lte(dailyQueues.queueDate, assignmentDateStr)))
       .orderBy(asc(dailyQueues.queueDate)),
     getDailyPreferences(userId),
   ]);
@@ -743,12 +808,13 @@ async function getDailyCatchupItems(
 
   const candidateSlots = queues.flatMap((queue) =>
     asQueueSlots(queue.slots)
-      .filter((slot) =>
-        isCatchUpQueueDateEligible(String(queue.queueDate), assignmentDateStr) &&
-        isCatchUpSlotEligible(slot) &&
-        !isRestingDomain(slot.domain),
+      .filter(
+        (slot) =>
+          isCatchUpQueueDateEligible(String(queue.queueDate), assignmentDateStr) &&
+          isCatchUpSlotEligible(slot) &&
+          !isRestingDomain(slot.domain),
       )
-      .map((slot) => ({ queue, slot }))
+      .map((slot) => ({ queue, slot })),
   );
 
   const generatedIds = candidateSlots
@@ -766,32 +832,36 @@ async function getDailyCatchupItems(
       ? db
           .select()
           .from(generatedQuestions)
-          .where(and(
-            eq(generatedQuestions.userId, userId),
-            inArray(generatedQuestions.id, generatedIds),
-            // Terminal hard-block for LLM-origin content: an upheld-inappropriate
-            // report is the generated equivalent of visibility='blocked'.
-            notBlockedGeneratedByContentReport(generatedQuestions.id),
-          ))
-      : Promise.resolve<typeof generatedQuestions.$inferSelect[]>([]),
+          .where(
+            and(
+              eq(generatedQuestions.userId, userId),
+              inArray(generatedQuestions.id, generatedIds),
+              // Terminal hard-block for LLM-origin content: an upheld-inappropriate
+              // report is the generated equivalent of visibility='blocked'.
+              notBlockedGeneratedByContentReport(generatedQuestions.id),
+            ),
+          )
+      : Promise.resolve<(typeof generatedQuestions.$inferSelect)[]>([]),
     canonicalIds.length > 0
       ? db
           .select()
           .from(canonicalQuestions)
-          .where(and(
-            inArray(canonicalQuestions.id, canonicalIds),
-            // Safety hard-block: a question blocked after assignment (cron re-vet,
-            // upheld report) must not resurface in catch-up.
-            notBlocked(),
-            // AUTHORSHIP-EXCLUSION INVARIANT (B-CRAFTER-LIFECYCLE-01 Phase 3):
-            // never serve the viewer their own authored question. Structurally
-            // catch-up replays the viewer's own assigned slots (you aren't
-            // assigned your own questions), but with player authoring live the
-            // explicit predicate is load-bearing. NULL creators (house/LLM)
-            // must still pass — hence the isNull arm.
-            or(isNull(canonicalQuestions.creatorId), ne(canonicalQuestions.creatorId, userId)),
-          ))
-      : Promise.resolve<typeof canonicalQuestions.$inferSelect[]>([]),
+          .where(
+            and(
+              inArray(canonicalQuestions.id, canonicalIds),
+              // Safety hard-block: a question blocked after assignment (cron re-vet,
+              // upheld report) must not resurface in catch-up.
+              notBlocked(),
+              // AUTHORSHIP-EXCLUSION INVARIANT (B-CRAFTER-LIFECYCLE-01 Phase 3):
+              // never serve the viewer their own authored question. Structurally
+              // catch-up replays the viewer's own assigned slots (you aren't
+              // assigned your own questions), but with player authoring live the
+              // explicit predicate is load-bearing. NULL creators (house/LLM)
+              // must still pass — hence the isNull arm.
+              or(isNull(canonicalQuestions.creatorId), ne(canonicalQuestions.creatorId, userId)),
+            ),
+          )
+      : Promise.resolve<(typeof canonicalQuestions.$inferSelect)[]>([]),
   ]);
   const generatedById = new Map(generatedRows.map((question) => [question.id, question]));
   const canonicalById = new Map(canonicalRows.map((question) => [question.id, question]));
@@ -853,16 +923,22 @@ async function getDailyCatchupItems(
       if (!slot.question_id) return null;
       const question = canonicalById.get(slot.question_id);
       if (!question || question.deletedAt) return null;
-      const domain = slot.domain || question.canonicalSubcategory || question.broadCategory || question.category;
+      const domain =
+        slot.domain || question.canonicalSubcategory || question.broadCategory || question.category;
       if (!domain || isGenericSubcategory(domain)) return null;
-      const difficulty = asQueueSlotDifficulty(
-        question.calibratedDifficulty ?? question.llmDifficulty ?? question.difficultyEstimate ?? null,
-      ) ?? null;
-      const explanation = question.explainerFullWrong
-        ?? question.explainerFull
-        ?? question.explainerBrief
-        ?? question.factualExplanation
-        ?? null;
+      const difficulty =
+        asQueueSlotDifficulty(
+          question.calibratedDifficulty ??
+            question.llmDifficulty ??
+            question.difficultyEstimate ??
+            null,
+        ) ?? null;
+      const explanation =
+        question.explainerFullWrong ??
+        question.explainerFull ??
+        question.explainerBrief ??
+        question.factualExplanation ??
+        null;
       return {
         dailyQueueItemId: dailyQueueItemId(queue.id, slot.slot_index),
         surface: 'daily',
@@ -888,7 +964,11 @@ async function getDailyCatchupItems(
         wasSkipped: Boolean(slot.skipped),
         questionType: question.questionType,
         authorId: question.creatorId ?? null,
-        ...resolveAuthorDisplay(question.creatorId, question.source, question.creatorId ? authorNameById.get(question.creatorId) ?? null : null),
+        ...resolveAuthorDisplay(
+          question.creatorId,
+          question.source,
+          question.creatorId ? (authorNameById.get(question.creatorId) ?? null) : null,
+        ),
         reportTarget: { questionId: slot.question_id },
       } satisfies CatchupQuestion;
     })
@@ -905,26 +985,31 @@ async function getFeedCatchupItems(
   const oldestDate = new Date(`${assignmentDateStr}T00:00:00.000Z`);
   oldestDate.setUTCDate(oldestDate.getUTCDate() - CATCHUP_LOOKBACK_DAYS);
 
-  let rows: Array<{ feedItem: typeof feedItems.$inferSelect; question: typeof canonicalQuestions.$inferSelect }>;
+  let rows: Array<{
+    feedItem: typeof feedItems.$inferSelect;
+    question: typeof canonicalQuestions.$inferSelect;
+  }>;
   try {
     rows = await db
       .select({ feedItem: feedItems, question: canonicalQuestions })
       .from(feedItems)
       .innerJoin(canonicalQuestions, eq(feedItems.questionId, canonicalQuestions.id))
-      .where(and(
-        eq(feedItems.recipientUserId, userId),
-        eq(feedItems.state, 'answered'),
-        eq(feedItems.answerResult, 'incorrect'),
-        isNull(feedItems.catchupResolvedAt),
-        gte(feedItems.sourceEventAt, oldestDate),
-        // Safety hard-block: a question blocked after the original answer
-        // (cron re-vet, upheld report) must not resurface in catch-up.
-        ne(canonicalQuestions.visibility, 'blocked'),
-        // AUTHORSHIP-EXCLUSION INVARIANT (B-CRAFTER-LIFECYCLE-01 Phase 3):
-        // never serve the viewer their own authored question, even via a feed
-        // replay. NULL creators (house/LLM) still pass.
-        or(isNull(canonicalQuestions.creatorId), ne(canonicalQuestions.creatorId, userId)),
-      ))
+      .where(
+        and(
+          eq(feedItems.recipientUserId, userId),
+          eq(feedItems.state, 'answered'),
+          eq(feedItems.answerResult, 'incorrect'),
+          isNull(feedItems.catchupResolvedAt),
+          gte(feedItems.sourceEventAt, oldestDate),
+          // Safety hard-block: a question blocked after the original answer
+          // (cron re-vet, upheld report) must not resurface in catch-up.
+          ne(canonicalQuestions.visibility, 'blocked'),
+          // AUTHORSHIP-EXCLUSION INVARIANT (B-CRAFTER-LIFECYCLE-01 Phase 3):
+          // never serve the viewer their own authored question, even via a feed
+          // replay. NULL creators (house/LLM) still pass.
+          or(isNull(canonicalQuestions.creatorId), ne(canonicalQuestions.creatorId, userId)),
+        ),
+      )
       .orderBy(desc(feedItems.sourceEventAt));
   } catch (error) {
     // catchupResolvedAt is added by migration 0038; tolerate a brief window
@@ -943,15 +1028,20 @@ async function getFeedCatchupItems(
       if (!domain || isGenericSubcategory(domain)) return null;
       const queueDate = feedItem.sourceEventAt.toISOString().slice(0, 10);
       const expiresAt = catchUpExpiresAt(queueDate);
-      const difficulty = asQueueSlotDifficulty(
-        question.calibratedDifficulty ?? question.llmDifficulty ?? question.difficultyEstimate ?? null,
-      ) ?? null;
+      const difficulty =
+        asQueueSlotDifficulty(
+          question.calibratedDifficulty ??
+            question.llmDifficulty ??
+            question.difficultyEstimate ??
+            null,
+        ) ?? null;
       const basePoints = getBasePoints(difficulty, 'first_correct');
-      const explanation = question.explainerFullWrong
-        ?? question.explainerFull
-        ?? question.explainerBrief
-        ?? question.factualExplanation
-        ?? null;
+      const explanation =
+        question.explainerFullWrong ??
+        question.explainerFull ??
+        question.explainerBrief ??
+        question.factualExplanation ??
+        null;
       return {
         dailyQueueItemId: feedCatchupItemId(feedItem.id),
         surface: 'feed',
@@ -976,7 +1066,11 @@ async function getFeedCatchupItems(
         wasSkipped: false,
         questionType: question.questionType,
         authorId: question.creatorId ?? null,
-        ...resolveAuthorDisplay(question.creatorId, question.source, question.creatorId ? authorNameById.get(question.creatorId) ?? null : null),
+        ...resolveAuthorDisplay(
+          question.creatorId,
+          question.source,
+          question.creatorId ? (authorNameById.get(question.creatorId) ?? null) : null,
+        ),
         reportTarget: { questionId: question.id },
       } satisfies CatchupQuestion;
     })
@@ -1022,11 +1116,13 @@ export async function createDailyQueueItem(
   const [question] = await db
     .select()
     .from(generatedQuestions)
-    .where(and(
-      eq(generatedQuestions.id, generatedQuestionId),
-      eq(generatedQuestions.userId, userId),
-      isNotNull(generatedQuestions.id),
-    ))
+    .where(
+      and(
+        eq(generatedQuestions.id, generatedQuestionId),
+        eq(generatedQuestions.userId, userId),
+        isNotNull(generatedQuestions.id),
+      ),
+    )
     .limit(1);
 
   if (!question) {
@@ -1195,11 +1291,13 @@ export async function createDailyQueueItemFromPresence(
   const [question] = await db
     .select()
     .from(generatedQuestions)
-    .where(and(
-      eq(generatedQuestions.id, generatedQuestionId),
-      eq(generatedQuestions.userId, userId),
-      isNotNull(generatedQuestions.id),
-    ))
+    .where(
+      and(
+        eq(generatedQuestions.id, generatedQuestionId),
+        eq(generatedQuestions.userId, userId),
+        isNotNull(generatedQuestions.id),
+      ),
+    )
     .limit(1);
 
   if (!question) {
@@ -1332,18 +1430,17 @@ export async function pickEligibleAuthoredQuestions(
     db
       .select({ questionId: masteryEvents.questionId })
       .from(masteryEvents)
-      .where(and(
-        eq(masteryEvents.userId, viewerUserId),
-        inArray(masteryEvents.sourceType, ['live_correct', 'catchup_correct']),
-        isNotNull(masteryEvents.questionId),
-      )),
+      .where(
+        and(
+          eq(masteryEvents.userId, viewerUserId),
+          inArray(masteryEvents.sourceType, ['live_correct', 'catchup_correct']),
+          isNotNull(masteryEvents.questionId),
+        ),
+      ),
     db
       .select({ questionId: feedItems.questionId })
       .from(feedItems)
-      .where(and(
-        eq(feedItems.recipientUserId, viewerUserId),
-        isNotNull(feedItems.questionId),
-      )),
+      .where(and(eq(feedItems.recipientUserId, viewerUserId), isNotNull(feedItems.questionId))),
   ]);
   const seenQuestionIds = new Set<string>();
   for (const row of pastQueues) {
@@ -1381,20 +1478,19 @@ export async function pickEligibleAuthoredQuestions(
       createdAt: canonicalQuestions.createdAt,
     })
     .from(canonicalQuestions)
-    .where(and(
-      eq(canonicalQuestions.publicStatus, 'eligible_pending'),
-      eq(canonicalQuestions.visibility, 'public'),
-      isNotNull(canonicalQuestions.creatorId),
-      isNotNull(canonicalQuestions.canonicalSubcategory),
-      inArray(canonicalQuestions.canonicalSubcategory, [...allowedSubcategories]),
-      isNull(canonicalQuestions.deletedAt),
-      // B-Report-3: never draw a reported question into a new daily queue.
-      notSuppressedByContentReport(canonicalQuestions.id, 'question'),
-    ))
-    .orderBy(
-      desc(canonicalQuestions.publicEligibilityScore),
-      desc(canonicalQuestions.createdAt),
+    .where(
+      and(
+        eq(canonicalQuestions.publicStatus, 'eligible_pending'),
+        eq(canonicalQuestions.visibility, 'public'),
+        isNotNull(canonicalQuestions.creatorId),
+        isNotNull(canonicalQuestions.canonicalSubcategory),
+        inArray(canonicalQuestions.canonicalSubcategory, [...allowedSubcategories]),
+        isNull(canonicalQuestions.deletedAt),
+        // B-Report-3: never draw a reported question into a new daily queue.
+        notSuppressedByContentReport(canonicalQuestions.id, 'question'),
+      ),
     )
+    .orderBy(desc(canonicalQuestions.publicEligibilityScore), desc(canonicalQuestions.createdAt))
     .limit(overFetch);
 
   // Tier-gate (B4 Phase 3): friend-facing requires human_validated|author_confirmed.
@@ -1433,28 +1529,33 @@ export async function pickEligibleAuthoredQuestions(
   if (filtered.length === 0) return [];
 
   // Hydrate author display names in one shot.
-  const authorIds = [...new Set(filtered.map((c) => c.row.creatorId).filter((id): id is string => Boolean(id)))];
+  const authorIds = [
+    ...new Set(filtered.map((c) => c.row.creatorId).filter((id): id is string => Boolean(id))),
+  ];
   const authorRows = await db
     .select({ id: users.id, displayName: users.displayName })
     .from(users)
     .where(inArray(users.id, authorIds));
   const nameById = new Map(authorRows.map((u) => [u.id, u.displayName] as const));
 
-  return filtered.map(({ row }) => ({
-    id: row.id,
-    creatorId: row.creatorId,
-    questionText: row.questionText,
-    answerText: row.answerText,
-    alternateAnswers: row.alternateAnswers ?? [],
-    factualExplanation: row.factualExplanation,
-    canonicalSubcategory: row.canonicalSubcategory ?? '',
-    broadCategory: row.broadCategory,
-    category: String(row.category ?? ''),
-    difficultyEstimate: asQueueSlotDifficulty(row.difficultyEstimate ?? null) ?? null,
-    subjectEntity: row.subjectEntity ?? null,
-    authorName: row.creatorId ? nameById.get(row.creatorId) ?? null : null,
-    authorNote: row.creatorNote ?? null,
-  } satisfies AuthoredPick));
+  return filtered.map(
+    ({ row }) =>
+      ({
+        id: row.id,
+        creatorId: row.creatorId,
+        questionText: row.questionText,
+        answerText: row.answerText,
+        alternateAnswers: row.alternateAnswers ?? [],
+        factualExplanation: row.factualExplanation,
+        canonicalSubcategory: row.canonicalSubcategory ?? '',
+        broadCategory: row.broadCategory,
+        category: String(row.category ?? ''),
+        difficultyEstimate: asQueueSlotDifficulty(row.difficultyEstimate ?? null) ?? null,
+        subjectEntity: row.subjectEntity ?? null,
+        authorName: row.creatorId ? (nameById.get(row.creatorId) ?? null) : null,
+        authorNote: row.creatorNote ?? null,
+      }) satisfies AuthoredPick,
+  );
 }
 
 /**
@@ -1519,15 +1620,16 @@ export function buildReturnSlot(
     generated_question_id: isCanonical ? undefined : question.id,
     // LLM-origin questions have no human author; the client renders its own
     // non-person attribution for those rather than implying someone wrote it.
-    author_id: isCanonical ? question.creatorId ?? undefined : undefined,
-    author_name: isCanonical ? question.authorName ?? null : null,
-    author_note: isCanonical ? question.creatorNote ?? null : null,
+    author_id: isCanonical ? (question.creatorId ?? undefined) : undefined,
+    author_name: isCanonical ? (question.authorName ?? null) : null,
+    author_note: isCanonical ? (question.creatorNote ?? null) : null,
     return_scope: candidate.scope,
     return_last_seen_at: candidate.lastSeenAt.toISOString(),
     // 1-based: the return the player is about to see. Expired first appearances
     // stay at 0 + 1 = 1 but never advance the stored count (§2).
     return_count: candidate.returnCount + 1,
-    domain: question.canonicalSubcategory ?? question.broadCategory ?? question.category ?? 'general',
+    domain:
+      question.canonicalSubcategory ?? question.broadCategory ?? question.category ?? 'general',
     broad_category: question.broadCategory ?? null,
     category: question.category || null,
     question_text: question.questionText,
@@ -1622,19 +1724,22 @@ export function selectHousePicks(
     .filter((row) => row.canonicalSubcategory && !isGenericSubcategory(row.canonicalSubcategory))
     .sort((a, b) => (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0))
     .slice(0, limit)
-    .map((row) => ({
-      id: row.id,
-      questionText: row.questionText,
-      answerText: row.answerText,
-      alternateAnswers: row.alternateAnswers ?? [],
-      factualExplanation: row.factualExplanation,
-      canonicalSubcategory: row.canonicalSubcategory ?? '',
-      broadCategory: row.broadCategory,
-      category: String(row.category ?? ''),
-      difficultyEstimate: asQueueSlotDifficulty(row.difficultyEstimate ?? null) ?? null,
-      subjectEntity: row.subjectEntity ?? null,
-      authorNote: row.creatorNote ?? null,
-    } satisfies HousePick));
+    .map(
+      (row) =>
+        ({
+          id: row.id,
+          questionText: row.questionText,
+          answerText: row.answerText,
+          alternateAnswers: row.alternateAnswers ?? [],
+          factualExplanation: row.factualExplanation,
+          canonicalSubcategory: row.canonicalSubcategory ?? '',
+          broadCategory: row.broadCategory,
+          category: String(row.category ?? ''),
+          difficultyEstimate: asQueueSlotDifficulty(row.difficultyEstimate ?? null) ?? null,
+          subjectEntity: row.subjectEntity ?? null,
+          authorNote: row.creatorNote ?? null,
+        }) satisfies HousePick,
+    );
 }
 
 /**
@@ -1668,11 +1773,13 @@ export async function pickHouseQuestions(
     db
       .select({ questionId: masteryEvents.questionId })
       .from(masteryEvents)
-      .where(and(
-        eq(masteryEvents.userId, viewerUserId),
-        inArray(masteryEvents.sourceType, ['live_correct', 'catchup_correct']),
-        isNotNull(masteryEvents.questionId),
-      )),
+      .where(
+        and(
+          eq(masteryEvents.userId, viewerUserId),
+          inArray(masteryEvents.sourceType, ['live_correct', 'catchup_correct']),
+          isNotNull(masteryEvents.questionId),
+        ),
+      ),
   ]);
   const seenQuestionIds = new Set<string>();
   for (const row of pastQueues) {
@@ -1701,16 +1808,18 @@ export async function pickHouseQuestions(
       createdAt: canonicalQuestions.createdAt,
     })
     .from(canonicalQuestions)
-    .where(and(
-      eq(canonicalQuestions.source, 'house_authored'),
-      isNull(canonicalQuestions.creatorId),
-      eq(canonicalQuestions.visibility, 'public'),
-      isNotNull(canonicalQuestions.canonicalSubcategory),
-      inArray(canonicalQuestions.canonicalSubcategory, [...allowedSubcategories]),
-      isNull(canonicalQuestions.deletedAt),
-      // B-Report-3: a reported house question is suppressed from new queues too.
-      notSuppressedByContentReport(canonicalQuestions.id, 'question'),
-    ))
+    .where(
+      and(
+        eq(canonicalQuestions.source, 'house_authored'),
+        isNull(canonicalQuestions.creatorId),
+        eq(canonicalQuestions.visibility, 'public'),
+        isNotNull(canonicalQuestions.canonicalSubcategory),
+        inArray(canonicalQuestions.canonicalSubcategory, [...allowedSubcategories]),
+        isNull(canonicalQuestions.deletedAt),
+        // B-Report-3: a reported house question is suppressed from new queues too.
+        notSuppressedByContentReport(canonicalQuestions.id, 'question'),
+      ),
+    )
     .orderBy(desc(canonicalQuestions.createdAt))
     .limit(Math.max(limit * 4, 20));
 
@@ -1953,7 +2062,8 @@ export function rankAndFilterBankCandidates<
   }
   // Array.prototype.sort is stable, so equal-rank rows keep their shuffled order.
   ranked.sort(
-    (a, b) => (TRUST_RANK[b.trustTier as TrustTier] ?? 0) - (TRUST_RANK[a.trustTier as TrustTier] ?? 0),
+    (a, b) =>
+      (TRUST_RANK[b.trustTier as TrustTier] ?? 0) - (TRUST_RANK[a.trustTier as TrustTier] ?? 0),
   );
   return { ranked, dudsExcluded };
 }
@@ -1983,10 +2093,7 @@ export async function pickBankSource(
   const viewerClause = isBankIncludeOwnUnusedEnabled()
     ? or(
         sql`${generatedQuestions.userId} <> ${userId}`,
-        and(
-          eq(generatedQuestions.userId, userId),
-          eq(generatedQuestions.usedInQueue, false),
-        ),
+        and(eq(generatedQuestions.userId, userId), eq(generatedQuestions.usedInQueue, false)),
       )
     : sql`${generatedQuestions.userId} <> ${userId}`;
 
@@ -1995,37 +2102,39 @@ export async function pickBankSource(
     candidates = await db
       .select()
       .from(generatedQuestions)
-      .where(and(
-        // BP-7 / C5: match on the folded domain_key (written by domainKey() at
-        // every pool insert) so spelling variants of one domain share stock —
-        // with the legacy exact-string predicate as the fallback for rows that
-        // pre-date the 0074 backfill. No age predicate: the pool is durable
-        // (D8) — recency only biases the window below, it never excludes.
-        or(
-          eq(generatedQuestions.domainKey, domainKey(domain)),
-          eq(generatedQuestions.canonicalSubcategory, domain),
-        ),
-        eq(generatedQuestions.difficultyEstimate, difficulty),
-        isNotNull(generatedQuestions.factKey),
-        viewerClause,
-        eq(generatedQuestions.isDuplicate, false),
-        // B-Report-3: skip generated questions under an open/upheld report.
-        notSuppressedByContentReport(generatedQuestions.id, 'generated'),
-        // Full-set dedup (D-SUPPLY-NEVER-REPEAT-01): exclude ANY row whose fact
-        // the viewer has already answered, on any surface, however long ago —
-        // the MASTERY_EVENTS → canonical-twin → fact_key bridge, enforced in
-        // SQL so it cannot be capped. The in-memory avoidFactKeys set below
-        // still covers same-build/batch avoidance, but it is built from the
-        // recency-limited getRecentFactKeys (200) and a 445-fact history
-        // already overflows it — this clause is the uncapped guarantee.
-        sql`NOT EXISTS (
+      .where(
+        and(
+          // BP-7 / C5: match on the folded domain_key (written by domainKey() at
+          // every pool insert) so spelling variants of one domain share stock —
+          // with the legacy exact-string predicate as the fallback for rows that
+          // pre-date the 0074 backfill. No age predicate: the pool is durable
+          // (D8) — recency only biases the window below, it never excludes.
+          or(
+            eq(generatedQuestions.domainKey, domainKey(domain)),
+            eq(generatedQuestions.canonicalSubcategory, domain),
+          ),
+          eq(generatedQuestions.difficultyEstimate, difficulty),
+          isNotNull(generatedQuestions.factKey),
+          viewerClause,
+          eq(generatedQuestions.isDuplicate, false),
+          // B-Report-3: skip generated questions under an open/upheld report.
+          notSuppressedByContentReport(generatedQuestions.id, 'generated'),
+          // Full-set dedup (D-SUPPLY-NEVER-REPEAT-01): exclude ANY row whose fact
+          // the viewer has already answered, on any surface, however long ago —
+          // the MASTERY_EVENTS → canonical-twin → fact_key bridge, enforced in
+          // SQL so it cannot be capped. The in-memory avoidFactKeys set below
+          // still covers same-build/batch avoidance, but it is built from the
+          // recency-limited getRecentFactKeys (200) and a 445-fact history
+          // already overflows it — this clause is the uncapped guarantee.
+          sql`NOT EXISTS (
           SELECT 1 FROM "MASTERY_EVENTS" me
           JOIN "Question" cq ON me.question_id = cq.id
           JOIN "GeneratedQuestion" agq ON cq.generated_question_id = agq.id
           WHERE me.answered_by_user_id = ${userId}
             AND agq.fact_key = ${generatedQuestions.factKey}
         )`,
-      ))
+        ),
+      )
       .orderBy(desc(generatedQuestions.createdAt))
       .limit(BANK_RECENCY_WINDOW);
   } catch (error) {
@@ -2109,10 +2218,7 @@ export async function getRecentDomainCounts(
       count: sql<number>`count(*)::int`,
     })
     .from(generatedQuestions)
-    .where(and(
-      eq(generatedQuestions.userId, userId),
-      gte(generatedQuestions.createdAt, since),
-    ))
+    .where(and(eq(generatedQuestions.userId, userId), gte(generatedQuestions.createdAt, since)))
     .groupBy(generatedQuestions.canonicalSubcategory);
 
   // SQL groups by the raw column, so two spelling variants arrive as separate
@@ -2269,13 +2375,15 @@ export async function getRecentAnsweredCanonicalTexts(
     })
     .from(masteryEvents)
     .innerJoin(canonicalQuestions, eq(masteryEvents.questionId, canonicalQuestions.id))
-    .where(and(
-      eq(masteryEvents.answeredByUserId, userId),
-      isNotNull(masteryEvents.questionId),
-      gte(masteryEvents.createdAt, since),
-      sql`${canonicalQuestions.source} <> 'daily_generated'`,
-      isNull(canonicalQuestions.deletedAt),
-    ))
+    .where(
+      and(
+        eq(masteryEvents.answeredByUserId, userId),
+        isNotNull(masteryEvents.questionId),
+        gte(masteryEvents.createdAt, since),
+        sql`${canonicalQuestions.source} <> 'daily_generated'`,
+        isNull(canonicalQuestions.deletedAt),
+      ),
+    )
     .orderBy(desc(masteryEvents.createdAt))
     .limit(limit);
 
@@ -2311,10 +2419,9 @@ export async function getRecentSkipCountsByDomain(
       count: sql<number>`count(*)::int`,
     })
     .from(skippedDailyQuestions)
-    .where(and(
-      eq(skippedDailyQuestions.userId, userId),
-      gte(skippedDailyQuestions.skippedAt, since),
-    ))
+    .where(
+      and(eq(skippedDailyQuestions.userId, userId), gte(skippedDailyQuestions.skippedAt, since)),
+    )
     .groupBy(skippedDailyQuestions.canonicalSubcategory);
 
   const result = new Map<string, number>();
@@ -2349,10 +2456,12 @@ export async function getRecentSubAnglesByDomain(
         subAngles: generatedQuestions.subAngles,
       })
       .from(generatedQuestions)
-      .where(and(
-        eq(generatedQuestions.userId, userId),
-        inArray(generatedQuestions.canonicalSubcategory, domains),
-      ))
+      .where(
+        and(
+          eq(generatedQuestions.userId, userId),
+          inArray(generatedQuestions.canonicalSubcategory, domains),
+        ),
+      )
       .orderBy(sql`${generatedQuestions.createdAt} desc`)
       .limit(rowLimit);
   } catch (error) {
@@ -2426,10 +2535,7 @@ export async function getRecentFactKeys(
         generatedQuestions,
         eq(canonicalQuestions.generatedQuestionId, generatedQuestions.id),
       )
-      .where(and(
-        eq(masteryEvents.answeredByUserId, userId),
-        isNotNull(generatedQuestions.factKey),
-      ))
+      .where(and(eq(masteryEvents.answeredByUserId, userId), isNotNull(generatedQuestions.factKey)))
       .orderBy(sql`${masteryEvents.createdAt} desc`)
       .limit(limit),
     db
@@ -2438,10 +2544,7 @@ export async function getRecentFactKeys(
         domain: generatedQuestions.canonicalSubcategory,
       })
       .from(generatedQuestions)
-      .where(and(
-        eq(generatedQuestions.userId, userId),
-        isNotNull(generatedQuestions.factKey),
-      ))
+      .where(and(eq(generatedQuestions.userId, userId), isNotNull(generatedQuestions.factKey)))
       .orderBy(sql`${generatedQuestions.createdAt} desc`)
       .limit(limit),
   ]);
@@ -2481,10 +2584,9 @@ export async function getAnsweredFactKeysAmong(
       generatedQuestions,
       eq(canonicalQuestions.generatedQuestionId, generatedQuestions.id),
     )
-    .where(and(
-      eq(masteryEvents.answeredByUserId, userId),
-      inArray(generatedQuestions.factKey, keys),
-    ));
+    .where(
+      and(eq(masteryEvents.answeredByUserId, userId), inArray(generatedQuestions.factKey, keys)),
+    );
   return new Set(rows.map((row) => row.factKey).filter((key): key is string => Boolean(key)));
 }
 
@@ -2510,23 +2612,25 @@ export async function countServeableOwnBankStock(
       count: sql<number>`count(*)::int`,
     })
     .from(generatedQuestions)
-    .where(and(
-      eq(generatedQuestions.userId, userId),
-      eq(generatedQuestions.usedInQueue, false),
-      eq(generatedQuestions.isDuplicate, false),
-      isNotNull(generatedQuestions.factKey),
-      or(
-        inArray(generatedQuestions.domainKey, keys),
-        inArray(generatedQuestions.canonicalSubcategory, domains),
-      ),
-      sql`NOT EXISTS (
+    .where(
+      and(
+        eq(generatedQuestions.userId, userId),
+        eq(generatedQuestions.usedInQueue, false),
+        eq(generatedQuestions.isDuplicate, false),
+        isNotNull(generatedQuestions.factKey),
+        or(
+          inArray(generatedQuestions.domainKey, keys),
+          inArray(generatedQuestions.canonicalSubcategory, domains),
+        ),
+        sql`NOT EXISTS (
         SELECT 1 FROM "MASTERY_EVENTS" me
         JOIN "Question" cq ON me.question_id = cq.id
         JOIN "GeneratedQuestion" agq ON cq.generated_question_id = agq.id
         WHERE me.answered_by_user_id = ${userId}
           AND agq.fact_key = ${generatedQuestions.factKey}
       )`,
-    ))
+      ),
+    )
     .groupBy(generatedQuestions.canonicalSubcategory);
   const out = new Map<string, number>();
   for (const row of rows) {
@@ -2555,10 +2659,7 @@ export async function getAuthoredQuestionTexts(
       domain: canonicalQuestions.canonicalSubcategory,
     })
     .from(canonicalQuestions)
-    .where(and(
-      eq(canonicalQuestions.creatorId, userId),
-      isNull(canonicalQuestions.deletedAt),
-    ))
+    .where(and(eq(canonicalQuestions.creatorId, userId), isNull(canonicalQuestions.deletedAt)))
     .orderBy(desc(canonicalQuestions.createdAt))
     .limit(limit);
 
@@ -2594,12 +2695,14 @@ export async function getAuthoredExamplesForDomains(
       answerText: canonicalQuestions.answerText,
     })
     .from(canonicalQuestions)
-    .where(and(
-      inArray(canonicalQuestions.canonicalSubcategory, [...domains]),
-      inArray(canonicalQuestions.creatorId, [...authorIds]),
-      isNull(canonicalQuestions.deletedAt),
-      ne(canonicalQuestions.visibility, 'blocked'),
-    ))
+    .where(
+      and(
+        inArray(canonicalQuestions.canonicalSubcategory, [...domains]),
+        inArray(canonicalQuestions.creatorId, [...authorIds]),
+        isNull(canonicalQuestions.deletedAt),
+        ne(canonicalQuestions.visibility, 'blocked'),
+      ),
+    )
     .orderBy(desc(canonicalQuestions.createdAt));
 
   for (const row of rows) {
@@ -2624,11 +2727,13 @@ export async function getKBDomainEntry(userId: string, domain: string) {
   const [row] = await db
     .select()
     .from(declaredInterests)
-    .where(and(
-      eq(declaredInterests.userId, userId),
-      eq(declaredInterests.domain, domain),
-      eq(declaredInterests.isActive, true),
-    ))
+    .where(
+      and(
+        eq(declaredInterests.userId, userId),
+        eq(declaredInterests.domain, domain),
+        eq(declaredInterests.isActive, true),
+      ),
+    )
     .limit(1);
 
   return row ?? null;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -20,9 +20,14 @@ import {
   vector,
 } from 'drizzle-orm/pg-core';
 
-const id = (name = 'id') => text(name).primaryKey().default(sql`gen_random_uuid()::text`);
-const createdAt = (name = 'created_at') => timestamp(name, { withTimezone: true }).notNull().defaultNow();
-const updatedAt = (name = 'updated_at') => timestamp(name, { withTimezone: true }).notNull().defaultNow();
+const id = (name = 'id') =>
+  text(name)
+    .primaryKey()
+    .default(sql`gen_random_uuid()::text`);
+const createdAt = (name = 'created_at') =>
+  timestamp(name, { withTimezone: true }).notNull().defaultNow();
+const updatedAt = (name = 'updated_at') =>
+  timestamp(name, { withTimezone: true }).notNull().defaultNow();
 const textArrayDefault = sql`ARRAY[]::text[]`;
 
 export const categoryEnum = pgEnum('Category', [
@@ -41,7 +46,12 @@ export const categoryEnum = pgEnum('Category', [
 // 'blocked' is a safety hard-block terminal state (see verdictToBlockedVisibility):
 // a question that failed the safety vet. It is NOT user-selectable and is excluded
 // by questionVisibilityPredicate and every bank/send/game read path.
-export const questionVisibilityEnum = pgEnum('QuestionVisibility', ['private', 'public', 'friends', 'blocked']);
+export const questionVisibilityEnum = pgEnum('QuestionVisibility', [
+  'private',
+  'public',
+  'friends',
+  'blocked',
+]);
 
 // B1 pool substrate (PRD-D-5 §5.1 / §6). Trust climbs as a question earns it:
 // unverified (fresh, pre-checks) → machine_verified (retrieval + ask-to-answer,
@@ -80,7 +90,11 @@ export const publicStatusEnum = pgEnum('PublicStatus', [
   // ALTER TYPE ... ADD VALUE ordering in the migration.
   'needs_review',
 ]);
-export const answerSourceEnum = pgEnum('AnswerSource', ['llm_suggested', 'creator_written', 'llm_edited']);
+export const answerSourceEnum = pgEnum('AnswerSource', [
+  'llm_suggested',
+  'creator_written',
+  'llm_edited',
+]);
 export const questionStatusEnum = pgEnum('QuestionStatus', ['verified', 'unverified']);
 // B-QUESTION-QUALITY-AGENTS-01 — outcome of the batch verification sweep, stamped
 // on BOTH Question and GeneratedQuestion. `demoted` = a wrong answer / false
@@ -192,8 +206,17 @@ export const themePreferenceEnum = pgEnum('ThemePreference', [
   'sunday_margins',
   'parlor_index',
 ]);
-export const subscriptionPlanEnum = pgEnum('SubscriptionPlan', ['free', 'plus_monthly', 'plus_yearly']);
-export const masteryTierEnum = pgEnum('MasteryTier', ['establishing', 'familiar', 'solid', 'mastery']);
+export const subscriptionPlanEnum = pgEnum('SubscriptionPlan', [
+  'free',
+  'plus_monthly',
+  'plus_yearly',
+]);
+export const masteryTierEnum = pgEnum('MasteryTier', [
+  'establishing',
+  'familiar',
+  'solid',
+  'mastery',
+]);
 export const domainExclusionScopeEnum = pgEnum('DomainExclusionScope', [
   'subcategory',
   'broad_category',
@@ -236,6 +259,10 @@ export const users = pgTable(
     subscriptionPlan: subscriptionPlanEnum('subscription_plan').notNull().default('free'),
     smsOptIn: smsOptInEnum('sms_opt_in').notNull().default('not_asked'),
     smsReminderTime: integer('sms_reminder_time'),
+    smsOptInAt: timestamp('sms_opt_in_at', { withTimezone: true }),
+    smsOptOutAt: timestamp('sms_opt_out_at', { withTimezone: true }),
+    smsConsentSource: text('sms_consent_source'),
+    smsConsentPolicyVersion: text('sms_consent_policy_version'),
     emailOptIn: emailOptInEnum('email_opt_in').notNull().default('not_asked'),
     emailVerified: boolean('email_verified').notNull().default(false),
     pendingEmail: text('pending_email'),
@@ -246,10 +273,14 @@ export const users = pgTable(
     // the interstitial is "not now", not "never" — it must not retire the
     // standing inline RoundReminderCard, so it cannot share that column.
     reminderInterstitialSeenAt: timestamp('reminder_interstitial_seen_at', { withTimezone: true }),
-    areaTopUpPromptDismissedAt: timestamp('area_top_up_prompt_dismissed_at', { withTimezone: true }),
+    areaTopUpPromptDismissedAt: timestamp('area_top_up_prompt_dismissed_at', {
+      withTimezone: true,
+    }),
     lastActivityBellOpenedAt: timestamp('last_activity_bell_opened_at', { withTimezone: true }),
     knowledgeCardShareToken: text('knowledge_card_share_token'),
-    knowledgeCardShareExpiresAt: timestamp('knowledge_card_share_expires_at', { withTimezone: true }),
+    knowledgeCardShareExpiresAt: timestamp('knowledge_card_share_expires_at', {
+      withTimezone: true,
+    }),
     slug: text('slug'),
     handle: text('handle'),
     handleLastChangedAt: timestamp('handle_last_changed_at', { withTimezone: true }),
@@ -303,7 +334,9 @@ export const userSessions = pgTable(
   'UserSession',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     token: text('token').notNull(),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     createdAt: createdAt(),
@@ -332,7 +365,9 @@ export const questions = pgTable(
   {
     id: id(),
     creatorId: text('creator_id').references(() => users.id),
-    generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id, { onDelete: 'set null' }),
+    generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id, {
+      onDelete: 'set null',
+    }),
     source: text('source').$type<QuestionSource>().notNull().default('authored'),
     sourceQuestionId: text('source_question_id'),
     sourceCreatorId: text('source_creator_id'),
@@ -457,7 +492,9 @@ export const questionAudienceTags = pgTable(
   'QuestionAudienceTag',
   {
     id: id(),
-    questionId: text('question_id').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    questionId: text('question_id')
+      .notNull()
+      .references(() => questions.id, { onDelete: 'cascade' }),
     creatorId: text('creator_id').notNull(),
     tag: text('tag').notNull(),
     createdAt: createdAt(),
@@ -472,10 +509,16 @@ export const userQuestionBank = pgTable(
   'UserQuestionBank',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
-    questionId: text('question_id').notNull().references(() => questions.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    questionId: text('question_id')
+      .notNull()
+      .references(() => questions.id),
     addedAt: timestamp('added_at', { withTimezone: true }).notNull().defaultNow(),
-    addedFromContextType: text('added_from_context_type').$type<'feed' | 'joshing_game' | 'manual'>(),
+    addedFromContextType: text('added_from_context_type').$type<
+      'feed' | 'joshing_game' | 'manual'
+    >(),
     addedFromContextId: text('added_from_context_id'),
   },
   (table) => [
@@ -493,7 +536,9 @@ export const playerMastery = pgTable(
   'PLAYER_MASTERY',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     canonicalSubcategory: text('canonical_subcategory').notNull(),
     broadCategory: text('broad_category'),
     totalPoints: doublePrecision('total_points').notNull().default(0),
@@ -515,12 +560,14 @@ export const playerMastery = pgTable(
     updatedAt: updatedAt(),
   },
   (table) => [
-    unique('PLAYER_MASTERY_user_id_canonical_subcategory_key').on(table.userId, table.canonicalSubcategory),
+    unique('PLAYER_MASTERY_user_id_canonical_subcategory_key').on(
+      table.userId,
+      table.canonicalSubcategory,
+    ),
     index('PLAYER_MASTERY_user_id_idx').on(table.userId),
     index('PLAYER_MASTERY_canonical_subcategory_idx').on(table.canonicalSubcategory),
   ],
 );
-
 
 // Generic per-user-per-day usage counter for rate-limited, on-demand LLM
 // endpoints (answer suggestion, verify-answer, crafter drafting, critique,
@@ -532,15 +579,25 @@ export const llmUsageDaily = pgTable(
   'LlmUsageDaily',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     usageDate: date('usage_date').notNull(),
     action: text('action').notNull(),
     count: integer('count').notNull().default(0),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    unique('LlmUsageDaily_user_id_usage_date_action_key').on(table.userId, table.usageDate, table.action),
-    index('LlmUsageDaily_user_id_usage_date_action_idx').on(table.userId, table.usageDate, table.action),
+    unique('LlmUsageDaily_user_id_usage_date_action_key').on(
+      table.userId,
+      table.usageDate,
+      table.action,
+    ),
+    index('LlmUsageDaily_user_id_usage_date_action_idx').on(
+      table.userId,
+      table.usageDate,
+      table.action,
+    ),
   ],
 );
 
@@ -548,7 +605,9 @@ export const masteryEvents = pgTable(
   'MASTERY_EVENTS',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     canonicalSubcategory: text('canonical_subcategory').notNull(),
     sourceType: masterySourceTypeEnum('source_type').notNull(),
     questionId: text('question_id').references(() => questions.id),
@@ -609,9 +668,15 @@ export const questionReactions = pgTable(
   'QuestionReaction',
   {
     id: id(),
-    senderUserId: text('senderUserId').notNull().references(() => users.id),
-    recipientUserId: text('recipientUserId').notNull().references(() => users.id),
-    questionId: text('questionId').notNull().references(() => questions.id),
+    senderUserId: text('senderUserId')
+      .notNull()
+      .references(() => users.id),
+    recipientUserId: text('recipientUserId')
+      .notNull()
+      .references(() => users.id),
+    questionId: text('questionId')
+      .notNull()
+      .references(() => questions.id),
     contextType: text('contextType').$type<'feed' | 'joshing_game'>().notNull(),
     contextId: text('contextId'),
     reactionType: text('reactionType').notNull(),
@@ -624,7 +689,10 @@ export const questionReactions = pgTable(
     createdAt: createdAt(),
   },
   (table) => [
-    index('QuestionReaction_recipientUserId_repliedAt_idx').on(table.recipientUserId, table.repliedAt),
+    index('QuestionReaction_recipientUserId_repliedAt_idx').on(
+      table.recipientUserId,
+      table.repliedAt,
+    ),
     index('QuestionReaction_senderUserId_idx').on(table.senderUserId),
     index('QuestionReaction_questionId_idx').on(table.questionId),
     index('QuestionReaction_context_idx').on(table.contextType, table.contextId),
@@ -677,7 +745,9 @@ export const emailVerificationTokens = pgTable(
   'EmailVerificationToken',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     email: text('email').notNull(),
     tokenHash: text('token_hash').notNull(),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
@@ -698,7 +768,9 @@ export const generatedQuestions = pgTable(
   'GeneratedQuestion',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     canonicalSubcategory: text('canonical_subcategory').notNull(),
     // domainKey() fold of canonical_subcategory (apostrophes folded, whitespace
     // collapsed, lowercased), written by the TS fold at insert time. The bank
@@ -785,7 +857,10 @@ export const generatedQuestions = pgTable(
     index('GeneratedQuestion_is_duplicate_idx').on(table.isDuplicate),
     // Bank lookup path (BP-7 / C5): pickBankSource matches folded domain +
     // difficulty tier.
-    index('GeneratedQuestion_domain_key_difficulty_idx').on(table.domainKey, table.difficultyEstimate),
+    index('GeneratedQuestion_domain_key_difficulty_idx').on(
+      table.domainKey,
+      table.difficultyEstimate,
+    ),
   ],
 );
 
@@ -888,7 +963,9 @@ export const knowledgeParentMastery = pgTable(
   'KnowledgeParentMastery',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     parentDomainKey: text('parent_domain_key').notNull(),
     masteredAt: timestamp('mastered_at', { withTimezone: true }).notNull().defaultNow(),
   },
@@ -907,7 +984,9 @@ export const knowledgeLeafMastery = pgTable(
   'KnowledgeLeafMastery',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     leafDomainKey: text('leaf_domain_key').notNull(),
     masteredAt: timestamp('mastered_at', { withTimezone: true }).notNull().defaultNow(),
   },
@@ -921,7 +1000,9 @@ export const questionFeedback = pgTable(
   'QuestionFeedback',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     questionId: text('question_id').references(() => questions.id),
     generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id),
     signal: feedbackSignalEnum('signal').notNull(),
@@ -930,7 +1011,10 @@ export const questionFeedback = pgTable(
   (table) => [
     uniqueIndex('QuestionFeedback_generated_question_id_key').on(table.generatedQuestionId),
     unique('QuestionFeedback_user_id_question_id_key').on(table.userId, table.questionId),
-    unique('QuestionFeedback_user_id_generated_question_id_key').on(table.userId, table.generatedQuestionId),
+    unique('QuestionFeedback_user_id_generated_question_id_key').on(
+      table.userId,
+      table.generatedQuestionId,
+    ),
     index('QuestionFeedback_user_id_idx').on(table.userId),
     index('QuestionFeedback_question_id_idx').on(table.questionId),
   ],
@@ -940,8 +1024,12 @@ export const questionRatings = pgTable(
   'QuestionRating',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    userId: text('user_id').notNull().references(() => users.id),
-    questionId: text('question_id').notNull().references(() => questions.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    questionId: text('question_id')
+      .notNull()
+      .references(() => questions.id),
     rating: text('rating').notNull(),
     createdAt: createdAt(),
   },
@@ -956,7 +1044,9 @@ export const contentReports = pgTable(
   'ContentReport',
   {
     id: id(),
-    reporterUserId: text('reporter_user_id').notNull().references(() => users.id),
+    reporterUserId: text('reporter_user_id')
+      .notNull()
+      .references(() => users.id),
     questionId: text('question_id').references(() => questions.id),
     generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id),
     category: contentReportCategoryEnum('category').notNull(),
@@ -1001,7 +1091,9 @@ export const dailyQueues = pgTable(
   'DailyQueue',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     queueDate: date('queue_date').notNull(),
     slots: jsonb('slots').notNull(),
     createdAt: createdAt(),
@@ -1010,6 +1102,9 @@ export const dailyQueues = pgTable(
     // can't double-send; null = not yet sent, or released back to null after a
     // send failure so a later run can retry.
     emailReminderSentAt: timestamp('email_reminder_sent_at', { withTimezone: true }),
+    // Independent from the email marker: each channel owns its own atomic
+    // per-user/day claim and can be retried without double-sending the other.
+    smsReminderSentAt: timestamp('sms_reminder_sent_at', { withTimezone: true }),
   },
   (table) => [
     unique('DailyQueue_user_id_queue_date_key').on(table.userId, table.queueDate),
@@ -1021,7 +1116,9 @@ export const dailyPreferences = pgTable(
   'DailyPreference',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     friendIds: text('friend_ids').array().notNull().default(textArrayDefault),
     includeCommunity: boolean('include_community').notNull().default(false),
     difficulty: text('difficulty').notNull().default('adaptive'),
@@ -1054,8 +1151,12 @@ export const skippedDailyQuestions = pgTable(
   'SkippedDailyQuestion',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
-    queueId: text('queue_id').notNull().references(() => dailyQueues.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    queueId: text('queue_id')
+      .notNull()
+      .references(() => dailyQueues.id, { onDelete: 'cascade' }),
     questionId: text('question_id').references(() => questions.id),
     generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id),
     canonicalSubcategory: text('canonical_subcategory').notNull(),
@@ -1064,7 +1165,10 @@ export const skippedDailyQuestions = pgTable(
   (table) => [
     index('SkippedDailyQuestion_user_id_idx').on(table.userId),
     index('SkippedDailyQuestion_user_id_question_id_idx').on(table.userId, table.questionId),
-    index('SkippedDailyQuestion_user_id_generated_question_id_idx').on(table.userId, table.generatedQuestionId),
+    index('SkippedDailyQuestion_user_id_generated_question_id_idx').on(
+      table.userId,
+      table.generatedQuestionId,
+    ),
     index('SkippedDailyQuestion_queue_id_idx').on(table.queueId),
     // Standalone covering indexes for the question_id / generated_question_id
     // FKs (0083 / advisor 0001). The composites above lead with user_id, so they
@@ -1095,7 +1199,9 @@ export const hiddenQuestions = pgTable(
   'HiddenQuestion',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     questionId: text('question_id').references(() => questions.id),
     generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id),
     canonicalSubcategory: text('canonical_subcategory').notNull(),
@@ -1120,7 +1226,9 @@ export const userDomainDifficulties = pgTable(
   'USER_DOMAIN_DIFFICULTY',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     canonicalSubcategory: text('canonical_subcategory').notNull(),
     servedDifficulty: difficultyEstimateEnum('served_difficulty').notNull(),
     consecutiveCorrect: integer('consecutive_correct').notNull().default(0),
@@ -1151,7 +1259,9 @@ export const userDomainExclusions = pgTable(
   'USER_DOMAIN_EXCLUSIONS',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     canonicalSubcategory: text('canonical_subcategory').notNull(),
     scope: domainExclusionScopeEnum('scope').notNull().default('subcategory'),
     excludedAt: timestamp('excluded_at', { withTimezone: true }).notNull().defaultNow(),
@@ -1179,8 +1289,12 @@ export const dailyRefineDecisions = pgTable(
   'DAILY_REFINE_DECISION',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    queueId: text('queue_id').notNull().references(() => dailyQueues.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    queueId: text('queue_id')
+      .notNull()
+      .references(() => dailyQueues.id, { onDelete: 'cascade' }),
     // 'friend_expansion' | 'difficulty_escalation' | 'struggle_pruning'
     itemType: text('item_type').notNull(),
     canonicalSubcategory: text('canonical_subcategory').notNull(),
@@ -1212,9 +1326,14 @@ export const profileSectionVisibility = pgTable(
   'PROFILE_SECTION_VISIBILITY',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     section: profileSectionEnum('section').notNull(),
-    visibility: text('visibility').$type<'public' | 'friends' | 'private'>().notNull().default('public'),
+    visibility: text('visibility')
+      .$type<'public' | 'friends' | 'private'>()
+      .notNull()
+      .default('public'),
     updatedAt: updatedAt(),
   },
   (table) => [
@@ -1231,10 +1350,15 @@ export const profileDomainVisibility = pgTable(
   'PROFILE_DOMAIN_VISIBILITY',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     canonicalSubcategory: text('canonical_subcategory').notNull(),
     domain: text('domain').notNull(),
-    visibility: text('visibility').$type<'public' | 'friends' | 'private'>().notNull().default('public'),
+    visibility: text('visibility')
+      .$type<'public' | 'friends' | 'private'>()
+      .notNull()
+      .default('public'),
     isVisible: boolean('is_visible').notNull().default(true),
     updatedAt: updatedAt(),
   },
@@ -1256,7 +1380,9 @@ export const declaredInterests = pgTable(
   'DeclaredInterest',
   {
     id: id(),
-    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     domain: text('domain').notNull(),
     broadCategory: text('broadCategory'),
     declaredAt: timestamp('declaredAt', { withTimezone: true }).notNull().defaultNow(),
@@ -1280,7 +1406,9 @@ export const authorInvitations = pgTable(
   'AuthorInvitation',
   {
     id: id(),
-    userId: text('user_id').notNull().references(() => users.id),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
     domain: text('domain').notNull(),
     reason: text('reason').notNull().default('domain_exhausted'),
     // Nullable since 0114: a set-completion invitation is system-created and has
@@ -1311,7 +1439,9 @@ export const crafterDraftDecisions = pgTable(
   'CrafterDraftDecision',
   {
     id: id(),
-    deciderId: text('decider_id').notNull().references(() => users.id),
+    deciderId: text('decider_id')
+      .notNull()
+      .references(() => users.id),
     domain: text('domain').notNull(),
     tier: text('tier').$type<'shallow' | 'deep'>().notNull(),
     questionText: text('question_text').notNull(),
@@ -1344,14 +1474,19 @@ export const questionSalvageProposals = pgTable(
     // The demoted row's id, in whichever store it lives (see targetTable).
     questionId: text('question_id').notNull(),
     targetTable: text('target_table').$type<'question' | 'generated'>().notNull(),
-    kind: text('kind').$type<'extra_fact_stem' | 'extra_fact_explainer' | 'unsalvageable'>().notNull(),
+    kind: text('kind')
+      .$type<'extra_fact_stem' | 'extra_fact_explainer' | 'unsalvageable'>()
+      .notNull(),
     proposedStem: text('proposed_stem'),
     proposedExplanation: text('proposed_explanation'),
     // Outcome of re-verifying the PROPOSED version. A proposal is only surfaced
     // when this is 'ok' — the human never sees a fix that didn't actually pass.
     reverifyOutcome: text('reverify_outcome').$type<'ok' | 'demoted' | 'unverifiable'>().notNull(),
     reverifyReason: text('reverify_reason'),
-    status: text('status').$type<'ready' | 'applied' | 'rejected' | 'unsalvageable'>().notNull().default('ready'),
+    status: text('status')
+      .$type<'ready' | 'applied' | 'rejected' | 'unsalvageable'>()
+      .notNull()
+      .default('ready'),
     createdAt: createdAt(),
   },
   (table) => [
@@ -1367,10 +1502,16 @@ export const friendships = pgTable(
   'Friendship',
   {
     id: id(),
-    userAId: text('userAId').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    userBId: text('userBId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userAId: text('userAId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    userBId: text('userBId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     status: text('status').notNull().default('pending'),
-    requestedByUserId: text('requestedByUserId').notNull().references(() => users.id),
+    requestedByUserId: text('requestedByUserId')
+      .notNull()
+      .references(() => users.id),
     formedVia: text('formedVia').notNull(),
     formedAt: timestamp('formedAt', { withTimezone: true }),
     removedAt: timestamp('removedAt', { withTimezone: true }),
@@ -1401,8 +1542,12 @@ export const follows = pgTable(
   'Follow',
   {
     id: id(),
-    followerId: text('followerId').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    followeeId: text('followeeId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    followerId: text('followerId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    followeeId: text('followeeId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     state: followStateEnum('state').notNull().default('pending'),
     // Carried from the originating request so the incoming-request card can
     // still render a personal note and suggested interests.
@@ -1451,7 +1596,9 @@ export const joshingGames = pgTable(
   {
     id: id(),
     title: text('title').notNull(),
-    creatorId: text('creatorId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    creatorId: text('creatorId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
   },
@@ -1462,11 +1609,17 @@ export const feedItems = pgTable(
   'FeedItem',
   {
     id: id(),
-    recipientUserId: text('recipientUserId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    recipientUserId: text('recipientUserId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     questionId: text('questionId').references(() => questions.id),
-    joshingGameId: text('joshingGameId').references(() => joshingGames.id, { onDelete: 'set null' }),
+    joshingGameId: text('joshingGameId').references(() => joshingGames.id, {
+      onDelete: 'set null',
+    }),
     sourceType: text('sourceType').notNull(),
-    sourceUserId: text('sourceUserId').notNull().references(() => users.id),
+    sourceUserId: text('sourceUserId')
+      .notNull()
+      .references(() => users.id),
     // D-4 via-attribution: the user the FORWARDER got this question from — two
     // hops above the recipient. Stamped at forward time in /api/questions/send as
     // the forwarder's own sourceUserId (no lineage propagation); NULL when the
@@ -1496,9 +1649,17 @@ export const feedItems = pgTable(
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index('FeedItem_recipientUserId_state_idx').on(table.recipientUserId, table.state, table.sourceEventAt.desc()),
-    index('FeedItem_recipientUserId_pinned_idx').on(table.recipientUserId, table.isPinned).where(sql`"isPinned" = TRUE`),
-    uniqueIndex('FeedItem_recipientUserId_sourceAnswerId_key').on(table.recipientUserId, table.sourceAnswerId).where(sql`"sourceAnswerId" IS NOT NULL`),
+    index('FeedItem_recipientUserId_state_idx').on(
+      table.recipientUserId,
+      table.state,
+      table.sourceEventAt.desc(),
+    ),
+    index('FeedItem_recipientUserId_pinned_idx')
+      .on(table.recipientUserId, table.isPinned)
+      .where(sql`"isPinned" = TRUE`),
+    uniqueIndex('FeedItem_recipientUserId_sourceAnswerId_key')
+      .on(table.recipientUserId, table.sourceAnswerId)
+      .where(sql`"sourceAnswerId" IS NOT NULL`),
     // Covering indexes for hot-path foreign keys (B-PERF-03, migration 0079).
     index('FeedItem_questionId_idx').on(table.questionId),
     index('FeedItem_sourceUserId_idx').on(table.sourceUserId),
@@ -1513,8 +1674,12 @@ export const joshingGameRecipients = pgTable(
   'JoshingGameRecipient',
   {
     id: id(),
-    gameId: text('gameId').notNull().references(() => joshingGames.id, { onDelete: 'cascade' }),
-    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    gameId: text('gameId')
+      .notNull()
+      .references(() => joshingGames.id, { onDelete: 'cascade' }),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     sentAt: timestamp('sentAt', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
@@ -1528,8 +1693,12 @@ export const joshingGameQuestions = pgTable(
   'JoshingGameQuestion',
   {
     id: id(),
-    gameId: text('gameId').notNull().references(() => joshingGames.id, { onDelete: 'cascade' }),
-    questionId: text('questionId').notNull().references(() => questions.id),
+    gameId: text('gameId')
+      .notNull()
+      .references(() => joshingGames.id, { onDelete: 'cascade' }),
+    questionId: text('questionId')
+      .notNull()
+      .references(() => questions.id),
     position: integer('position').notNull(),
   },
   (table) => [
@@ -1546,9 +1715,15 @@ export const joshingGameResponses = pgTable(
   'JoshingGameResponse',
   {
     id: id(),
-    gameId: text('gameId').notNull().references(() => joshingGames.id, { onDelete: 'cascade' }),
-    questionId: text('questionId').notNull().references(() => questions.id),
-    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    gameId: text('gameId')
+      .notNull()
+      .references(() => joshingGames.id, { onDelete: 'cascade' }),
+    questionId: text('questionId')
+      .notNull()
+      .references(() => questions.id),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     submittedAnswer: text('submittedAnswer'),
     isCorrect: boolean('isCorrect'),
     isPartial: boolean('isPartial').notNull().default(false),
@@ -1558,7 +1733,11 @@ export const joshingGameResponses = pgTable(
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    unique('JoshingGameResponse_gameId_questionId_userId_key').on(table.gameId, table.questionId, table.userId),
+    unique('JoshingGameResponse_gameId_questionId_userId_key').on(
+      table.gameId,
+      table.questionId,
+      table.userId,
+    ),
     index('JoshingGameResponse_gameId_userId_idx').on(table.gameId, table.userId),
     index('JoshingGameResponse_userId_idx').on(table.userId),
     // Covering index for the questionId FK (0083 / advisor 0001).
@@ -1570,7 +1749,9 @@ export const biweeklyCeremonies = pgTable(
   'BiweeklyCeremony',
   {
     id: id(),
-    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     cycleStart: date('cycleStart').notNull(),
     cycleEnd: date('cycleEnd').notNull(),
     firedAt: timestamp('firedAt', { withTimezone: true }).notNull().defaultNow(),
@@ -1580,7 +1761,11 @@ export const biweeklyCeremonies = pgTable(
   },
   (table) => [
     uniqueIndex('BiweeklyCeremony_shareCardToken_key').on(table.shareCardToken),
-    uniqueIndex('BiweeklyCeremony_user_cycle_key').on(table.userId, table.cycleStart, table.cycleEnd),
+    uniqueIndex('BiweeklyCeremony_user_cycle_key').on(
+      table.userId,
+      table.cycleStart,
+      table.cycleEnd,
+    ),
     index('BiweeklyCeremony_userId_firedAt_idx').on(table.userId, table.firedAt.desc()),
   ],
 );
@@ -1589,7 +1774,9 @@ export const activityItems = pgTable(
   'ActivityItem',
   {
     id: id(),
-    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     type: text('type').notNull(),
     actorUserId: text('actorUserId').references(() => users.id, { onDelete: 'set null' }),
     referenceId: text('referenceId'),
@@ -1610,7 +1797,9 @@ export const feedDismissedDomains = pgTable(
   'FeedDismissedDomain',
   {
     id: id(),
-    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     canonicalSubcategory: text('canonicalSubcategory').notNull(),
     dismissedAt: timestamp('dismissedAt', { withTimezone: true }).notNull().defaultNow(),
     reinstatedAt: timestamp('reinstatedAt', { withTimezone: true }),
@@ -1634,8 +1823,12 @@ export const recoveredSetAside = pgTable(
   'RecoveredSetAside',
   {
     id: id(),
-    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    questionId: text('questionId')
+      .notNull()
+      .references(() => questions.id, { onDelete: 'cascade' }),
     setAsideAt: timestamp('setAsideAt', { withTimezone: true }).notNull().defaultNow(),
     reinstatedAt: timestamp('reinstatedAt', { withTimezone: true }),
   },
@@ -1661,8 +1854,12 @@ export const milestoneDismissed = pgTable(
   'MilestoneDismissed',
   {
     id: id(),
-    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
-    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    questionId: text('questionId')
+      .notNull()
+      .references(() => questions.id, { onDelete: 'cascade' }),
     dismissedAt: timestamp('dismissedAt', { withTimezone: true }).notNull().defaultNow(),
     reinstatedAt: timestamp('reinstatedAt', { withTimezone: true }),
   },
@@ -1706,7 +1903,9 @@ export const missedReturnDismissed = pgTable(
   'MissedReturnDismissed',
   {
     id: id(),
-    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     // Exactly ONE of these is set (DB CHECK, migration 0130), mirroring
     // CatchupQueueItem.reportTarget and DailyQueue.slots — the two other places
     // that carry "a question" that may live in either table.
@@ -1755,7 +1954,9 @@ export const missedReturnState = pgTable(
   'MissedReturnState',
   {
     id: id(),
-    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     // Exactly ONE of these is set (DB CHECK, migration 0130) — see the note on
     // MissedReturnDismissed above.
     questionId: text('questionId').references(() => questions.id, { onDelete: 'cascade' }),
@@ -1781,7 +1982,9 @@ export const friendInvitations = pgTable(
   'FriendInvitation',
   {
     id: id(),
-    inviterUserId: text('inviterUserId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    inviterUserId: text('inviterUserId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
     inviteePhone: text('inviteePhone').notNull(),
     inviteeDisplayName: text('inviteeDisplayName'),
     inviteeUserId: text('inviteeUserId').references(() => users.id),
@@ -1800,7 +2003,10 @@ export const friendInvitations = pgTable(
     // Covering index for the inviteeUserId FK (0083 / advisor 0001).
     index('FriendInvitation_inviteeUserId_idx').on(table.inviteeUserId),
     index('FriendInvitation_inviteePhone_idx').on(table.inviteePhone),
-    index('FriendInvitation_inviterUserId_inviteePhone_idx').on(table.inviterUserId, table.inviteePhone),
+    index('FriendInvitation_inviterUserId_inviteePhone_idx').on(
+      table.inviterUserId,
+      table.inviteePhone,
+    ),
   ],
 );
 
@@ -1823,7 +2029,10 @@ export const appSettings = pgTable(
   () => [
     check('AppSettings_singleton', sql`id = 'singleton'`),
     check('AppSettings_gen_provider_valid', sql`gen_provider IN ('anthropic', 'openai')`),
-    check('AppSettings_categorize_provider_valid', sql`categorize_provider IN ('anthropic', 'openai')`),
+    check(
+      'AppSettings_categorize_provider_valid',
+      sql`categorize_provider IN ('anthropic', 'openai')`,
+    ),
     check('AppSettings_suggest_provider_valid', sql`suggest_provider IN ('anthropic', 'openai')`),
     check('AppSettings_grade_provider_valid', sql`grade_provider IN ('anthropic', 'openai')`),
   ],
@@ -1845,7 +2054,10 @@ export const llmProviderChangeLog = pgTable(
     createdAt: createdAt(),
   },
   (table) => [
-    check('LlmProviderChangeLog_surface_valid', sql`surface IN ('gen', 'categorize', 'suggest', 'grade')`),
+    check(
+      'LlmProviderChangeLog_surface_valid',
+      sql`surface IN ('gen', 'categorize', 'suggest', 'grade')`,
+    ),
     check('LlmProviderChangeLog_from_valid', sql`from_provider IN ('anthropic', 'openai')`),
     check('LlmProviderChangeLog_to_valid', sql`to_provider IN ('anthropic', 'openai')`),
     index('LlmProviderChangeLog_created_at_idx').on(table.createdAt),
@@ -1909,10 +2121,7 @@ export const domainReferencePassage = pgTable(
     createdAt: createdAt(),
   },
   (table) => [
-    check(
-      'DomainReferencePassage_source_valid',
-      sql`source IN ('wikipedia', 'fandom', 'none')`,
-    ),
+    check('DomainReferencePassage_source_valid', sql`source IN ('wikipedia', 'fandom', 'none')`),
     uniqueIndex('DomainReferencePassage_domain_key').on(table.canonicalSubcategory),
   ],
 );
@@ -1971,9 +2180,7 @@ export const domainDepthEstimates = pgTable(
     computedAt: timestamp('computed_at', { withTimezone: true }).notNull().defaultNow(),
     createdAt: createdAt(),
   },
-  (table) => [
-    uniqueIndex('DomainDepthEstimate_domain_key').on(table.domainKey),
-  ],
+  (table) => [uniqueIndex('DomainDepthEstimate_domain_key').on(table.domainKey)],
 );
 
 // ReviewedDomainPair (0122, D-DOMAIN-MERGE-REVIEW-REDESIGN-01): permanent

--- a/src/server/sms.ts
+++ b/src/server/sms.ts
@@ -11,6 +11,25 @@ import { smsLogs } from '@/server/db/schema';
 
 type SmsLogMessageType = typeof smsLogs.$inferInsert.messageType;
 
+export type SmsSendResult =
+  | { ok: true }
+  | { ok: false; reason: 'disabled' | 'not_configured' | 'provider_error' | 'network_error' };
+
+const CAMPAIGN_MESSAGE_TYPES = new Set<SmsMessageType>([
+  'otp',
+  'daily_questions',
+  'daily_questions_batched',
+]);
+
+/**
+ * This A2P campaign is deliberately narrow. Legacy/future-facing call sites
+ * remain in the codebase, but Twilio credentials alone can never activate
+ * invitations, reactions, game/ceremony alerts, or other social messages.
+ */
+export function isSmsMessageTypeEnabled(messageType: SmsMessageType): boolean {
+  return CAMPAIGN_MESSAGE_TYPES.has(messageType);
+}
+
 /**
  * Send an SMS via Twilio and log the attempt.
  * Fails silently on missing env vars (dev environment).
@@ -19,8 +38,8 @@ export async function sendSms(
   to: string,
   body: string,
   messageType: SmsMessageType,
-  userId?: string
-): Promise<void> {
+  userId?: string,
+): Promise<SmsSendResult> {
   async function logAttempt() {
     try {
       await db.insert(smsLogs).values({
@@ -37,10 +56,15 @@ export async function sendSms(
   const authToken = process.env.TWILIO_AUTH_TOKEN;
   const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
 
+  if (!isSmsMessageTypeEnabled(messageType)) {
+    console.warn('[SMS] Message type disabled for current campaign:', messageType);
+    return { ok: false, reason: 'disabled' };
+  }
+
   if (!accountSid || !authToken || !messagingServiceSid) {
     console.warn('[SMS] Twilio env vars missing — SMS not sent:', messageType, to);
     await logAttempt();
-    return;
+    return { ok: false, reason: 'not_configured' };
   }
 
   try {
@@ -58,19 +82,29 @@ export async function sendSms(
           MessagingServiceSid: messagingServiceSid,
           Body: body,
         }).toString(),
-      }
+      },
     );
 
     if (!response.ok) {
-      const text = await response.text();
-      console.error('[SMS] Twilio error:', response.status, text);
+      // Do not log the provider response body: it may echo request details,
+      // and OTP contents must never reach application logs.
+      console.error('[SMS] Twilio error:', response.status, messageType);
+      await logAttempt();
+      return { ok: false, reason: 'provider_error' };
     }
-  } catch (err) {
-    console.error('[SMS] Network error sending SMS:', err);
+  } catch {
+    console.error('[SMS] Network error sending SMS:', messageType);
+    await logAttempt();
+    return { ok: false, reason: 'network_error' };
   }
 
   // Log the send attempt (never log message content per PRD)
   await logAttempt();
+  return { ok: true };
+}
+
+export function buildOtpMessage(code: string): string {
+  return `Joshing verification code: ${code}. Expires in 10 minutes. Do not share this code.`;
 }
 
 /**
@@ -84,7 +118,7 @@ export function buildGameCompleteSmsBody(
   winner: { display_name: string; user_id: string } | null,
   isTie: boolean,
   allMembers: GameWinnerMember[],
-  opts?: { ceremony_mode?: 'solo' | 'duo' | 'group'; host_display_name?: string | null }
+  opts?: { ceremony_mode?: 'solo' | 'duo' | 'group'; host_display_name?: string | null },
 ): string {
   const mode = opts?.ceremony_mode ?? 'group';
   const hostName = opts?.host_display_name?.trim();
@@ -145,7 +179,7 @@ export async function sendGameCompleteSms(
   winner: { display_name: string; user_id: string } | null = null,
   isTie: boolean = false,
   allMembers: GameWinnerMember[] = [],
-  ceremonyOpts?: { ceremony_mode?: 'solo' | 'duo' | 'group'; host_display_name?: string | null }
+  ceremonyOpts?: { ceremony_mode?: 'solo' | 'duo' | 'group'; host_display_name?: string | null },
 ): Promise<void> {
   // If allMembers not provided (legacy call), fetch them
   let members = allMembers;
@@ -165,11 +199,11 @@ export async function sendGameCompleteSms(
         winner,
         isTie,
         members,
-        ceremonyOpts
+        ceremonyOpts,
       );
       const truncated = body.length > 160 ? body.slice(0, 157) + '…' : body;
       sendSms(member.phone_number, truncated, 'joshing_game_complete', member.user_id).catch(
-        (err) => console.error('[SMS] joshing_game_complete send failed:', err)
+        (err) => console.error('[SMS] joshing_game_complete send failed:', err),
       );
     }
   }
@@ -186,7 +220,7 @@ export async function sendDailyReminder(
   userId: string,
   phoneNumber: string,
   groupNames: string[],
-  baseUrl: string
+  baseUrl: string,
 ): Promise<void> {
   if (groupNames.length === 0) return;
 
@@ -196,22 +230,24 @@ export async function sendDailyReminder(
     phoneNumber,
     message,
     (groupNames.length > 1 ? 'daily_questions_batched' : 'daily_questions') as SmsMessageType,
-    userId
+    userId,
   );
 }
 
 export function buildDailyReminderMessage(groupNames: string[], baseUrl: string): string {
-  let message: string;
-  if (groupNames.length === 1) {
-    message = `${groupNames[0]} — up to 5 questions waiting. Your queue refills daily: ${baseUrl}/play`;
-  } else if (groupNames.length === 2) {
-    message = `${groupNames[0]} and ${groupNames[1]} — questions waiting. Your queue refills daily: ${baseUrl}/today`;
-  } else {
-    message = `${groupNames[0]} and ${groupNames.length - 1} other groups — questions waiting. Your queue refills daily: ${baseUrl}/today`;
-  }
+  void groupNames;
+  return buildDailyReminderSmsBody(baseUrl);
+}
 
-  if (message.length > 160) {
-    return message.slice(0, 157) + '…';
-  }
-  return message;
+export function buildDailyReminderSmsBody(baseUrl: string): string {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '');
+  return `Joshing: Your five for today are ready: ${normalizedBaseUrl}/daily. Reply STOP to opt out, HELP for help. Msg & data rates may apply.`;
+}
+
+export function isEligibleForDailyReminder(user: {
+  phoneNumber: string | null;
+  phoneVerified: boolean;
+  smsOptIn: string;
+}): boolean {
+  return Boolean(user.phoneNumber && user.phoneVerified && user.smsOptIn === 'opted_in');
 }


### PR DESCRIPTION
## Summary
- add public Privacy Policy and expanded SMS Terms
- add separate OTP and daily-reminder web-form disclosures with auditable consent metadata
- deliver OTPs through Twilio while preserving non-production debug codes and surfacing provider failures
- make daily reminders verified, explicitly opted-in, compliant, and idempotent
- deny all invitation, reaction, game, ceremony, and social SMS types at the central transport
- document required Twilio Messaging Service configuration

## Migration
- 0132_sms_consent_and_daily_idempotency.sql adds SMS opt-in/out timestamps, source, policy version, and the per-day SMS send claim

## Verification
- npm test: 310 files passed, 2 skipped; 2405 tests passed, 23 skipped
- npm run lint: passed with 4 pre-existing warnings
- npm run build: passed
- npm run smoke:sms-message-types: passed

## Deployment follow-up
- apply the journaled Drizzle migration
- configure TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_MESSAGING_SERVICE_SID
- register and approve the Sole Proprietor A2P campaign, associate its Messaging Service, and verify STOP/HELP handling in Twilio
- no Vercel or Twilio production settings were changed by this PR