### PR TITLE
Suppress add-territories nudge on a day with a new demonstrated domain

### DIFF
--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -374,7 +374,7 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
     hasVerifiedEmail,
   } = await computeReminderPromptState(userId, dateString, totalAnswered);
   const refine: RefineSectionView = queue
-    ? await buildRefineSection(userId, queue.id, slots)
+    ? await buildRefineSection(userId, queue.id, slots, newTerritory.length > 0)
     : { queueId: null, items: [] };
   const touchedForExpansion: TouchedDomainForExpansion[] = [...touchedDomains].map((domain) => ({
     domain,

--- a/src/server/db/queries/refine.ts
+++ b/src/server/db/queries/refine.ts
@@ -291,6 +291,17 @@ export async function buildRefineSection(
   userId: string,
   queueId: string,
   slots: QueueSlot[],
+  /**
+   * True when today's round already demonstrated at least one new domain
+   * (daily-summary.ts's `newTerritory`) — a "Knowledge updated" moment the
+   * player just saw in the round. `getDaysSinceLastTerritoryAdd` reads
+   * `declaredInterests`, a DIFFERENT table from the `playerMastery` write a
+   * demonstrated add makes, so it stays blind to it and the inactivity nudge
+   * could otherwise say "you haven't added anything new" in the same summary
+   * (UX review Priority 6 / Screen 15). Suppress it outright on those days
+   * rather than let two different "added" claims contradict each other.
+   */
+  hasNewTerritoryToday: boolean = false,
 ): Promise<RefineSectionView> {
   if (slots.length === 0) return { queueId, items: [] };
   const [selected, pendingKeys, daysSinceLastAdd] = await Promise.all([
@@ -303,7 +314,11 @@ export async function buildRefineSection(
   // Inactivity nudge fills any room the evidence-based items leave open: if the
   // player hasn't added a territory recently, offer to add some. Lowest priority,
   // so an engaged day with three evidence items crowds it out.
-  if (items.length < REFINE_MAX_ITEMS && shouldNudgeAddTerritories(daysSinceLastAdd)) {
+  if (
+    items.length < REFINE_MAX_ITEMS &&
+    !hasNewTerritoryToday &&
+    shouldNudgeAddTerritories(daysSinceLastAdd)
+  ) {
     items.push(buildAddTerritoriesItem(queueId));
   }
 


### PR DESCRIPTION
## Summary
- Priority 6 (third piece) from the gameplay UX review: the daily summary's "Refine Your Game" inactivity nudge — "You haven't added anything new in a while" — could appear in the same summary as a "Knowledge updated" card, because they read from two unrelated tables. The nudge is driven by `declaredInterests` (explicit topics added via `/daily/setup`); a same-round demonstrated-knowledge add (correct answer in a new domain, or adopting a bonus domain) only writes `playerMastery` and never touches `declaredInterests`. Both surfaces use the word "added," so the nudge could contradict what the player just saw.
- The other two pieces of Priority 6 evidence were checked and are not being touched here: the summary tier-statement contradiction (Screens 13/14) was already fixed by #1592, and the live-play "Added X" / frequency-selector card (Screen 10, `NewTerritoryUndo.tsx`) already explains map-vs-rotation via its hint copy — confirmed not a real gap.
- Fix: `buildRefineSection` now takes whether today's round already demonstrated a new domain (`daily-summary.ts`'s existing `newTerritory` computation) and skips the add-territories nudge outright on those days.

## Test plan
- [x] `npx tsc -p tsconfig.typecheck.json` clean
- [x] `npx eslint` clean on both changed files
- [x] `add-territories-nudge.test.ts` (5 tests) passes
- [ ] Manual: play a round that opens a brand-new domain (correct answer or bonus adoption), confirm the summary's Refine section does not show "You haven't added anything new"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A