### PR TITLE
Make the per-user invite link the primary invitation path

### DIFF
--- a/_docs/INVITE-LINK-STAGED-BUILD-PROMPTS.md
+++ b/_docs/INVITE-LINK-STAGED-BUILD-PROMPTS.md
@@ -1,0 +1,188 @@
+# Joshing — Invite Link: Staged Build Prompts
+
+*Six stages, run one at a time. Each is a separate Claude Code session. Every prompt ends with "concerns before code" — do not let it start writing until it has raised anything that looks wrong. Stages 5 and 6 are loose ends and admin discoverability turned up along the way, not part of the original four-stage plan; both can run any time after Stage 1.*
+
+**Standing constraint for all four stages: both invitation paths stay available.**
+The per-user invite link (`/u/<handle>/<token>`) becomes the default *placement*. The named phone invitation (`AddFriendInvite` → `friendInvitations` → SMS handoff) keeps every capability it has today, including pre-seeded interests, edit-before-click, cancel, and expiry. Nothing in these stages removes, disables, or degrades it. If a stage looks like it requires removing the phone path to work, stop and say so.
+
+Codebase conventions to restate in each session: Drizzle (not Prisma); no `src/middleware.ts` — use `src/proxy.ts` and run `/check-middleware`; Zod on changed API inputs; DB access in `src/server/db/queries/`; Sonnet for generation, Haiku for grading; typecheck with `npx tsc -p tsconfig.typecheck.json`; after hand-writing any migration, reconcile `drizzle/meta/_journal.json` via `node scripts/reconcile-drizzle.mjs` (report-only; `--apply` to write the journal entry) — an unjournaled migration is invisible to the runtime migrator.
+
+Recurring failure mode in this codebase, to guard against in every stage: **a value correct on the server breaks at a boundary another feature reads.** A server change is not done when the route test passes — test the consumer and the render side too.
+
+---
+
+## Stage 1 — One inviter resolver
+
+*Correctness fix. Independent of every design decision in stages 2–4 and safe to ship on its own. Run this first: stages 2 and 3 make the bug it fixes far more visible.*
+
+### Prompt
+
+> Joshing has two ways a player can arrive, and one of them is a second-class citizen in three downstream surfaces.
+>
+> **The named path** creates a `FriendInvitation` row (`src/server/friends/invitations.ts` → `acceptFriendInvitation`), sets `acceptedAt` and `inviteeUserId`, and calls `upsertInvitationFriendship`.
+>
+> **The per-user invite-link path** (`/u/<handle>/<token>`, `src/server/friends/user-invite-token.ts` → `acceptUserInviteLink`) calls the same `upsertInvitationFriendship` — creating a mutual approved follow — but writes **no `FriendInvitation` row at all**.
+>
+> Three surfaces resolve "who invited this user" by querying `friendInvitations` directly, so for a link-arrived player they resolve to nothing:
+>
+> 1. `src/server/activity/invite-onboarding.ts` — `maybeNotifyInviterOfFirstFive` returns early at the `invitationRow` lookup, so **the inviter is never told their link-joined friend played their first five.**
+> 2. `src/server/daily/get-first-session-recap.ts` — the inviter lookup returns nothing, so the new player's first-session recap drops Beat 3 to its no-inviter copy.
+> 3. `src/app/page.tsx` — `welcomeInviterName` comes from `getPreSeededInterestsForUser(...).inviterName`, so the welcome tour says "a friend" instead of the inviter's name.
+>
+> This pattern has already bitten once and was patched locally: `src/app/onboarding/page.tsx` added `hasInviteLinkFriendship` as a second provenance signal to stop link signups redirect-looping. That patch is the precedent — but it is a boolean, and these three sites need the inviter's identity.
+>
+> **Build one shared resolver and route all call sites through it.**
+>
+> - Add `getInviterForUser(userId)` in `src/server/db/queries/` returning `{ inviterUserId, inviterName } | null`.
+> - Resolution order: (a) the most recently accepted `FriendInvitation` where `inviteeUserId = userId`, exactly as today; (b) failing that, the approved-follow edge left by `upsertInvitationFriendship` — the same signal `hasInviteLinkFriendship` already reads in `src/server/friends/user-invite-token.ts`.
+> - For (b): `follows` rows are **hard-deleted** on unfollow (every unfollow/remove path in `src/server/friends/friendships.ts` is a real `DELETE`, not a state change), so "the earliest surviving approved follow edge" is not a stable signal — if the inviter and invitee ever unfollow each other, that query silently reassigns to whichever unrelated follow happens to be earliest at query time. Do not use an unbounded "earliest surviving edge." Instead: the earliest approved follow edge (`followeeId = userId`) whose `approvedAt` falls within **7 days of the user's `users.createdAt`** — the mutual follow from `upsertInvitationFriendship` is written at accept time, which is at or near signup, so this window catches it while excluding any later organic follow. If no edge exists in that window, return `null` — a link-arrived user whose inviter-edge was deleted gets no-inviter treatment (the same fate a named invite gets if its `FriendInvitation` row is hard-deleted), not a misattributed one. State this rule in a comment on `getInviterForUser`.
+> - Update all three sites above. Keep the existing `FriendInvitation` branch as the first check so the named path's behaviour is byte-identical.
+> - `hasInviteLinkFriendship` and the onboarding gate can stay as they are; do not refactor the onboarding redirect while you are in here.
+>
+> **Acceptance:** a user created via `/u/<handle>/<token>` gets (1) the inviter notified at their fifth answer, (2) Beat 3 of the first-session recap naming the inviter, (3) the welcome tour naming the inviter. A user created via a named invitation behaves exactly as it does today. Add a unit test per resolution branch, and one test at the consumer level — not just the query — per the boundary rule above.
+>
+> Raise any concerns before writing code.
+
+---
+
+## Stage 2 — Topics that ride the link
+
+*Depends on Stage 1's resolver. This is the stage that closes the actual gap.*
+
+### The problem, stated precisely
+
+Onboarding is two screens (`src/app/onboarding/OnboardingFlow.tsx`): `setup` (display name + handle) and `review` (interests). The cultural-anchor step is gone. On `review`, the **only** source of candidate chips is `inviteSuggestions`, derived from the `preSeededInterests` prop, which `src/app/onboarding/page.tsx` gets from `getPreSeededInterestsForUser` — a read of `friendInvitations.preSeededInterests`.
+
+A link joiner has no such row. So `preSeededInterests` is `[]`, `hasSeeds` is false, the list renders *"Nothing yet — add a few below"*, and the only affordance is `AddTopicField`. They must invent three specific topics from a blank screen before the CTA unlocks at `MIN_INTERESTS = 3` — and the obvious answers are refused by `isTooBroadInterest`, which rejects every `STABLE_BROAD_CATEGORIES` bucket and alias.
+
+### Prompt
+
+> Give the per-user invite link a set of topics it carries, so a link-arrived player reaches the onboarding interests screen with suggestions instead of a blank list.
+>
+> **Storage.** There is nowhere to put this today: `users.inviteToken` is a bare text column, and `preSeededInterests` lives on `friendInvitations`, which the link path never creates. Add `inviteSeedInterests` as a nullable `jsonb` column on `User` via a Drizzle migration, shaped like the existing `friendInvitations.preSeededInterests` payload so `parseInvitationInterests` / `parsePreSeededInterests` can be reused rather than reimplemented. Cap at 3. Reconcile the journal per the standing convention above before moving on.
+>
+> **Two sources, one fallback.**
+> - **Curated:** whatever the user saved in `inviteSeedInterests`.
+> - **Automatic (default, when the column is null/empty):** the first three from `getActiveDeclaredInterests(inviterUserId)` (`src/server/db/queries/declared-interests.ts`), which already returns them first-picked first.
+>
+> The automatic fallback is what makes this useful on day one with zero setup. Do not require the user to configure anything for the link to carry topics.
+>
+> **Minimal curated-set editor.** Nothing today lets a user set `inviteSeedInterests` — without an editor the "curated" source is dead code. Add a small section to `src/components/profile/settings/PrivacyForm.tsx`, next to the existing rotate-token control: up to 3 topics, add/remove, no reordering UI needed. Save through a new Zod-validated endpoint (or extend the existing invite-token route) that runs saved topics through the same `isTooBroadInterest` check used at onboarding-consumption time before writing — reject too-broad entries at save, don't just filter them silently at read. This is the "editor" Stage 3's topic-count line links to; keep it minimal, it does not need its own review/convergence flow.
+>
+> **Where they surface.**
+> 1. `src/app/u/[handle]/[token]/page.tsx` — `resolveInviteLink` already returns `inviterUserId`. Extend the resolution to include the seed topics and render them on the invite card for a logged-out visitor, as read-only chips under a line naming the inviter. Then carry them through the existing `loginHref` redirect. Respect `profileDomainVisibility` — a domain the inviter has marked non-public must not appear.
+> 2. `src/app/login/page.tsx` — the `inviteContext` built from `resolveInviteLink` currently carries name and avatar colour only. Add the topics so the invite card on the login panel shows them too.
+> 3. `src/app/onboarding/page.tsx` — when `getPreSeededInterestsForUser` returns no interests, resolve the inviter with **Stage 1's `getInviterForUser`** and read their seed topics as the `preSeededInterests` prop. This is why Stage 1 runs first; do not build a second resolver here.
+>
+> **The rule that must not be violated.** In `OnboardingFlow.tsx`, `preSeededInterests` currently pre-populates `selectedInterests` in the initial state. That is correct for a named invite — the inviter chose those topics *for that person*. It is wrong for a link, which may be in a bio and reach someone the inviter never had in mind. **Link-sourced seeds must arrive unselected**, rendering only through the existing `renderSuggestionChips` `+` affordance, with `selectedInterests` starting empty and the CTA still locked until 3. Add a prop or a discriminated seed source to carry this distinction; do not infer it from array length or from whether a `FriendInvitation` exists at read time.
+>
+> Update the `hasSeeds` copy branch so a link joiner gets the "here are a few from {inviter} — take any that are yours" framing rather than either of today's two strings.
+>
+> **Reuse the existing validation.** Seeds still pass through `isTooBroadInterest`, `assessInterestAnswerability` and `convergeDomain` in `onboarding/page.tsx`. Do not add a parallel path. Note that automatic seeds come from `declaredInterests`, which are already converged canonical domains, so they should pass cleanly — if they do not, that is a finding worth reporting, not a reason to skip the checks.
+>
+> **Do not touch the named path.** `friendInvitations.preSeededInterests`, the four-step `AddFriendInvite` modal, and the pre-selection behaviour for named invites all stay exactly as they are.
+>
+> **Acceptance:** a logged-out visitor tapping `/u/<handle>/<token>` sees the inviter's name and up to three topics; after login and the name/handle step, those topics appear as unselected `+` chips on the interests screen with the counter reading "0 selected · pick at least 3 more"; a named-invite arrival still lands with its topics **pre-selected** and its counter reading "3 selected"; an inviter with no declared interests and no curated set produces a link that behaves exactly as today; saving 1–3 topics in the new `PrivacyForm.tsx` editor makes the link show exactly those instead of the automatic fallback, and a too-broad entry is rejected at save with an inline error rather than silently dropped. Test both arrival paths at the render level, not only the query.
+>
+> Raise any concerns before writing code.
+
+---
+
+## Stage 3 — Share, don't copy
+
+*UI only. Depends on Stage 2 for the "your link carries N topics" line; everything else is independent.*
+
+### Prompt
+
+> Make the invite link the default way to invite someone, without removing the phone invitation.
+>
+> **Today.** The link is reachable from exactly two places, both buried: `src/components/profile/settings/PrivacyForm.tsx` (account settings, beside a rotate control) and `src/components/friends/InviteSomeoneNew.tsx` on `/friends/find`, where "Copy invite link" is `btn-ghost` beside `btn-primary` "Text a personal invite". The Friends hub itself (`src/components/FriendsHubPage.tsx`) has **no invite affordance at all** — the standalone block was deliberately removed, and inviting is reached only by typing into the search field and hitting a no-match, which opens the four-step phone modal.
+>
+> **Three changes.**
+>
+> 1. **Swap the emphasis in `InviteSomeoneNew.tsx`.** "Share invite link" becomes `btn-primary`; "Text a personal invite" becomes `btn-ghost`. Both stay. The personal invite keeps dispatching `friend-invitations:create-new` exactly as it does now.
+>
+> 2. **Replace copy with share.** The current handler is `navigator.clipboard.writeText(body.url)` on a bare URL — the user then composes the message themselves every time. Use `navigator.share({ text, url })` with pre-written copy ("I'm playing Joshing — come be my friend."), falling back to the existing clipboard path when `navigator.share` is unavailable, with the same toast. Keep the existing `/api/account/invite-token` fetch and its error states.
+>
+> 3. **Put the block on the Friends hub.** Add `InviteSomeoneNew` to `FriendsHubPage.tsx` above or beside the existing `FindFriendsSearch`. The no-match → `AddFriendInvite` hand-off (`handleLookupInvite`, and the phone/name seeding it does) must keep working unchanged — this is an addition, not a replacement. Update the stale comment in that file that says the standalone invite block is gone.
+>
+> **After Stage 2 only:** add a quiet line under the buttons reading how many topics the link currently carries, linking to the editor. If Stage 2 has not shipped, omit the line rather than stubbing it.
+>
+> **Do not** change `users.inviteToken` generation, `rotateInviteToken`, `resolveInviteLink`, or the `request-otp` / `verify-otp` gates. The link mechanism is correct; this stage is placement and message only.
+>
+> **Acceptance:** the link is offered as the primary action on both `/friends` and `/friends/find`; the phone invitation is reachable from both in one tap; the share sheet opens with the message pre-filled on a browser that supports it, and copies with a toast on one that does not; the search no-match hand-off still opens the modal seeded with a phone or a name as it does today.
+>
+> Raise any concerns before writing code.
+
+---
+
+## Stage 4 — Both paths, verified
+
+*Run after 1–3. This is an audit prompt: it reports, it does not build, except for defects it finds and you approve.*
+
+### Prompt
+
+> Stages 1–3 changed the invitation surface. Audit both arrival paths end to end and report findings — do not fix anything without flagging it first.
+>
+> **The standing product constraint:** the per-user invite link and the named phone invitation are both first-class. The link is the default *placement*; the named invitation retains every capability it has today. Any finding that shows the named path degraded is a blocker.
+>
+> Walk and report on each of these, naming the file and line for every claim:
+>
+> **A — The named phone path, unchanged.** `AddFriendInvite` four-step flow (identity → interests → review → handoff); `createFriendInvitation` / `updateFriendInvitation` / `cancelFriendInvitation`; the 14-day `DEFAULT_INVITATION_TTL_MS`; the phone-first login prefill (`getInvitePrefillByToken`, `useInvitePhone`) and its deliberate full-number client exposure; `acceptFriendInvitation`'s `phone_mismatch` rejection; pre-seeded interests arriving **pre-selected** in onboarding.
+>
+> **B — The link path, complete.** `/u/<handle>/<token>` for logged-out, logged-in-as-someone-else, and logged-in-as-self; `resolveInviteLink` returning null identically for a wrong handle and a wrong token; `request-otp`'s `invitedByLink` gate; `verify-otp` → `acceptUserInviteLink` → mutual approved follow + `backfillInviterFeedItems`; `rotateInviteToken` invalidating the old link immediately; the onboarding provenance gate not redirect-looping.
+>
+> **C — Parity between them.** For a user who arrived by link: inviter notified at their fifth answer; first-session recap Beat 3 names the inviter; welcome tour names the inviter; seed topics present and **unselected**. For a user who arrived by named invitation: all of the above, with seeds **pre-selected**. Confirm there is exactly one `getInviterForUser` and no second resolver was introduced.
+>
+> **D — Boundary check.** For every server value Stages 1–3 changed, confirm the consumer and render side were tested, not just the route. This codebase's recurring defect is a value correct on the server and dropped in a client hook.
+>
+> **E — Known non-blocking observations to confirm or clear.** `src/components/PeopleYouInvited.tsx` is still unimported — it is a management console for outgoing phone invitations (masked numbers, `sms:` hrefs, resend/edit/cancel). Report whether it now has a caller. **Do not delete it** — the phone path is retained by decision, and whether that console gets wired up is an open product question, not a cleanup.
+>
+> Report as a findings list ranked by severity, each with file, line, and the concrete failure it produces. No fixes without approval.
+
+---
+
+## Stage 5 — Loose ends from Stages 1–2
+
+*Independent of stages 2–4; can run any time after Stage 1 (item 3 also depends on Stage 2). Small fixes bundled into one stage because none is worth its own session.*
+
+### Prompt
+
+> Stages 1 and 2 (the `getInviterForUser` resolver and invite-link seed topics) each surfaced something they didn't fix. Close them out.
+>
+> **1 — Consumer-level test coverage for `src/app/page.tsx`'s `welcomeInviterName`.** Stage 1 added consumer-level tests for two of the three call sites (`invite-onboarding.ts`, `get-first-session-recap.ts`) but not the third: `welcomeInviterName = normalizePersonName((await getInviterForUser(session.userId))?.inviterName)` in `page.tsx`, which has zero test coverage today — no `page.tsx` test exists anywhere in `src/app`, and mocking the full Home server component (session, `buildHomeEdition`, daily queue, ceremony, missed-return, friend requests, etc.) just to cover one derived line was judged disproportionate at the time. Options, in order of preference: (a) extract the `welcomeInviterName` computation into a small named function in a DB-free-import-adjacent module that can be unit-tested without dragging in the rest of Home's dependency graph, or (b) write the full-page mock if (a) turns out not to be practical. Either way, land coverage for both branches: an inviter resolved (link or named) renders the name, no inviter renders the existing "a friend" fallback in `WelcomeTourScreen`.
+>
+> **2 — CORRECTED, then fixed — `listInviteReflections` was excluding on the wrong (frozen) relationship model.** The original diagnosis for this item ("queries a table that no longer exists") was wrong — a grep with a too-narrow pattern (`pgTable('Friendship'` on one line) missed the real definition, which wraps the table name onto its own line: `export const friendships = pgTable(\n  'Friendship',\n  ...)` in `src/server/db/schema.ts`. The table exists and is actively read/updated/deleted elsewhere (`account.ts`, `contact-hashes.ts`, the `expire-friend-requests` cron, `instrumentation.ts` guards) — it just has no `db.insert(friendships)` call anywhere. That's the real bug: it's **frozen** (read-only, pre-follow-model), so `listInviteReflections`'s `NOT EXISTS` check against it can never see a friendship formed under the current `follows` model — a same-day mutual follow between the inviter and an invitee sailed straight through and still got listed as "not yet friended." Fixed by keeping the existing SQL check (still correct for pre-follow-model rows) and adding a second exclusion using the `relationship.state === 'friends'` value from `getRelationships` — already fetched in this function for the `isBlocked` filter, so no new follows query was needed. Regression test added (this function had none before).
+>
+> **3 — Consumer-level test coverage for `src/app/login/page.tsx`'s `inviteContext.topics` wiring.** Stage 2 added `topics: userInviteResolution.seedTopics` to the `inviteContext` object built for the per-user invite-link branch, and both sides of that wiring are independently tested (`resolveInviteLink`'s `seedTopics` field in `src/server/friends/__tests__/user-invite-token.test.ts`, and `LoginPanel`'s chip rendering in `src/app/login/__tests__/LoginPanel.sms.test.tsx`) — but the one-line mapping in `page.tsx` itself has no test, and no `login/page.tsx` test file exists yet. Same judgment call as item 1: this server component pulls in `getSession`, `getInvitePrefillByToken`, and `resolveInviteLink`, so weigh a full mock harness against extracting the `inviteContext` construction into a small pure/testable function before deciding it's worth a dedicated test.
+>
+> Raise any concerns before writing code.
+
+---
+
+## Stage 6 — Admin links to the new screens/flows
+
+*Independent of stages 1–5; can run any time. Two of these screens have no real-data path to reach them (the link path's login card needs a real invite token; the link path's onboarding step needs a real link-arrived session) — closing that is what makes "add a link" mean something rather than linking to a screen nobody can actually open.*
+
+### Prompt
+
+> Stages 1–3 shipped several screens/flows that have no discoverable entry point from the admin/dev tooling. Add them to the "Developer tools" section (`src/components/profile/settings/AccountActions.tsx`, rendered on the owner's own `/users/[id]` profile) as a new `Growth` `DevToolGroup`, following the exact pattern the existing groups use (`{kind: 'link', icon, title, subtitle, href}`, picked up automatically by `getExistingDevToolHrefs()` for availability-dimming since these all live under `/dev/` or are real routes).
+>
+> Two of the four links need a small preview surface built first, because there is currently no way to reach that state without a real invite link or a real link-arrived session:
+>
+> 1. **The per-user invite-link's topic-chip card on `/login`** (Stage 2/3 — `LoginPanel`'s `InviteContextCard` rendering `inviteContext.topics`). `src/app/dev/invite-login/page.tsx` already previews the NAMED phone-first path (`invitePrefill`) with two tabs, but never the per-user LINK path (`inviteContext`) — its own title, "Phone-first invite login," says as much. Add a third preview tab ("Screen 1c — invite-link card" or similar) that renders the same `LoginPanel` with a synthetic `inviteContext` (name + up to 3 synthetic topics, no `invitePrefill`) so the topic-chip card is inspectable. Look-only, matching the existing two tabs — no real token, no real invitation.
+> 2. **The link-arrived onboarding interests screen** (Stage 2 — `OnboardingFlow`'s `seedSource="link"`, unselected chips, "here are a few from {inviter}" copy). `src/app/dev/onboarding/intro/page.tsx` always renders with `MOCK_INTERESTS` pre-selected (the named-path experience). Add a `?seedSource=link` query param (mirroring the existing `?walk=1` pattern) that swaps in `seedSource="link"` and adjusts the mock inviter name/copy so the unselected-chips experience is previewable without a real link-arrived session.
+>
+> Then add the `Growth` group with links to: the new invite-link login-card tab, the new onboarding link-variant, and the two real pages Stage 3 changed placement on — `/friends` and `/friends/find` (both now lead with "Share invite link"; no preview needed, they're live pages any session can reach, but they earned a shortcut since that's literally where the placement change landed).
+>
+> **Do not** touch the PrivacyForm topic editor (`/users/[id]` itself) — the admin is already on that page when looking at Developer tools, so a self-referential link adds nothing.
+>
+> Raise any concerns before writing code.
+
+---
+
+## Open, deliberately not decided here
+
+- **Link caps and expiry.** The link is evergreen, uncapped, and rotatable only; named invitations expire in 30 days (`DEFAULT_INVITATION_TTL_MS`, `src/server/friends/invitations.ts:23` — corrected from an earlier "14 days" claim in this doc, per the Stage 4 audit). Decision taken: leave the link evergreen so it can live in a bio. Revisit if the invite-only promise starts mattering more than reach.
+- **`PeopleYouInvited`.** Wire it into `/friends` as an outgoing-invitation manager, or leave it dark. Not decided; explicitly not deleted.
+- **The post-join nudge** ("Stan just joined — send him his first question") reuses the existing send-a-question flow and is a separate stage, not folded into these four.

--- a/drizzle/0134_invite_seed_interests.sql
+++ b/drizzle/0134_invite_seed_interests.sql
@@ -1,0 +1,13 @@
+-- Topics the per-user invite link (/u/<handle>/<token>) carries.
+--
+-- Nullable jsonb, shaped like the existing FriendInvitation.preSeededInterests
+-- payload (array of {label, description?, broadCategory?}) so
+-- parseInvitationInterests / parsePreSeededInterests can parse it without a
+-- second parser. Capped at 3 entries by the app layer, not the column.
+--
+-- NULL/empty means "no curated set" — getInviteLinkSeedTopics (Stage 2) falls
+-- back to the inviter's top declared interests instead of requiring setup.
+-- Existing users are unaffected: the column starts NULL for everyone.
+--
+-- Rollback: ALTER TABLE "User" DROP COLUMN IF EXISTS "invite_seed_interests";
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "invite_seed_interests" jsonb;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -939,6 +939,13 @@
       "when": 1788359890909,
       "tag": "0133_sms_opt_in_confirmation",
       "breakpoints": true
+    },
+    {
+      "idx": 134,
+      "version": "7",
+      "when": 1788394823476,
+      "tag": "0134_invite_seed_interests",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/account/invite-token/__tests__/route.test.ts
+++ b/src/app/api/account/invite-token/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { getSessionMock, getOrCreateInviteTokenMock, getInviteLinkSeedTopicsMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  getOrCreateInviteTokenMock: vi.fn(),
+  getInviteLinkSeedTopicsMock: vi.fn(),
+}))
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }))
+vi.mock('@/server/friends/user-invite-token', () => ({
+  getOrCreateInviteToken: getOrCreateInviteTokenMock,
+  getInviteLinkSeedTopics: getInviteLinkSeedTopicsMock,
+  buildInviteUrl: (baseUrl: string, handle: string, token: string) =>
+    `${baseUrl}/u/${handle}/${token}`,
+  getBaseUrl: () => 'https://example.com',
+}))
+
+import { GET } from '@/app/api/account/invite-token/route'
+
+describe('GET /api/account/invite-token', () => {
+  it('401s when there is no session', async () => {
+    getSessionMock.mockResolvedValueOnce(null)
+    const response = await GET(new Request('https://example.com/api/account/invite-token'))
+    expect(response.status).toBe(401)
+  })
+
+  it('409s when the user has no handle yet', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
+    getOrCreateInviteTokenMock.mockResolvedValueOnce({ token: 'tok', handle: null })
+    const response = await GET(new Request('https://example.com/api/account/invite-token'))
+    expect(response.status).toBe(409)
+  })
+
+  // Stage 3 addition: userId + the RESOLVED topic count (curated set, or the
+  // automatic declared-interests fallback) so InviteSomeoneNew's "N topics"
+  // line reflects what the link actually carries, and can link to /users/<id>
+  // without a second fetch.
+  it('includes userId and the resolved topic count', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
+    getOrCreateInviteTokenMock.mockResolvedValueOnce({ token: 'tok', handle: 'josh' })
+    getInviteLinkSeedTopicsMock.mockResolvedValueOnce([
+      { label: 'Jazz' },
+      { label: 'Poetry' },
+    ])
+
+    const response = await GET(new Request('https://example.com/api/account/invite-token'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({
+      token: 'tok',
+      url: 'https://example.com/u/josh/tok',
+      userId: 'u1',
+      topicCount: 2,
+    })
+    expect(getInviteLinkSeedTopicsMock).toHaveBeenCalledWith('u1')
+  })
+
+  it('reports 0 topics when the link has neither a curated set nor declared interests', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
+    getOrCreateInviteTokenMock.mockResolvedValueOnce({ token: 'tok', handle: 'josh' })
+    getInviteLinkSeedTopicsMock.mockResolvedValueOnce([])
+
+    const response = await GET(new Request('https://example.com/api/account/invite-token'))
+    const body = await response.json()
+
+    expect(body.topicCount).toBe(0)
+  })
+})

--- a/src/app/api/account/invite-token/route.ts
+++ b/src/app/api/account/invite-token/route.ts
@@ -4,6 +4,7 @@ import { getSession } from '@/server/auth/session'
 import {
   buildInviteUrl,
   getBaseUrl,
+  getInviteLinkSeedTopics,
   getOrCreateInviteToken,
 } from '@/server/friends/user-invite-token'
 
@@ -26,5 +27,10 @@ export async function GET(request: Request) {
   }
 
   const url = buildInviteUrl(getBaseUrl(request), result.handle, result.token)
-  return NextResponse.json({ token: result.token, url })
+  // The RESOLVED topic count (curated set, or the automatic declared-interests
+  // fallback) — what the link actually carries right now, not just what's
+  // curated. Used by InviteSomeoneNew's "N topics" line (Stage 3); userId lets
+  // that line link to the caller's own settings page without a second fetch.
+  const topicCount = (await getInviteLinkSeedTopics(session.userId)).length
+  return NextResponse.json({ token: result.token, url, userId: session.userId, topicCount })
 }

--- a/src/app/api/account/invite-token/topics/__tests__/route.test.ts
+++ b/src/app/api/account/invite-token/topics/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { vi } from 'vitest'
+
+const { getSessionMock, getCuratedInviteSeedTopicsMock, setCuratedInviteSeedTopicsMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  getCuratedInviteSeedTopicsMock: vi.fn(),
+  setCuratedInviteSeedTopicsMock: vi.fn(),
+}))
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }))
+vi.mock('@/server/friends/user-invite-token', () => ({
+  getCuratedInviteSeedTopics: getCuratedInviteSeedTopicsMock,
+  setCuratedInviteSeedTopics: setCuratedInviteSeedTopicsMock,
+}))
+
+import { GET, PATCH } from '@/app/api/account/invite-token/topics/route'
+
+function patchRequest(body: unknown) {
+  return new Request('https://example.com/api/account/invite-token/topics', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('GET /api/account/invite-token/topics', () => {
+  it('401s when there is no session', async () => {
+    getSessionMock.mockResolvedValueOnce(null)
+    const response = await GET()
+    expect(response.status).toBe(401)
+  })
+
+  it('returns the curated topics', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
+    getCuratedInviteSeedTopicsMock.mockResolvedValueOnce(['Jazz', 'Poetry'])
+    const response = await GET()
+    const body = await response.json()
+    expect(body).toEqual({ topics: ['Jazz', 'Poetry'] })
+  })
+})
+
+describe('PATCH /api/account/invite-token/topics', () => {
+  it('401s when there is no session', async () => {
+    getSessionMock.mockResolvedValueOnce(null)
+    const response = await PATCH(patchRequest({ topics: ['Jazz'] }))
+    expect(response.status).toBe(401)
+  })
+
+  it('400s on a malformed body (not an object with a topics array)', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
+    const response = await PATCH(patchRequest({ nope: true }))
+    expect(response.status).toBe(400)
+    expect(setCuratedInviteSeedTopicsMock).not.toHaveBeenCalled()
+  })
+
+  it('400s when more than 3 topics are submitted', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
+    const response = await PATCH(patchRequest({ topics: ['A', 'B', 'C', 'D'] }))
+    expect(response.status).toBe(400)
+    expect(setCuratedInviteSeedTopicsMock).not.toHaveBeenCalled()
+  })
+
+  it('400s and does NOT save when one topic is too broad — rejects the whole batch', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
+    const response = await PATCH(patchRequest({ topics: ['Jazz', 'Music'] }))
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('too_broad')
+    expect(body.message).toContain('Music')
+    expect(setCuratedInviteSeedTopicsMock).not.toHaveBeenCalled()
+  })
+
+  it('saves and returns the persisted topics on success', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
+    setCuratedInviteSeedTopicsMock.mockResolvedValueOnce(undefined)
+    getCuratedInviteSeedTopicsMock.mockResolvedValueOnce(['Jazz', 'Poetry'])
+
+    const response = await PATCH(patchRequest({ topics: ['Jazz', 'Poetry'] }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(setCuratedInviteSeedTopicsMock).toHaveBeenCalledWith('u1', ['Jazz', 'Poetry'])
+    expect(body).toEqual({ topics: ['Jazz', 'Poetry'] })
+  })
+
+  it('an empty array clears the curated set (reverts to the automatic fallback)', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
+    setCuratedInviteSeedTopicsMock.mockResolvedValueOnce(undefined)
+    getCuratedInviteSeedTopicsMock.mockResolvedValueOnce([])
+
+    const response = await PATCH(patchRequest({ topics: [] }))
+
+    expect(response.status).toBe(200)
+    expect(setCuratedInviteSeedTopicsMock).toHaveBeenCalledWith('u1', [])
+  })
+})

--- a/src/app/api/account/invite-token/topics/route.ts
+++ b/src/app/api/account/invite-token/topics/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity'
+import { getSession } from '@/server/auth/session'
+import {
+  getCuratedInviteSeedTopics,
+  setCuratedInviteSeedTopics,
+} from '@/server/friends/user-invite-token'
+
+export const dynamic = 'force-dynamic'
+
+const SEED_TOPIC_CAP = 3
+
+const bodySchema = z.object({
+  topics: z.array(z.string().trim().min(1).max(80)).max(SEED_TOPIC_CAP),
+})
+
+export async function GET() {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const topics = await getCuratedInviteSeedTopics(session.userId)
+  return NextResponse.json({ topics })
+}
+
+// Overwrites the curated invite-link topic set. Each topic is validated with
+// the same isTooBroadInterest check onboarding runs when consuming these
+// topics — reject the whole save on a too-broad entry rather than silently
+// dropping it, so the editor can point at exactly what to fix.
+export async function PATCH(request: Request) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const json = await request.json().catch(() => null)
+  const parsed = bodySchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_body', message: `Up to ${SEED_TOPIC_CAP} short topics, please.` },
+      { status: 400 },
+    )
+  }
+
+  const tooBroad = parsed.data.topics.find((topic) => isTooBroadInterest(topic))
+  if (tooBroad) {
+    return NextResponse.json(
+      {
+        error: 'too_broad',
+        message: `"${tooBroad}" is too broad — try something more specific.`,
+      },
+      { status: 400 },
+    )
+  }
+
+  await setCuratedInviteSeedTopics(session.userId, parsed.data.topics)
+  const topics = await getCuratedInviteSeedTopics(session.userId)
+  return NextResponse.json({ topics })
+}

--- a/src/app/dev/invite-login/__tests__/page.test.tsx
+++ b/src/app/dev/invite-login/__tests__/page.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+const searchParams = new URLSearchParams()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => searchParams,
+}))
+
+import DevInviteLoginPage from '@/app/dev/invite-login/page'
+
+// Stage 6: the ?screen=linkCard param (linked from the Growth dev-tools
+// group) must land directly on the invite-LINK preview tab — no phone field,
+// synthetic topic chips instead.
+describe('DevInviteLoginPage', () => {
+  it('defaults to the named phone-first tab when no ?screen param is set', () => {
+    searchParams.delete('screen')
+    const html = renderToStaticMarkup(<DevInviteLoginPage />)
+
+    expect(html).toContain('aria-selected="true"')
+    // The named (invitePrefill) path shows a specific number to confirm, not
+    // the generic "what is your number" entry.
+    expect(html).toContain('We just need to send a text to confirm it')
+    expect(html).toContain('(734) 555-6819')
+  })
+
+  it('lands on the invite-link card tab via ?screen=linkCard, with topic chips and no known number to confirm', () => {
+    searchParams.set('screen', 'linkCard')
+    const html = renderToStaticMarkup(<DevInviteLoginPage />)
+
+    // inviterFirstName() truncates to the first token.
+    expect(html).toContain('Robyn invited you to Joshing')
+    expect(html).toContain('Jazz')
+    expect(html).toContain('Chess Openings')
+    expect(html).toContain('1990s Sitcoms')
+    // No invitePrefill on this tab, so the number-to-confirm screen never
+    // renders — only the generic phone-entry form does (a link visitor's
+    // number isn't known ahead of time, unlike a named invite).
+    expect(html).not.toContain('(734) 555-6819')
+    expect(html).toContain('What is your phone number?')
+  })
+
+  it('ignores an unrecognized ?screen value and falls back to the phone tab', () => {
+    searchParams.set('screen', 'bogus')
+    const html = renderToStaticMarkup(<DevInviteLoginPage />)
+
+    expect(html).toContain('We just need to send a text to confirm it')
+  })
+})

--- a/src/app/dev/invite-login/page.tsx
+++ b/src/app/dev/invite-login/page.tsx
@@ -2,19 +2,27 @@
 
 import { Suspense, useState } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { ChevronLeft, Info } from 'lucide-react';
 
 import LoginPanel from '@/app/login/LoginPanel';
 
 /**
- * Dev tool: preview the phone-first invite login (D-AUTH-INVITE-PHONE-FIRST).
+ * Dev tool: preview the invite login screens (D-AUTH-INVITE-PHONE-FIRST +
+ * Stage 2/3 of the invite-link build).
  *
  * Linked from the Developer tools section of the profile page. It renders the
- * real `LoginPanel` with synthetic invite data so the two new surfaces — the
- * confirm-your-number screen (Screen 1) and the warm "not my number" dead-end
- * (Screen 1b) — can be inspected WITHOUT minting a real invitation or sending
- * an OTP. It is look-only: the synthetic token doesn't resolve server-side, so
- * the buttons won't complete a login (no account is created). The dead-end is
+ * real `LoginPanel` with synthetic invite data so three surfaces can be
+ * inspected WITHOUT minting a real invitation, generating a real per-user
+ * link, or sending an OTP:
+ *   - Screen 1 — the named (FriendInvitation) phone-first confirm-your-number
+ *     screen
+ *   - Screen 1b — its warm "not my number" dead-end
+ *   - Screen 1c — the per-user invite-LINK's card, with topic chips (Stage 2)
+ *     — this path never carries a `invitePrefill`, only `inviteContext`, so
+ *     the phone field never renders here
+ * It is look-only: the synthetic data doesn't resolve server-side, so the
+ * buttons won't complete a login (no account is created). The dead-end is
  * seeded via LoginPanel's dev-only `previewDeadEnd` prop rather than a live
  * failed gate round-trip.
  */
@@ -29,10 +37,38 @@ const PREVIEW_INVITER = {
 };
 const PREVIEW_PREFILL = { ...PREVIEW_INVITER, inviteePhone: '+17345556819' };
 
-type PreviewScreen = 'phone' | 'deadEnd';
+// Screen 1c: the per-user invite-link path. No `invitePrefill` — a link
+// visitor's phone isn't known ahead of time, unlike a named invite.
+const PREVIEW_LINK_CONTEXT = {
+  inviterName: 'Robyn Sample',
+  inviterUserId: 'dev-preview-link-inviter',
+  inviterAvatarColor: null,
+  topics: ['Jazz', 'Chess Openings', '1990s Sitcoms'],
+};
 
+type PreviewScreen = 'phone' | 'deadEnd' | 'linkCard';
+
+function isPreviewScreen(value: string | null): value is PreviewScreen {
+  return value === 'phone' || value === 'deadEnd' || value === 'linkCard';
+}
+
+// `useSearchParams` requires a Suspense boundary at or above its call site
+// during static rendering — this wraps the real page so the Developer-tools
+// link (`?screen=linkCard`) can land directly on a tab.
 export default function DevInviteLoginPage() {
-  const [screen, setScreen] = useState<PreviewScreen>('phone');
+  return (
+    <Suspense fallback={null}>
+      <DevInviteLoginPageInner />
+    </Suspense>
+  );
+}
+
+function DevInviteLoginPageInner() {
+  const searchParams = useSearchParams();
+  const initialScreen = searchParams.get('screen');
+  const [screen, setScreen] = useState<PreviewScreen>(
+    isPreviewScreen(initialScreen) ? initialScreen : 'phone',
+  );
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 pt-10 pb-28">
@@ -78,16 +114,23 @@ export default function DevInviteLoginPage() {
           onClick={() => setScreen('deadEnd')}
           label="Screen 1b — not my number"
         />
+        <PreviewTab
+          active={screen === 'linkCard'}
+          onClick={() => setScreen('linkCard')}
+          label="Screen 1c — invite-link card"
+        />
       </div>
 
       {/* Render the real LoginPanel so the preview can never drift from prod.
-          `key` remounts it on toggle so the seeded step/dead-end state resets. */}
+          `key` remounts it on toggle so the seeded step/dead-end state resets.
+          Screen 1c omits invitePrefill entirely — a link visitor has no known
+          phone number, unlike a named invite. */}
       <div className="mt-6 flex justify-center">
         <Suspense fallback={null}>
           <LoginPanel
             key={screen}
-            invitePrefill={PREVIEW_PREFILL}
-            inviteContext={PREVIEW_INVITER}
+            invitePrefill={screen === 'linkCard' ? null : PREVIEW_PREFILL}
+            inviteContext={screen === 'linkCard' ? PREVIEW_LINK_CONTEXT : PREVIEW_INVITER}
             previewDeadEnd={screen === 'deadEnd'}
           />
         </Suspense>

--- a/src/app/dev/onboarding/intro/__tests__/page.test.tsx
+++ b/src/app/dev/onboarding/intro/__tests__/page.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}))
+
+import DevOnboardingIntroPage from '@/app/dev/onboarding/intro/page'
+
+async function renderPage(searchParams: { walk?: string; seedSource?: string } = {}) {
+  const element = await DevOnboardingIntroPage({ searchParams: Promise.resolve(searchParams) })
+  return renderToStaticMarkup(element)
+}
+
+// Stage 6: ?seedSource=link previews the invite-link experience (Stage 2) —
+// the same mock topics, but unselected and with the link-specific copy —
+// without needing a real link-arrived session. The harness always lands on
+// the name/call-sign setup step first (no interests screen reachable via a
+// static render — that transition needs real interaction), so these tests
+// cover the query-param parsing and prop-threading via the status bar badge
+// rather than the interests-screen content itself (already covered directly
+// against OnboardingFlow in src/app/onboarding/__tests__/OnboardingFlow.test.tsx).
+describe('DevOnboardingIntroPage', () => {
+  it('defaults to the named-invite experience: no invite-link badge', async () => {
+    const html = await renderPage()
+
+    expect(html).toContain('Read-only replay · writes stubbed')
+    expect(html).not.toContain('invite-link seeds')
+    // Setup step first — the harness never pre-fills a name/handle.
+    expect(html).toContain('Set up your profile')
+  })
+
+  it('?seedSource=link surfaces the invite-link badge', async () => {
+    const html = await renderPage({ seedSource: 'link' })
+
+    expect(html).toContain('Read-only replay · writes stubbed · invite-link seeds')
+  })
+
+  it('an unrecognized seedSource value falls back to the named experience (no badge)', async () => {
+    const html = await renderPage({ seedSource: 'bogus' })
+
+    expect(html).not.toContain('invite-link seeds')
+  })
+
+  it('?walk=1 still chains to the walkthrough welcome-tour href regardless of seedSource', async () => {
+    const html = await renderPage({ walk: '1', seedSource: 'link' })
+
+    expect(html).toContain('Full walkthrough · writes stubbed · invite-link seeds')
+  })
+})

--- a/src/app/dev/onboarding/intro/page.tsx
+++ b/src/app/dev/onboarding/intro/page.tsx
@@ -14,6 +14,12 @@ export const dynamic = 'force-dynamic';
  * (no PATCH /api/account, no save-interests). Finishing the areas step chains to
  * the welcome-tour preview. Driven by mock invite data so the inviter-seeded
  * path renders. In `?walk=1` mode the chain carries the walkthrough flag onward.
+ *
+ * `?seedSource=link` (Stage 2 of the invite-link build): swaps in the
+ * per-user invite-link experience — the same mock topics arrive UNSELECTED as
+ * suggestion chips instead of pre-selected, with the "here are a few from
+ * {inviter}" copy — since a link may reach someone the inviter never had in
+ * mind. Default (omitted) stays the named-invite experience: pre-selected.
  */
 
 const MOCK_INTERESTS: PreSeededInterest[] = [
@@ -25,10 +31,11 @@ const MOCK_INTERESTS: PreSeededInterest[] = [
 export default async function DevOnboardingIntroPage({
   searchParams,
 }: {
-  searchParams: Promise<{ walk?: string }>;
+  searchParams: Promise<{ walk?: string; seedSource?: string }>;
 }) {
   const params = await searchParams;
   const walk = params?.walk === '1';
+  const seedSource = params?.seedSource === 'link' ? 'link' : 'named';
   const nextHref = walk ? '/dev/welcome-tour?walk=1' : '/dev/welcome-tour';
 
   return (
@@ -40,14 +47,16 @@ export default async function DevOnboardingIntroPage({
         </Link>
         <span className="text-[12px] font-bold tracking-[0.1em] uppercase">
           {walk ? 'Full walkthrough · writes stubbed' : 'Read-only replay · writes stubbed'}
+          {seedSource === 'link' ? ' · invite-link seeds' : ''}
         </span>
       </div>
       <div style={{ paddingTop: '2.5rem' }}>
         <OnboardingFlow
           previewMode
           previewNextHref={nextHref}
+          seedSource={seedSource}
           preSeededInterests={MOCK_INTERESTS}
-          inviterName="Maya"
+          inviterName={seedSource === 'link' ? 'Robyn' : 'Maya'}
           inviteeDisplayName={null}
           initialDisplayName={null}
           initialHandle={null}

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -87,6 +87,11 @@ type InviteContext = {
   inviterName: string;
   inviterUserId: string;
   inviterAvatarColor: string | null;
+  // Per-user invite-link topics only (up to 3), already filtered to what a
+  // not-yet-friend visitor may see (resolveInviteLink). Absent/empty for the
+  // named FriendInvitation path, which has its own separate seeded-interests
+  // flow inside onboarding rather than a pre-login preview.
+  topics?: string[];
 };
 
 // Phone-first invite path: the full invited number crosses to the client so
@@ -178,12 +183,25 @@ function LoadingLabel({ verb }: { verb: string }) {
 }
 
 function InviteContextCard({ invite }: { invite: InviteContext }) {
+  const topics = invite.topics?.filter((topic) => topic.trim().length > 0) ?? [];
   return (
     <div className="space-y-3 rounded-[var(--radius-md)] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
       <p className="text-[15px] leading-6 text-black/75">
         {inviterFirstName(invite.inviterName)} invited you to Joshing, a new trivia game. We just
         need to verify your phone number and then you can start playing.
       </p>
+      {topics.length > 0 ? (
+        <div className="flex flex-wrap justify-center gap-2">
+          {topics.map((topic) => (
+            <span
+              key={topic}
+              className="rounded-full border border-[var(--accent-gold)]/40 bg-white/70 px-3 py-1 text-xs font-medium text-black/70"
+            >
+              {topic}
+            </span>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/login/__tests__/LoginPanel.sms.test.tsx
+++ b/src/app/login/__tests__/LoginPanel.sms.test.tsx
@@ -53,3 +53,60 @@ describe('LoginPanel OTP request disclosure', () => {
     expectOneOtpDisclosure(html);
   });
 });
+
+// Stage 2 (invite-link seed topics): the per-user invite-link card shows up
+// to 3 topics; the named FriendInvitation path never carries them.
+describe('LoginPanel invite context topics', () => {
+  beforeEach(() => {
+    searchParamsMock.delete('invitationToken');
+  });
+
+  it('renders topics on the per-user invite-link card', () => {
+    const html = renderToStaticMarkup(
+      <LoginPanel
+        inviteContext={{
+          inviterName: 'Jaime',
+          inviterUserId: 'inviter-1',
+          inviterAvatarColor: null,
+          topics: ['Jazz', 'Poetry'],
+        }}
+      />,
+    );
+
+    expect(html).toContain('Jaime invited you to Joshing');
+    expect(html).toContain('Jazz');
+    expect(html).toContain('Poetry');
+  });
+
+  it('renders no topic chips for the named-invitation path (topics absent)', () => {
+    const html = renderToStaticMarkup(
+      <LoginPanel
+        inviteContext={{
+          inviterName: 'Alex',
+          inviterUserId: 'inviter-2',
+          inviterAvatarColor: null,
+        }}
+      />,
+    );
+
+    expect(html).toContain('Alex invited you to Joshing');
+    // No chip markup at all — the wrapping div is conditional on topics.length.
+    expect(html).not.toContain('rounded-full border border-[var(--accent-gold)]/40 bg-white/70');
+  });
+
+  it('renders no topic chips when topics resolved to an empty array', () => {
+    const html = renderToStaticMarkup(
+      <LoginPanel
+        inviteContext={{
+          inviterName: 'Robyn',
+          inviterUserId: 'inviter-3',
+          inviterAvatarColor: null,
+          topics: [],
+        }}
+      />,
+    );
+
+    expect(html).toContain('Robyn invited you to Joshing');
+    expect(html).not.toContain('rounded-full border border-[var(--accent-gold)]/40 bg-white/70');
+  });
+});

--- a/src/app/login/__tests__/build-invite-views.test.ts
+++ b/src/app/login/__tests__/build-invite-views.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildLoginInviteViews } from '@/app/login/build-invite-views'
+
+describe('buildLoginInviteViews', () => {
+  it('returns both null when neither a prefill nor a link resolution exists', () => {
+    const result = buildLoginInviteViews(null, null)
+    expect(result).toEqual({ invitePrefill: null, inviteContext: null })
+  })
+
+  it('the named (FriendInvitation) prefill builds both invitePrefill and a topic-free inviteContext', () => {
+    const prefill = {
+      inviterName: 'Alex Inviter',
+      inviterUserId: 'inviter-1',
+      inviterAvatarColor: '#abc',
+      inviteePhone: '+17345550123',
+    }
+
+    const result = buildLoginInviteViews(prefill, null)
+
+    expect(result.invitePrefill).toEqual(prefill)
+    expect(result.inviteContext).toEqual({
+      inviterName: 'Alex Inviter',
+      inviterUserId: 'inviter-1',
+      inviterAvatarColor: '#abc',
+    })
+    // Boundary-level check per the Stage 4 audit's rule ("Do not touch the
+    // named path"): the named path never carries topics.
+    expect(result.inviteContext).not.toHaveProperty('topics')
+  })
+
+  it('the per-user invite-link resolution builds only inviteContext, with its seedTopics as topics', () => {
+    const userInviteResolution = {
+      inviterDisplayName: 'Jaime Rivera',
+      inviterHandle: 'jaime',
+      inviterUserId: 'inviter-2',
+      inviterAvatarColor: '#def',
+      seedTopics: ['Jazz', 'Poetry'],
+    }
+
+    const result = buildLoginInviteViews(null, userInviteResolution)
+
+    expect(result.invitePrefill).toBeNull()
+    expect(result.inviteContext).toEqual({
+      inviterName: 'Jaime Rivera',
+      inviterUserId: 'inviter-2',
+      inviterAvatarColor: '#def',
+      topics: ['Jazz', 'Poetry'],
+    })
+  })
+
+  it('falls back to "@handle" when the link inviter has no display name', () => {
+    const userInviteResolution = {
+      inviterDisplayName: null,
+      inviterHandle: 'jaime',
+      inviterUserId: 'inviter-2',
+      inviterAvatarColor: null,
+      seedTopics: [],
+    }
+
+    const result = buildLoginInviteViews(null, userInviteResolution)
+
+    expect(result.inviteContext?.inviterName).toBe('@jaime')
+    expect(result.inviteContext?.topics).toEqual([])
+  })
+
+  it('the named prefill wins over a simultaneous link resolution', () => {
+    const prefill = {
+      inviterName: 'Alex Inviter',
+      inviterUserId: 'inviter-1',
+      inviterAvatarColor: null,
+      inviteePhone: '+17345550123',
+    }
+    const userInviteResolution = {
+      inviterDisplayName: 'Jaime Rivera',
+      inviterHandle: 'jaime',
+      inviterUserId: 'inviter-2',
+      inviterAvatarColor: null,
+      seedTopics: ['Jazz'],
+    }
+
+    const result = buildLoginInviteViews(prefill, userInviteResolution)
+
+    expect(result.invitePrefill?.inviterUserId).toBe('inviter-1')
+    expect(result.inviteContext?.inviterUserId).toBe('inviter-1')
+    expect(result.inviteContext).not.toHaveProperty('topics')
+  })
+})

--- a/src/app/login/build-invite-views.ts
+++ b/src/app/login/build-invite-views.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure data-shaping for LoginPanel's two invite props, pulled out of
+ * src/app/login/page.tsx (Stage 5 of the invite-link build) so this logic is
+ * directly testable without mocking getSession/getInvitePrefillByToken/
+ * resolveInviteLink or rendering the page. Deliberately DB-free — the inputs
+ * are the already-resolved query results, not the queries themselves.
+ */
+
+export type InvitePrefillView = {
+  inviterName: string;
+  inviterUserId: string;
+  inviterAvatarColor: string | null;
+  inviteePhone: string;
+};
+
+export type InviteContextView = {
+  inviterName: string;
+  inviterUserId: string;
+  inviterAvatarColor: string | null;
+  topics?: string[];
+};
+
+type PrefillInput = {
+  inviterName: string;
+  inviterUserId: string;
+  inviterAvatarColor: string | null;
+  inviteePhone: string;
+} | null;
+
+type UserInviteResolutionInput = {
+  inviterDisplayName: string | null;
+  inviterHandle: string;
+  inviterUserId: string;
+  inviterAvatarColor: string | null;
+  seedTopics: string[];
+} | null;
+
+/**
+ * The named (FriendInvitation) prefill wins when present — it already knows
+ * the invitee's phone number. Otherwise, a per-user invite-LINK resolution
+ * builds inviteContext with its seedTopics (Stage 2); the named path never
+ * carries topics here — it has its own separate pre-seeded-interests flow
+ * inside onboarding.
+ */
+export function buildLoginInviteViews(
+  prefill: PrefillInput,
+  userInviteResolution: UserInviteResolutionInput,
+): { invitePrefill: InvitePrefillView | null; inviteContext: InviteContextView | null } {
+  const invitePrefill: InvitePrefillView | null = prefill
+    ? {
+        inviterName: prefill.inviterName,
+        inviterUserId: prefill.inviterUserId,
+        inviterAvatarColor: prefill.inviterAvatarColor,
+        // Full number (not masked): the phone-first field pre-fills it so the
+        // invitee can confirm or correct it (D-AUTH-INVITE-PHONE-FIRST §2.3).
+        inviteePhone: prefill.inviteePhone,
+      }
+    : null;
+
+  const inviteContext: InviteContextView | null = prefill
+    ? {
+        inviterName: prefill.inviterName,
+        inviterUserId: prefill.inviterUserId,
+        inviterAvatarColor: prefill.inviterAvatarColor,
+      }
+    : userInviteResolution
+      ? {
+          inviterName:
+            userInviteResolution.inviterDisplayName?.trim() ||
+            `@${userInviteResolution.inviterHandle}`,
+          inviterUserId: userInviteResolution.inviterUserId,
+          inviterAvatarColor: userInviteResolution.inviterAvatarColor,
+          topics: userInviteResolution.seedTopics,
+        }
+      : null;
+
+  return { invitePrefill, inviteContext };
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { getSession } from '@/server/auth/session';
 import { getInvitePrefillByToken } from '@/server/friends/invitations';
 import { resolveInviteLink } from '@/server/friends/user-invite-token';
 
+import { buildLoginInviteViews } from './build-invite-views';
 import LoginPanel from './LoginPanel';
 
 // Mirror LoginPanel.readInvitationToken: accept any of the aliases an invite
@@ -74,31 +75,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   const userInviteResolution = userInvite
     ? await resolveInviteLink(userInvite.handle, userInvite.token)
     : null;
-  const invitePrefill = prefill
-    ? {
-        inviterName: prefill.inviterName,
-        inviterUserId: prefill.inviterUserId,
-        inviterAvatarColor: prefill.inviterAvatarColor,
-        // Full number (not masked): the phone-first field pre-fills it so the
-        // invitee can confirm or correct it (D-AUTH-INVITE-PHONE-FIRST §2.3).
-        inviteePhone: prefill.inviteePhone,
-      }
-    : null;
-  const inviteContext = prefill
-    ? {
-        inviterName: prefill.inviterName,
-        inviterUserId: prefill.inviterUserId,
-        inviterAvatarColor: prefill.inviterAvatarColor,
-      }
-    : userInviteResolution
-      ? {
-          inviterName:
-            userInviteResolution.inviterDisplayName?.trim() ||
-            `@${userInviteResolution.inviterHandle}`,
-          inviterUserId: userInviteResolution.inviterUserId,
-          inviterAvatarColor: userInviteResolution.inviterAvatarColor,
-        }
-      : null;
+  const { invitePrefill, inviteContext } = buildLoginInviteViews(prefill, userInviteResolution);
 
   return (
     <TriangleBackground>

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -28,6 +28,17 @@ export type PreSeededInterest = ProposedInterest
 
 type OnboardingFlowProps = {
   preSeededInterests: PreSeededInterest[]
+  /**
+   * Where preSeededInterests came from — controls both pre-selection and copy.
+   * 'named': the inviter chose these topics FOR this specific person
+   * (AddFriendInvite) — they arrive pre-selected, as today.
+   * 'link': the topics rode a per-user invite link (curated or auto-fallback
+   * from the inviter's declared interests) that may reach anyone, not someone
+   * the inviter had in mind — they arrive UNSELECTED, offered only as
+   * suggestion chips. Defaults to 'named' so every existing caller (the dev
+   * preview harness included) keeps today's pre-selecting behavior unchanged.
+   */
+  seedSource?: 'named' | 'link'
   inviterName?: string | null
   inviteeDisplayName?: string | null
   initialDisplayName?: string | null
@@ -133,6 +144,7 @@ function StepHeader({ title, subtitle }: { title: string; subtitle: string }) {
 
 export default function OnboardingFlow({
   preSeededInterests,
+  seedSource = 'named',
   inviterName,
   inviteeDisplayName,
   initialDisplayName,
@@ -174,15 +186,19 @@ export default function OnboardingFlow({
   // invitee keeps, ignores, or removes them (and adds their own), but never edits
   // the wording inline — so this is a stable value, not state.
   const inviteInterests: PreSeededInterest[] = preSeededInterests
+  // Link-sourced seeds may reach someone the inviter never had in mind, so they
+  // must NOT pre-populate the selection — only a named invite's topics do.
   const [selectedInterests, setSelectedInterests] = useState<
     SelectedInterest[]
   >(() =>
-    preSeededInterests
-      .flatMap((interest) => {
-        const selected = toSelected(interest)
-        return selected ? [selected] : []
-      })
-      .slice(0, MAX_INTERESTS)
+    seedSource === 'named'
+      ? preSeededInterests
+          .flatMap((interest) => {
+            const selected = toSelected(interest)
+            return selected ? [selected] : []
+          })
+          .slice(0, MAX_INTERESTS)
+      : []
   )
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -643,9 +659,11 @@ export default function OnboardingFlow({
                   Welcome to Joshing
                 </h1>
                 <p className="text-muted-foreground text-base leading-7">
-                  {hasSeeds
-                    ? "A new trivia game. Here are some topics we picked for you — remove any that don't fit, or add your own."
-                    : "A new trivia game. Add a few topics you'd want questions about, and we'll build your first round from them."}
+                  {!hasSeeds
+                    ? "A new trivia game. Add a few topics you'd want questions about, and we'll build your first round from them."
+                    : seedSource === 'link'
+                      ? `A new trivia game. Here are a few from ${displayInviterName} — take any that are yours, or add your own.`
+                      : "A new trivia game. Here are some topics we picked for you — remove any that don't fit, or add your own."}
                 </p>
               </div>
 

--- a/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -63,6 +63,54 @@ describe('OnboardingFlow invited interests', () => {
   })
 })
 
+// Stage 2 (invite-link seed topics): link-sourced seeds must render as
+// unselected suggestion chips, never pre-populate the selection the way a
+// named invite's seeds do — a link may reach someone the inviter never had in
+// mind.
+describe('OnboardingFlow seedSource = link', () => {
+  it('renders link-sourced topics unselected, not pre-selected', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingFlow
+        seedSource="link"
+        inviterName="Josh"
+        initialDisplayName="Returning User"
+        initialHandle="returninguser"
+        preSeededInterests={[
+          { domain: 'Sondheim', broadCategory: 'Theater', rationale: null },
+          { domain: 'Jazz', broadCategory: 'Music', rationale: null },
+        ]}
+      />
+    )
+
+    // Counter reads 0 selected, not 2 — the topics are offered, not chosen.
+    expect(html).toContain('0 selected')
+    expect(html).not.toContain('2 selected')
+    // Still surfaced as suggestion chips the invitee can tap to add.
+    expect(html).toContain('Sondheim')
+    expect(html).toContain('Jazz')
+    // Link-specific framing, not the named-invite "we picked for you" copy.
+    expect(html).toContain('Here are a few from Josh')
+    expect(html).not.toContain('Here are some topics we picked for you')
+  })
+
+  it('a named invite (default seedSource) still pre-selects, for contrast', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingFlow
+        inviterName="Josh"
+        initialDisplayName="Returning User"
+        initialHandle="returninguser"
+        preSeededInterests={[
+          { domain: 'Sondheim', broadCategory: 'Theater', rationale: null },
+          { domain: 'Jazz', broadCategory: 'Music', rationale: null },
+        ]}
+      />
+    )
+
+    expect(html).toContain('2 selected · pick at least 1 more')
+    expect(html).toContain('Here are some topics we picked for you')
+  })
+})
+
 describe('OnboardingFlow display-name gate', () => {
   it('renders the setup step first when no displayName is set', () => {
     const html = renderToStaticMarkup(

--- a/src/app/onboarding/__tests__/page.test.ts
+++ b/src/app/onboarding/__tests__/page.test.ts
@@ -5,13 +5,30 @@ const {
   getUserOnboardingProfileMock,
   getPreSeededInterestsForUserMock,
   hasInviteLinkFriendshipMock,
+  getInviterForUserMock,
+  getInviteLinkSeedTopicsMock,
   friendInvitationRowsMock,
   redirectMock,
+  onboardingFlowMock,
 } = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
   getUserOnboardingProfileMock: vi.fn(),
   getPreSeededInterestsForUserMock: vi.fn(),
   hasInviteLinkFriendshipMock: vi.fn(async () => false),
+  // Stage 2: resolves null by default so tests whose interests come back
+  // empty for reasons OTHER than a link arrival (e.g. an unrelated redirect
+  // guard test) don't accidentally exercise the link-fallback branch.
+  getInviterForUserMock: vi.fn(async () => null as {
+    inviterUserId: string
+    inviterName: string | null
+    sourceId: string
+    sourceType: 'friend_invitation' | 'follow'
+  } | null),
+  getInviteLinkSeedTopicsMock: vi.fn(async () => [] as Array<{
+    label: string
+    description?: string | null
+    broadCategory?: string | null
+  }>),
   // Drives the FriendInvitation grandfather-guard query result.
   friendInvitationRowsMock: vi.fn(
     async () => [{ id: 'inv-1' }] as Array<{ id: string }>,
@@ -20,6 +37,7 @@ const {
     // Mirror Next.js: redirect() throws to short-circuit rendering.
     throw new Error(`__REDIRECT__:${target}`)
   }),
+  onboardingFlowMock: vi.fn(() => null),
 }))
 
 vi.mock('next/navigation', () => ({
@@ -33,6 +51,10 @@ vi.mock('@/server/auth/session', () => ({
 vi.mock('@/server/db/queries/users', () => ({
   getUserOnboardingProfile: getUserOnboardingProfileMock,
   getPreSeededInterestsForUser: getPreSeededInterestsForUserMock,
+  normalizePersonName: (value: string | null | undefined) => {
+    const trimmed = value?.trim().replace(/\s+/g, ' ')
+    return trimmed ? trimmed.slice(0, 80) : null
+  },
 }))
 
 // The page runs a grandfather-guard query (select FriendInvitation … limit 1)
@@ -60,6 +82,11 @@ vi.mock('@/server/db', () => ({
 
 vi.mock('@/server/friends/user-invite-token', () => ({
   hasInviteLinkFriendship: hasInviteLinkFriendshipMock,
+  getInviteLinkSeedTopics: getInviteLinkSeedTopicsMock,
+}))
+
+vi.mock('@/server/db/queries/friend-invitations', () => ({
+  getInviterForUser: getInviterForUserMock,
 }))
 
 // Seeds run through convergeDomain server-side; stub it to a passthrough (no
@@ -68,17 +95,22 @@ vi.mock('@/server/knowledge/converge-domain', () => ({
   convergeDomain: vi.fn(async (label: string) => ({ raw: label, candidates: [] })),
 }))
 
-// Stub the client component import so this test stays server-side.
+// Stub the client component import so this test stays server-side. Captures
+// props via onboardingFlowMock so tests can assert on seedSource/topics
+// without rendering.
 vi.mock('@/app/onboarding/OnboardingFlow', () => ({
-  default: () => null,
+  default: onboardingFlowMock,
 }))
 
 import OnboardingPage from '@/app/onboarding/page'
 
 async function callPage() {
   try {
-    await OnboardingPage()
-    return { redirected: false as const }
+    const element = await OnboardingPage()
+    // JSX creation doesn't invoke the component function — it just builds a
+    // descriptor — so props live on the returned element, not on a call to
+    // the mocked OnboardingFlow. Expose them for assertions without a real render.
+    return { redirected: false as const, props: (element as { props?: Record<string, unknown> })?.props }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     const match = message.match(/^__REDIRECT__:(.+)$/)
@@ -101,6 +133,10 @@ describe('OnboardingPage guard', () => {
     hasInviteLinkFriendshipMock.mockResolvedValue(false)
     friendInvitationRowsMock.mockReset()
     friendInvitationRowsMock.mockResolvedValue([{ id: 'inv-1' }])
+    getInviterForUserMock.mockReset()
+    getInviterForUserMock.mockResolvedValue(null)
+    getInviteLinkSeedTopicsMock.mockReset()
+    getInviteLinkSeedTopicsMock.mockResolvedValue([])
   })
 
   it('redirects to /login when there is no session', async () => {
@@ -133,7 +169,7 @@ describe('OnboardingPage guard', () => {
       onboardingComplete: false,
     })
     const result = await callPage()
-    expect(result).toEqual({ redirected: false })
+    expect(result.redirected).toBe(false)
     expect(getPreSeededInterestsForUserMock).toHaveBeenCalledWith('u1')
   })
 
@@ -145,8 +181,65 @@ describe('OnboardingPage guard', () => {
     })
     friendInvitationRowsMock.mockResolvedValueOnce([]) // no SMS-style invitation
     hasInviteLinkFriendshipMock.mockResolvedValueOnce(true) // arrived via /u/<handle>/<token>
+    // getPreSeededInterestsForUser finds no accepted FriendInvitation, so it
+    // resolves with no interests AND no inviter name — realistic for a pure
+    // link arrival (matches getPreSeededInterestsForUser's real behavior).
+    getPreSeededInterestsForUserMock.mockResolvedValueOnce({
+      inviterName: null,
+      inviteeDisplayName: null,
+      interests: [],
+    })
+    getInviterForUserMock.mockResolvedValueOnce({
+      inviterUserId: 'inviter-1',
+      inviterName: 'Jaime',
+      sourceId: 'follow-1',
+      sourceType: 'follow',
+    })
+    getInviteLinkSeedTopicsMock.mockResolvedValueOnce([
+      { label: 'Jazz', broadCategory: 'Music' },
+    ])
+
     const result = await callPage()
-    expect(result).toEqual({ redirected: false })
+
+    expect(result.redirected).toBe(false)
+    // Boundary-level check per Stage 1/2's recurring-failure guard: the
+    // resolved link topics must actually reach the OnboardingFlow props, not
+    // just come back correctly from the query.
+    expect(result.props?.seedSource).toBe('link')
+    expect(result.props?.inviterName).toBe('Jaime')
+    expect(result.props?.preSeededInterests).toEqual([
+      { domain: 'Jazz', broadCategory: 'Music', rationale: null },
+    ])
+  })
+
+  it('does NOT fall back to invite-link topics for a named invite with zero seeded interests', async () => {
+    // A named invite where the inviter simply seeded nothing — Stage 2 must
+    // not change what this shows (still the empty "add a few below" state),
+    // even though seeded.interests.length === 0 looks identical to the link
+    // case at first glance. Distinguished via getInviterForUser's sourceType.
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1', id: 's1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce({
+      id: 'u1',
+      onboardingComplete: false,
+    })
+    getPreSeededInterestsForUserMock.mockResolvedValueOnce({
+      inviterName: 'Alex',
+      inviteeDisplayName: null,
+      interests: [],
+    })
+    getInviterForUserMock.mockResolvedValueOnce({
+      inviterUserId: 'inviter-2',
+      inviterName: 'Alex',
+      sourceId: 'inv-2',
+      sourceType: 'friend_invitation',
+    })
+
+    const result = await callPage()
+
+    expect(result.redirected).toBe(false)
+    expect(getInviteLinkSeedTopicsMock).not.toHaveBeenCalled()
+    expect(result.props?.seedSource).toBe('named')
+    expect(result.props?.preSeededInterests).toEqual([])
   })
 
   it('redirects to /login when there is neither a FriendInvitation nor an invite-link friendship', async () => {

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -3,8 +3,13 @@ import { redirect } from 'next/navigation';
 
 import { getSession } from '@/server/auth/session';
 import { db, friendInvitations } from '@/server/db';
-import { getPreSeededInterestsForUser, getUserOnboardingProfile } from '@/server/db/queries/users';
-import { hasInviteLinkFriendship } from '@/server/friends/user-invite-token';
+import { getInviterForUser } from '@/server/db/queries/friend-invitations';
+import {
+  getPreSeededInterestsForUser,
+  getUserOnboardingProfile,
+  normalizePersonName,
+} from '@/server/db/queries/users';
+import { getInviteLinkSeedTopics, hasInviteLinkFriendship } from '@/server/friends/user-invite-token';
 import { assessInterestAnswerability } from '@/server/llm/interests';
 import { convergeDomain } from '@/server/knowledge/converge-domain';
 import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
@@ -50,7 +55,30 @@ export default async function OnboardingPage() {
     redirect('/login');
   }
 
-  const seeded = await getPreSeededInterestsForUser(session.userId);
+  let seeded = await getPreSeededInterestsForUser(session.userId);
+  // 'named': topics came from friendInvitations.preSeededInterests — the
+  // inviter chose them FOR this person, so OnboardingFlow pre-selects them.
+  // 'link': topics came from the per-user invite link's own resolution below
+  // — they may reach anyone, so OnboardingFlow must NOT pre-select them.
+  let seedSource: 'named' | 'link' = 'named';
+
+  if (seeded.interests.length === 0) {
+    const inviter = await getInviterForUser(session.userId);
+    // Only fall back when the resolved provenance is genuinely the invite-link
+    // follow edge (no FriendInvitation at all). A named invite with a *empty*
+    // seed list also lands here with `seeded.interests.length === 0`, but its
+    // getInviterForUser resolution is sourceType 'friend_invitation' — Stage 2
+    // must not change what that case shows, so it's deliberately excluded.
+    if (inviter?.sourceType === 'follow') {
+      const topics = await getInviteLinkSeedTopics(inviter.inviterUserId);
+      seeded = {
+        interests: topics,
+        inviterName: normalizePersonName(inviter.inviterName),
+        inviteeDisplayName: seeded.inviteeDisplayName,
+      };
+      seedSource = 'link';
+    }
+  }
 
   // Validate the inviter's free-text suggestions at the invitee's first login,
   // before the interests step renders. The inviter can seed anything ("your
@@ -89,6 +117,7 @@ export default async function OnboardingPage() {
   return (
     <OnboardingFlow
       preSeededInterests={preSeededInterests}
+      seedSource={seedSource}
       inviterName={seeded.inviterName}
       inviteeDisplayName={seeded.inviteeDisplayName}
       initialDisplayName={user.displayName}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,8 +12,8 @@ import { AddTopicHomeCard } from '@/components/home/AddTopicHomeCard'
 import { LoadingMomentPrimer } from '@/components/loading-moment/LoadingMomentPrimer'
 import { getSession } from '@/server/auth/session'
 import { getHomeFriendRequests } from '@/server/db/queries/friends'
-import { getPreSeededInterestsForUser } from '@/server/db/queries/users'
 import { buildHomeEdition } from '@/server/home/build-edition'
+import { getWelcomeInviterName } from '@/server/home/welcome-inviter-name'
 import { DAILY_QUEUE_SIZE, isRoundComplete, type QueueSlot } from '@/server/daily/types'
 import { getBonusSlots } from '@/server/daily/bonus'
 import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/daily'
@@ -41,10 +41,7 @@ export default async function Home({
   // sample reads it), falling back to "a friend" when there's no invitation.
   // Only queried on the one-time welcome path so the normal home render is
   // untouched.
-  const welcomeInviterName =
-    tourActive && session
-      ? (await getPreSeededInterestsForUser(session.userId)).inviterName
-      : null
+  const welcomeInviterName = await getWelcomeInviterName(tourActive, session?.userId ?? null)
 
   return (
     <>

--- a/src/app/users/[id]/__tests__/page.test.tsx
+++ b/src/app/users/[id]/__tests__/page.test.tsx
@@ -96,6 +96,7 @@ vi.mock('@/server/profile/preview', () => ({
 
 vi.mock('@/server/friends/user-invite-token', () => ({
   getOrCreateInviteToken: getOrCreateInviteTokenMock,
+  getCuratedInviteSeedTopics: async () => [] as string[],
   buildInviteUrl: (baseUrl: string, handle: string, token: string) =>
     `${baseUrl}/u/${handle}/${token}`,
   getBaseUrl: () => 'https://example.com',

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -43,6 +43,7 @@ import { resolvePreviewAs } from '@/server/profile/preview';
 import {
   buildInviteUrl,
   getBaseUrl,
+  getCuratedInviteSeedTopics,
   getOrCreateInviteToken,
 } from '@/server/friends/user-invite-token';
 
@@ -142,6 +143,7 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
     discoverability,
     reminderState,
     inviteTokenResult,
+    curatedInviteSeedTopics,
   ] = await Promise.all([
     getUserMasteryOverview(portrait.user.id),
     getKnowledgePageData(portrait.user.id),
@@ -175,6 +177,7 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
     isOwnerView ? getDiscoverability(session.userId) : Promise.resolve(null),
     isOwnerView ? getReminderState(session.userId) : Promise.resolve(null),
     isOwnerView ? getOrCreateInviteToken(session.userId) : Promise.resolve(null),
+    isOwnerView ? getCuratedInviteSeedTopics(session.userId) : Promise.resolve([]),
   ]);
 
   let inviteUrl: string | null = null;
@@ -310,7 +313,11 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
           <p className="text-muted-foreground mb-3 text-sm">
             Choose how other people can find you on Joshing.
           </p>
-          <PrivacyForm initialState={discoverability} initialInviteUrl={inviteUrl} />
+          <PrivacyForm
+            initialState={discoverability}
+            initialInviteUrl={inviteUrl}
+            initialSeedTopics={curatedInviteSeedTopics}
+          />
         </section>
 
         <section className="mb-8" id="notifications">

--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import AddFriendInvite from '@/components/AddFriendInvite';
 import FriendsList from '@/components/FriendsList';
 import { FindFriendsSearch } from '@/components/friends/FindFriendsSearch';
+import { InviteSomeoneNew } from '@/components/friends/InviteSomeoneNew';
 import type { QueryClassification } from '@/components/friends/add-someone';
 
 export default function FriendsHubPage() {
@@ -33,17 +34,21 @@ export default function FriendsHubPage() {
         <h1 className="text-foreground font-serif text-3xl font-semibold">Friends</h1>
       </header>
 
-      {/* One entry point: a single lookup field. An exact @handle/number match
-          offers to send a friend request; no match (or a typed name) drops into
-          the field's own "invite them" state, which expands the invite flow
-          below. The standalone "Invite someone" block is gone — inviting is
-          reachable straight from the field. */}
+      {/* Lookup field: an exact @handle/number match offers to send a friend
+          request; no match (or a typed name) drops into the field's own
+          "invite them" state, which expands the phone-invite flow below. */}
       <section className="border-primary/15 bg-primary/5 text-card-foreground mb-5 rounded-[var(--radius-card)] border p-6 shadow-[var(--shadow-card)]">
         {!inviteOpen ? (
           <FindFriendsSearch variant="add" onInvite={handleLookupInvite} />
         ) : null}
         <AddFriendInvite embedded onExpandedChange={setInviteOpen} />
       </section>
+      {/* Standalone invite block (Stage 3, B-Friends-3): the link is the
+          primary invite action, reachable from here in one tap rather than
+          only via a search no-match. */}
+      <div className="mb-5">
+        <InviteSomeoneNew />
+      </div>
       <FriendsList />
     </main>
   );

--- a/src/components/__tests__/FriendsHubPage.test.tsx
+++ b/src/components/__tests__/FriendsHubPage.test.tsx
@@ -24,11 +24,13 @@ describe('Friends page QA surface', () => {
     const html = renderToStaticMarkup(<FriendsHubPage />);
 
     expect(html).toContain('Friends');
-    // The single lookup-field entry point ("Add a friend" / "Add someone")
-    // replaced the standalone "Invite Someone" block — see the comment in
-    // FriendsHubPage.tsx; inviting is reachable from the field's no-match state.
+    // The lookup field ("Add a friend" / "Add someone") is one entry point;
+    // the invite-link block (Stage 3, B-Friends-3) is the other, reachable
+    // without a search no-match — see the comment in FriendsHubPage.tsx.
     expect(html).toContain('Add a friend');
     expect(html).toContain('Add someone');
+    expect(html).toContain('Share invite link');
+    expect(html).toContain('Text a personal invite');
     expect(html).not.toMatch(forbiddenGamificationCopy);
     expect(html).not.toMatch(forbiddenRelationshipCopy);
   });

--- a/src/components/friends/InviteSomeoneNew.tsx
+++ b/src/components/friends/InviteSomeoneNew.tsx
@@ -1,16 +1,27 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 
-type InviteTokenResponse = { token: string; url: string }
+type InviteTokenResponse = {
+  token: string
+  url: string
+  userId?: string
+  topicCount?: number
+}
 
-// Side-by-side: "Send a personal invite" (opens the existing AddFriendInvite
-// 3-step modal via the friend-invitations:create-new event) and "Copy invite
-// link" (fetches/persists the per-user invite token and copies the URL).
+const SHARE_TEXT = "I'm playing Joshing — come be my friend."
+
+// Side-by-side: "Share invite link" (navigator.share, falling back to copy)
+// and "Text a personal invite" (opens the existing AddFriendInvite 3-step
+// modal via the friend-invitations:create-new event). The link is the
+// primary action — most people should never need the phone-first flow.
 export function InviteSomeoneNew() {
-  const [copying, setCopying] = useState(false)
+  const [sharing, setSharing] = useState(false)
   const [toast, setToast] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [ownUserId, setOwnUserId] = useState<string | null>(null)
+  const [topicCount, setTopicCount] = useState<number | null>(null)
 
   useEffect(() => {
     if (!toast) return
@@ -24,9 +35,9 @@ export function InviteSomeoneNew() {
     )
   }
 
-  async function copyInviteLink() {
-    if (copying) return
-    setCopying(true)
+  async function shareInviteLink() {
+    if (sharing) return
+    setSharing(true)
     setError(null)
     try {
       const response = await fetch('/api/account/invite-token', {
@@ -42,12 +53,27 @@ export function InviteSomeoneNew() {
         setError('Could not build your invite link.')
         return
       }
+      setOwnUserId(body.userId ?? null)
+      setTopicCount(typeof body.topicCount === 'number' ? body.topicCount : null)
+
+      if (typeof navigator.share === 'function') {
+        try {
+          await navigator.share({ text: SHARE_TEXT, url: body.url })
+          return
+        } catch (shareError) {
+          // The user closing the share sheet is not a failure — leave it
+          // silent rather than falling back to a surprise clipboard copy.
+          if (shareError instanceof Error && shareError.name === 'AbortError') return
+          // Any other share failure (unsupported target, etc.) falls through
+          // to the clipboard path below.
+        }
+      }
       await navigator.clipboard.writeText(body.url)
       setToast('Link copied.')
     } catch {
-      setError('Could not copy your invite link.')
+      setError('Could not share your invite link.')
     } finally {
-      setCopying(false)
+      setSharing(false)
     }
   }
 
@@ -55,25 +81,35 @@ export function InviteSomeoneNew() {
     <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
       <h2 className="font-serif text-lg font-semibold">Invite someone new</h2>
       <p className="text-muted-foreground mt-1 text-sm">
-        Text a personal note to someone&rsquo;s phone, or copy a link you can share anywhere.
+        Share a link you can send anywhere, or text a personal note to someone&rsquo;s phone.
       </p>
       <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
         <button
           type="button"
-          onClick={openPersonalInvite}
+          onClick={() => void shareInviteLink()}
+          disabled={sharing}
           className="btn-primary px-4"
         >
-          Text a personal invite
+          {sharing ? 'Loading…' : 'Share invite link'}
         </button>
         <button
           type="button"
-          onClick={() => void copyInviteLink()}
-          disabled={copying}
+          onClick={openPersonalInvite}
           className="btn-ghost px-4"
         >
-          {copying ? 'Loading…' : 'Copy invite link'}
+          Text a personal invite
         </button>
       </div>
+      {topicCount !== null ? (
+        <p className="text-muted-foreground mt-2 text-xs">
+          Your link shows {topicCount} {topicCount === 1 ? 'topic' : 'topics'}.{' '}
+          {ownUserId ? (
+            <Link href={`/users/${ownUserId}`} className="underline underline-offset-2">
+              Edit
+            </Link>
+          ) : null}
+        </p>
+      ) : null}
       {error ? <p className="text-destructive mt-2 text-sm">{error}</p> : null}
       {toast ? (
         <div className="fixed bottom-24 left-1/2 z-[var(--z-toast)] -translate-x-1/2 rounded-full bg-foreground px-4 py-2 text-sm text-background shadow-lg">

--- a/src/components/friends/__tests__/InviteSomeoneNew.test.tsx
+++ b/src/components/friends/__tests__/InviteSomeoneNew.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { InviteSomeoneNew } from '@/components/friends/InviteSomeoneNew'
+
+// Stage 3 (B-Friends-3): the invite link is the default placement — verify
+// its button carries the primary emphasis and the phone path stays reachable
+// as the secondary action, not removed. Interactive behavior (navigator.share,
+// the clipboard fallback, the AbortError-is-not-an-error path) isn't covered
+// here: this codebase's component tests are static renderToStaticMarkup only
+// (no @testing-library/react / jsdom event simulation installed), so those
+// paths were verified by reading the implementation and manually in a
+// browser rather than via an automated click.
+describe('InviteSomeoneNew', () => {
+  it('renders the invite link as the primary action, phone invite as secondary', () => {
+    const html = renderToStaticMarkup(<InviteSomeoneNew />)
+
+    expect(html).toContain('Share invite link')
+    expect(html).toContain('Text a personal invite')
+
+    const shareButtonIndex = html.indexOf('Share invite link')
+    const shareButtonOpenTag = html.lastIndexOf('<button', shareButtonIndex)
+    const personalButtonIndex = html.indexOf('Text a personal invite')
+    const personalButtonOpenTag = html.lastIndexOf('<button', personalButtonIndex)
+
+    expect(html.slice(shareButtonOpenTag, shareButtonIndex)).toContain('btn-primary')
+    expect(html.slice(personalButtonOpenTag, personalButtonIndex)).toContain('btn-ghost')
+  })
+
+  it('does not render a topic count before the invite link has loaded', () => {
+    const html = renderToStaticMarkup(<InviteSomeoneNew />)
+
+    expect(html).not.toContain('Your link shows')
+  })
+})

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -11,6 +11,7 @@ import {
   FlaskConical,
   Hammer,
   Hourglass,
+  Link2,
   Loader2,
   LogOut,
   Network,
@@ -236,6 +237,44 @@ export function AccountActions({
       ],
     },
     {
+      // Stage 6 of the invite-link build: entry points to the screens/flows
+      // Stages 1–3 shipped. The two dev-preview links land directly on the
+      // new tab/variant via a query param; the other two are real live pages
+      // (no preview needed) linked here because that's where the Stage 3
+      // placement change actually landed.
+      eyebrow: 'Growth',
+      tools: [
+        {
+          kind: 'link',
+          icon: <Link2 className="size-5" />,
+          title: 'Invite-link login card',
+          subtitle: 'The per-user link’s topic-chip card on the login screen',
+          href: '/dev/invite-login?screen=linkCard',
+        },
+        {
+          kind: 'link',
+          icon: <Link2 className="size-5" />,
+          title: 'Areas of knowledge (invite-link)',
+          subtitle: 'The interests step seeded via the link — topics arrive unselected',
+          href: '/dev/onboarding/intro?seedSource=link',
+        },
+        {
+          kind: 'link',
+          icon: <UserPlus className="size-5" />,
+          title: 'Invite someone',
+          subtitle: 'Friends hub: Share invite link is now the primary action',
+          href: '/friends',
+        },
+        {
+          kind: 'link',
+          icon: <UserPlus className="size-5" />,
+          title: 'Find friends',
+          subtitle: 'Same invite block, plus the invite-reflection list',
+          href: '/friends/find',
+        },
+      ],
+    },
+    {
       eyebrow: 'Game & session',
       tools: [
         {
@@ -362,8 +401,14 @@ export function AccountActions({
   // null/undefined => the server couldn't run the route-exists check; fail open.
   // Strip any query string first — the availability scan keys on bare route
   // paths, so `/dev/onboarding/intro?walk=1` checks against `/dev/onboarding/intro`.
-  const isToolAvailable = (href: string) =>
-    availableToolHrefs == null || availableToolHrefs.includes(href.split('?')[0]);
+  const isToolAvailable = (href: string) => {
+    const path = href.split('?')[0];
+    // getExistingDevToolHrefs only scans /dev/* and /admin/* — a real core
+    // route (e.g. /friends, linked from the Growth group) always exists and
+    // was never a candidate for this WIP-existence check.
+    if (!path.startsWith('/dev/') && !path.startsWith('/admin/')) return true;
+    return availableToolHrefs == null || availableToolHrefs.includes(path);
+  };
 
   function renderTool(tool: DevTool) {
     if (tool.kind === 'action') {

--- a/src/components/profile/settings/PrivacyForm.tsx
+++ b/src/components/profile/settings/PrivacyForm.tsx
@@ -8,11 +8,16 @@ import type { DiscoverabilityState } from '@/server/db/queries/account';
 type Props = {
   initialState: DiscoverabilityState;
   initialInviteUrl: string | null;
+  initialSeedTopics: string[];
 };
 
 type PatchKey = 'contacts' | 'mutualFriends' | 'nicheMatch';
 
 type InviteTokenResponse = { token: string; url: string };
+
+const SEED_TOPIC_CAP = 3;
+
+type TopicsResponse = { topics?: string[]; message?: string };
 
 async function patchDiscoverability(
   body: Partial<Record<PatchKey, boolean>>,
@@ -70,7 +75,7 @@ function ToggleRow({
   );
 }
 
-export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
+export function PrivacyForm({ initialState, initialInviteUrl, initialSeedTopics }: Props) {
   const [state, setState] = useState<DiscoverabilityState>(initialState);
   const [savingKey, setSavingKey] = useState<PatchKey | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -79,6 +84,11 @@ export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
   const [confirmingRotate, setConfirmingRotate] = useState(false);
   const [inviteToast, setInviteToast] = useState<string | null>(null);
   const [inviteError, setInviteError] = useState<string | null>(null);
+  const [seedTopics, setSeedTopics] = useState<string[]>(initialSeedTopics);
+  const [seedTopicDraft, setSeedTopicDraft] = useState('');
+  const [savingTopics, setSavingTopics] = useState(false);
+  const [seedTopicsError, setSeedTopicsError] = useState<string | null>(null);
+  const [seedTopicsSaved, setSeedTopicsSaved] = useState(false);
 
   useEffect(() => {
     if (!inviteToast) return;
@@ -123,6 +133,49 @@ export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
       setInviteError('Network error. Try again.');
     } finally {
       setRotating(false);
+    }
+  }
+
+  function addSeedTopicDraft() {
+    const topic = seedTopicDraft.trim();
+    if (!topic || seedTopics.length >= SEED_TOPIC_CAP) return;
+    if (seedTopics.some((existing) => existing.toLowerCase() === topic.toLowerCase())) {
+      setSeedTopicDraft('');
+      return;
+    }
+    setSeedTopics([...seedTopics, topic]);
+    setSeedTopicDraft('');
+    setSeedTopicsSaved(false);
+  }
+
+  function removeSeedTopic(topic: string) {
+    setSeedTopics(seedTopics.filter((existing) => existing !== topic));
+    setSeedTopicsSaved(false);
+  }
+
+  async function saveSeedTopics() {
+    if (savingTopics) return;
+    setSavingTopics(true);
+    setSeedTopicsError(null);
+    setSeedTopicsSaved(false);
+    try {
+      const response = await fetch('/api/account/invite-token/topics', {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ topics: seedTopics }),
+      });
+      const body = (await response.json().catch(() => null)) as TopicsResponse | null;
+      if (!response.ok) {
+        setSeedTopicsError(body?.message ?? 'Could not save your topics.');
+        return;
+      }
+      setSeedTopics(body?.topics ?? seedTopics);
+      setSeedTopicsSaved(true);
+    } catch {
+      setSeedTopicsError('Network error. Try again.');
+    } finally {
+      setSavingTopics(false);
     }
   }
 
@@ -248,6 +301,69 @@ export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
             Rotating invalidates the old link. Use this if you accidentally shared it broadly.
           </p>
           {inviteError ? <p className="mt-2 text-sm text-destructive">{inviteError}</p> : null}
+
+          <div className="mt-4 border-t pt-4">
+            <h4 className="text-sm font-semibold">Topics your link shows</h4>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Up to {SEED_TOPIC_CAP} topics shown to whoever taps your link. Leave blank to
+              automatically use your own top topics instead.
+            </p>
+            {seedTopics.length > 0 ? (
+              <ul className="mt-2 flex flex-wrap gap-2">
+                {seedTopics.map((topic) => (
+                  <li
+                    key={topic}
+                    className="flex items-center gap-1 rounded-full border bg-background px-3 py-1 text-sm"
+                  >
+                    {topic}
+                    <button
+                      type="button"
+                      onClick={() => removeSeedTopic(topic)}
+                      aria-label={`Remove ${topic}`}
+                      className="text-muted-foreground hover:text-foreground"
+                    >
+                      ×
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {seedTopics.length < SEED_TOPIC_CAP ? (
+              <div className="mt-2 flex gap-2">
+                <input
+                  type="text"
+                  value={seedTopicDraft}
+                  onChange={(event) => setSeedTopicDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key !== 'Enter') return;
+                    event.preventDefault();
+                    addSeedTopicDraft();
+                  }}
+                  placeholder="Add a topic"
+                  className="border-input bg-background text-foreground h-9 flex-1 rounded-md border px-3 text-sm outline-none focus:border-[var(--brand-navy)]"
+                />
+                <button type="button" onClick={addSeedTopicDraft} className="btn-ghost px-3">
+                  Add
+                </button>
+              </div>
+            ) : null}
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void saveSeedTopics()}
+                disabled={savingTopics}
+                className="btn-primary px-4"
+              >
+                {savingTopics ? 'Saving…' : 'Save topics'}
+              </button>
+              {seedTopicsSaved ? (
+                <span className="text-xs text-muted-foreground">Saved.</span>
+              ) : null}
+            </div>
+            {seedTopicsError ? (
+              <p className="mt-2 text-sm text-destructive">{seedTopicsError}</p>
+            ) : null}
+          </div>
           {inviteToast ? (
             <div className="fixed bottom-24 left-1/2 z-[var(--z-toast)] -translate-x-1/2 rounded-full bg-foreground px-4 py-2 text-sm text-background shadow-lg">
               {inviteToast}

--- a/src/components/profile/settings/__tests__/AccountActions.dev-tools.test.tsx
+++ b/src/components/profile/settings/__tests__/AccountActions.dev-tools.test.tsx
@@ -12,11 +12,34 @@ import { AccountActions } from '../AccountActions';
  * tool participates in a route-exists check driven by `availableToolHrefs`.
  */
 describe('AccountActions — dev-tools grouping & availability', () => {
-  it('renders the three eyebrow groups', () => {
+  it('renders the four eyebrow groups', () => {
     const html = renderToStaticMarkup(<AccountActions isAdmin />);
     expect(html).toContain('First-time experience');
+    expect(html).toContain('Growth');
     expect(html).toContain('Game &amp; session');
     expect(html).toContain('Diagnostics &amp; flags');
+  });
+
+  // Stage 6 of the invite-link build: entry points to the new screens/flows.
+  it('the Growth group links to the invite-link previews and the live Friends pages', () => {
+    const html = renderToStaticMarkup(<AccountActions isAdmin />);
+    expect(html).toContain('href="/dev/invite-login?screen=linkCard"');
+    expect(html).toContain('href="/dev/onboarding/intro?seedSource=link"');
+    expect(html).toContain('href="/friends"');
+    expect(html).toContain('href="/friends/find"');
+  });
+
+  it('never dims /friends or /friends/find, even when availableToolHrefs omits them', () => {
+    // getExistingDevToolHrefs only ever scans /dev/* and /admin/* — a real
+    // core route like /friends was never a candidate for that WIP-existence
+    // check. An unavailable row renders as a plain <div> with no href at all
+    // (see SettingsRow), so the mere presence of these hrefs as real links
+    // proves they weren't dimmed.
+    const html = renderToStaticMarkup(
+      <AccountActions isAdmin availableToolHrefs={['/dev/first-time-player']} />,
+    );
+    expect(html).toContain('href="/friends"');
+    expect(html).toContain('href="/friends/find"');
   });
 
   it('fails open (no Unavailable pill) when availableToolHrefs is omitted', () => {

--- a/src/components/profile/settings/__tests__/PrivacyForm.test.tsx
+++ b/src/components/profile/settings/__tests__/PrivacyForm.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { PrivacyForm } from '@/components/profile/settings/PrivacyForm'
+import type { DiscoverabilityState } from '@/server/db/queries/account'
+
+const baseState: DiscoverabilityState = {
+  discoverableByContacts: false,
+  discoverableByMutualFriends: false,
+  discoverableByNicheMatch: false,
+}
+
+// Static-render coverage only, matching this codebase's component-test
+// convention (renderToStaticMarkup, no @testing-library/react / jsdom event
+// simulation installed) — the add/remove/save interactions themselves are
+// exercised by src/app/api/account/invite-token/topics/__tests__/route.test.ts
+// (the endpoint this form calls) rather than by clicking through the UI here.
+describe('PrivacyForm invite-link topic editor', () => {
+  it('renders the seeded curated topics as chips', () => {
+    const html = renderToStaticMarkup(
+      <PrivacyForm
+        initialState={baseState}
+        initialInviteUrl="https://example.com/u/josh/tok"
+        initialSeedTopics={['Jazz', 'Poetry']}
+      />,
+    )
+
+    expect(html).toContain('Topics your link shows')
+    expect(html).toContain('Jazz')
+    expect(html).toContain('Poetry')
+    expect(html).toContain('Save topics')
+    // Add input still offered — under the 3-topic cap.
+    expect(html).toContain('Add a topic')
+  })
+
+  it('hides the add-topic input once the 3-topic cap is reached', () => {
+    const html = renderToStaticMarkup(
+      <PrivacyForm
+        initialState={baseState}
+        initialInviteUrl="https://example.com/u/josh/tok"
+        initialSeedTopics={['Jazz', 'Poetry', 'Chess']}
+      />,
+    )
+
+    expect(html).toContain('Jazz')
+    expect(html).toContain('Poetry')
+    expect(html).toContain('Chess')
+    expect(html).not.toContain('Add a topic')
+  })
+
+  it('renders no chips and offers the add input when nothing is curated', () => {
+    const html = renderToStaticMarkup(
+      <PrivacyForm
+        initialState={baseState}
+        initialInviteUrl="https://example.com/u/josh/tok"
+        initialSeedTopics={[]}
+      />,
+    )
+
+    expect(html).toContain('Topics your link shows')
+    expect(html).toContain('Add a topic')
+    expect(html).toContain('automatically use your own top topics')
+  })
+
+  it('renders nothing invite-related when there is no invite URL yet', () => {
+    const html = renderToStaticMarkup(
+      <PrivacyForm initialState={baseState} initialInviteUrl={null} initialSeedTopics={[]} />,
+    )
+
+    expect(html).not.toContain('Your invite link')
+    expect(html).not.toContain('Topics your link shows')
+  })
+})

--- a/src/server/activity/__tests__/invite-onboarding.test.ts
+++ b/src/server/activity/__tests__/invite-onboarding.test.ts
@@ -1,17 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { state, writeActivityMock, dbMock, masteryEvents, friendInvitations, activityItems } =
+const { state, writeActivityMock, dbMock, getInviterForUserMock, masteryEvents, activityItems } =
   vi.hoisted(() => {
     const state = {
       played: 0,
-      invitationRows: [] as Array<{ id: string; inviterUserId: string }>,
+      inviter: null as {
+        inviterUserId: string
+        inviterName: string | null
+        sourceId: string
+        sourceType: 'friend_invitation' | 'follow'
+      } | null,
       existingActivityRows: [] as Array<{ id: string }>,
     }
 
     // Sentinel table objects so the db mock can dispatch on which table a
     // select reads from.
     const masteryEvents = { __table: 'mastery' }
-    const friendInvitations = { __table: 'invitations' }
     const activityItems = { __table: 'activities' }
 
     const dbMock = {
@@ -20,11 +24,6 @@ const { state, writeActivityMock, dbMock, masteryEvents, friendInvitations, acti
           if (table === masteryEvents) {
             // Counting query: awaited directly off .where(), no .limit().
             return { where: vi.fn(async () => [{ played: state.played }]) }
-          }
-          if (table === friendInvitations) {
-            return {
-              where: vi.fn(() => ({ limit: vi.fn(async () => state.invitationRows) })),
-            }
           }
           return {
             where: vi.fn(() => ({ limit: vi.fn(async () => state.existingActivityRows) })),
@@ -37,8 +36,8 @@ const { state, writeActivityMock, dbMock, masteryEvents, friendInvitations, acti
       state,
       writeActivityMock: vi.fn(async () => {}),
       dbMock,
+      getInviterForUserMock: vi.fn(async () => state.inviter),
       masteryEvents,
-      friendInvitations,
       activityItems,
     }
   })
@@ -46,34 +45,47 @@ const { state, writeActivityMock, dbMock, masteryEvents, friendInvitations, acti
 vi.mock('@/server/db', () => ({
   db: dbMock,
   masteryEvents,
-  friendInvitations,
   activityItems,
 }))
 
 vi.mock('@/server/activity/write-activity', () => ({ writeActivity: writeActivityMock }))
+vi.mock('@/server/db/queries/friend-invitations', () => ({
+  getInviterForUser: getInviterForUserMock,
+}))
 
 import { maybeNotifyInviterOfFirstFive } from '@/server/activity/invite-onboarding'
 
 describe('maybeNotifyInviterOfFirstFive', () => {
   beforeEach(() => {
     state.played = 0
-    state.invitationRows = []
+    state.inviter = null
     state.existingActivityRows = []
     writeActivityMock.mockClear()
+    getInviterForUserMock.mockClear()
   })
 
   it('does nothing before the fifth play', async () => {
     state.played = 4
-    state.invitationRows = [{ id: 'inv1', inviterUserId: 'inviter1' }]
+    state.inviter = {
+      inviterUserId: 'inviter1',
+      inviterName: null,
+      sourceId: 'inv1',
+      sourceType: 'friend_invitation',
+    }
 
     await maybeNotifyInviterOfFirstFive('invitee1')
 
     expect(writeActivityMock).not.toHaveBeenCalled()
   })
 
-  it('notifies the inviter on the exact fifth play', async () => {
+  it('notifies the inviter on the exact fifth play (named invitation)', async () => {
     state.played = 5
-    state.invitationRows = [{ id: 'inv1', inviterUserId: 'inviter1' }]
+    state.inviter = {
+      inviterUserId: 'inviter1',
+      inviterName: null,
+      sourceId: 'inv1',
+      sourceType: 'friend_invitation',
+    }
 
     await maybeNotifyInviterOfFirstFive('invitee1')
 
@@ -87,18 +99,48 @@ describe('maybeNotifyInviterOfFirstFive', () => {
     })
   })
 
+  // Boundary-level coverage per Stage 1: a link-arrived user has no
+  // FriendInvitation row — the resolver falls back to the Follow edge, and
+  // this consumer must write the milestone against THAT id/type, not silently
+  // skip the notification the way the pre-resolver code did.
+  it('notifies the inviter on the exact fifth play (link-arrived, follow fallback)', async () => {
+    state.played = 5
+    state.inviter = {
+      inviterUserId: 'inviter2',
+      inviterName: 'Jaime',
+      sourceId: 'follow-1',
+      sourceType: 'follow',
+    }
+
+    await maybeNotifyInviterOfFirstFive('invitee2')
+
+    expect(writeActivityMock).toHaveBeenCalledTimes(1)
+    expect(writeActivityMock).toHaveBeenCalledWith({
+      userId: 'inviter2',
+      type: 'invited_friend_played_first_five',
+      actorUserId: 'invitee2',
+      referenceId: 'follow-1',
+      referenceType: 'follow',
+    })
+  })
+
   it('does not re-fire past the fifth play', async () => {
     state.played = 6
-    state.invitationRows = [{ id: 'inv1', inviterUserId: 'inviter1' }]
+    state.inviter = {
+      inviterUserId: 'inviter1',
+      inviterName: null,
+      sourceId: 'inv1',
+      sourceType: 'friend_invitation',
+    }
 
     await maybeNotifyInviterOfFirstFive('invitee1')
 
     expect(writeActivityMock).not.toHaveBeenCalled()
   })
 
-  it('does nothing when the user did not join via an invitation', async () => {
+  it('does nothing when the user did not join via an invitation or invite link', async () => {
     state.played = 5
-    state.invitationRows = []
+    state.inviter = null
 
     await maybeNotifyInviterOfFirstFive('invitee1')
 
@@ -107,7 +149,12 @@ describe('maybeNotifyInviterOfFirstFive', () => {
 
   it('is idempotent when the milestone activity already exists', async () => {
     state.played = 5
-    state.invitationRows = [{ id: 'inv1', inviterUserId: 'inviter1' }]
+    state.inviter = {
+      inviterUserId: 'inviter1',
+      inviterName: null,
+      sourceId: 'inv1',
+      sourceType: 'friend_invitation',
+    }
     state.existingActivityRows = [{ id: 'existing1' }]
 
     await maybeNotifyInviterOfFirstFive('invitee1')

--- a/src/server/activity/invite-onboarding-policy.ts
+++ b/src/server/activity/invite-onboarding-policy.ts
@@ -19,7 +19,13 @@ export type FirstFiveActivity = {
   type: typeof INVITED_FRIEND_FIRST_FIVE_TYPE;
   actorUserId: string;
   referenceId: string;
-  referenceType: 'friend_invitation';
+  // 'friend_invitation' for the named path (referenceId -> FriendInvitation.id);
+  // 'follow' for a link-arrived user, who has no FriendInvitation row — there
+  // referenceId points at the Follow edge left by acceptUserInviteLink instead.
+  // Nothing dereferences this activity type's referenceId against either table
+  // for rendering (see src/lib/activity-stream.ts), so this is a dedup key, not
+  // a strict FK typing.
+  referenceType: 'friend_invitation' | 'follow';
 };
 
 /**
@@ -34,7 +40,11 @@ export type FirstFiveActivity = {
 export function firstFiveActivityToWrite(params: {
   inviteeUserId: string;
   playedCount: number;
-  invitation: { id: string; inviterUserId: string } | null;
+  invitation: {
+    id: string;
+    inviterUserId: string;
+    referenceType: 'friend_invitation' | 'follow';
+  } | null;
   alreadyNotified: boolean;
 }): FirstFiveActivity | null {
   if (params.playedCount !== FIRST_FIVE_THRESHOLD) return null;
@@ -46,6 +56,6 @@ export function firstFiveActivityToWrite(params: {
     type: INVITED_FRIEND_FIRST_FIVE_TYPE,
     actorUserId: params.inviteeUserId,
     referenceId: params.invitation.id,
-    referenceType: 'friend_invitation',
+    referenceType: params.invitation.referenceType,
   };
 }

--- a/src/server/activity/invite-onboarding.ts
+++ b/src/server/activity/invite-onboarding.ts
@@ -1,7 +1,8 @@
-import { and, count, eq, inArray, isNotNull } from 'drizzle-orm';
+import { and, count, eq, inArray } from 'drizzle-orm';
 
-import { activityItems, db, friendInvitations, masteryEvents } from '@/server/db';
+import { activityItems, db, masteryEvents } from '@/server/db';
 import { writeActivity } from '@/server/activity/write-activity';
+import { getInviterForUser } from '@/server/db/queries/friend-invitations';
 import {
   FIRST_FIVE_PLAY_SURFACES,
   FIRST_FIVE_THRESHOLD,
@@ -37,22 +38,10 @@ export async function maybeNotifyInviterOfFirstFive(inviteeUserId: string): Prom
     // Cheap gate before the extra lookups: only the exact crossing matters.
     if (playedCount !== FIRST_FIVE_THRESHOLD) return;
 
-    // Did this user join via a friend's invitation?
-    const [invitationRow] = await db
-      .select({
-        id: friendInvitations.id,
-        inviterUserId: friendInvitations.inviterUserId,
-      })
-      .from(friendInvitations)
-      .where(
-        and(
-          eq(friendInvitations.inviteeUserId, inviteeUserId),
-          isNotNull(friendInvitations.acceptedAt),
-        ),
-      )
-      .limit(1);
-
-    if (!invitationRow) return;
+    // Did this user join via a friend's invitation (named path) or a per-user
+    // invite link (which leaves a Follow edge but no FriendInvitation row)?
+    const inviter = await getInviterForUser(inviteeUserId);
+    if (!inviter) return;
 
     // Defensive idempotency: never write the same milestone twice for one
     // invitation (covers retries and two answers that both observe count == 5).
@@ -61,9 +50,9 @@ export async function maybeNotifyInviterOfFirstFive(inviteeUserId: string): Prom
       .from(activityItems)
       .where(
         and(
-          eq(activityItems.userId, invitationRow.inviterUserId),
+          eq(activityItems.userId, inviter.inviterUserId),
           eq(activityItems.type, INVITED_FRIEND_FIRST_FIVE_TYPE),
-          eq(activityItems.referenceId, invitationRow.id),
+          eq(activityItems.referenceId, inviter.sourceId),
         ),
       )
       .limit(1);
@@ -71,7 +60,11 @@ export async function maybeNotifyInviterOfFirstFive(inviteeUserId: string): Prom
     const activity = firstFiveActivityToWrite({
       inviteeUserId,
       playedCount,
-      invitation: invitationRow,
+      invitation: {
+        id: inviter.sourceId,
+        inviterUserId: inviter.inviterUserId,
+        referenceType: inviter.sourceType,
+      },
       alreadyNotified: Boolean(existing),
     });
     if (!activity) return;

--- a/src/server/daily/__tests__/get-first-session-recap.test.ts
+++ b/src/server/daily/__tests__/get-first-session-recap.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// getFirstSessionRecap touches two tables through db.select: `users` (seen
+// signal + display name) and `feedItems` (inviter-backfill presence check).
+// The mock dispatches on table identity, same pattern as the other db-mock
+// tests in this codebase (e.g. invite-onboarding.test.ts).
+const { state, dbMock, getInviterForUserMock, getDailySummaryMock, users, feedItems } =
+  vi.hoisted(() => {
+    const state = {
+      userRows: [] as Array<{ displayName: string | null; seenAt: Date | null }>,
+      feedItemRows: [] as Array<{ id: string }>,
+      inviter: null as {
+        inviterUserId: string
+        inviterName: string | null
+        sourceId: string
+        sourceType: 'friend_invitation' | 'follow'
+      } | null,
+    }
+
+    const users = { __table: 'users' }
+    const feedItems = { __table: 'feedItems' }
+
+    const dbMock = {
+      select: vi.fn(() => ({
+        from: vi.fn((table: unknown) => {
+          if (table === users) {
+            return { where: vi.fn(() => ({ limit: vi.fn(async () => state.userRows) })) }
+          }
+          return { where: vi.fn(() => ({ limit: vi.fn(async () => state.feedItemRows) })) }
+        }),
+      })),
+      update: vi.fn(),
+    }
+
+    return {
+      state,
+      dbMock,
+      getInviterForUserMock: vi.fn(async () => state.inviter),
+      getDailySummaryMock: vi.fn(),
+      users,
+      feedItems,
+    }
+  })
+
+vi.mock('@/server/db', () => ({ db: dbMock, users, feedItems }))
+vi.mock('@/server/db/queries/daily-summary', () => ({ getDailySummary: getDailySummaryMock }))
+vi.mock('@/server/db/queries/friend-invitations', () => ({
+  getInviterForUser: getInviterForUserMock,
+}))
+vi.mock('@/server/feed/visibility', () => ({ SOCIAL_FEED_SOURCE_TYPE: 'social' }))
+
+import { getFirstSessionRecap } from '@/server/daily/get-first-session-recap'
+
+function baseSummary(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    isFirstCompletedRound: true,
+    questions: [{ domainDisplayName: 'History', isCorrect: true, isSkipped: false }],
+    ...overrides,
+  }
+}
+
+describe('getFirstSessionRecap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.userRows = [{ displayName: 'Ada', seenAt: null }]
+    state.feedItemRows = []
+    state.inviter = null
+    getDailySummaryMock.mockResolvedValue(baseSummary())
+  })
+
+  it('returns null when the recap has already been seen', async () => {
+    state.userRows = [{ displayName: 'Ada', seenAt: new Date('2026-06-01T00:00:00.000Z') }]
+
+    await expect(getFirstSessionRecap('user-1')).resolves.toBeNull()
+    expect(getInviterForUserMock).not.toHaveBeenCalled()
+  })
+
+  it('Beat 3 is no-inviter when getInviterForUser resolves null', async () => {
+    state.inviter = null
+
+    const view = await getFirstSessionRecap('user-1')
+
+    expect(view?.beat3).toEqual({ kind: 'no_inviter' })
+  })
+
+  // Boundary-level coverage per Stage 1: a link-arrived user's inviter comes
+  // back through the follow-fallback branch of getInviterForUser (no
+  // FriendInvitation row) — Beat 3 must still name them, not silently drop to
+  // the no-inviter copy the way the pre-resolver inline query did.
+  it('Beat 3 names the inviter resolved via the follow fallback (link-arrived user)', async () => {
+    state.inviter = {
+      inviterUserId: 'inviter-2',
+      inviterName: 'Jaime',
+      sourceId: 'follow-1',
+      sourceType: 'follow',
+    }
+    state.feedItemRows = [] // backfill hasn't landed yet -> future tense
+
+    const view = await getFirstSessionRecap('user-2')
+
+    expect(view?.beat3).toEqual({ kind: 'inviter_future', inviterName: 'Jaime' })
+  })
+
+  it('Beat 3 is present-tense when the inviter backfill seeded the home feed', async () => {
+    state.inviter = {
+      inviterUserId: 'inviter-2',
+      inviterName: 'Jaime',
+      sourceId: 'follow-1',
+      sourceType: 'follow',
+    }
+    state.feedItemRows = [{ id: 'feed-1' }]
+
+    const view = await getFirstSessionRecap('user-2')
+
+    expect(view?.beat3).toEqual({ kind: 'inviter_present', inviterName: 'Jaime' })
+  })
+
+  it('falls back to "Your friend" when the inviter has no display name set', async () => {
+    state.inviter = {
+      inviterUserId: 'inviter-3',
+      inviterName: null,
+      sourceId: 'inv-3',
+      sourceType: 'friend_invitation',
+    }
+
+    const view = await getFirstSessionRecap('user-3')
+
+    expect(view?.beat3).toEqual({ kind: 'inviter_future', inviterName: 'Your friend' })
+  })
+})

--- a/src/server/daily/get-first-session-recap.ts
+++ b/src/server/daily/get-first-session-recap.ts
@@ -11,11 +11,12 @@
  * completed round). The seen-marker is set separately when the recap is shown.
  */
 
-import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
-import { db, feedItems, friendInvitations, users } from '@/server/db';
+import { db, feedItems, users } from '@/server/db';
 import { getDailySummary } from '@/server/db/queries/daily-summary';
+import { getInviterForUser } from '@/server/db/queries/friend-invitations';
 import { SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 import {
   computeFirstSessionRecapBeats,
@@ -56,22 +57,9 @@ export async function getFirstSessionRecap(
     return null;
   }
 
-  // Resolve the inviter (most recently accepted invitation), if any.
-  const [invitation] = await db
-    .select({
-      inviterUserId: friendInvitations.inviterUserId,
-      inviterName: users.displayName,
-    })
-    .from(friendInvitations)
-    .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
-    .where(
-      and(
-        eq(friendInvitations.inviteeUserId, userId),
-        isNotNull(friendInvitations.acceptedAt),
-      ),
-    )
-    .orderBy(desc(friendInvitations.acceptedAt))
-    .limit(1);
+  // Resolve the inviter across both arrival paths (named invitation, or a
+  // per-user invite link that leaves a Follow edge but no FriendInvitation row).
+  const invitation = await getInviterForUser(userId);
 
   let inviter: { name: string } | null = null;
   let inviterBackfillItemCount = 0;

--- a/src/server/db/queries/__tests__/friend-invitations.test.ts
+++ b/src/server/db/queries/__tests__/friend-invitations.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// getInviterForUser issues up to three SEQUENTIAL db.select() calls (named
+// invitation lookup, then — only on a miss — the user's createdAt, then the
+// follow-fallback lookup). The mock queues one result array per expected call,
+// consumed in call order via chain.then().
+const { dbMock, state } = vi.hoisted(() => {
+  const state = { queue: [] as unknown[][] }
+
+  function makeChain() {
+    const chain: Record<string, unknown> = {}
+    for (const method of ['from', 'leftJoin', 'where', 'orderBy', 'limit']) {
+      chain[method] = vi.fn(() => chain)
+    }
+    chain.then = (resolve: (rows: unknown[]) => unknown) => resolve(state.queue.shift() ?? [])
+    return chain
+  }
+
+  const dbMock = { select: vi.fn(() => makeChain()) }
+  return { dbMock, state }
+})
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  follows: {
+    id: 'follows.id',
+    followerId: 'follows.followerId',
+    followeeId: 'follows.followeeId',
+    state: 'follows.state',
+    approvedAt: 'follows.approvedAt',
+  },
+  friendInvitations: {
+    id: 'friendInvitations.id',
+    inviterUserId: 'friendInvitations.inviterUserId',
+    inviteeUserId: 'friendInvitations.inviteeUserId',
+    acceptedAt: 'friendInvitations.acceptedAt',
+  },
+  users: {
+    id: 'users.id',
+    displayName: 'users.displayName',
+    createdAt: 'users.createdAt',
+  },
+}))
+
+vi.mock('@/server/db/queries/friend-requests', () => ({
+  getRelationships: vi.fn(async () => new Map()),
+}))
+
+import { getInviterForUser } from '@/server/db/queries/friend-invitations'
+
+describe('getInviterForUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.queue = []
+  })
+
+  it('(a) resolves via the most recently accepted FriendInvitation when one exists', async () => {
+    state.queue = [[{ id: 'inv-1', inviterUserId: 'inviter-1', inviterName: 'Robyn' }]]
+
+    await expect(getInviterForUser('invitee-1')).resolves.toEqual({
+      inviterUserId: 'inviter-1',
+      inviterName: 'Robyn',
+      sourceId: 'inv-1',
+      sourceType: 'friend_invitation',
+    })
+    // Named-path hit short-circuits — no createdAt or follow lookup needed.
+    expect(dbMock.select).toHaveBeenCalledTimes(1)
+  })
+
+  it('(b) falls back to the earliest approved follow-in within 7 days of signup', async () => {
+    state.queue = [
+      [], // no FriendInvitation row
+      [{ createdAt: new Date('2026-06-01T00:00:00.000Z') }], // account created
+      [{ id: 'follow-1', inviterUserId: 'inviter-2', inviterName: 'Jaime' }], // follow-in edge
+    ]
+
+    await expect(getInviterForUser('invitee-2')).resolves.toEqual({
+      inviterUserId: 'inviter-2',
+      inviterName: 'Jaime',
+      sourceId: 'follow-1',
+      sourceType: 'follow',
+    })
+    expect(dbMock.select).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns null when no FriendInvitation and no follow-in edge exists', async () => {
+    state.queue = [
+      [],
+      [{ createdAt: new Date('2026-06-01T00:00:00.000Z') }],
+      [], // no approved follower in the window
+    ]
+
+    await expect(getInviterForUser('invitee-3')).resolves.toBeNull()
+  })
+
+  it('returns null when the user does not exist', async () => {
+    state.queue = [[], []] // no invitation, no user row
+
+    await expect(getInviterForUser('ghost')).resolves.toBeNull()
+    // Never reaches the follow-fallback query without a createdAt to window off.
+    expect(dbMock.select).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/server/db/queries/__tests__/list-invite-reflections.test.ts
+++ b/src/server/db/queries/__tests__/list-invite-reflections.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { dbMock, getRelationshipsMock, state } = vi.hoisted(() => {
+  const state = {
+    rows: [] as Array<{
+      invitation_id: string
+      invitee_user_id: string
+      handle: string | null
+      display_name: string | null
+      avatar_color: string | null
+      joined_at: Date
+      invited_at: Date
+      accepted_at: Date | null
+    }>,
+  }
+
+  const dbMock = {
+    execute: vi.fn(async () => ({ rows: state.rows })),
+  }
+
+  return {
+    dbMock,
+    getRelationshipsMock: vi.fn(),
+    state,
+  }
+})
+
+vi.mock('@/server/db', () => ({ db: dbMock }))
+vi.mock('@/server/db/queries/friend-requests', () => ({
+  getRelationships: getRelationshipsMock,
+}))
+
+import { listInviteReflections } from '@/server/db/queries/friend-invitations'
+
+function row(inviteeUserId: string, overrides: Partial<(typeof state.rows)[number]> = {}) {
+  return {
+    invitation_id: `inv-${inviteeUserId}`,
+    invitee_user_id: inviteeUserId,
+    handle: inviteeUserId,
+    display_name: `Display ${inviteeUserId}`,
+    avatar_color: null,
+    joined_at: new Date('2026-08-01T00:00:00.000Z'),
+    invited_at: new Date('2026-07-01T00:00:00.000Z'),
+    accepted_at: new Date('2026-08-01T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+// Regression test for the Stage 5 fix: the SQL's NOT EXISTS against the
+// legacy "Friendship" table only catches pre-follow-model connections — the
+// follow model has never written a Friendship row, so a same-day mutual
+// follow used to sail straight through and still get listed as "not yet
+// friended." The post-fetch relationship.state === 'friends' check closes
+// that gap using the same getRelationships the isBlocked filter already read.
+describe('listInviteReflections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.rows = []
+  })
+
+  it('excludes an invitee who is already mutual friends via the follows model', async () => {
+    state.rows = [row('invitee-friends'), row('invitee-none')]
+    getRelationshipsMock.mockResolvedValueOnce(
+      new Map([
+        ['invitee-friends', { state: 'friends', friendshipId: 'f1', formedAt: new Date(), isBlocked: false }],
+        ['invitee-none', { state: 'none', friendshipId: null, formedAt: null, isBlocked: false }],
+      ]),
+    )
+
+    const result = await listInviteReflections('viewer-1')
+
+    expect(result.map((r) => r.inviteeUserId)).toEqual(['invitee-none'])
+  })
+
+  it('keeps a one-directional or pending relationship (only fully mutual is excluded)', async () => {
+    state.rows = [row('invitee-following'), row('invitee-pending-out')]
+    getRelationshipsMock.mockResolvedValueOnce(
+      new Map([
+        ['invitee-following', { state: 'following', friendshipId: 'f1', formedAt: new Date(), isBlocked: false }],
+        ['invitee-pending-out', { state: 'pending_outbound', friendshipId: 'f2', formedAt: null, isBlocked: false }],
+      ]),
+    )
+
+    const result = await listInviteReflections('viewer-1')
+
+    expect(result.map((r) => r.inviteeUserId).sort()).toEqual(
+      ['invitee-following', 'invitee-pending-out'].sort(),
+    )
+  })
+
+  it('still excludes blocked rows regardless of relationship state', async () => {
+    state.rows = [row('invitee-blocked')]
+    getRelationshipsMock.mockResolvedValueOnce(
+      new Map([['invitee-blocked', { state: 'none', friendshipId: null, formedAt: null, isBlocked: true }]]),
+    )
+
+    const result = await listInviteReflections('viewer-1')
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] without calling getRelationships when there are no SQL rows', async () => {
+    state.rows = []
+
+    const result = await listInviteReflections('viewer-1')
+
+    expect(result).toEqual([])
+    expect(getRelationshipsMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/db/queries/friend-invitations.ts
+++ b/src/server/db/queries/friend-invitations.ts
@@ -1,7 +1,107 @@
-import { sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gte, isNotNull, sql } from 'drizzle-orm'
 
-import { db } from '@/server/db'
+import { db, follows, friendInvitations, users } from '@/server/db'
 import { getRelationships, type RelationshipResult } from '@/server/db/queries/friend-requests'
+
+const FOLLOW_FALLBACK_WINDOW_DAYS = 7
+
+export type InviterForUser = {
+  inviterUserId: string
+  inviterName: string | null
+  // The row that proves the invitation, and its table — carried through so
+  // callers that write an idempotency marker (e.g. maybeNotifyInviterOfFirstFive)
+  // have a stable id even for a link-arrived user, who has no FriendInvitation
+  // row at all.
+  sourceId: string
+  sourceType: 'friend_invitation' | 'follow'
+}
+
+/**
+ * Resolves "who invited this user" across both arrival paths.
+ *
+ * (a) The named path (AddFriendInvite -> friendInvitations) always wins when
+ *     present: it is explicit and permanent. Matches the most-recently-accepted
+ *     row, same as the prior inline queries in get-first-session-recap.ts and
+ *     invite-onboarding.ts.
+ * (b) The per-user invite-link path (/u/<handle>/<token> -> acceptUserInviteLink)
+ *     never writes a FriendInvitation row — it only leaves a mutual approved
+ *     Follow edge (see src/server/friends/user-invite-token.ts). As a fallback,
+ *     we look for the earliest approved follow-in edge within 7 days of the
+ *     user's account creation.
+ *
+ *     The 7-day window matters: `follows` rows are HARD-DELETED on unfollow
+ *     (every unfollow/remove path in src/server/friends/friendships.ts is a
+ *     real DELETE, not a state change), so an unbounded "earliest surviving
+ *     edge" query is not a stable signal — if the inviter and invitee ever
+ *     unfollow each other, it would silently reassign to whichever unrelated
+ *     follow happens to be earliest at query time. Bounding to the signup
+ *     window (the mutual follow is written at accept time, at/near signup)
+ *     means a deleted inviter-edge yields `null` (no-inviter treatment,
+ *     matching what a named invite gets if its FriendInvitation row is
+ *     hard-deleted) rather than a misattributed one.
+ */
+export async function getInviterForUser(userId: string): Promise<InviterForUser | null> {
+  const [invitation] = await db
+    .select({
+      id: friendInvitations.id,
+      inviterUserId: friendInvitations.inviterUserId,
+      inviterName: users.displayName,
+    })
+    .from(friendInvitations)
+    .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
+    .where(
+      and(eq(friendInvitations.inviteeUserId, userId), isNotNull(friendInvitations.acceptedAt)),
+    )
+    .orderBy(desc(friendInvitations.acceptedAt))
+    .limit(1)
+
+  if (invitation?.inviterUserId) {
+    return {
+      inviterUserId: invitation.inviterUserId,
+      inviterName: invitation.inviterName,
+      sourceId: invitation.id,
+      sourceType: 'friend_invitation',
+    }
+  }
+
+  const [target] = await db
+    .select({ createdAt: users.createdAt })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1)
+  if (!target) return null
+
+  const windowStart = new Date(
+    target.createdAt.getTime() - FOLLOW_FALLBACK_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+  )
+
+  const [follow] = await db
+    .select({
+      id: follows.id,
+      inviterUserId: follows.followerId,
+      inviterName: users.displayName,
+    })
+    .from(follows)
+    .leftJoin(users, eq(follows.followerId, users.id))
+    .where(
+      and(
+        eq(follows.followeeId, userId),
+        eq(follows.state, 'approved'),
+        gte(follows.approvedAt, windowStart),
+      ),
+    )
+    .orderBy(asc(follows.approvedAt))
+    .limit(1)
+
+  if (!follow?.inviterUserId) return null
+
+  return {
+    inviterUserId: follow.inviterUserId,
+    inviterName: follow.inviterName,
+    sourceId: follow.id,
+    sourceType: 'follow',
+  }
+}
 
 export type InviteReflection = {
   invitationId: string
@@ -16,11 +116,24 @@ export type InviteReflection = {
 }
 
 // Lists users that this player previously invited (via the SMS-style
-// FriendInvitation flow) who have since joined Joshing AND don't already
-// have an active or pending Friendship with the player. Used by the Find
-// Friends page Block 3 ("here are people you nudged who showed up").
+// FriendInvitation flow) who have since joined Joshing AND don't already have
+// a resolved connection with the player. Used by the Find Friends page
+// Block 3 ("here are people you nudged who showed up").
 //
-// Filters out blocked rows (isBlocked === true from getRelationships).
+// Two exclusion layers, because there are two relationship models in this
+// codebase's history:
+// - The SQL's NOT EXISTS against the legacy "Friendship" table (still a real
+//   table — despite looking stale, it's frozen-but-present, see
+//   src/server/db/schema.ts's `friendships` export) catches pre-follow-model
+//   connections that were never migrated into `follows`.
+// - The post-fetch `relationship.state === 'friends'` check below catches
+//   everything formed under the CURRENT model: nothing has ever INSERTed into
+//   Friendship since the follow model shipped, so a same-day mutual follow
+//   would otherwise sail through the SQL check and still get listed as
+//   "not yet friended." getRelationships (already fetched here for the
+//   isBlocked filter) is the canonical follows-based relationship read, so
+//   this reuses it rather than hand-rolling a second follows NOT EXISTS.
+// Both stay: dropping either regresses coverage for the model it protects.
 export async function listInviteReflections(userId: string, limit = 20): Promise<InviteReflection[]> {
   const rows = await db.execute<{
     invitation_id: string
@@ -66,6 +179,7 @@ export async function listInviteReflections(userId: string, limit = 20): Promise
   for (const row of rows.rows) {
     const relationship = relationships.get(row.invitee_user_id)
     if (!relationship || relationship.isBlocked) continue
+    if (relationship.state === 'friends') continue
     result.push({
       invitationId: row.invitation_id,
       inviteeUserId: row.invitee_user_id,

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -387,7 +387,10 @@ export const getUserOnboardingProfile = cache(async (userId: string) => {
   return user ?? null;
 });
 
-function normalizePersonName(value: string | null | undefined) {
+// Exported for src/app/page.tsx, which needs the same trim/collapse/80-char
+// normalization when it resolves the inviter through getInviterForUser
+// instead of this file's own getPreSeededInterestsForUser.
+export function normalizePersonName(value: string | null | undefined) {
   const normalized = value?.trim().replace(/\s+/g, ' ');
   return normalized ? normalized.slice(0, 80) : null;
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -286,6 +286,13 @@ export const users = pgTable(
     handle: text('handle'),
     handleLastChangedAt: timestamp('handle_last_changed_at', { withTimezone: true }),
     inviteToken: text('invite_token'),
+    // Topics the per-user invite link (/u/<handle>/<token>) shows a logged-out
+    // visitor and pre-populates onboarding suggestions with. Shaped like
+    // FriendInvitation.preSeededInterests (array of {label, description?,
+    // broadCategory?}), capped at 3 by the app layer, not the column. NULL/empty
+    // means "no curated set" — the invite link falls back to the inviter's top
+    // declared interests instead (see getActiveDeclaredInterests).
+    inviteSeedInterests: jsonb('invite_seed_interests'),
     avatarColor: text('avatar_color'),
     discoverableByContacts: boolean('discoverable_by_contacts').notNull().default(false),
     discoverableByMutualFriends: boolean('discoverable_by_mutual_friends').notNull().default(false),

--- a/src/server/friends/__tests__/user-invite-token.test.ts
+++ b/src/server/friends/__tests__/user-invite-token.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Table-keyed queues: each table gets its own FIFO result queue so tests don't
+// have to track cross-table call interleaving (resolveInviteLink runs its
+// seed-topic and visibility lookups concurrently via Promise.all).
+const { dbMock, state, users, profileDomainVisibility, getActiveDeclaredInterestsMock } =
+  vi.hoisted(() => {
+    const state = {
+      usersQueue: [] as unknown[][],
+      profileDomainVisibilityQueue: [] as unknown[][],
+      updateSetCalls: [] as unknown[],
+    }
+
+    const users = { __table: 'users' }
+    const profileDomainVisibility = { __table: 'profileDomainVisibility' }
+
+    const dbMock = {
+      select: vi.fn(() => {
+        // `from(table)` determines which queue this call reads from; capture
+        // it via a chain whose `from` remembers the table before resolving.
+        let selectedTable: unknown
+        const chain: Record<string, unknown> = {
+          from: vi.fn((table: unknown) => {
+            selectedTable = table
+            return chain
+          }),
+          where: vi.fn(() => chain),
+          limit: vi.fn(() => chain),
+        }
+        chain.then = (resolve: (rows: unknown[]) => unknown) => {
+          const queue = selectedTable === users ? state.usersQueue : state.profileDomainVisibilityQueue
+          return resolve(queue.shift() ?? [])
+        }
+        return chain
+      }),
+      update: vi.fn(() => ({
+        set: vi.fn((values: unknown) => {
+          state.updateSetCalls.push(values)
+          return { where: vi.fn(async () => {}) }
+        }),
+      })),
+    }
+
+    return {
+      dbMock,
+      state,
+      users,
+      profileDomainVisibility,
+      getActiveDeclaredInterestsMock: vi.fn(async () => [] as Array<{
+        domain: string
+        broadCategory: string | null
+      }>),
+    }
+  })
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  users,
+  follows: {},
+  profileDomainVisibility,
+}))
+
+vi.mock('@/server/db/queries/declared-interests', () => ({
+  getActiveDeclaredInterests: getActiveDeclaredInterestsMock,
+}))
+
+vi.mock('@/server/feed/backfill-inviter-feed', () => ({
+  backfillInviterFeedItems: vi.fn(async () => {}),
+}))
+
+vi.mock('@/server/friends/friendships', () => ({
+  upsertInvitationFriendship: vi.fn(async () => {}),
+}))
+
+import {
+  getCuratedInviteSeedTopics,
+  getInviteLinkSeedTopics,
+  resolveInviteLink,
+  setCuratedInviteSeedTopics,
+} from '@/server/friends/user-invite-token'
+
+describe('getInviteLinkSeedTopics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.usersQueue = []
+    state.profileDomainVisibilityQueue = []
+    state.updateSetCalls = []
+  })
+
+  it('returns the curated set when present, without touching declared interests', async () => {
+    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }] }]]
+
+    const topics = await getInviteLinkSeedTopics('inviter-1')
+
+    expect(topics.map((topic) => topic.label)).toEqual(['Sondheim', 'Jazz'])
+    expect(getActiveDeclaredInterestsMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the top 3 declared interests when nothing is curated', async () => {
+    state.usersQueue = [[{ inviteSeedInterests: null }]]
+    getActiveDeclaredInterestsMock.mockResolvedValueOnce([
+      { domain: 'History', broadCategory: 'Humanities' },
+      { domain: 'Jazz', broadCategory: 'Music' },
+      { domain: 'Poetry', broadCategory: 'Literature' },
+      { domain: 'Chess', broadCategory: 'Games' },
+    ])
+
+    await expect(getInviteLinkSeedTopics('inviter-2')).resolves.toEqual([
+      { label: 'History', broadCategory: 'Humanities' },
+      { label: 'Jazz', broadCategory: 'Music' },
+      { label: 'Poetry', broadCategory: 'Literature' },
+    ])
+  })
+})
+
+describe('getCuratedInviteSeedTopics / setCuratedInviteSeedTopics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.usersQueue = []
+    state.updateSetCalls = []
+  })
+
+  it('reads back only the curated labels, capped at 3', async () => {
+    state.usersQueue = [
+      [{ inviteSeedInterests: [{ label: 'A' }, { label: 'B' }, { label: 'C' }, { label: 'D' }] }],
+    ]
+
+    await expect(getCuratedInviteSeedTopics('user-1')).resolves.toEqual(['A', 'B', 'C'])
+  })
+
+  it('cleans, dedupes, and caps before writing', async () => {
+    await setCuratedInviteSeedTopics('user-1', ['  Jazz ', 'jazz', 'Poetry', 'Chess', 'Extra'])
+
+    expect(state.updateSetCalls).toHaveLength(1)
+    expect((state.updateSetCalls[0] as { inviteSeedInterests: unknown }).inviteSeedInterests).toEqual([
+      { label: 'Jazz' },
+      { label: 'Poetry' },
+      { label: 'Chess' },
+    ])
+  })
+
+  it('clearing to an empty array reverts to the automatic fallback', async () => {
+    await setCuratedInviteSeedTopics('user-1', [])
+
+    expect((state.updateSetCalls[0] as { inviteSeedInterests: unknown }).inviteSeedInterests).toEqual([])
+  })
+})
+
+describe('resolveInviteLink — seed topics + visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.usersQueue = []
+    state.profileDomainVisibilityQueue = []
+  })
+
+  function seedResolution() {
+    // Main handle/token lookup.
+    state.usersQueue.push([
+      {
+        id: 'inviter-1',
+        handle: 'josh',
+        displayName: 'Josh',
+        avatarColor: '#fff',
+        inviteToken: 'tok123',
+      },
+    ])
+  }
+
+  it('returns null on a token mismatch without leaking topics', async () => {
+    seedResolution()
+
+    await expect(resolveInviteLink('josh', 'wrong-token')).resolves.toBeNull()
+  })
+
+  it('includes a public topic and excludes a private one', async () => {
+    seedResolution()
+    // getInviteLinkSeedTopics: curated set present.
+    state.usersQueue.push([
+      { inviteSeedInterests: [{ label: 'Jazz' }, { label: 'Secret Hobby' }] },
+    ])
+    // getPubliclyHiddenDomainKeys: one row marking "Secret Hobby" private.
+    state.profileDomainVisibilityQueue.push([
+      {
+        domain: 'Secret Hobby',
+        canonicalSubcategory: 'Secret Hobby',
+        visibility: 'private',
+        isVisible: false,
+      },
+    ])
+
+    const result = await resolveInviteLink('josh', 'tok123')
+
+    expect(result?.seedTopics).toEqual(['Jazz'])
+  })
+
+  it('shows a topic with no PROFILE_DOMAIN_VISIBILITY row at all (default public)', async () => {
+    seedResolution()
+    state.usersQueue.push([{ inviteSeedInterests: [{ label: 'Jazz' }] }])
+    state.profileDomainVisibilityQueue.push([]) // no rows for this user
+
+    const result = await resolveInviteLink('josh', 'tok123')
+
+    expect(result?.seedTopics).toEqual(['Jazz'])
+  })
+})

--- a/src/server/friends/user-invite-token.ts
+++ b/src/server/friends/user-invite-token.ts
@@ -2,9 +2,114 @@ import { randomBytes } from 'node:crypto'
 
 import { and, eq, sql } from 'drizzle-orm'
 
-import { db, follows, users } from '@/server/db'
+import { domainKey } from '@/lib/knowledge/domain-key'
+import { db, follows, profileDomainVisibility, users } from '@/server/db'
+import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests'
+import { parsePreSeededInterests, type PreSeededInterest } from '@/server/db/queries/users'
 import { backfillInviterFeedItems } from '@/server/feed/backfill-inviter-feed'
 import { upsertInvitationFriendship } from '@/server/friends/friendships'
+
+// Cap applies to both sources: a curated inviteSeedInterests set and the
+// automatic declared-interests fallback.
+const SEED_TOPIC_CAP = 3
+
+// Resolves the topics a per-user invite link carries: whatever the inviter
+// curated in users.invite_seed_interests, or — when that's empty — their top
+// SEED_TOPIC_CAP active declared interests (already first-picked-first
+// ordered by getActiveDeclaredInterests, so slicing keeps that order). The
+// automatic fallback is what makes a link useful on day one with zero setup.
+//
+// Unfiltered by profile domain visibility — this is the raw resolution used
+// by both the public invite card (resolveInviteLink, which DOES filter before
+// exposing it to a not-yet-friend visitor) and onboarding (where the invitee
+// is already a mutual-approved friend by the time this is read, so the public
+// visibility bar doesn't apply).
+export async function getInviteLinkSeedTopics(inviterUserId: string): Promise<PreSeededInterest[]> {
+  const [row] = await db
+    .select({ inviteSeedInterests: users.inviteSeedInterests })
+    .from(users)
+    .where(eq(users.id, inviterUserId))
+    .limit(1)
+
+  const curated = parsePreSeededInterests(row?.inviteSeedInterests).slice(0, SEED_TOPIC_CAP)
+  if (curated.length > 0) return curated
+
+  const declared = await getActiveDeclaredInterests(inviterUserId)
+  return declared.slice(0, SEED_TOPIC_CAP).map((interest) => ({
+    label: interest.domain,
+    broadCategory: interest.broadCategory,
+  }))
+}
+
+// The curated set only — no automatic-fallback resolution. This is what the
+// PrivacyForm editor shows and edits; it must read back "nothing curated" as
+// empty, not silently pre-fill the inviter's declared interests as though
+// they were a saved choice (that fallback is invisible/implicit by design).
+export async function getCuratedInviteSeedTopics(userId: string): Promise<string[]> {
+  const [row] = await db
+    .select({ inviteSeedInterests: users.inviteSeedInterests })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1)
+
+  return parsePreSeededInterests(row?.inviteSeedInterests)
+    .slice(0, SEED_TOPIC_CAP)
+    .map((interest) => interest.label)
+}
+
+// Overwrites the curated set. Callers are responsible for validating each
+// topic (e.g. isTooBroadInterest) before calling this — it trusts its input
+// and just cleans/caps/persists. An empty array clears the curated set,
+// reverting the link to the automatic declared-interests fallback.
+export async function setCuratedInviteSeedTopics(userId: string, topics: string[]): Promise<void> {
+  const seen = new Set<string>()
+  const cleaned: string[] = []
+  for (const raw of topics) {
+    const topic = raw.trim()
+    if (!topic) continue
+    const key = topic.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    cleaned.push(topic)
+    if (cleaned.length === SEED_TOPIC_CAP) break
+  }
+
+  await db
+    .update(users)
+    .set({
+      inviteSeedInterests: cleaned.map((label) => ({ label })),
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, userId))
+}
+
+// The bar for a visitor who is not yet a friend of the inviter: PUBLIC and
+// visible, full stop. Deliberately stricter than knowledge.ts's
+// getHiddenDomainKeys (which only excludes 'private'/isVisible=false and is
+// used for contexts where the viewer already clears a lower bar) — a random
+// visitor of an evergreen link posted in a bio has cleared no bar at all.
+// Absence of a PROFILE_DOMAIN_VISIBILITY row means the schema default
+// (public, visible), so only rows that exist AND fail the public+visible
+// check count as hidden.
+async function getPubliclyHiddenDomainKeys(userId: string): Promise<Set<string>> {
+  const rows = await db
+    .select({
+      domain: profileDomainVisibility.domain,
+      canonicalSubcategory: profileDomainVisibility.canonicalSubcategory,
+      visibility: profileDomainVisibility.visibility,
+      isVisible: profileDomainVisibility.isVisible,
+    })
+    .from(profileDomainVisibility)
+    .where(eq(profileDomainVisibility.userId, userId))
+
+  const hidden = new Set<string>()
+  for (const row of rows) {
+    if (row.visibility === 'public' && row.isVisible) continue
+    const label = row.domain ?? row.canonicalSubcategory
+    if (label) hidden.add(domainKey(label))
+  }
+  return hidden
+}
 
 // Match the prior-art token primitive used for FriendInvitation tokens at
 // src/server/friends/invitations.ts:166 — randomBytes(32).toString('base64url')
@@ -97,6 +202,10 @@ export type InviteLinkResolution = {
   inviterHandle: string
   inviterDisplayName: string | null
   inviterAvatarColor: string | null
+  // Up to 3 topic labels, already filtered to what a not-yet-friend visitor
+  // may see (getPubliclyHiddenDomainKeys). Empty when the inviter has no
+  // curated set AND no declared interests.
+  seedTopics: string[]
 }
 
 export async function resolveInviteLink(handle: string, token: string): Promise<InviteLinkResolution | null> {
@@ -115,11 +224,20 @@ export async function resolveInviteLink(handle: string, token: string): Promise<
   if (!row || !row.handle || !row.inviteToken) return null
   if (row.inviteToken !== token) return null
 
+  const [topics, hiddenDomainKeys] = await Promise.all([
+    getInviteLinkSeedTopics(row.id),
+    getPubliclyHiddenDomainKeys(row.id),
+  ])
+  const seedTopics = topics
+    .filter((topic) => !hiddenDomainKeys.has(domainKey(topic.label)))
+    .map((topic) => topic.label)
+
   return {
     inviterUserId: row.id,
     inviterHandle: row.handle,
     inviterDisplayName: row.displayName,
     inviterAvatarColor: row.avatarColor,
+    seedTopics,
   }
 }
 

--- a/src/server/home/__tests__/welcome-inviter-name.test.ts
+++ b/src/server/home/__tests__/welcome-inviter-name.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getInviterForUserMock } = vi.hoisted(() => ({
+  getInviterForUserMock: vi.fn(),
+}))
+
+// Only the DB-touching resolver is mocked. normalizePersonName is imported
+// for real — it's a pure string helper, safe even though it lives in
+// @/server/db/queries/users (vitest.setup.ts stubs DATABASE_URL so that
+// module's top-level `db` init doesn't throw at import).
+vi.mock('@/server/db/queries/friend-invitations', () => ({
+  getInviterForUser: getInviterForUserMock,
+}))
+
+import { getWelcomeInviterName } from '@/server/home/welcome-inviter-name'
+
+describe('getWelcomeInviterName', () => {
+  beforeEach(() => {
+    getInviterForUserMock.mockReset()
+  })
+
+  it('returns null without querying when the tour is not active', async () => {
+    const result = await getWelcomeInviterName(false, 'user-1')
+    expect(result).toBeNull()
+    expect(getInviterForUserMock).not.toHaveBeenCalled()
+  })
+
+  it('returns null without querying when there is no session (userId null)', async () => {
+    const result = await getWelcomeInviterName(true, null)
+    expect(result).toBeNull()
+    expect(getInviterForUserMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves and normalizes the inviter name when one exists (named or link — getInviterForUser already merges both)', async () => {
+    getInviterForUserMock.mockResolvedValueOnce({
+      inviterUserId: 'inviter-1',
+      inviterName: '  Jaime   Rivera  ',
+      sourceId: 'follow-1',
+      sourceType: 'follow',
+    })
+
+    const result = await getWelcomeInviterName(true, 'user-1')
+
+    expect(getInviterForUserMock).toHaveBeenCalledWith('user-1')
+    // normalizePersonName trims + collapses internal whitespace.
+    expect(result).toBe('Jaime Rivera')
+  })
+
+  it('returns null (WelcomeTourScreen\'s own "a friend" fallback applies) when there is no inviter', async () => {
+    getInviterForUserMock.mockResolvedValueOnce(null)
+
+    const result = await getWelcomeInviterName(true, 'user-1')
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the inviter has no display name set', async () => {
+    getInviterForUserMock.mockResolvedValueOnce({
+      inviterUserId: 'inviter-1',
+      inviterName: null,
+      sourceId: 'inv-1',
+      sourceType: 'friend_invitation',
+    })
+
+    const result = await getWelcomeInviterName(true, 'user-1')
+
+    expect(result).toBeNull()
+  })
+})

--- a/src/server/home/welcome-inviter-name.ts
+++ b/src/server/home/welcome-inviter-name.ts
@@ -1,0 +1,25 @@
+import { getInviterForUser } from '@/server/db/queries/friend-invitations';
+import { normalizePersonName } from '@/server/db/queries/users';
+
+/**
+ * Resolves the inviter name the first-run welcome tour personalizes its
+ * For-You sample with (falls back to "a friend" in WelcomeTourScreen itself
+ * when this is null).
+ *
+ * Pulled out of src/app/page.tsx (Stage 5 of the invite-link build) so this
+ * one derived value can be tested in isolation — Home's own dependency graph
+ * (buildHomeEdition, daily queue, ceremony, missed-return, friend requests,
+ * ...) is otherwise disproportionate to mock just to cover this line.
+ *
+ * `tourActive` already encodes "session present AND ?welcome=1" at the call
+ * site; `userId` is null whenever there's no session, which this short-
+ * circuits on identically to the inline check it replaced.
+ */
+export async function getWelcomeInviterName(
+  tourActive: boolean,
+  userId: string | null,
+): Promise<string | null> {
+  if (!tourActive || !userId) return null;
+  const inviter = await getInviterForUser(userId);
+  return normalizePersonName(inviter?.inviterName);
+}


### PR DESCRIPTION
## Summary

Six-stage build promoting the per-user invite link (`/u/<handle>/<token>`) to the default invitation placement, while keeping the named phone invitation fully capable throughout. Full stage-by-stage plan: [`_docs/INVITE-LINK-STAGED-BUILD-PROMPTS.md`](../blob/claude/invite-link-primary-placement/_docs/INVITE-LINK-STAGED-BUILD-PROMPTS.md).

- **Stage 1 — One inviter resolver.** `getInviterForUser()` unifies "who invited this user" across the named (`FriendInvitation`) and link (`Follow`-edge fallback, 7-day window bounded against hard-deleted follows) paths. Fixes three surfaces that silently dropped inviter identity for link-arrived users: the first-five notification, the first-session recap's Beat 3, and the welcome tour.
- **Stage 2 — Topics that ride the link.** New `invite_seed_interests` column (migration `0134`, applied) lets the link carry up to 3 topics — curated, or an automatic fallback to the inviter's top declared interests. Surfaces on the pre-login invite card and onboarding's interests screen; link-sourced seeds arrive **unselected** (a link may reach someone the inviter never had in mind), named-invite seeds stay **pre-selected** as before.
- **Stage 3 — Share, don't copy.** The link is now the primary CTA on `/friends` and `/friends/find`, with `navigator.share` (falling back to clipboard) and pre-written share copy; the phone invite stays one tap away.
- **Stage 4 — Audit.** Verified the named path is byte-identical and confirmed exactly one inviter resolver exists. Found and fixed two real test-coverage gaps (the topics PATCH route, the `PrivacyForm` editor).
- **Stage 5 — Loose ends.** Extracted `getWelcomeInviterName` and `buildLoginInviteViews` into small testable modules so Home's welcome tour and the login invite card have coverage without mocking their whole host pages. Also fixed a real bug in `listInviteReflections`: it excluded on a frozen pre-follow-model table, so a same-day mutual follow under the current model wasn't excluded from "people you invited" — added a second exclusion using the already-fetched relationship state.
- **Stage 6 — Admin discoverability.** Added a `Growth` group to the Developer-tools section linking to the new screens/flows, including two new dev-preview surfaces (the invite-link login card, the link-sourced onboarding variant) that had no real-data path to reach otherwise.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` — clean
- [x] `npm run lint` — 0 errors (4 pre-existing, unrelated warnings)
- [x] `npx vitest run` — 2481 passed, 0 regressions (up from the pre-PR baseline; ~110 new tests across all six stages)
- [x] All five design ratchets (colors/fonts/spacing/radius/z-index/type-size) pass
- [x] `check-middleware` — `src/proxy.ts` intact, no stray `src/middleware.ts`
- [x] Migration `0134_invite_seed_interests.sql` applied to prod (`npm run db:migrate`); verified column exists via direct query
- [x] Browser-verified on the live dev server: button emphasis swap correct on `/friends` and `/friends/find`, phone-invite modal still opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJwiXeNJPqExdRGRdZGrTh