### PR TITLE
Fix daily summary core-count and mastery-tier display bugs

### DIFF
--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -131,12 +131,20 @@ export default function DailySummaryPage() {
   )
   const growthCircleItems = useMemo(() => {
     if (!summary) return []
+    // Same crossing record the interpretive "you moved to X" sentence reads
+    // (summary.tierCrossings) — passing its fromTier through as tier_before
+    // lets the circle show the TRUE this-round delta instead of guessing a
+    // "next milestone" that could contradict the sentence above it.
+    const crossingByDomain = new Map(
+      summary.tierCrossings.map((crossing) => [crossing.domain, crossing])
+    )
     return summary.domainGains.map((gain) => ({
       canonical_subcategory: gain.displayName,
       broad_category: gain.broadCategory,
       points_total: gain.totalPoints,
       points_gained_this_round: gain.pointsGained,
       tier_current: gain.currentTier,
+      tier_before: crossingByDomain.get(gain.domain)?.fromTier,
     }))
   }, [summary])
   const firstTierCrossing = summary?.tierCrossings[0] ?? null
@@ -191,7 +199,7 @@ export default function DailySummaryPage() {
   // questions are additive and never enter the spoken X/Y (or the share). X and
   // Y both come from the same (visible) core rows so they can never disagree;
   // bonus performance is reflected in the bonus dot-group, not the headline.
-  const coreQuestions = summary.questions.filter((q) => !q.isBonus)
+  const coreQuestions = summary.questions.filter((q) => !q.isAdditive)
   const coreCorrect = coreQuestions.filter((q) => q.isCorrect).length
   const coreTotal = coreQuestions.length
 
@@ -398,7 +406,7 @@ function interpretiveLine(summary: DailySummaryView): string | null {
   // 3 & 4 are the "perfect/whiffed five" beats — gated on the CORE five (D-F3:
   // bonus is additive and never enters the count), so they fire on a clean or
   // missed core round regardless of how the +2 bonus went.
-  const coreAnswered = answered.filter((q) => !q.isBonus)
+  const coreAnswered = answered.filter((q) => !q.isAdditive)
   const coreAnsweredCorrect = coreAnswered.filter((q) => q.isCorrect).length
 
   // 3. 5/5
@@ -486,13 +494,19 @@ function ResultDot({
 // "+{N} friend bonus" label. The bonus signal is the gap + label (real
 // text), never color. Mirrors the live-session GeometricProgress track.
 function ResultDots({ questions }: { questions: QuestionRecap[] }) {
-  const core = questions.filter((q) => !q.isBonus)
-  const bonus = questions.filter((q) => q.isBonus)
+  // D-F3 / D-MISSED-RETURN-01: the additive tail is friend bonus AND missed-
+  // question return ("Second look") rows — both are appended past the core
+  // five and neither enters the spoken X/5. `isBonus` (narrower) still
+  // decides the per-dot "from friends" wording so a Second look doesn't get
+  // mislabeled as a friend's gift.
+  const core = questions.filter((q) => !q.isAdditive)
+  const additive = questions.filter((q) => q.isAdditive)
+  const friendBonusCount = additive.filter((q) => q.isBonus).length
 
   const outcome = (q: QuestionRecap) =>
     q.isSkipped ? 'skipped' : q.isCorrect ? 'correct' : 'not this time'
 
-  if (bonus.length === 0) {
+  if (additive.length === 0) {
     return (
       <div className="flex items-center gap-2" aria-label="Question results">
         {core.map((question, index) => (
@@ -520,16 +534,22 @@ function ResultDots({ questions }: { questions: QuestionRecap[] }) {
         className="mx-0.5 h-3 w-px shrink-0"
         style={{ backgroundColor: 'color-mix(in srgb, var(--brand-ink) 28%, transparent)' }}
       />
-      {bonus.map((question, index) => (
+      {additive.map((question, index) => (
         <ResultDot
           key={question.questionId}
           question={question}
-          ariaLabel={`Bonus question ${index + 1} of ${bonus.length}, from friends: ${outcome(question)}`}
+          ariaLabel={
+            question.isBonus
+              ? `Bonus question ${index + 1} of ${additive.length}, from friends: ${outcome(question)}`
+              : `Second look question ${index + 1} of ${additive.length}: ${outcome(question)}`
+          }
         />
       ))}
-      <span className="ml-1 text-[0.7rem] font-medium text-[var(--brand-ink-400)]">
-        +{bonus.length} friend bonus
-      </span>
+      {friendBonusCount > 0 ? (
+        <span className="ml-1 text-[0.7rem] font-medium text-[var(--brand-ink-400)]">
+          +{friendBonusCount} friend bonus
+        </span>
+      ) : null}
     </div>
   )
 }

--- a/src/components/knowledge/CategoryCircles.tsx
+++ b/src/components/knowledge/CategoryCircles.tsx
@@ -24,6 +24,14 @@ export type RoundCircleItem = {
   points_total: number;
   points_gained_this_round: number;
   tier_current: string;
+  /**
+   * The domain's tier at the START of this round, when known (from the
+   * server's authoritative tier-crossing record — the same one a same-page
+   * "you moved to X" sentence draws from). Omit when no crossing happened
+   * this round. Presence gates whether the row shows the TRUE this-round
+   * delta or the forward "next milestone" teaser — see `RoundCircleRow`.
+   */
+  tier_before?: string;
 };
 
 // Re-export for callers that imported getDomainColor from this module.
@@ -66,14 +74,16 @@ function displayTier(raw: string): string {
   return key ? KNOWLEDGE_TIER_LABEL[key] : raw;
 }
 
+// Forward-looking "what's next" teaser for a domain that did NOT cross a
+// tier boundary this round/game. Deliberately does not use the "X → Y" arrow
+// form — that form is reserved for a REAL before/after delta (see
+// `tierChanged` below), so this can never be misread as a completed move.
 function tierProgression(rawTier: string): string {
   const key = tierKey(rawTier);
   if (!key) return rawTier;
   const idx = TIER_ORDER.indexOf(key);
   const next = TIER_ORDER[idx + 1];
-  return next
-    ? `${KNOWLEDGE_TIER_LABEL[key]} → ${KNOWLEDGE_TIER_LABEL[next]}`
-    : KNOWLEDGE_TIER_LABEL.mastery;
+  return next ? `Next: ${KNOWLEDGE_TIER_LABEL[next]}` : KNOWLEDGE_TIER_LABEL.mastery;
 }
 
 // ── Animated knowledge circle — matches PortraitDomainCircle visual style ─────
@@ -304,6 +314,14 @@ function RoundCircleRow({
   }, [index]);
 
   const isMastery = tierKey(item.tier_current) === 'mastery';
+  // A REAL this-round crossing, from the same server-computed record the
+  // page's "you moved to X" sentence draws from — not the forward "next
+  // milestone" guess. Only this form ever uses the "X → Y" arrow, so the
+  // arrow never appears unless a crossing actually happened (Priority 6 /
+  // Screen 13: this used to always show "current → next tier" regardless of
+  // whether the player had actually reached the second tier this round).
+  const tierChanged = Boolean(item.tier_before) && item.tier_before !== item.tier_current;
+  const dc = getPortraitDomainColor(item.broad_category);
 
   return (
     <div
@@ -343,10 +361,14 @@ function RoundCircleRow({
             fontFamily: 'var(--font-mono)',
             letterSpacing: '0.1em',
             textTransform: 'uppercase',
-            color: 'var(--text-muted)',
+            color: tierChanged ? dc.primary : 'var(--text-muted)',
           }}
         >
-          {isMastery ? KNOWLEDGE_TIER_LABEL.mastery : tierProgression(item.tier_current)}
+          {isMastery
+            ? KNOWLEDGE_TIER_LABEL.mastery
+            : tierChanged
+              ? `${displayTier(item.tier_before as string)} → ${displayTier(item.tier_current)}`
+              : tierProgression(item.tier_current)}
         </div>
         <div
           style={{

--- a/src/components/review/CategoryGainsDisplay.tsx
+++ b/src/components/review/CategoryGainsDisplay.tsx
@@ -37,6 +37,10 @@ function itemsFromDeltas(deltas: DeltaCircleRow[]): RoundCircleItem[] {
       points_total: row.total,
       points_gained_this_round: row.points_earned,
       tier_current: row.new_tier ?? row.current_tier,
+      // `new_tier` is set only when this answer actually crossed a tier
+      // boundary — that's a real before/after, not a guess, so pass it
+      // through the same way the daily summary does.
+      tier_before: row.new_tier ? row.current_tier : undefined,
     }));
 }
 

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -35,7 +35,7 @@ import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { buildRefineSection } from '@/server/db/queries/refine';
 import { getFeedPagePayload } from '@/server/feed/get-feed-page';
 import type { QueueSlot } from '@/server/daily/types';
-import { getSlotPresence, isBonusSlot } from '@/server/daily/bonus';
+import { getSlotPresence, isAdditiveSlot, isBonusSlot } from '@/server/daily/bonus';
 import type { RefineSectionView } from '@/server/refine/types';
 import type { MasteryTier } from '@/types/db';
 
@@ -136,11 +136,21 @@ export type QuestionRecap = {
   /** D-3: the author is the non-human house/editorial author (Editorial badge, non-relational copy). */
   authorIsHouse: boolean;
   /**
-   * Daily Five +2: this recap row is an additive bonus question (D-4 §B), set via
-   * the shared bonus selector. Drives the recap dot-track split (core | gap |
-   * bonus). Never enters the spoken X/5 count.
+   * True iff the underlying slot carries a friend-presence source (D-4 §B) — a
+   * genuine +2 bonus question. Narrower than `isAdditive`: a missed-question
+   * return ("Second look") slot is additive but NOT a friend bonus, so it's
+   * false here. Use this only for friend-attribution copy ("from friends"),
+   * never for the core/X-of-5 count — use `isAdditive` for that (see below).
    */
   isBonus: boolean;
+  /**
+   * Daily Five +2 / Second look: this recap row is APPENDED past the core five
+   * — either a friend bonus or a missed-question return slot (D-F3, D-MISSED-
+   * RETURN-01 §2 R3), set via the shared `isAdditiveSlot` selector. Drives the
+   * recap dot-track split (core | gap | additive) and every core count/X-of-5
+   * denominator. Never enters the spoken X/5.
+   */
+  isAdditive: boolean;
   /**
    * Presence attribution for a +2 bonus row: the named friend whose knowledge
    * surfaced this domain, for the quiet "from {Name}'s knowledge" sub-line (D-F4).
@@ -331,6 +341,7 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
       authorNote: slot.source === 'friend' || slot.source === 'house' ? (slot.author_note ?? null) : null,
       authorIsHouse: slot.source === 'house',
       isBonus: isBonusSlot(slot),
+      isAdditive: isAdditiveSlot(slot),
       bonusPresence:
         presence && presence.name
           ? { name: presence.name, extraCount: presence.extraCount }


### PR DESCRIPTION
## Summary
- Fixes the recap's "5 core" count silently becoming 6+ after a skip/replacement — `daily-summary.ts` was deriving core/bonus classification from `isBonusSlot` (friend-presence only), missing "Second look" return slots, which are additive per D-F3/D-MISSED-RETURN-01 but weren't treated that way in the summary. Added `isAdditive` (backed by the shared `isAdditiveSlot` selector) and moved every count/denominator site onto it.
- Fixes the Growth Recap circle showing "Familiar → Solid" (implying a completed transition) directly under a "You moved to Familiar" sentence, when nothing contradictory actually happened — the circle's arrow was always a "current tier → next milestone" teaser, not a real this-round delta. It now takes an optional `tier_before` sourced from the same `tierCrossings` record the sentence reads, uses the arrow only for a genuine crossing, and falls back to an unambiguous "Next: X" label otherwise. Applied the same fix to the feed-card delta path (`itemsFromDeltas`), which had real before/after data available but wasn't using it.

Surfaced by a UX review of the daily ritual flow; these were two of the concrete, code-verified findings from it (Priority 1 and Priority 6 in that review's ranking).

## Test plan
- [x] `npx tsc -p tsconfig.typecheck.json` clean
- [x] `npx eslint` clean on the four changed files
- [ ] Manual: play a Daily Five that includes a skip → confirm the recap's core count stays at 5 and the "Second look" dot isn't labeled "from friends"
- [ ] Manual: play a round where a domain crosses a tier → confirm the Growth Recap circle's tier range matches the interpretive sentence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A