### PR TITLE
Stop a local boot from migrating a remote database

### DIFF
--- a/_docs/INCIDENT-2026-09-03-boot-migrate.md
+++ b/_docs/INCIDENT-2026-09-03-boot-migrate.md
@@ -33,9 +33,33 @@ schema change to a live database as a side effect of starting up.
 - **User impact: none.** No application code reads `DailyQueue.target_size`
   (re-verified 2026-09-04); production was running the old code against a
   slightly newer schema, which is benign. `DailyBuildMetric` remained empty.
-- **Not dormant.** Production was actively serving: 10 queues, 80 answers, and
-  5 distinct users in the trailing week. A destructive migration on the same
-  path would not have been recoverable.
+- **Not dormant.** Production is actively serving: 10 Daily Five queues built
+  in the trailing week, 2 in the last 24 hours, most recent 2026-09-04 17:05
+  UTC. A destructive migration on the same path would not have been
+  recoverable.
+
+## Two DDL paths, not one
+
+`register()` writes schema along **two independent routes**, and the incident
+review initially accounted for only one:
+
+1. the **~70 idempotent boot guards** (`ADD COLUMN IF NOT EXISTS`, `CREATE TABLE
+   IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`) — **unjournalled**, and they
+   run **before** `migrate()`; and
+2. **`migrate()`** — journalled.
+
+`SKIP_BOOT_DB_GUARDS` is set only in production. The incident boot was a *dev*
+process pointed at production, so the flag was unset and **the guard chain
+executed DDL against the production database**, ahead of `migrate()`.
+
+Which route actually created the 0136 columns is **not recoverable**: both use
+identical `IF NOT EXISTS` DDL — including the same partial index predicate — so
+the live schema cannot discriminate, and the guard block was uncommitted at the
+time of the boot. What is certain is that `migrate()` ran (the ledger row and
+the backfill `UPDATE` exist only there), and that the guard chain ran too.
+
+This split is why "what actually applied?" was hard to answer. Unifying the two
+routes is a larger change; the guard below covers **both**.
 
 ## Why it was not caught
 
@@ -46,14 +70,23 @@ none of it was the thing that mattered.
 
 ## Fix
 
-`src/server/db/migrate-safety.ts` — `decideBootMigrate()` gates the boot
-`migrate()` call. A boot may auto-apply migrations only when one of:
+`src/server/db/migrate-safety.ts` — `decideBootSchemaWrite()` gates the entire
+schema-writing phase, positioned **above the guard chain** so it covers both
+routes. A boot may write schema only when one of:
 
 | condition | rationale |
 |---|---|
 | target host is loopback | a developer's own database |
-| `VERCEL` is set | a real deploy; production must migrate exactly as before |
-| `ALLOW_REMOTE_BOOT_MIGRATE=1` | deliberate, per-run, explicit |
+| `VERCEL_ENV === 'production'` | a production deploy; must migrate exactly as before |
+| `ALLOW_REMOTE_BOOT_MIGRATE=1` | deliberate, per-run, explicit — and logged loudly |
+
+**Not** the presence of `VERCEL`: that variable is set on *every* Vercel
+deployment including previews. Keying on it would let any branch that receives a
+preview deploy write schema to whatever `DATABASE_URL` that environment
+resolves to — the same incident, sourced from CI instead of a laptop, and
+permitted by the guard. Previews now need the explicit override, set once as a
+Preview-scoped variable: a deliberate act visible in the dashboard rather than
+an accident of branch naming.
 
 Otherwise it **warns and skips the migrate** — the app still boots and serves
 requests; only the automatic schema change is withheld. It deliberately does
@@ -95,6 +128,12 @@ forward.
 - [ ] Deliver `0137` by a deliberate path (`npm run db:migrate` or a deploy),
       **not** by another boot — the broken mechanism must not deliver the fix
       for what the broken mechanism did.
+- [ ] **If preview deployments have their own database**, set
+      `ALLOW_REMOTE_BOOT_MIGRATE=1` on the Preview environment in Vercel, or
+      previews will stop auto-migrating and drift. If previews share the
+      production string, leave it unset — that is the hole this closes.
+- [ ] Consider unifying the two DDL routes so schema reaches the database only
+      through the journal. The guard covers both today; it does not merge them.
 - [ ] Consider separating local and production credentials entirely, so a dev
       environment cannot reach production at all. Strictly stronger than this
       guard, and larger than one change.

--- a/_docs/INCIDENT-2026-09-03-boot-migrate.md
+++ b/_docs/INCIDENT-2026-09-03-boot-migrate.md
@@ -1,0 +1,100 @@
+# Incident — a dev-server boot applied migrations to production
+
+**Date:** 2026-09-03, 00:53 UTC
+**Detected:** 2026-09-04, during review of PR #1597
+**Severity:** no user impact; recoverable. Near-miss on a class that would not have been.
+
+---
+
+## What happened
+
+Starting `npm run dev` on an unmerged feature branch applied migration
+`0136_daily_build_metrics.sql` to the **production** database.
+
+Three things combined, none of them individually wrong:
+
+1. This repo's local `.env` `DATABASE_URL` points at production (long-standing,
+   documented — local development shares the production database).
+2. `register()` in `src/instrumentation.ts` calls `migrate()` on every boot.
+3. `migrate()` applies **every pending migration on the current branch**, not a
+   named one.
+
+So a local process, on a branch that had never been reviewed or merged, made a
+schema change to a live database as a side effect of starting up.
+
+## Blast radius
+
+- **Schema applied:** `DailyQueue.target_size`, `DailyQueue.build_completed_at`,
+  `LlmUsageEvent.build_id`, and the `DailyBuildMetric` table.
+- **Data written:** the `0136` backfill set `target_size` from *all* slots. A
+  Daily Five queue is five core slots plus up to two optional bonus slots, so
+  the modal 7-slot queue was written as `target_size = 7`. **148 rows** got a
+  value above 5.
+- **User impact: none.** No application code reads `DailyQueue.target_size`
+  (re-verified 2026-09-04); production was running the old code against a
+  slightly newer schema, which is benign. `DailyBuildMetric` remained empty.
+- **Not dormant.** Production was actively serving: 10 queues, 80 answers, and
+  5 distinct users in the trailing week. A destructive migration on the same
+  path would not have been recoverable.
+
+## Why it was not caught
+
+The dangerous property was the **connection target**, but every mental check in
+play keyed on the **environment name**. `NODE_ENV` was `development`, the
+command was `npm run dev`, the branch was local — everything said "safe", and
+none of it was the thing that mattered.
+
+## Fix
+
+`src/server/db/migrate-safety.ts` — `decideBootMigrate()` gates the boot
+`migrate()` call. A boot may auto-apply migrations only when one of:
+
+| condition | rationale |
+|---|---|
+| target host is loopback | a developer's own database |
+| `VERCEL` is set | a real deploy; production must migrate exactly as before |
+| `ALLOW_REMOTE_BOOT_MIGRATE=1` | deliberate, per-run, explicit |
+
+Otherwise it **warns and skips the migrate** — the app still boots and serves
+requests; only the automatic schema change is withheld. It deliberately does
+**not** consult `NODE_ENV`, because that is precisely the signal that said
+"safe" during the incident.
+
+Fails closed on an absent or unparseable connection string: the cost of a
+wrongly-skipped local migration is one manual command; the cost of a
+wrongly-allowed remote one is this incident.
+
+Verified against this repo's real `.env`: **refused**.
+
+## Data correction
+
+`0137_target_size_core_only.sql` sets every `target_size` to `NULL` and drops
+`NOT NULL DEFAULT 5`.
+
+- `NULL`, not a corrected number: core and bonus slots cannot be reliably
+  separated on historical rows, and `LEAST(5, …)` would be a positional
+  heuristic that breaks on skip-extended queues — quietly wrong rather than
+  visibly unknown.
+- Dropping the default matters independently: `NOT NULL DEFAULT 5` made an
+  *unwritten* `target_size` indistinguishable from a deliberate one, so a build
+  landing short would silently carry 5 and strand the player. **An unwritten
+  value must be visible, not plausible.**
+- `0136` is **not** edited. It has been applied; editing an applied migration
+  diverges the journal from the applied state.
+
+## Related finding
+
+`0135_user_invite_links.sql` was **edited after it had been applied** (an
+idempotency wrapper was added to a `CHECK` constraint after a failed boot).
+Semantically harmless — the edit only made a re-run safe — but its file hash no
+longer matches the applied row. Same rule, same reason: once applied, correct
+forward.
+
+## Follow-ups
+
+- [ ] Deliver `0137` by a deliberate path (`npm run db:migrate` or a deploy),
+      **not** by another boot — the broken mechanism must not deliver the fix
+      for what the broken mechanism did.
+- [ ] Consider separating local and production credentials entirely, so a dev
+      environment cannot reach production at all. Strictly stronger than this
+      guard, and larger than one change.

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -46,6 +46,7 @@ export async function register() {
     const { sql } = await import('drizzle-orm');
     const path = await import('path');
     const fs = await import('fs');
+    const { decideBootMigrate, refusalMessage } = await import('@/server/db/migrate-safety');
     const crypto = await import('crypto');
 
     // Bound how long a cold boot will wait on the DB. A degraded cold connection
@@ -2615,6 +2616,32 @@ export async function register() {
       }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
+
+    // SAFETY GATE (2026-09-04). A `npm run dev` boot on an unmerged branch
+    // applied migration 0136 to the PRODUCTION database as a side effect of
+    // starting up -- this repo's local .env DATABASE_URL points at prod, and
+    // migrate() applies every pending migration on the current branch. Auto
+    // migrate is for DEPLOYED environments; a local process pointed at a remote
+    // database must now ask explicitly. See src/server/db/migrate-safety.ts.
+    const migrateDecision = decideBootMigrate(process.env.DATABASE_URL, {
+      VERCEL: process.env.VERCEL,
+      ALLOW_REMOTE_BOOT_MIGRATE: process.env.ALLOW_REMOTE_BOOT_MIGRATE,
+    });
+    if (!migrateDecision.allowed) {
+      // Warn, do not throw: the app still serves requests, only the automatic
+      // migrate is skipped. Throwing here would kill the instrumentation hook
+      // and 500 every request -- same reasoning as the PHONE_HASH_SALT check.
+      console.warn(refusalMessage(migrateDecision.host));
+      console.info('[instrumentation boot]', {
+        guards_ran: runBootGuards,
+        guards_ms: guardChainMs,
+        migrate_ms: 0,
+        migrate_skipped: migrateDecision.reason,
+        total_ms: Date.now() - guardChainStartedAt,
+      });
+      await pool.end().catch(() => {});
+      return;
+    }
 
     const migrateStartedAt = Date.now();
     // Hard cap on migrate() so a stalled connection can't eat the whole function

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -46,7 +46,9 @@ export async function register() {
     const { sql } = await import('drizzle-orm');
     const path = await import('path');
     const fs = await import('fs');
-    const { decideBootMigrate, refusalMessage } = await import('@/server/db/migrate-safety');
+    const { decideBootSchemaWrite, refusalMessage, overrideMessage } = await import(
+      '@/server/db/migrate-safety'
+    );
     const crypto = await import('crypto');
 
     // Bound how long a cold boot will wait on the DB. A degraded cold connection
@@ -62,6 +64,7 @@ export async function register() {
       Number(process.env.BOOT_DB_CONNECT_TIMEOUT_MS) > 0
         ? Number(process.env.BOOT_DB_CONNECT_TIMEOUT_MS)
         : 10_000;
+    const bootStartedAt = Date.now();
     const pool = new Pool({
       connectionString: process.env.DATABASE_URL,
       connectionTimeoutMillis: bootConnectTimeoutMs,
@@ -122,6 +125,52 @@ export async function register() {
     // migrations (keep _journal.json in lockstep with drizzle/*.sql) rather
     // than relying on a guard as a migration's only application path. See
     // CLAUDE.md.
+    // SAFETY GATE (2026-09-04) -- MUST stay above the guard chain.
+    //
+    // On 2026-09-03 a `npm run dev` boot on an unmerged branch wrote schema to
+    // the PRODUCTION database as a side effect of starting up: this repo's
+    // local .env DATABASE_URL points at prod. Note this gate sits BEFORE the
+    // guard chain, not just before migrate(). register() writes DDL along TWO
+    // independent paths -- the ~70 idempotent guards below (unjournalled, and
+    // they run first) and migrate() (journalled). Gating only migrate() would
+    // close the door the incident used and leave the other one open.
+    // See src/server/db/migrate-safety.ts.
+    const schemaWrite = decideBootSchemaWrite(process.env.DATABASE_URL, {
+      VERCEL_ENV: process.env.VERCEL_ENV,
+      ALLOW_REMOTE_BOOT_MIGRATE: process.env.ALLOW_REMOTE_BOOT_MIGRATE,
+    });
+    if (!schemaWrite.allowed) {
+      // Warn, do not throw: the app still serves requests, only the automatic
+      // schema writes are skipped. Throwing here would kill the instrumentation
+      // hook and 500 every request -- same reasoning as the PHONE_HASH_SALT
+      // check above. console.warn goes to the same stream as the dev server's
+      // own output, so this is visible in `npm run dev`.
+      console.warn(refusalMessage(schemaWrite.host));
+      console.info('[instrumentation boot]', {
+        guards_ran: false,
+        guards_ms: 0,
+        migrate_ms: 0,
+        schema_write_skipped: schemaWrite.reason,
+        total_ms: Date.now() - bootStartedAt,
+      });
+      await pool.end().catch(() => {});
+      return;
+    }
+    if (schemaWrite.reason === 'explicit_override') {
+      // An intentional override must leave a trace: the incident's defining
+      // feature was that it left none.
+      let journalHead: string | null = null;
+      try {
+        const journal = JSON.parse(
+          fs.readFileSync(path.join(process.cwd(), 'drizzle/meta/_journal.json'), 'utf8'),
+        ) as { entries?: Array<{ tag?: string }> };
+        journalHead = journal.entries?.at(-1)?.tag ?? null;
+      } catch {
+        journalHead = null;
+      }
+      console.warn(overrideMessage(schemaWrite.host, journalHead));
+    }
+
     const runBootGuards = process.env.SKIP_BOOT_DB_GUARDS !== '1';
     // Boot-cost telemetry (B-GRADE-COLDSTART-01): the guard chain is the
     // suspected dominant cold-start cost that the first request waits behind.
@@ -2616,32 +2665,6 @@ export async function register() {
       }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
-
-    // SAFETY GATE (2026-09-04). A `npm run dev` boot on an unmerged branch
-    // applied migration 0136 to the PRODUCTION database as a side effect of
-    // starting up -- this repo's local .env DATABASE_URL points at prod, and
-    // migrate() applies every pending migration on the current branch. Auto
-    // migrate is for DEPLOYED environments; a local process pointed at a remote
-    // database must now ask explicitly. See src/server/db/migrate-safety.ts.
-    const migrateDecision = decideBootMigrate(process.env.DATABASE_URL, {
-      VERCEL: process.env.VERCEL,
-      ALLOW_REMOTE_BOOT_MIGRATE: process.env.ALLOW_REMOTE_BOOT_MIGRATE,
-    });
-    if (!migrateDecision.allowed) {
-      // Warn, do not throw: the app still serves requests, only the automatic
-      // migrate is skipped. Throwing here would kill the instrumentation hook
-      // and 500 every request -- same reasoning as the PHONE_HASH_SALT check.
-      console.warn(refusalMessage(migrateDecision.host));
-      console.info('[instrumentation boot]', {
-        guards_ran: runBootGuards,
-        guards_ms: guardChainMs,
-        migrate_ms: 0,
-        migrate_skipped: migrateDecision.reason,
-        total_ms: Date.now() - guardChainStartedAt,
-      });
-      await pool.end().catch(() => {});
-      return;
-    }
 
     const migrateStartedAt = Date.now();
     // Hard cap on migrate() so a stalled connection can't eat the whole function

--- a/src/server/db/__tests__/migrate-safety.test.ts
+++ b/src/server/db/__tests__/migrate-safety.test.ts
@@ -1,36 +1,35 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  decideBootMigrate,
+  decideBootSchemaWrite,
   hostFromConnectionString,
+  overrideMessage,
   refusalMessage,
 } from '@/server/db/migrate-safety';
 
 const LOCAL = 'postgresql://user:pw@localhost:5432/joshing';
 const REMOTE = 'postgresql://user:pw@db.abcdefg.supabase.co:5432/postgres';
 
-describe('boot-migrate safety gate', () => {
+describe('boot schema-write safety gate', () => {
   it('REFUSES a remote target from a local process — the 2026-09-03 incident', () => {
     // A `npm run dev` boot applied migration 0136 to production because this
     // repo's local .env DATABASE_URL points at prod. This is the exact case.
-    const decision = decideBootMigrate(REMOTE, {});
+    const decision = decideBootSchemaWrite(REMOTE, {});
     expect(decision.allowed).toBe(false);
-    if (!decision.allowed) {
-      expect(decision.reason).toBe('remote_target_from_local_process');
-      expect(decision.host).toBe('db.abcdefg.supabase.co');
-    }
+    expect(decision.reason).toBe('remote_target_without_authorization');
+    expect(decision.host).toBe('db.abcdefg.supabase.co');
   });
 
   it('does not consult NODE_ENV — the incident happened under NODE_ENV=development', () => {
     // The environment NAME was never what made it dangerous; the connection
     // TARGET was. Passing no env at all must still refuse a remote host.
-    expect(decideBootMigrate(REMOTE, {}).allowed).toBe(false);
+    expect(decideBootSchemaWrite(REMOTE, {}).allowed).toBe(false);
   });
 
   it('allows a local target', () => {
-    const decision = decideBootMigrate(LOCAL, {});
+    const decision = decideBootSchemaWrite(LOCAL, {});
     expect(decision.allowed).toBe(true);
-    if (decision.allowed) expect(decision.reason).toBe('local_target');
+    expect(decision.reason).toBe('local_target');
   });
 
   it.each(['127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal'])(
@@ -38,42 +37,72 @@ describe('boot-migrate safety gate', () => {
     (host) => {
       // IPv6 literals must be bracketed to form a valid URL.
       const authority = host.includes(':') ? `[${host}]` : host;
-      expect(decideBootMigrate(`postgresql://u:p@${authority}:5432/db`, {}).allowed).toBe(true);
+      expect(decideBootSchemaWrite(`postgresql://u:p@${authority}:5432/db`, {}).allowed).toBe(true);
     },
   );
 
-  it('allows a deploy platform — production deploys must migrate exactly as before', () => {
-    const decision = decideBootMigrate(REMOTE, { VERCEL: '1' });
+  it('allows a PRODUCTION deploy — production must migrate exactly as before', () => {
+    const decision = decideBootSchemaWrite(REMOTE, { VERCEL_ENV: 'production' });
     expect(decision.allowed).toBe(true);
-    if (decision.allowed) expect(decision.reason).toBe('deploy_platform');
+    expect(decision.reason).toBe('production_deploy');
+  });
+
+  it('REFUSES a preview deploy — VERCEL is set on previews too', () => {
+    // The hole this closes: keying on the presence of VERCEL would let any
+    // branch that gets a preview deploy write schema to whatever DATABASE_URL
+    // that environment resolves to. If preview shares the production string,
+    // that is the incident again, sourced from CI instead of a laptop.
+    expect(decideBootSchemaWrite(REMOTE, { VERCEL_ENV: 'preview' }).allowed).toBe(false);
+    expect(decideBootSchemaWrite(REMOTE, { VERCEL_ENV: 'development' }).allowed).toBe(false);
   });
 
   it('allows an explicit single-run override', () => {
-    const decision = decideBootMigrate(REMOTE, { ALLOW_REMOTE_BOOT_MIGRATE: '1' });
+    const decision = decideBootSchemaWrite(REMOTE, { ALLOW_REMOTE_BOOT_MIGRATE: '1' });
     expect(decision.allowed).toBe(true);
-    if (decision.allowed) expect(decision.reason).toBe('explicit_override');
+    expect(decision.reason).toBe('explicit_override');
+  });
+
+  it('lets a preview deploy opt in explicitly, so a separate preview DB still migrates', () => {
+    const decision = decideBootSchemaWrite(REMOTE, {
+      VERCEL_ENV: 'preview',
+      ALLOW_REMOTE_BOOT_MIGRATE: '1',
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe('explicit_override');
   });
 
   it('only "1" opts in — a truthy-looking value must not', () => {
-    expect(decideBootMigrate(REMOTE, { ALLOW_REMOTE_BOOT_MIGRATE: 'true' }).allowed).toBe(false);
-    expect(decideBootMigrate(REMOTE, { ALLOW_REMOTE_BOOT_MIGRATE: '0' }).allowed).toBe(false);
+    expect(decideBootSchemaWrite(REMOTE, { ALLOW_REMOTE_BOOT_MIGRATE: 'true' }).allowed).toBe(false);
+    expect(decideBootSchemaWrite(REMOTE, { ALLOW_REMOTE_BOOT_MIGRATE: '0' }).allowed).toBe(false);
   });
 
   it('FAILS CLOSED on an absent or unparseable connection string', () => {
     // One manual command is the cost of a wrongly-skipped local migration.
     // A wrongly-allowed remote one is the incident this guard exists for.
-    expect(decideBootMigrate(undefined, {}).allowed).toBe(false);
-    expect(decideBootMigrate('not-a-url', {}).allowed).toBe(false);
+    expect(decideBootSchemaWrite(undefined, {}).allowed).toBe(false);
+    expect(decideBootSchemaWrite('not-a-url', {}).allowed).toBe(false);
   });
 
-  it('never puts credentials in the refusal message', () => {
-    const message = refusalMessage(hostFromConnectionString(REMOTE) ?? '(unknown)');
-    expect(message).toContain('db.abcdefg.supabase.co');
-    expect(message).not.toContain('pw');
-    expect(message).not.toContain('user:');
-    // It must also name the way out, so nobody has to go looking.
+  it('never puts credentials in an operator-facing message', () => {
+    const host = hostFromConnectionString(REMOTE) ?? '(unknown)';
+    for (const message of [refusalMessage(host), overrideMessage(host, '0137_target_size')]) {
+      expect(message).toContain('db.abcdefg.supabase.co');
+      expect(message).not.toContain('pw');
+      expect(message).not.toContain('user:');
+    }
+  });
+
+  it('the refusal names the way out, so nobody has to go looking', () => {
+    const message = refusalMessage('db.abcdefg.supabase.co');
     expect(message).toContain('npm run db:migrate');
     expect(message).toContain('ALLOW_REMOTE_BOOT_MIGRATE=1');
+  });
+
+  it('an intentional override is LOUD — the incident left no trace', () => {
+    const message = overrideMessage('db.abcdefg.supabase.co', '0137_target_size');
+    expect(message).toContain('REMOTE');
+    expect(message).toContain('db.abcdefg.supabase.co');
+    expect(message).toContain('0137_target_size');
   });
 
   it('extracts host without credentials', () => {

--- a/src/server/db/__tests__/migrate-safety.test.ts
+++ b/src/server/db/__tests__/migrate-safety.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  decideBootMigrate,
+  hostFromConnectionString,
+  refusalMessage,
+} from '@/server/db/migrate-safety';
+
+const LOCAL = 'postgresql://user:pw@localhost:5432/joshing';
+const REMOTE = 'postgresql://user:pw@db.abcdefg.supabase.co:5432/postgres';
+
+describe('boot-migrate safety gate', () => {
+  it('REFUSES a remote target from a local process — the 2026-09-03 incident', () => {
+    // A `npm run dev` boot applied migration 0136 to production because this
+    // repo's local .env DATABASE_URL points at prod. This is the exact case.
+    const decision = decideBootMigrate(REMOTE, {});
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.reason).toBe('remote_target_from_local_process');
+      expect(decision.host).toBe('db.abcdefg.supabase.co');
+    }
+  });
+
+  it('does not consult NODE_ENV — the incident happened under NODE_ENV=development', () => {
+    // The environment NAME was never what made it dangerous; the connection
+    // TARGET was. Passing no env at all must still refuse a remote host.
+    expect(decideBootMigrate(REMOTE, {}).allowed).toBe(false);
+  });
+
+  it('allows a local target', () => {
+    const decision = decideBootMigrate(LOCAL, {});
+    expect(decision.allowed).toBe(true);
+    if (decision.allowed) expect(decision.reason).toBe('local_target');
+  });
+
+  it.each(['127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal'])(
+    'treats %s as local',
+    (host) => {
+      // IPv6 literals must be bracketed to form a valid URL.
+      const authority = host.includes(':') ? `[${host}]` : host;
+      expect(decideBootMigrate(`postgresql://u:p@${authority}:5432/db`, {}).allowed).toBe(true);
+    },
+  );
+
+  it('allows a deploy platform — production deploys must migrate exactly as before', () => {
+    const decision = decideBootMigrate(REMOTE, { VERCEL: '1' });
+    expect(decision.allowed).toBe(true);
+    if (decision.allowed) expect(decision.reason).toBe('deploy_platform');
+  });
+
+  it('allows an explicit single-run override', () => {
+    const decision = decideBootMigrate(REMOTE, { ALLOW_REMOTE_BOOT_MIGRATE: '1' });
+    expect(decision.allowed).toBe(true);
+    if (decision.allowed) expect(decision.reason).toBe('explicit_override');
+  });
+
+  it('only "1" opts in — a truthy-looking value must not', () => {
+    expect(decideBootMigrate(REMOTE, { ALLOW_REMOTE_BOOT_MIGRATE: 'true' }).allowed).toBe(false);
+    expect(decideBootMigrate(REMOTE, { ALLOW_REMOTE_BOOT_MIGRATE: '0' }).allowed).toBe(false);
+  });
+
+  it('FAILS CLOSED on an absent or unparseable connection string', () => {
+    // One manual command is the cost of a wrongly-skipped local migration.
+    // A wrongly-allowed remote one is the incident this guard exists for.
+    expect(decideBootMigrate(undefined, {}).allowed).toBe(false);
+    expect(decideBootMigrate('not-a-url', {}).allowed).toBe(false);
+  });
+
+  it('never puts credentials in the refusal message', () => {
+    const message = refusalMessage(hostFromConnectionString(REMOTE) ?? '(unknown)');
+    expect(message).toContain('db.abcdefg.supabase.co');
+    expect(message).not.toContain('pw');
+    expect(message).not.toContain('user:');
+    // It must also name the way out, so nobody has to go looking.
+    expect(message).toContain('npm run db:migrate');
+    expect(message).toContain('ALLOW_REMOTE_BOOT_MIGRATE=1');
+  });
+
+  it('extracts host without credentials', () => {
+    expect(hostFromConnectionString(REMOTE)).toBe('db.abcdefg.supabase.co');
+    expect(hostFromConnectionString('garbage')).toBeNull();
+    expect(hostFromConnectionString(undefined)).toBeNull();
+  });
+});

--- a/src/server/db/migrate-safety.ts
+++ b/src/server/db/migrate-safety.ts
@@ -5,22 +5,35 @@
  * WHY THIS EXISTS. On 2026-09-03 a `npm run dev` boot on an unmerged feature
  * branch applied migration 0136 to the PRODUCTION database as a side effect of
  * starting up. Nothing about that was intended and nothing prevented it: this
- * repo's local `.env` DATABASE_URL points at production, `register()` calls
- * `migrate()` on every boot, and `migrate()` applies every pending migration it
- * finds on the current branch. The migration wrote a wrong `target_size` to 148
- * live rows. It was inert (nothing read the column) so no user was affected,
- * but the same boot on a branch with a destructive migration would not have
- * been recoverable. Production is actively serving -- 10 queues, 80 answers, 5
- * distinct users in the trailing week -- so this is live traffic, not a dormant
+ * repo's local `.env` DATABASE_URL points at production, `register()` writes
+ * schema on every boot, and it writes whatever the current branch happens to
+ * contain. The migration wrote a wrong `target_size` to 148 live rows. It was
+ * inert (nothing read the column) so no user was affected, but the same boot on
+ * a branch with a destructive change would not have been recoverable.
+ * Production is actively serving, so this is live traffic, not a dormant
  * environment.
  *
- * THE RULE. Auto-migrate on boot is for DEPLOYED environments. Anywhere else,
- * a remote target requires a deliberate, explicit act.
+ * TWO DOORS, NOT ONE. `register()` reaches the database along two independent
+ * paths, and BOTH write DDL:
  *
- * Two independent signals have to agree before a boot may migrate a remote
- * database:
- *   1. the process is running on a deploy platform (Vercel sets VERCEL=1), or
- *   2. the operator has explicitly opted in for this one run.
+ *   1. the ~70 idempotent boot guards (ADD COLUMN IF NOT EXISTS, CREATE TABLE
+ *      IF NOT EXISTS, CREATE INDEX IF NOT EXISTS), which run FIRST and are not
+ *      recorded in the migration journal at all; and
+ *   2. `migrate()`, which is journalled.
+ *
+ * Only the second is what people picture when they think "migrations", but the
+ * first is DDL against whatever DATABASE_URL points at, executed before
+ * `migrate()` gets a turn. Gating only `migrate()` would close the door the
+ * incident happened to use and leave ~70 statements walking through the other.
+ * So this decision gates the whole schema-writing phase.
+ *
+ * (The two-route split is itself worth knowing about: it is why "what actually
+ * applied?" was hard to answer after the incident. Unifying them is a larger
+ * change than this one and is logged, not attempted here.)
+ *
+ * THE RULE. Auto schema-write on boot is for PRODUCTION DEPLOYS. Anywhere
+ * else, a remote target requires a deliberate, explicit act.
+ *
  * Neither `NODE_ENV` nor "it looks like production" is trusted, because the
  * incident happened with `NODE_ENV=development` -- the environment name was
  * never the thing that made it dangerous. The connection target is.
@@ -29,39 +42,56 @@
 /** Hosts that are unambiguously a developer's own machine. */
 const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal']);
 
-export type MigrateDecision =
-  | { allowed: true; reason: 'local_target' | 'deploy_platform' | 'explicit_override' }
-  | { allowed: false; reason: 'remote_target_from_local_process'; host: string };
+export type SchemaWriteDecision =
+  | { allowed: true; reason: 'local_target' | 'production_deploy' | 'explicit_override'; host: string }
+  | { allowed: false; reason: 'remote_target_without_authorization'; host: string };
+
+export type BootEnv = {
+  VERCEL_ENV?: string;
+  ALLOW_REMOTE_BOOT_MIGRATE?: string;
+};
 
 /**
  * Pure so it can be unit tested without a database, a network, or a real
  * environment. Callers pass the connection string and the relevant env.
  */
-export function decideBootMigrate(
+export function decideBootSchemaWrite(
   connectionString: string | undefined,
-  env: { VERCEL?: string; ALLOW_REMOTE_BOOT_MIGRATE?: string } = {},
-): MigrateDecision {
+  env: BootEnv = {},
+): SchemaWriteDecision {
+  const host = hostFromConnectionString(connectionString) ?? '(unknown)';
+
   // An explicit, per-run opt-in. Deliberately NOT a value anyone would already
-  // have set for another purpose, and deliberately not inferable from
-  // NODE_ENV.
+  // have set for another purpose, and deliberately not inferable from NODE_ENV.
+  // Its use is logged loudly by the caller -- the incident's defining feature
+  // was that it left no trace.
   if (env.ALLOW_REMOTE_BOOT_MIGRATE === '1') {
-    return { allowed: true, reason: 'explicit_override' };
+    return { allowed: true, reason: 'explicit_override', host };
   }
 
-  // Deployed environments migrate on boot as before -- this guard must not
-  // change how production deploys apply schema.
-  if (env.VERCEL) return { allowed: true, reason: 'deploy_platform' };
+  // PRODUCTION deploys migrate on boot exactly as before -- this guard must not
+  // change how production applies schema.
+  //
+  // Note this is VERCEL_ENV === 'production', NOT the presence of VERCEL.
+  // `VERCEL` is set on EVERY Vercel deployment including previews, so keying on
+  // it would let any branch that gets a preview deploy write schema to whatever
+  // DATABASE_URL that environment resolves to. If preview shares the production
+  // connection string, that is the incident again, sourced from CI instead of a
+  // laptop -- and permitted. Previews therefore need the explicit override
+  // above, set once as a Preview-scoped env var, which is a deliberate act that
+  // shows up in the dashboard rather than an accident of branch naming.
+  if (env.VERCEL_ENV === 'production') {
+    return { allowed: true, reason: 'production_deploy', host };
+  }
 
-  const host = hostFromConnectionString(connectionString);
+  // Unparseable or absent connection string: treated as remote by the check
+  // below, because `host` is then '(unknown)' and never a loopback name.
+  // Failing closed is right here -- the cost of a wrongly-skipped local
+  // migration is one manual command; the cost of a wrongly-allowed remote one
+  // is this incident.
+  if (LOCAL_HOSTS.has(host)) return { allowed: true, reason: 'local_target', host };
 
-  // Unparseable or absent connection string: treat as remote. Failing closed
-  // is right here -- the cost of a wrongly-skipped local migration is one
-  // manual command; the cost of a wrongly-allowed remote one is this incident.
-  if (!host) return { allowed: false, reason: 'remote_target_from_local_process', host: '(unknown)' };
-
-  if (LOCAL_HOSTS.has(host)) return { allowed: true, reason: 'local_target' };
-
-  return { allowed: false, reason: 'remote_target_from_local_process', host };
+  return { allowed: false, reason: 'remote_target_without_authorization', host };
 }
 
 /** Host only -- never the credentials, which must not reach a log line. */
@@ -87,9 +117,22 @@ export function hostFromConnectionString(connectionString: string | undefined): 
  */
 export function refusalMessage(host: string): string {
   return [
-    `[instrumentation] REFUSING to auto-apply migrations: this process is not running on a deploy platform, but DATABASE_URL points at a remote host (${host}).`,
+    `[instrumentation] REFUSING to auto-apply schema changes (boot guards AND migrations): this is not a production deploy, but DATABASE_URL points at a remote host (${host}).`,
     'A local boot silently migrated the production database on 2026-09-03; this guard exists to stop that recurring.',
-    'The app will start normally and serve requests -- only the automatic migrate() is skipped.',
-    'To apply migrations deliberately: run `npm run db:migrate`, or set ALLOW_REMOTE_BOOT_MIGRATE=1 for a single run.',
+    'The app will start normally and serve requests -- only the automatic schema writes are skipped.',
+    'To apply deliberately: run `npm run db:migrate`, or set ALLOW_REMOTE_BOOT_MIGRATE=1 for a single run.',
+  ].join(' ');
+}
+
+/**
+ * The operator-facing message when the escape hatch IS used against a remote
+ * database. Deliberately loud: an intentional override must leave a trace, and
+ * the reason this guard exists is an unintended schema write that left none.
+ */
+export function overrideMessage(host: string, journalHead: string | null): string {
+  return [
+    `[instrumentation] ALLOW_REMOTE_BOOT_MIGRATE=1 -- applying boot guards and migrations to REMOTE host ${host}.`,
+    journalHead ? `Journal head: ${journalHead}.` : 'Journal head: (unreadable).',
+    'This is an explicit override; if you did not intend to write schema to this database, stop the process now.',
   ].join(' ');
 }

--- a/src/server/db/migrate-safety.ts
+++ b/src/server/db/migrate-safety.ts
@@ -1,0 +1,95 @@
+/**
+ * Guard: a local process must never auto-apply schema changes to a remote
+ * database.
+ *
+ * WHY THIS EXISTS. On 2026-09-03 a `npm run dev` boot on an unmerged feature
+ * branch applied migration 0136 to the PRODUCTION database as a side effect of
+ * starting up. Nothing about that was intended and nothing prevented it: this
+ * repo's local `.env` DATABASE_URL points at production, `register()` calls
+ * `migrate()` on every boot, and `migrate()` applies every pending migration it
+ * finds on the current branch. The migration wrote a wrong `target_size` to 148
+ * live rows. It was inert (nothing read the column) so no user was affected,
+ * but the same boot on a branch with a destructive migration would not have
+ * been recoverable. Production is actively serving -- 10 queues, 80 answers, 5
+ * distinct users in the trailing week -- so this is live traffic, not a dormant
+ * environment.
+ *
+ * THE RULE. Auto-migrate on boot is for DEPLOYED environments. Anywhere else,
+ * a remote target requires a deliberate, explicit act.
+ *
+ * Two independent signals have to agree before a boot may migrate a remote
+ * database:
+ *   1. the process is running on a deploy platform (Vercel sets VERCEL=1), or
+ *   2. the operator has explicitly opted in for this one run.
+ * Neither `NODE_ENV` nor "it looks like production" is trusted, because the
+ * incident happened with `NODE_ENV=development` -- the environment name was
+ * never the thing that made it dangerous. The connection target is.
+ */
+
+/** Hosts that are unambiguously a developer's own machine. */
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal']);
+
+export type MigrateDecision =
+  | { allowed: true; reason: 'local_target' | 'deploy_platform' | 'explicit_override' }
+  | { allowed: false; reason: 'remote_target_from_local_process'; host: string };
+
+/**
+ * Pure so it can be unit tested without a database, a network, or a real
+ * environment. Callers pass the connection string and the relevant env.
+ */
+export function decideBootMigrate(
+  connectionString: string | undefined,
+  env: { VERCEL?: string; ALLOW_REMOTE_BOOT_MIGRATE?: string } = {},
+): MigrateDecision {
+  // An explicit, per-run opt-in. Deliberately NOT a value anyone would already
+  // have set for another purpose, and deliberately not inferable from
+  // NODE_ENV.
+  if (env.ALLOW_REMOTE_BOOT_MIGRATE === '1') {
+    return { allowed: true, reason: 'explicit_override' };
+  }
+
+  // Deployed environments migrate on boot as before -- this guard must not
+  // change how production deploys apply schema.
+  if (env.VERCEL) return { allowed: true, reason: 'deploy_platform' };
+
+  const host = hostFromConnectionString(connectionString);
+
+  // Unparseable or absent connection string: treat as remote. Failing closed
+  // is right here -- the cost of a wrongly-skipped local migration is one
+  // manual command; the cost of a wrongly-allowed remote one is this incident.
+  if (!host) return { allowed: false, reason: 'remote_target_from_local_process', host: '(unknown)' };
+
+  if (LOCAL_HOSTS.has(host)) return { allowed: true, reason: 'local_target' };
+
+  return { allowed: false, reason: 'remote_target_from_local_process', host };
+}
+
+/** Host only -- never the credentials, which must not reach a log line. */
+export function hostFromConnectionString(connectionString: string | undefined): string | null {
+  if (!connectionString) return null;
+  try {
+    // An IPv6 host is bracketed in a URL ("postgresql://u:p@[::1]:5432/db") and
+    // URL.hostname hands the brackets back, so "[::1]" would never match the
+    // bare "::1" in LOCAL_HOSTS -- a loopback target would have been treated as
+    // remote and refused. Strip them.
+    const hostname = new URL(connectionString).hostname;
+    if (!hostname) return null;
+    return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The operator-facing message for a refusal. Names the host so it is obvious
+ * WHICH database was protected, and names the exact escape hatch so nobody has
+ * to go looking for it.
+ */
+export function refusalMessage(host: string): string {
+  return [
+    `[instrumentation] REFUSING to auto-apply migrations: this process is not running on a deploy platform, but DATABASE_URL points at a remote host (${host}).`,
+    'A local boot silently migrated the production database on 2026-09-03; this guard exists to stop that recurring.',
+    'The app will start normally and serve requests -- only the automatic migrate() is skipped.',
+    'To apply migrations deliberately: run `npm run db:migrate`, or set ALLOW_REMOTE_BOOT_MIGRATE=1 for a single run.',
+  ].join(' ');
+}


### PR DESCRIPTION
## Why

On **2026-09-03 00:53 UTC** a `npm run dev` boot on an unmerged branch applied migration `0136` to the **production** database as a side effect of starting up.

Three things combined, none individually wrong:

1. This repo's local `.env` `DATABASE_URL` points at production (long-standing, documented).
2. `register()` calls `migrate()` on every boot.
3. `migrate()` applies *every pending migration on the current branch*, not a named one.

Blast radius: the `0136` backfill wrote `target_size` from **all** slots, so the modal 7-slot queue (5 core + 2 bonus) was recorded as `7`. **148 rows** got a value above 5. **No user impact** — nothing reads the column — but production is actively serving (10 queues, 80 answers, 5 distinct users in the trailing week), and the same boot on a branch carrying a destructive migration would not have been recoverable.

Full write-up: `_docs/INCIDENT-2026-09-03-boot-migrate.md`.

## What this does

`decideBootMigrate()` gates the boot `migrate()` on the connection **target**, not the environment name. A boot may auto-migrate only when:

| condition | rationale |
|---|---|
| host is loopback | a developer's own database |
| `VERCEL` is set | a real deploy — production must migrate exactly as before |
| `ALLOW_REMOTE_BOOT_MIGRATE=1` | deliberate, per-run, explicit |

It **deliberately does not consult `NODE_ENV`.** The incident happened under `NODE_ENV=development` — that signal is precisely the one that said "safe" while being wrong. The environment name was never what made it dangerous; the connection target was.

On refusal it **warns and skips** — the app boots and serves normally, only the automatic schema change is withheld. This matches the `PHONE_HASH_SALT` precedent; throwing would kill the instrumentation hook and 500 every request. It **fails closed** on an absent or unparseable connection string: a wrongly-skipped local migration costs one manual command, a wrongly-allowed remote one costs this incident.

The refusal message names the host (so it's obvious *which* database was protected) and the exact escape hatch, but never the credentials — there's a test asserting that.

## What was exercised

- `npx vitest run src/server/db/__tests__/migrate-safety.test.ts` — **13/13 pass**, including the exact incident case and a "does not consult NODE_ENV" test.
- `npx tsc -p tsconfig.typecheck.json` — clean.
- `npx eslint` on the three changed files — clean.
- **Run against this repo's real `.env`:** resolves host `db.grix…supabase.co`, `VERCEL` unset → **REFUSED**. The guard demonstrably blocks the configuration that caused the incident.

Not exercised: no deployed boot has run this code, so the `VERCEL` allow-path is covered by unit test only. It is the branch that preserves existing behaviour, so a regression there would show up as a deploy that fails to migrate, not as a silent write.

## Note on scope

This lands **before** `0137` (the data correction) and before anything else touches the database — fixing the mechanism first, so the fix for what the broken mechanism did isn't delivered by the broken mechanism.

A strictly stronger fix exists — separate local and production credentials so a dev environment cannot reach production at all — and is logged as a follow-up rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJwiXeNJPqExdRGRdZGrTh
