### PR TITLE
Complete a round on its core slots, not its bonus slots (A1a)

### DIFF
--- a/src/server/daily/__tests__/round-complete-core-only.test.ts
+++ b/src/server/daily/__tests__/round-complete-core-only.test.ts
@@ -87,3 +87,20 @@ describe('isRoundComplete — core-only (A1a)', () => {
     expect(isRoundComplete(slots)).toBe(true);
   });
 });
+
+describe('skip replacements are core, not additive', () => {
+  it('a marker-less replacement slot holds the round open', () => {
+    // buildBotSlot (the skip-replacement builder in db/queries/daily.ts) sets
+    // neither presence_source_id nor return_scope, so getCoreSlots classifies
+    // it as CORE. This is what preserves the original 2026-05-28 fix: a
+    // skip-extended queue is not complete until the replacement is resolved.
+    // If a replacement ever starts carrying a marker, this test fails and the
+    // skip-extension guarantee is silently gone.
+    const slots = [
+      ...[0, 1, 2, 3].map((i) => core(i, { answered: true })),
+      core(4, { skipped: true }),
+      core(5), // replacement, marker-less
+    ];
+    expect(isRoundComplete(slots)).toBe(false);
+  });
+});

--- a/src/server/daily/__tests__/round-complete-core-only.test.ts
+++ b/src/server/daily/__tests__/round-complete-core-only.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasPendingSlot, isRoundComplete, type QueueSlot } from '@/server/daily/types';
+
+function slot(overrides: Partial<QueueSlot>): QueueSlot {
+  return {
+    slot_index: 0,
+    source: 'bot',
+    domain: 'general',
+    question_text: 'q',
+    answered: false,
+    ...overrides,
+  };
+}
+
+const core = (i: number, o: Partial<QueueSlot> = {}) => slot({ slot_index: i, ...o });
+const bonus = (i: number, o: Partial<QueueSlot> = {}) =>
+  slot({ slot_index: i, presence_source_id: 'friend-1', ...o });
+const ret = (i: number, o: Partial<QueueSlot> = {}) =>
+  slot({ slot_index: i, return_scope: 'wrong', ...o });
+
+describe('isRoundComplete — core-only (A1a)', () => {
+  it('COMPLETES the modal queue when all five core are answered and bonus is untouched', () => {
+    // The live stranding bug. 5 core + 2 bonus; the player answers the five and
+    // stops, because the bonus two are optional. Under the old all-slots rule
+    // the bonus slots stayed pending and the round NEVER completed -- measured
+    // on 5 production queues, four of them exactly this shape.
+    const slots = [
+      ...[0, 1, 2, 3, 4].map((i) => core(i, { answered: true })),
+      bonus(5),
+      bonus(6),
+    ];
+    expect(isRoundComplete(slots)).toBe(true);
+  });
+
+  it('COMPLETES when a return slot is left pending', () => {
+    // Return slots are additive by the same rule as bonus (D-MISSED-RETURN-01
+    // R3), so they must not hold the round open either.
+    const slots = [...[0, 1, 2, 3, 4].map((i) => core(i, { answered: true })), ret(5)];
+    expect(isRoundComplete(slots)).toBe(true);
+  });
+
+  it('stays INCOMPLETE while a core slot is pending, even if every bonus is answered', () => {
+    const slots = [
+      ...[0, 1, 2, 3].map((i) => core(i, { answered: true })),
+      core(4),
+      bonus(5, { answered: true }),
+    ];
+    expect(isRoundComplete(slots)).toBe(false);
+  });
+
+  it('treats a skipped core slot as resolved, not pending', () => {
+    // Pre-existing behaviour, preserved: a skipped slot whose replacement
+    // failed to generate leaves nothing to play, so the round is genuinely over.
+    const slots = [
+      ...[0, 1, 2, 3].map((i) => core(i, { answered: true })),
+      core(4, { skipped: true }),
+    ];
+    expect(isRoundComplete(slots)).toBe(true);
+  });
+
+  it('completes a SHORT queue once its core slots are resolved', () => {
+    // A1a deliberately does NOT fix short-queue over-completion -- that needs
+    // target_size compared at persist (A1b) and is under-delivery, not
+    // stranding. Pinned here so A1b's arrival is a visible change.
+    const slots = [...[0, 1, 2].map((i) => core(i, { answered: true })), bonus(3)];
+    expect(isRoundComplete(slots)).toBe(true);
+  });
+
+  it('is false for an empty queue', () => {
+    expect(isRoundComplete([])).toBe(false);
+  });
+
+  it('falls back to all slots when a queue has no core slots at all', () => {
+    // Degenerate shape the core-only rule was not designed for; falling back
+    // keeps it completable instead of stranding it forever.
+    expect(isRoundComplete([bonus(0, { answered: true })])).toBe(true);
+    expect(isRoundComplete([bonus(0)])).toBe(false);
+  });
+
+  it('leaves hasPendingSlot alone — navigation must still see bonus slots', () => {
+    // The player can still PLAY a pending bonus slot; only the completeness
+    // verdict is core-scoped. If this ever changes, /daily stops offering the
+    // bonus questions at all.
+    const slots = [...[0, 1, 2, 3, 4].map((i) => core(i, { answered: true })), bonus(5)];
+    expect(hasPendingSlot(slots)).toBe(true);
+    expect(isRoundComplete(slots)).toBe(true);
+  });
+});

--- a/src/server/daily/__tests__/round-completion.test.ts
+++ b/src/server/daily/__tests__/round-completion.test.ts
@@ -65,9 +65,25 @@ describe('isRoundComplete / hasPendingSlot', () => {
   });
 });
 
-// Daily Five +2: the queue is variable-length (core 5 + 0–2 bonus slots), so
-// completion must track the ACTUAL slot count at 5, 6, and 7 — not a fixed five.
-describe('isRoundComplete — variable 5–7 slot queues (Daily Five +2)', () => {
+// Daily Five +2: the queue is variable-length (core 5 + 0-2 bonus slots).
+//
+// REVERSED BY A1a. This block previously asserted that completion tracks the
+// ACTUAL slot count -- a 7-slot queue stayed incomplete until all seven were
+// answered. That was a deliberate decision, made to stop completion being
+// hardcoded to five, and the variable-length concern behind it is still valid.
+// But applied to ADDITIVE slots it stranded the modal queue: bonus questions
+// are optional, so a player who answers the five core questions and stops
+// leaves them pending forever and the round never completes. Measured on the
+// live database: 5 queues permanently in that state, four of them
+// 5-answered-of-5 with a bonus slot open. Completion also gates the demand-pull
+// bank replenish, so those rounds never restocked.
+//
+// The rule is now: completion tracks the actual CORE count (still not a
+// hardcoded five), and additive slots -- bonus and missed-question returns --
+// never hold the round open. That matches the D-F3 canon these helpers already
+// enforce everywhere else: bonus slots never count toward the five, so they
+// must not decide whether the five are done.
+describe('isRoundComplete -- variable-length queues, core-scoped (A1a)', () => {
   function bonusSlot(slot_index: number, answered: boolean): QueueSlot {
     return {
       ...slot(slot_index, { answered }),
@@ -77,19 +93,40 @@ describe('isRoundComplete — variable 5–7 slot queues (Daily Five +2)', () =>
     } as QueueSlot;
   }
 
-  for (const total of [5, 6, 7]) {
-    it(`a ${total}-slot queue is incomplete until the last slot is answered`, () => {
-      const indices = Array.from({ length: total }, (_, i) => i);
+  // The original concern, preserved: completion must follow the real core
+  // count, never a hardcoded 5.
+  for (const coreCount of [3, 4, 5]) {
+    it(`a ${coreCount}-core queue is incomplete until the last CORE slot is resolved`, () => {
+      const indices = Array.from({ length: coreCount }, (_, i) => i);
       const partial = indices.map((i) =>
-        i < total - 1
-          ? (i < 5 ? slot(i, { answered: true }) : bonusSlot(i, true))
-          : (i < 5 ? slot(i) : bonusSlot(i, false)),
+        i < coreCount - 1 ? slot(i, { answered: true }) : slot(i),
       );
       expect(isRoundComplete(partial)).toBe(false);
 
-      const full = indices.map((i) => (i < 5 ? slot(i, { answered: true }) : bonusSlot(i, true)));
+      const full = indices.map((i) => slot(i, { answered: true }));
       expect(isRoundComplete(full)).toBe(true);
-      expect(hasPendingSlot(full)).toBe(false);
     });
   }
+
+  for (const bonusCount of [1, 2]) {
+    it(`${bonusCount} unanswered bonus slot(s) do NOT hold the round open`, () => {
+      const slots = [
+        ...[0, 1, 2, 3, 4].map((i) => slot(i, { answered: true })),
+        ...Array.from({ length: bonusCount }, (_, b) => bonusSlot(5 + b, false)),
+      ];
+      expect(isRoundComplete(slots)).toBe(true);
+      // ...but they remain playable: navigation still sees them.
+      expect(hasPendingSlot(slots)).toBe(true);
+    });
+  }
+
+  it('answering the bonus slots too still reads complete', () => {
+    const slots = [
+      ...[0, 1, 2, 3, 4].map((i) => slot(i, { answered: true })),
+      bonusSlot(5, true),
+      bonusSlot(6, true),
+    ];
+    expect(isRoundComplete(slots)).toBe(true);
+    expect(hasPendingSlot(slots)).toBe(false);
+  });
 });

--- a/src/server/daily/__tests__/round-completion.test.ts
+++ b/src/server/daily/__tests__/round-completion.test.ts
@@ -67,22 +67,29 @@ describe('isRoundComplete / hasPendingSlot', () => {
 
 // Daily Five +2: the queue is variable-length (core 5 + 0-2 bonus slots).
 //
-// REVERSED BY A1a. This block previously asserted that completion tracks the
-// ACTUAL slot count -- a 7-slot queue stayed incomplete until all seven were
-// answered. That was a deliberate decision, made to stop completion being
-// hardcoded to five, and the variable-length concern behind it is still valid.
-// But applied to ADDITIVE slots it stranded the modal queue: bonus questions
-// are optional, so a player who answers the five core questions and stops
-// leaves them pending forever and the round never completes. Measured on the
-// live database: 5 queues permanently in that state, four of them
-// 5-answered-of-5 with a bonus slot open. Completion also gates the demand-pull
-// bank replenish, so those rounds never restocked.
+// WHAT A1a CHANGES, PRECISELY. This block was added 2026-06-01 in the +2 commit
+// itself ("Daily Five +2: append accessible friend-answered bonus slots"), and
+// its fixtures used the then-current bonus marker `answerer_id` (replaced by
+// `presence_source_id` a day later). So it DID knowingly assert that an
+// unanswered bonus slot holds the round open. A1a reverses that specific
+// behaviour -- not by accident, and not because the test was stale.
 //
-// The rule is now: completion tracks the actual CORE count (still not a
-// hardcoded five), and additive slots -- bonus and missed-question returns --
-// never hold the round open. That matches the D-F3 canon these helpers already
-// enforce everywhere else: bonus slots never count toward the five, so they
-// must not decide whether the five are done.
+// What it does NOT reverse is the concern the comment actually states: "track
+// the ACTUAL slot count, not a fixed five". Skip replacements are built by
+// buildBotSlot, which carries neither `presence_source_id` nor `return_scope`,
+// so getCoreSlots classifies them as CORE. A skip-extended 6-slot queue still
+// has 6 core slots and still needs all six resolved. That half is preserved
+// exactly, and is pinned below.
+//
+// Why the bonus half had to go: counting additive slots stranded the modal
+// queue permanently. 5 core + 2 bonus, the player answers the five core
+// questions and stops -- the bonus two are optional, so they stay pending and
+// the round never completes. Measured on the live database: 5 queues in exactly
+// that state, four of them 5-answered-of-5 with a bonus slot open. Completion
+// also gates the demand-pull bank replenish, so those rounds never restocked.
+// And it contradicted the D-F3 canon these helpers enforce everywhere else:
+// bonus slots never count toward the five, so they must not decide whether the
+// five are done.
 describe('isRoundComplete -- variable-length queues, core-scoped (A1a)', () => {
   function bonusSlot(slot_index: number, answered: boolean): QueueSlot {
     return {

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -10,6 +10,7 @@
 
 import { z } from 'zod';
 import type { DifficultyEstimate } from '@/types/db';
+import { getCoreSlots } from './bonus';
 
 type DailyDifficultyEstimate = DifficultyEstimate | 'accessible' | 'moderate' | 'specialist';
 
@@ -205,15 +206,44 @@ export function hasPendingSlot(slots: QueueSlot[]): boolean {
 }
 
 /**
- * A round is complete once it has slots and none of them are still pending.
+ * A round is complete once its CORE slots are all resolved (answered or
+ * skipped). Additive slots — the +2 bonus and missed-question returns — are
+ * deliberately excluded.
  *
- * This is the canonical definition of "done" — the status API and the play
- * page both derive from it so the home card and the player can't disagree
- * (a skipped-but-unreplaced slot used to leave the round advertising "Resume"
- * while the player bounced straight to the summary).
+ * This is the canonical definition of "done": the status API and the home card
+ * both derive from it so they can't disagree (a skipped-but-unreplaced slot
+ * used to leave the home card advertising "Resume" while /daily bounced
+ * straight to the summary).
+ *
+ * WHY CORE ONLY (A1a). This predicate used to count EVERY slot, which stranded
+ * the modal queue permanently: 5 core + 2 bonus, player answers all five core
+ * questions and stops — the bonus two are optional, so they stay
+ * `answered: false, skipped: false`, stay pending, and the round never
+ * completes. Measured on the live database: 5 queues in exactly that state,
+ * four of them 5-answered-of-5 with a bonus slot left open. That is not
+ * cosmetic — completion also gates the demand-pull bank replenish in
+ * /api/daily/answer, so a stranded round never restocks the player's bank.
+ * Counting additive slots also contradicted the D-F3 canon these very helpers
+ * enforce: bonus slots never count toward the five, so they must not decide
+ * whether the five are done.
+ *
+ * It is also a PRECONDITION of deferring bonus generation. Under deferral the
+ * bonus slots are appended AFTER the queue is persisted and being played, so a
+ * player could finish all five, see the round complete, and have it flip back
+ * to incomplete when the deferred slots land.
+ *
+ * `hasPendingSlot` is deliberately NOT changed: navigation ("is there another
+ * slot to play?") must still see bonus slots, because the player can still play
+ * them. Only the completeness verdict is core-scoped.
+ *
+ * Degenerate case: a queue with no core slots at all falls back to judging
+ * every slot, so an all-additive queue can still complete rather than
+ * stranding forever on the new rule.
  */
 export function isRoundComplete(slots: QueueSlot[]): boolean {
-  return slots.length > 0 && !hasPendingSlot(slots);
+  const core = getCoreSlots(slots);
+  const considered = core.length > 0 ? core : slots;
+  return considered.length > 0 && !hasPendingSlot(considered);
 }
 
 /**

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -147,7 +147,9 @@ export type QueueSlotAnswerState = z.infer<typeof queueSlotAnswerStateSchema>;
 export type QueueSlot = z.infer<typeof queueSlotSchema>;
 
 /**
- * Phase 4 skip mechanic — capped at 3 skips per round, server-enforced.
+ * Phase 4 skip mechanic — capped at DAILY_SKIP_LIMIT skips per round,
+ * server-enforced. (This line used to say "3"; the constant below has been 5.
+ * Code beats comment — the enforced limit is the constant.)
  * A skip writes a SkippedDailyQuestion row and temporarily cools that question
  * down in the queue builder.
  */


### PR DESCRIPTION
## The bug, live in production today

`isRoundComplete` counted **every** slot:

```ts
hasPendingSlot: slots.some(s => !s.answered && !s.skipped)
isRoundComplete: slots.length > 0 && !hasPendingSlot(slots)
```

On the modal queue — 5 core + 2 bonus — the player answers the five core questions and stops, because the bonus two are optional. Those slots stay `answered: false, skipped: false`, stay pending, and **the round never completes.**

**Measured on the live database: 5 queues permanently in that state.**

| queue_date | core | answered | skipped | pending additive |
|---|---|---|---|---|
| 2026-07-24 | 5 | 5 | 0 | 1 |
| 2026-06-27 | 5 | 5 | 0 | 1 |
| 2026-06-26 | 5 | 5 | 0 | 1 |
| 2026-06-12 | 5 | 5 | 0 | 2 |
| 2026-06-08 | 3 | 3 | 0 | 1 |

**This is not cosmetic — it withholds supply.** `isRoundComplete` gates three consumers, and one has teeth:

1. **Demand-pull bank replenish** (`api/daily/answer:618`) fires on the *transition* to complete. A stranded round **never restocks that player's bank** → the next build finds less ready stock → more live generation → slower build. The stranding bug feeds the latency problem.
2. Home card — "Resume round" vs done (`app/page.tsx:351`).
3. Status API `isComplete` / `questionsRemaining` (`api/daily/status:88`).

No streak consumer exists, so nothing is revoked.

## The fix

```ts
const core = getCoreSlots(slots);
const considered = core.length > 0 ? core : slots;
return considered.length > 0 && !hasPendingSlot(considered);
```

`getCoreSlots` already exists, is marker-based (never positional), and is the designated single source of truth from B-BONUS-QUESTION-STANDARDIZE-01. No migration, no `target_size`, no dependency on anything in flight.

`hasPendingSlot` is **deliberately unchanged** — navigation must still see bonus slots, because the player can still play them. Only the completeness *verdict* is core-scoped.

## What this reverses, precisely

Two reads settled this, and they split — so both halves are stated rather than the convenient one.

**It IS a real reversal.** The disputed test block was added **2026-06-01** in the +2 commit itself ("Daily Five +2: append accessible friend-answered bonus slots"), and its fixtures used the then-current bonus marker `answerer_id` — replaced by `presence_source_id` a day later on 2026-06-02. So it **knowingly** asserted that an unanswered bonus slot holds the round open. This is not a stale test and not a restoration of original intent.

**But the stated concern is fully preserved.** The comment's actual worry — *"track the ACTUAL slot count, not a fixed five"* — survives intact, because **skip replacements are core**: they're built by `buildBotSlot`, which sets neither `presence_source_id` nor `return_scope`, so `getCoreSlots` classifies them as core. A skip-extended 6-slot queue still has 6 core slots and still needs all six resolved. Pinned by a new test that fails if a replacement ever starts carrying a marker.

So: the *variable-length* half is preserved; the *bonus-holds-the-round-open* half is deliberately reversed. Bonus is opt-in by canon everywhere else — `getCoreSlots` treats malformed slots as core precisely because bonus is opt-in — and "you must play the bonus to finish" contradicts every other place the distinction is made.

## Precondition of the bonus deferral

Under deferral, bonus slots are appended **after** the queue is persisted and being played:

1. Queue persists with 5 core. Player answers all five. Complete → **true**.
2. Deferred bonus generation lands, appends 2 slots with `answered: false`.
3. Complete → **false**.

Completeness would flip back *after the player finished*. A1a removes that, so it lands before the deferral, not after.

## Scope limits, stated

- **A short queue (3 core, 3 answered) still reads complete.** That's under-delivery, not stranding; it needs `target_size` compared at persist (A1b, strictly after `0137` → write-at-persist). Pinned in a test so A1b's arrival is visible. 39 queues are in that population.
- **Pre-marker queues are not fixed.** The bonus marker first appears 2026-06-04; 117 of 309 queues (38%) predate it and classify as all-core, so their bonus slots still read as core and stay stranded. Nothing to do — they're old rounds. It also means 5/228 is a *lower bound* on historical incidence, though the correct forward rate, since every new queue carries markers.
- **No backfill.** The 5 stranded queues become complete on read once deployed, since completeness is derived, not stored. Nothing recovers the replenish calls they missed.

## Also included

`DAILY_SKIP_LIMIT`'s docstring said "capped at 3 skips per round" while the constant has been 5. Truth repair, code beats comment.

## What was exercised

- **502 tests pass**, 14 skipped, across `src/server/daily` and `src/app/api/daily` — status route, answer route, catchup, bonus helpers.
- 9 new tests for the core-only rule: the exact production shape, return slots, the `hasPendingSlot` guard, the degenerate no-core fallback, and the skip-replacement guarantee.
- Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJwiXeNJPqExdRGRdZGrTh
