### PR TITLE
Add public SMS consent program page

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -61,6 +61,16 @@ describe('proxy unauthenticated route preservation', () => {
     expect(response.headers.get('location')).toBeNull();
   });
 
+  it('passes the public /sms-consent page through logged-out', async () => {
+    readSessionClaimsMock.mockResolvedValueOnce(null);
+
+    const response = await proxy(makeRequest('/sms-consent'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+    expect(response.headers.get('location')).toBeNull();
+  });
+
   it('lets authenticated readers reach /terms without onboarding/login redirects', async () => {
     readSessionClaimsMock.mockResolvedValueOnce({
       userId: 'u1',
@@ -85,6 +95,21 @@ describe('proxy unauthenticated route preservation', () => {
     });
 
     const response = await proxy(makeRequest('/privacy'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+    expect(response.headers.get('location')).toBeNull();
+  });
+
+  it('lets authenticated readers reach /sms-consent without onboarding redirects', async () => {
+    readSessionClaimsMock.mockResolvedValueOnce({
+      userId: 'u1',
+      sessionId: 's1',
+      invitationAccepted: true,
+      onboardingComplete: true,
+    });
+
+    const response = await proxy(makeRequest('/sms-consent'));
 
     expect(response.status).toBe(200);
     expect(response.headers.get('x-middleware-next')).toBe('1');

--- a/src/app/__tests__/legal-pages.test.tsx
+++ b/src/app/__tests__/legal-pages.test.tsx
@@ -10,6 +10,7 @@ vi.mock('@/server/auth/session', () => ({
 }));
 
 import PrivacyPage from '@/app/privacy/page';
+import SmsConsentPage from '@/app/sms-consent/page';
 import TermsPage from '@/app/terms/page';
 
 describe('public legal pages', () => {
@@ -32,6 +33,25 @@ describe('public legal pages', () => {
     expect(html).toContain('SMS Terms');
     expect(html).toContain('Consent to receive reminder texts is not a condition of purchase');
     expect(html).toContain('href="/privacy"');
+    expect(html).toContain('href="/sms-consent"');
     expect(html).toContain('href="/login"');
+  });
+
+  it('renders the SMS consent program details for a signed-out visitor', async () => {
+    const html = renderToStaticMarkup(await SmsConsentPage());
+    expect(html).toContain('SMS Consent &amp; Program Details');
+    expect(html).toContain('Daily reminders are separate from account verification');
+    expect(html).toContain('Reply STOP to opt out or HELP for help');
+    expect(html).toContain('Consent is not a condition of purchase');
+    expect(html).toContain('href="/terms"');
+    expect(html).toContain('href="/privacy"');
+    expect(html).toContain('Sign in to manage SMS reminders');
+  });
+
+  it('links authenticated readers directly to the real notification settings control', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' });
+    const html = renderToStaticMarkup(await SmsConsentPage());
+    expect(html).toContain('href="/users/me#notifications"');
+    expect(html).toContain('Manage SMS reminders');
   });
 });

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -107,7 +107,14 @@ export default async function PrivacyPage() {
             >
               Terms &amp; Disclaimer
             </Link>{' '}
-            for the SMS program terms.
+            for the SMS program terms or the public{' '}
+            <Link
+              href="/sms-consent"
+              className="font-medium text-[var(--brand-orange)] underline underline-offset-4"
+            >
+              SMS consent details
+            </Link>
+            .
           </p>
         </section>
 

--- a/src/app/sms-consent/page.tsx
+++ b/src/app/sms-consent/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { getSession } from '@/server/auth/session';
+
+export const metadata: Metadata = {
+  title: 'SMS Consent · Joshing',
+  description: 'How Joshing SMS verification codes and optional daily reminders work.',
+};
+
+const CONTACT_EMAIL = 'Joshuapalay+joshingsupport@gmail.com';
+
+export default async function SmsConsentPage() {
+  const session = await getSession();
+  const manageHref = session ? '/users/me#notifications' : '/login';
+  const manageLabel = session ? 'Manage SMS reminders' : 'Sign in to manage SMS reminders';
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-10 pb-28">
+      <div className="mb-6">
+        <Link
+          href={session ? '/users/me' : '/login'}
+          className="text-sm font-medium text-muted-foreground underline-offset-4 hover:underline"
+        >
+          {session ? '← Back to profile' : '← Back to sign in'}
+        </Link>
+      </div>
+
+      <h1 className="font-serif text-3xl font-semibold">SMS Consent &amp; Program Details</h1>
+      <p className="mt-4 text-sm leading-6 text-muted-foreground">
+        Joshing SMS is limited to requested account verification codes and one optional daily
+        reminder that your questions are ready.
+      </p>
+
+      <div className="mt-8 space-y-8 text-sm leading-6 text-foreground">
+        <section>
+          <h2 className="font-serif text-xl font-semibold">Verification codes</h2>
+          <p className="mt-2">
+            When you enter your phone number and continue, you request a one-time Joshing
+            verification code. Verification messages are sent only when requested. Message and
+            data rates may apply.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="font-serif text-xl font-semibold">Optional daily reminder</h2>
+          <p className="mt-2">
+            Daily reminders are separate from account verification and are off by default. After
+            signing in with a verified phone number, you can turn them on under Profile →
+            Notifications. The consent control displays:
+          </p>
+          <blockquote className="mt-4 rounded-[var(--radius-md)] border border-[var(--accent-gold)]/40 bg-[var(--brand-cream-card)] p-4">
+            “Get one Joshing reminder each day when your questions are ready. Message and data
+            rates may apply. Reply STOP to opt out or HELP for help.”
+          </blockquote>
+          <p className="mt-4">
+            Reminder frequency is up to one message per day. Consent is not a condition of
+            purchase. You can turn reminders off at any time in your profile or by replying STOP.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="font-serif text-xl font-semibold">Your choices and support</h2>
+          <p className="mt-2">
+            Reply STOP to opt out of reminder messages. Reply HELP for help, or email{' '}
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
+              className="font-medium text-[var(--brand-orange)] underline underline-offset-4"
+            >
+              {CONTACT_EMAIL}
+            </a>
+            . Turning off reminders does not prevent you from requesting a future account
+            verification code.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="font-serif text-xl font-semibold">Mobile information</h2>
+          <p className="mt-2">
+            Mobile information is not shared with third parties or affiliates for marketing or
+            promotional purposes. Text-message opt-in data and consent are not shared except with
+            providers necessary to deliver the messaging service.
+          </p>
+        </section>
+      </div>
+
+      <div className="mt-10 rounded-[var(--radius-md)] border bg-card p-5">
+        <Link href={manageHref} className="btn-primary inline-flex min-h-11 items-center">
+          {manageLabel}
+        </Link>
+        <p className="mt-4 text-xs leading-5 text-muted-foreground">
+          Review the{' '}
+          <Link href="/terms" className="font-medium underline underline-offset-2">
+            Terms
+          </Link>{' '}
+          and{' '}
+          <Link href="/privacy" className="font-medium underline underline-offset-2">
+            Privacy Policy
+          </Link>
+          .
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -114,7 +114,14 @@ export default async function TermsPage() {
             >
               Privacy Policy
             </Link>{' '}
-            for how we handle mobile information and consent records.
+            for how we handle mobile information and consent records, and review the public{' '}
+            <Link
+              href="/sms-consent"
+              className="font-medium text-[var(--brand-orange)] underline underline-offset-4"
+            >
+              SMS consent details
+            </Link>
+            .
           </p>
         </div>
       </section>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -32,13 +32,13 @@ export async function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
   const isApi = pathname.startsWith('/api/');
 
-  // Terms and Privacy are standalone public pages: they are linked from the
+  // Terms, Privacy, and SMS program details are standalone public pages: they are linked from the
   // logged-out /login card (opened in a new tab), so it must resolve without
   // a session — otherwise the proxy bounces the unauthenticated reader to
   // /login?next=/terms, a loop back into the very screen they came from. It
   // is equally readable when authenticated, so allow it through for everyone
   // before any auth/onboarding routing runs.
-  if (pathname === '/terms' || pathname === '/privacy') {
+  if (pathname === '/terms' || pathname === '/privacy' || pathname === '/sms-consent') {
     return tagTiming(NextResponse.next(), startedAt);
   }
 


### PR DESCRIPTION
## Summary
- add a public /sms-consent page with the exact reminder disclosure, verification-code explanation, frequency, STOP/HELP, optional-consent language, support contact, and mobile-data statement
- route signed-in users to the existing Profile Notifications consent control
- cross-link the page from Terms and Privacy
- allow the page through the signed-out proxy gate

## Verification
- focused legal-page and proxy tests: 13 passed
- npm run lint: passed with 5 pre-existing warnings
- npm run build: passed and lists /sms-consent in the route manifest