### PR TITLE
Cap "often" domains at 2, same as everything else

### DIFF
--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -900,7 +900,7 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
           onClick={() => updateFeedback('thumbs_up')}
         >
           <Heart className={cn('size-4', rating === 'thumbs_up' ? 'fill-current' : '')} />
-          React
+          Like
         </button>
         <SendQuestionAction
           question={{

--- a/src/server/daily/__tests__/diversity-cap.test.ts
+++ b/src/server/daily/__tests__/diversity-cap.test.ts
@@ -297,10 +297,14 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
     expect(core).toHaveLength(DAILY_QUEUE_SIZE);
   });
 
-  it('exempts an "often"-marked subcategory from the cap (Game settings honored)', async () => {
-    // The player explicitly asked to see lots of Botany. The diversity cap must NOT
-    // throttle a topic the player deliberately requested — "often" is exempt, so a
-    // botany-heavy day the player asked for is delivered in full.
+  it('no longer exempts an "often"-marked subcategory from the cap (Josh 2026-09-02, after a 4-of-5 prod incident)', async () => {
+    // "often" used to bypass the cap entirely (bounded only by DAILY_QUEUE_SIZE).
+    // A real Five landed 4-of-5 on one "often" domain (20th Century Composers,
+    // 2026-09-02) and Josh called it too many — "often" now shares the exact
+    // same DAILY_QUEUE_MAX_PER_SUBCATEGORY cap as every other tier. Here Botany
+    // is the ONLY domain with real supply, so once it's held to the cap the
+    // build can't reach the floor — it must fail loudly rather than quietly
+    // serve five repeats of a topic the player merely asked to see often.
     mocks.getDailyPreferences.mockResolvedValue({
       difficulty: 'adaptive',
       domainMode: 'random',
@@ -315,16 +319,13 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
       genq('b5', 'Botany'),
     ]);
 
-    await fillDailyQueueForUser(USER);
-
-    // All five botany slots persisted — not capped at DAILY_QUEUE_MAX_PER_SUBCATEGORY.
-    expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
+    await expect(fillDailyQueueForUser(USER)).rejects.toThrow(DailyQueueFillError);
   });
 
-  it('still caps OTHER subcategories while an "often" one runs free', async () => {
-    // Botany is "often" (exempt); Jazz is unset (base cap). A mixed batch should let
-    // botany exceed the base cap while jazz is still spaced out — the cap and the
-    // frequency preference coexist.
+  it('caps an "often"-marked subcategory the same as an unset one, and degrades rather than repeats', async () => {
+    // Botany is "often"; Jazz is unset. Both now hit the same base cap, so a
+    // batch with 3 of each admits only 2+2 = 4 and stops there — a short Five
+    // is the correct outcome when the alternative is a 3rd "often" repeat.
     mocks.getDailyPreferences.mockResolvedValue({
       difficulty: 'adaptive',
       domainMode: 'random',
@@ -342,15 +343,11 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
 
     await fillDailyQueueForUser(USER);
 
-    expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
+    expect(persistedBotSlots()).toHaveLength(2 * DAILY_QUEUE_MAX_PER_SUBCATEGORY);
     const domains = persistedGeneratedDomains();
-    // Botany (often) exceeds the base cap; Jazz (unset) is held at it.
-    expect(domains.filter((d) => d === 'Botany').length).toBeGreaterThan(
-      DAILY_QUEUE_MAX_PER_SUBCATEGORY,
-    );
-    expect(domains.filter((d) => d === 'Jazz').length).toBeLessThanOrEqual(
-      DAILY_QUEUE_MAX_PER_SUBCATEGORY,
-    );
+    // Neither domain — "often" or unset — exceeds the base cap.
+    expect(domains.filter((d) => d === 'Botany').length).toBe(DAILY_QUEUE_MAX_PER_SUBCATEGORY);
+    expect(domains.filter((d) => d === 'Jazz').length).toBe(DAILY_QUEUE_MAX_PER_SUBCATEGORY);
   });
 
   it('does not shorten a queue when only one subcategory is available (soft cap)', async () => {

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -478,10 +478,7 @@ async function buildDailyQueueForUser(
       : DAILY_QUEUE_SIZE;
 
   // In concert with the Game settings page, the diversity cap is frequency-aware
-  // at both ends:
-  //   • "often"    → EXEMPT (bounded only by queue size). The cap exists to break
-  //                  up runs the player did NOT request; an explicit "often" IS
-  //                  that request, so it wins.
+  // at the low end only:
   //   • "blue_moon"→ capped at 1 per round. "See rarely" must mean a Blue Moon
   //                  domain can't take two of the five slots — and because THIS
   //                  shared gate also runs over friend-authored picks (unlike the
@@ -490,19 +487,22 @@ async function buildDailyQueueForUser(
   //                  Blue Moon domain from doubling up. Starvation is impossible:
   //                  a deflected 2nd pick goes to the reserve and is backfilled if
   //                  the queue would otherwise come up short.
-  //   • "sometimes"/unset → the base cap (2, scaled up only for very thin KBs).
+  //   • "often"/"sometimes"/unset → the base cap (2, scaled up only for very
+  //                  thin KBs). "often" used to be EXEMPT here (bounded only by
+  //                  queue size) — Josh 2026-09-02, after a 4-of-5 "20th Century
+  //                  Composers" Five: two is the max he wants to see for ANY
+  //                  domain, including an explicit "often". "Often" still does
+  //                  its job through the frequency *weighting* upstream (more
+  //                  likely to be picked at all, and to reappear more days), it
+  //                  just can no longer crowd out the rest of one day's Five.
   //   • "resting"  → already removed from allowedSubcategories upstream.
   // Keys are lowercased to match how restingDomains is built above and how the gate
   // normalizes each subcategory.
   const freqEntries = Object.entries(preferences.domainPreferenceFrequency ?? {});
-  const oftenDomains = new Set(
-    freqEntries.filter(([, frequency]) => frequency === 'often').map(([domain]) => domain.toLowerCase()),
-  );
   const blueMoonDomains = new Set(
     freqEntries.filter(([, frequency]) => frequency === 'blue_moon').map(([domain]) => domain.toLowerCase()),
   );
   const capForSubcategory = (normalizedSubcategory: string): number => {
-    if (oftenDomains.has(normalizedSubcategory)) return DAILY_QUEUE_SIZE;
     if (blueMoonDomains.has(normalizedSubcategory)) return 1;
     return baseDiversityCap;
   };
@@ -901,15 +901,14 @@ async function buildDailyQueueForUser(
   // capForSubcategory(key) + 1 — to avoid a single reserve monopolizing a
   // shortfall, e.g. prod's 5/5 "Beethoven" house incident on 2026-08-30. Per Josh
   // 2026-09-01: even the +1 relaxation (3 of the same subcategory in one Five) is
-  // too many — two is the max he wants to see, full stop). "often" domains stay
-  // exempt — that's still an explicit player request, not a fallback artifact. A
-  // queue that can't reach five under this hard cap stays short rather than
-  // repetitive; DAILY_QUEUE_MIN_SIZE is the floor.
-  const backfillCapForSubcategory = (normalizedSubcategory: string): number => {
-    if (oftenDomains.has(normalizedSubcategory)) return DAILY_QUEUE_SIZE;
-    return capForSubcategory(normalizedSubcategory);
-  };
-  const backfillGate = makeSubcategoryDiversityGate(backfillCapForSubcategory);
+  // too many — two is the max he wants to see, full stop). The "often" exemption
+  // that survived THAT fix is gone too now — Josh 2026-09-02, after a 4-of-5
+  // "20th Century Composers" Five reached exactly this path (the reserve, not
+  // the primary pass, is what let a 4th "often" pick through). Backfill now
+  // shares capForSubcategory outright rather than wrapping it. A queue that
+  // can't reach five under this hard cap stays short rather than repetitive;
+  // DAILY_QUEUE_MIN_SIZE is the floor.
+  const backfillGate = makeSubcategoryDiversityGate(capForSubcategory);
   for (const pick of authored) backfillGate.admit(pick.canonicalSubcategory);
   for (const pick of housePicks) backfillGate.admit(pick.canonicalSubcategory);
   for (const question of generatedForQueue) backfillGate.admit(question.canonicalSubcategory);
@@ -1068,7 +1067,6 @@ async function buildDailyQueueForUser(
       droppedGeneric,
       droppedHidden,
       baseDiversityCap,
-      oftenDomains: oftenDomains.size,
       deflectedForDiversity,
       deflectedForAnswerCooldown,
       deflectedForSubjectCooldown,
@@ -1115,7 +1113,6 @@ async function buildDailyQueueForUser(
       droppedGeneric,
       droppedHidden,
       baseDiversityCap,
-      oftenDomains: oftenDomains.size,
       deflectedForDiversity,
       deflectedForAnswerCooldown,
       deflectedForSubjectCooldown,


### PR DESCRIPTION
## Summary

- **Diversity cap.** "Often" domains were exempt from the intra-day diversity cap in both the primary pick and the backfill reserve — bounded only by queue size. Today's Daily Five hit that directly: 4 of 5 core slots landed on "20th Century Composers" because it's tagged "often." Removed the exemption in both places (the backfill's own wrapper only existed to re-apply it, so it's gone too); "often" now caps at `DAILY_QUEUE_MAX_PER_SUBCATEGORY` (2) like every other tier. It still steers what gets *generated* and how often it resurfaces across days via the upstream frequency weighting — it just can't crowd out one day's Five anymore.
- **Label rename.** The reveal-card "React" button (thumbs-up question feedback, `/api/daily/feedback`) is renamed to "Like." It's an unrelated, still-live feature — not the retired `QuestionReaction` peer-reaction system — but the label read as if that retired feature had come back. `aria-label="Love this question"` was already unambiguous and needed no change.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` — clean
- [x] `npx vitest run src/server/daily` — 430 tests pass (2 diversity-cap tests rewritten to pin the new capped behavior instead of the old exemption)
- [x] `npm run lint` — clean (4 pre-existing warnings, unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJwiXeNJPqExdRGRdZGrTh