### PR TITLE
Clarify session-close copy and let wrong-answer explainers expand inline

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -938,6 +938,52 @@ function ExplainerLine({ text }: { text: string }) {
   );
 }
 
+// A wrong/discovery reveal's explainer: the one-sentence line by default, with
+// a "More" disclosure for the rest — inline, so a curious player doesn't have
+// to leave the round and wait for the End of Session Review to read the full
+// explanation. Recheck stays a separate, always-visible action below this;
+// only the explanation text itself collapses.
+function ExpandableExplainer({ sentence, full }: { sentence: string; full: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasMore = full.trim().length > sentence.trim().length;
+  return (
+    <div style={{ marginTop: '8px' }}>
+      <p
+        style={{
+          fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
+          fontSize: '0.92rem',
+          color: 'color-mix(in srgb, var(--text-muted) 35%, var(--text))',
+          lineHeight: 1.5,
+        }}
+      >
+        {expanded ? full : sentence}
+      </p>
+      {hasMore ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          style={{
+            marginTop: '4px',
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            cursor: 'pointer',
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.65rem',
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            textDecoration: 'underline',
+            textUnderlineOffset: '3px',
+            color: 'var(--text-muted)',
+          }}
+        >
+          {expanded ? 'Less' : 'More'}
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
 function reactionEmoji(value: string): string {
   switch (value) {
     case ':exploding_head:':
@@ -1248,8 +1294,10 @@ function ResultRow({
   const expired = result === 'expired';
   const correct = result === 'correct';
   const gaveUp = result === 'gave_up';
-  // Every reveal shows a one-sentence explainer directly under the answer; the
-  // full text always remains in the End of Session Review, so nothing is lost.
+  // Every reveal shows a one-sentence explainer directly under the answer. On
+  // a wrong/discovery reveal it expands inline via "More" (ExpandableExplainer
+  // below) rather than sending the player to the End of Session Review to read
+  // the rest — recheck stays a separate, always-visible action either way.
   // Sourced from the stored explainer that arrives with the answer response —
   // not the async breadcrumb — so the line is shown once and never swaps in
   // longer/replacement content after the fact.
@@ -1510,7 +1558,7 @@ function ResultRow({
           </>
         )}
         {showDiscoveryExplainer && explainerSentence ? (
-          <ExplainerLine text={explainerSentence} />
+          <ExpandableExplainer sentence={explainerSentence} full={explanation ?? explainerSentence} />
         ) : null}
         {typeof pointsAwarded === 'number' ? (
           <p
@@ -1559,7 +1607,7 @@ function SessionCloseRow({
       {summaryHref ? (
         <div className="pt-3">
           <Link href={summaryHref} className="btn-primary inline-flex">
-            See summary →
+            See my recap →
           </Link>
         </div>
       ) : null}

--- a/src/components/play/SessionCloseMessage.tsx
+++ b/src/components/play/SessionCloseMessage.tsx
@@ -28,7 +28,15 @@ export function SessionCloseMessage({
 
   return (
     <>
-      <p className="font-serif text-[1.22rem] text-[var(--text)] leading-relaxed">{scoreLine}</p>
+      {/* This card is a deliberate confirmation gate, not a recap — the
+          previous auto-navigate-to-recap felt jarring, hence the tap. The
+          score line alone ("Untouched.") doesn't say that on its own, so
+          this eyebrow states plainly that the round is over before the
+          stylized line renders underneath it. */}
+      <p className="font-mono text-xs font-bold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+        Today&apos;s Joshing: finished
+      </p>
+      <p className="mt-1 font-serif text-[1.22rem] text-[var(--text)] leading-relaxed">{scoreLine}</p>
       {interpretiveLine ? (
         <p
           className="mt-1 text-[1.05rem] text-[var(--text-muted)] leading-relaxed"


### PR DESCRIPTION
## Summary
- **Priority 3 (refined per Josh):** the completion card only had the stylized score line ("Untouched.") as a status signal, which the UX review flagged as opaque. Reviewed and narrowed the review's proposed fix — this card is a deliberate confirmation gate (tap to advance), not a recap surface, and shouldn't duplicate content (Second look, domain movement, etc.) that already lives on the next page. Added a plain "Today's Joshing: finished" eyebrow above the score line, and reworded the CTA from "See summary" to "See my recap" so the moment reads as an intentional next step rather than a passive link.
- **Priority 4 (refined per Josh):** recheck stays exactly as-is, a first-class always-visible action on a wrong answer. Only the explanation text changes — it already showed just the first sentence with the rest deferred to the End of Session Review; now a "More" toggle (`ExpandableExplainer`) expands the full explanation inline so a curious player doesn't have to leave the round to read the rest.

Follow-up to #1592 from the same UX review; opened separately since these are copy/interaction tuning rather than bug fixes.

## Test plan
- [x] `npx tsc -p tsconfig.typecheck.json` clean
- [x] `npx eslint` clean on both changed files
- [x] Ratchets (`check:typesize`, `check:spacing`, `check:colors`) all pass
- [x] `GameplayChat.*.test.tsx` (24 tests) and `session-close-copy.test.ts` (13 tests) pass
- [ ] Manual: finish a Daily Five, confirm the completion card reads clearly and "See my recap" advances normally
- [ ] Manual: miss a question with a multi-sentence explanation, confirm "More" expands it inline and Recheck still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A