### PR TITLE
Fix daily-queue backfill: hard 2-per-subcategory cap, no cooldown bypass

### DIFF
--- a/src/server/daily/__tests__/diversity-cap.test.ts
+++ b/src/server/daily/__tests__/diversity-cap.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DAILY_QUEUE_MAX_PER_SUBCATEGORY, DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE } from '@/server/daily/types';
+import { DAILY_QUEUE_MAX_PER_SUBCATEGORY, DAILY_QUEUE_SIZE } from '@/server/daily/types';
 
 // Same wholesale-mock strategy as queue-floor.test.ts: fillDailyQueueForUser
 // orchestrates DB pickers + LLM generation, all of which touch @/server/db (which
@@ -23,6 +23,8 @@ const mocks = vi.hoisted(() => ({
   generateDailyQuestionsFromKnowledgeBase: vi.fn(),
   generateBonusQuestionsForDomains: vi.fn(),
   isGenericSubcategory: vi.fn(),
+  getRecentAnsweredAnswerKeys: vi.fn(),
+  getRecentAnsweredEntities: vi.fn(),
 }));
 
 // The orchestrator assembles the queue in memory via pure slot builders, then
@@ -37,8 +39,8 @@ vi.mock('@/server/db/queries/daily', () => ({
   getExcludedKnowledgeDomains: mocks.getExcludedKnowledgeDomains,
   pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
   pickHouseQuestions: mocks.pickHouseQuestions,
-  getRecentAnsweredAnswerKeys: vi.fn(async () => new Set<string>()),
-  getRecentAnsweredEntities: vi.fn(async () => new Set<string>()),
+  getRecentAnsweredAnswerKeys: mocks.getRecentAnsweredAnswerKeys,
+  getRecentAnsweredEntities: mocks.getRecentAnsweredEntities,
   persistDailyQueue: mocks.persistDailyQueue,
   buildAuthoredSlot: (a: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
     slot_index: position, source: 'friend', question_id: a.id, domain: a.canonicalSubcategory, question_text: a.questionText, answered: false,
@@ -81,7 +83,7 @@ vi.mock('@/server/refine/commit', () => ({
   commitPendingRefineDecisions: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
+import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
 
 const USER = 'user-1';
 
@@ -172,6 +174,8 @@ beforeEach(() => {
   mocks.pickEligibleAuthoredQuestions.mockResolvedValue([]);
   mocks.pickHouseQuestions.mockResolvedValue([]);
   mocks.getFriendAndFoFUserIds.mockResolvedValue({ direct: new Set(), extended: new Set() });
+  mocks.getRecentAnsweredAnswerKeys.mockResolvedValue(new Set<string>());
+  mocks.getRecentAnsweredEntities.mockResolvedValue(new Set<string>());
 
   mocks.getFriendDomainsForBonus.mockResolvedValue([]);
   mocks.generateBonusQuestionsForDomains.mockResolvedValue([]);
@@ -368,14 +372,17 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
     expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
   });
 
-  it('caps the soft-cap backfill at one slot past the normal cap (prod incident 2026-08-30)', async () => {
-    // Reproduces the incident directly: a house bank with only ONE covered
-    // subcategory (5 Botany picks, mirroring the 10-question "Beethoven" house
-    // bank) and generation that comes back empty every round. Before the
-    // B-DIVERSITY-BACKFILL-CAP-01 fix, the soft-cap backfill drained the whole
-    // house reserve to keep the queue full — 5/5 Botany. The backfill must now
-    // stop at ONE slot past the normal cap (3, not 5) and let the queue serve
-    // short rather than repeat the same subcategory past that ceiling.
+  it('never lets the soft-cap backfill exceed the normal cap (prod incidents 2026-08-30 and 2026-09-01)', async () => {
+    // Reproduces the 2026-08-30 incident directly: a house bank with only ONE
+    // covered subcategory (5 Botany picks, mirroring the 10-question "Beethoven"
+    // house bank) and generation that comes back empty every round. The original
+    // B-DIVERSITY-BACKFILL-CAP-01 fix stopped the backfill at one slot past the
+    // normal cap (3/5), which itself proved to be one too many in prod on
+    // 2026-09-01 (3 Beethoven questions in one Five, one of them a genuine
+    // answer-cooldown repeat let back in by the backfill). The backfill must now
+    // never exceed the normal per-subcategory cap (2), even mid-relaxation, and
+    // a knowledge base too narrow to diversify past that must serve short/retry
+    // rather than repeat the same subcategory a third time.
     mocks.pickHouseQuestions.mockResolvedValue([
       houseQuestion('h1', 'Botany'),
       houseQuestion('h2', 'Botany'),
@@ -385,17 +392,49 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
     ]);
     mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([]);
 
+    // Only 2 Botany house picks clear the cap; with nothing else to diversify
+    // with and generation empty, the build lands below DAILY_QUEUE_MIN_SIZE and
+    // fails closed (retryable) rather than persisting a 3rd repeat.
+    await expect(fillDailyQueueForUser(USER)).rejects.toMatchObject({
+      code: 'generation_failed',
+    });
+    expect(mocks.persistDailyQueue).not.toHaveBeenCalled();
+  });
+
+  it('never backfills a pick that was deflected for answer-cooldown, not diversity (prod incident 2026-09-01)', async () => {
+    // Direct regression for the 2026-09-01 incident: a house pick whose answer
+    // the player already gave within the cooldown window must stay excluded
+    // even though it would otherwise have clean room under the diversity cap.
+    // 3 authored Hamlet picks (unrelated to the repeat, just enough filler to
+    // clear the DAILY_QUEUE_MIN_SIZE floor either way) plus one fresh Botany
+    // house pick that's admitted normally, plus a 2nd Botany house pick whose
+    // answer collides with something the player already answered — diversity
+    // has room for it (cap is 2, only 1 Botany admitted so far), so only the
+    // answer-cooldown gate stands between it and the queue. Before the fix, a
+    // cooldown-deflected pick landed in the same reserve as a diversity-deflected
+    // one and could be pulled back in by the backfill step, which only re-checks
+    // the diversity gate. It must never be re-admitted by ANY path.
+    mocks.pickEligibleAuthoredQuestions.mockResolvedValue([
+      authoredPick('a1', 'Hamlet'),
+      authoredPick('a2', 'Hamlet'),
+      authoredPick('a3', 'Hamlet'),
+    ]);
+    mocks.pickHouseQuestions.mockResolvedValue([
+      houseQuestion('h1', 'Botany'),
+      { ...houseQuestion('h2', 'Botany'), answerText: 'Repeated Answer' },
+    ]);
+    mocks.getRecentAnsweredAnswerKeys.mockResolvedValue(new Set(['repeated answer']));
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([]);
+
     await fillDailyQueueForUser(USER);
 
-    const houseSlots = persistedSlots().filter(
-      (slot) => slot.source === 'house' && slot.domain === 'Botany',
-    );
-    // Normal cap (2) + exactly one extra slot from the backfill relaxation = 3.
-    expect(houseSlots).toHaveLength(DAILY_QUEUE_MAX_PER_SUBCATEGORY + 1);
-    // With nothing else available to diversify with, the queue serves short —
-    // exactly the floor — rather than padding out to five with more Botany.
-    const core = persistedSlots().filter((slot) => !slot.presence_source_id);
-    expect(core).toHaveLength(DAILY_QUEUE_MIN_SIZE);
+    const questionIds = persistedSlots().map((slot) => slot.question_id);
+    // h2 (the cooldown-blocked repeat) must never appear, via the normal pass
+    // or the backfill.
+    expect(questionIds).not.toContain('h2');
+    const houseSlots = persistedSlots().filter((slot) => slot.source === 'house');
+    expect(houseSlots).toHaveLength(1);
+    expect(houseSlots[0]?.question_id).toBe('h1');
   });
 
   it('logs the per-domain, per-reason deflection trail whenever a pick is held back', async () => {

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -571,11 +571,14 @@ async function buildDailyQueueForUser(
   // Cap authored picks first (highest trust → first claim on each subcategory's
   // slots); deflected picks go to a reserve the backfill can draw on if the cap
   // would otherwise leave the queue short.
+  // NOTE: only the diversity_cap branch below pushes into `authoredReserve` —
+  // see the "reserves are diversity-only" comment above the backfill loop for
+  // why answer_cooldown / subject_cooldown deflections must NEVER be backfill-
+  // eligible.
   const authoredReserve: typeof authoredAll = [];
   const authored = authoredAll.filter((pick) => {
     if (answerCooldownGate.blocks(pick.answerText)) {
       deflectedForAnswerCooldown += 1;
-      authoredReserve.push(pick);
       reserveDeflections.push({
         source: 'authored',
         subcategory: pick.canonicalSubcategory ?? '',
@@ -585,7 +588,6 @@ async function buildDailyQueueForUser(
     }
     if (subjectCooldownGate.blocks(pick.subjectEntity, pick.answerText)) {
       deflectedForSubjectCooldown += 1;
-      authoredReserve.push(pick);
       reserveDeflections.push({
         source: 'authored',
         subcategory: pick.canonicalSubcategory ?? '',
@@ -621,7 +623,6 @@ async function buildDailyQueueForUser(
   const housePicks = housePicksAll.filter((pick) => {
     if (answerCooldownGate.blocks(pick.answerText)) {
       deflectedForAnswerCooldown += 1;
-      houseReserve.push(pick);
       reserveDeflections.push({
         source: 'house',
         subcategory: pick.canonicalSubcategory ?? '',
@@ -631,7 +632,6 @@ async function buildDailyQueueForUser(
     }
     if (subjectCooldownGate.blocks(pick.subjectEntity, pick.answerText)) {
       deflectedForSubjectCooldown += 1;
-      houseReserve.push(pick);
       reserveDeflections.push({
         source: 'house',
         subcategory: pick.canonicalSubcategory ?? '',
@@ -719,7 +719,6 @@ async function buildDailyQueueForUser(
     // via the reserve like a diversity deflection.
     if (answerCooldownGate.blocks(question.answer)) {
       deflectedForAnswerCooldown += 1;
-      generatedReserve.push(question);
       reserveDeflections.push({
         source: 'generated',
         subcategory: question.canonicalSubcategory ?? '',
@@ -729,7 +728,6 @@ async function buildDailyQueueForUser(
     }
     if (subjectCooldownGate.blocks(question.subjectEntity, question.answer)) {
       deflectedForSubjectCooldown += 1;
-      generatedReserve.push(question);
       reserveDeflections.push({
         source: 'generated',
         subcategory: question.canonicalSubcategory ?? '',
@@ -887,22 +885,29 @@ async function buildDailyQueueForUser(
   // exactly the queue it would have built without the cap — never shorter, and never
   // a spurious generation_failed below the floor.
   //
-  // A SECOND, higher cap still applies during backfill (B-DIVERSITY-BACKFILL-CAP-01,
-  // 2026-08-30): capForSubcategory(key) + 1 — one more than the normal cap, never
-  // unbounded. Without this, one reserve fully absorbing a shortfall before another
-  // ever gets drawn from could relax a whole Five back down to a single subcategory —
-  // seen in prod: 5/5 "Beethoven" house questions, even though a genuinely diverse
-  // batch of fresh questions had generated successfully that same build and was
-  // sitting in generatedReserve. It never got drawn from because the house reserve
-  // (3 cap-deflected Beethoven house questions) alone fully covered the shortfall
-  // first, per the authored → house → generated draw order above. "often" domains
-  // stay exempt — that's still an explicit player request, not a fallback artifact —
-  // but every other subcategory can take at most one extra slot during relaxation. A
-  // queue that still can't reach five under this stays short rather than repetitive;
-  // DAILY_QUEUE_MIN_SIZE is the floor.
+  // The reserves feeding this backfill hold ONLY diversity_cap-deflected picks —
+  // answer_cooldown and subject_cooldown deflections are filtered out upstream
+  // (never pushed into authoredReserve/houseReserve/generatedReserve) and are
+  // absolute for this build, exactly like the hidden-question drop above. Prod
+  // incident 2026-09-01: a "Beethoven's only opera" pick was answer-cooldown-
+  // deflected (Josh had answered the identical fact 18 days earlier) but the
+  // backfill loop used to re-admit ANY reserved pick it could find room for under
+  // the diversity gate alone, without re-checking why the pick was reserved in the
+  // first place — silently reintroducing the very repeat the cooldown exists to
+  // prevent. Never let backfill re-admit a cooldown-deflected pick.
+  //
+  // The backfill draw is capped by the SAME per-subcategory limit as the primary
+  // pass (B-DIVERSITY-BACKFILL-CAP-01 originally allowed one extra slot here —
+  // capForSubcategory(key) + 1 — to avoid a single reserve monopolizing a
+  // shortfall, e.g. prod's 5/5 "Beethoven" house incident on 2026-08-30. Per Josh
+  // 2026-09-01: even the +1 relaxation (3 of the same subcategory in one Five) is
+  // too many — two is the max he wants to see, full stop). "often" domains stay
+  // exempt — that's still an explicit player request, not a fallback artifact. A
+  // queue that can't reach five under this hard cap stays short rather than
+  // repetitive; DAILY_QUEUE_MIN_SIZE is the floor.
   const backfillCapForSubcategory = (normalizedSubcategory: string): number => {
     if (oftenDomains.has(normalizedSubcategory)) return DAILY_QUEUE_SIZE;
-    return capForSubcategory(normalizedSubcategory) + 1;
+    return capForSubcategory(normalizedSubcategory);
   };
   const backfillGate = makeSubcategoryDiversityGate(backfillCapForSubcategory);
   for (const pick of authored) backfillGate.admit(pick.canonicalSubcategory);


### PR DESCRIPTION
## Summary
- The soft-cap backfill in `queue-orchestrator.ts` (added by #1578 to fix the 5/5 "Beethoven" incident) had two bugs: it relaxed the per-subcategory diversity cap to 3 instead of holding at 2, and it re-admitted reserve picks by checking only the diversity gate — regardless of whether they'd originally been deflected for `answer_cooldown` or `subject_cooldown`.
- Diagnosed against prod: 2026-09-01's Daily Five served 3 Beethoven questions (should be ≤2), and one of them ("What is the title of Beethoven's only opera?") was a genuine repeat of a question answered 18 days earlier — the answer-cooldown gate correctly deflected it, but the backfill silently let it back in anyway.
- Fix: reserves feeding the backfill now hold only `diversity_cap` deflections (cooldown deflections never enter them), and the backfill cap is now identical to the normal per-subcategory cap (2) — no more `+1` relaxation.

## Test plan
- [x] `npx vitest run src/server/daily/__tests__/diversity-cap.test.ts` — 10/10 pass, including a new direct regression test for the cooldown-bypass bug and an updated hard-cap test
- [x] `npx vitest run src/server/daily` — 430 passed / 14 skipped, no regressions
- [x] `npx tsc -p tsconfig.typecheck.json` — clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A