### PR TITLE
Fix phone verification for SMS reminders

### DIFF
--- a/src/app/api/account/phone/verify/__tests__/route.test.ts
+++ b/src/app/api/account/phone/verify/__tests__/route.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ReminderState } from '@/server/db/queries/account';
+
+const {
+  getSessionMock,
+  getReminderStateMock,
+  markPhoneVerifiedMock,
+  getOtpBypassCodeForPhoneMock,
+  requestOtpMock,
+  verifyOtpMock,
+  sendSmsMock,
+} = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  getReminderStateMock: vi.fn(),
+  markPhoneVerifiedMock: vi.fn(),
+  getOtpBypassCodeForPhoneMock: vi.fn(),
+  requestOtpMock: vi.fn(),
+  verifyOtpMock: vi.fn(),
+  sendSmsMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/auth', () => ({
+  getOtpBypassCodeForPhone: getOtpBypassCodeForPhoneMock,
+  requestOtp: requestOtpMock,
+  verifyOtp: verifyOtpMock,
+}));
+vi.mock('@/server/db/queries/account', () => ({
+  getReminderState: getReminderStateMock,
+  markPhoneVerified: markPhoneVerifiedMock,
+}));
+vi.mock('@/server/sms', () => ({
+  buildOtpMessage: (code: string) => `Verification code: ${code}`,
+  sendSms: sendSmsMock,
+}));
+
+import { POST } from '@/app/api/account/phone/verify/route';
+
+const unverifiedState: ReminderState = {
+  smsOptIn: 'not_asked',
+  emailOptIn: 'not_asked',
+  phoneVerified: false,
+  emailVerified: false,
+  email: null,
+  pendingEmail: null,
+  phoneNumber: '+12025550147',
+  smsOptInAt: null,
+  smsOptOutAt: null,
+  smsConsentSource: null,
+  smsConsentPolicyVersion: null,
+  reminderPromptDismissedAt: null,
+  reminderInterstitialSeenAt: null,
+};
+
+const verifiedState: ReminderState = { ...unverifiedState, phoneVerified: true };
+
+function request(body: unknown) {
+  return new Request('https://joshing.test/api/account/phone/verify', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('/api/account/phone/verify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ userId: 'user-1' });
+    getReminderStateMock.mockResolvedValue(unverifiedState);
+    markPhoneVerifiedMock.mockResolvedValue(verifiedState);
+    getOtpBypassCodeForPhoneMock.mockReturnValue(null);
+    requestOtpMock.mockResolvedValue({ code: '123456', normalizedPhone: '+12025550147' });
+    verifyOtpMock.mockResolvedValue('+12025550147');
+    sendSmsMock.mockResolvedValue({ ok: true });
+  });
+
+  it('sends a code to the signed-in account phone number', async () => {
+    const response = await POST(request({ action: 'send' }));
+
+    expect(response.status).toBe(200);
+    expect(requestOtpMock).toHaveBeenCalledWith('+12025550147');
+    expect(sendSmsMock).toHaveBeenCalledWith(
+      '+12025550147',
+      'Verification code: 123456',
+      'otp',
+      'user-1',
+    );
+  });
+
+  it('marks the account phone verified after a valid code', async () => {
+    const response = await POST(request({ action: 'confirm', code: '123456' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ verified: true, state: verifiedState });
+    expect(verifyOtpMock).toHaveBeenCalledWith('+12025550147', '123456');
+    expect(markPhoneVerifiedMock).toHaveBeenCalledWith('user-1');
+  });
+
+  it('rejects an invalid code without changing the account', async () => {
+    verifyOtpMock.mockResolvedValue(null);
+
+    const response = await POST(request({ action: 'confirm', code: '999999' }));
+
+    expect(response.status).toBe(401);
+    expect(markPhoneVerifiedMock).not.toHaveBeenCalled();
+  });
+
+  it('does not send another code when the phone is already verified', async () => {
+    getReminderStateMock.mockResolvedValue(verifiedState);
+
+    const response = await POST(request({ action: 'send' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ verified: true, state: verifiedState });
+    expect(requestOtpMock).not.toHaveBeenCalled();
+    expect(sendSmsMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/account/phone/verify/route.ts
+++ b/src/app/api/account/phone/verify/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getOtpBypassCodeForPhone, requestOtp, verifyOtp } from '@/server/auth';
+import { getSession } from '@/server/auth/session';
+import { getReminderState, markPhoneVerified } from '@/server/db/queries/account';
+import { buildOtpMessage, sendSms } from '@/server/sms';
+
+const bodySchema = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('send') }),
+  z.object({
+    action: z.literal('confirm'),
+    code: z
+      .string()
+      .trim()
+      .regex(/^\d{6}$/),
+  }),
+]);
+
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_request', message: 'Enter the 6-digit verification code.' },
+      { status: 400 },
+    );
+  }
+
+  const state = await getReminderState(session.userId);
+  if (!state) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  if (state.phoneVerified) {
+    return NextResponse.json({ ok: true, verified: true, state });
+  }
+
+  if (parsed.data.action === 'send') {
+    const bypassCode = getOtpBypassCodeForPhone(state.phoneNumber);
+    const code = bypassCode ?? (await requestOtp(state.phoneNumber)).code;
+    const delivery = bypassCode
+      ? { ok: true as const }
+      : await sendSms(state.phoneNumber, buildOtpMessage(code), 'otp', session.userId);
+
+    if (process.env.NODE_ENV === 'production' && !delivery.ok) {
+      return NextResponse.json(
+        { error: 'sms_delivery_failed', message: 'Unable to send code. Please try again.' },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      verified: false,
+      ...(process.env.NODE_ENV !== 'production' ? { debugCode: code } : {}),
+    });
+  }
+
+  const verifiedPhone = await verifyOtp(state.phoneNumber, parsed.data.code);
+  if (verifiedPhone !== state.phoneNumber) {
+    return NextResponse.json(
+      { error: 'invalid_code', message: 'Code invalid or expired.' },
+      { status: 401 },
+    );
+  }
+
+  const updatedState = await markPhoneVerified(session.userId);
+  if (!updatedState) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  return NextResponse.json({ ok: true, verified: true, state: updatedState });
+}

--- a/src/app/api/account/reminders/__tests__/route.test.ts
+++ b/src/app/api/account/reminders/__tests__/route.test.ts
@@ -35,6 +35,7 @@ import { PATCH } from '@/app/api/account/reminders/route';
 const baseState: ReminderState = {
   smsOptIn: 'not_asked',
   emailOptIn: 'not_asked',
+  phoneVerified: true,
   emailVerified: false,
   email: null,
   pendingEmail: null,

--- a/src/app/api/auth/verify-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/verify-otp/__tests__/route.test.ts
@@ -19,6 +19,11 @@ const {
     async () => [] as Array<Record<string, unknown>>
   )
   const dbMock = {
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(async () => undefined),
+      })),
+    })),
     insert: vi.fn(() => ({
       values: vi.fn(() => ({
         onConflictDoNothing: vi.fn(() => ({
@@ -67,6 +72,8 @@ vi.mock('@/server/db', () => ({
     handle: 'users.handle',
     timezone: 'users.timezone',
     onboardingComplete: 'users.onboardingComplete',
+    phoneVerified: 'users.phoneVerified',
+    updatedAt: 'users.updatedAt',
   },
 }))
 

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -99,7 +99,13 @@ async function provisionUserForPhone(
   const phoneHash = computePhoneHash(phoneNumber)
   const [created] = await db
     .insert(users)
-    .values({ id, phoneNumber, avatarColor: colorForUser(id), phoneHash })
+    .values({
+      id,
+      phoneNumber,
+      phoneVerified: true,
+      avatarColor: colorForUser(id),
+      phoneHash,
+    })
     .onConflictDoNothing({ target: users.phoneNumber })
     .returning(USER_SELECTION)
 
@@ -192,6 +198,14 @@ export async function POST(request: Request) {
     // gate was added are grandfathered — they re-authenticate freely. Only
     // brand-new accounts must arrive via an accepted friend invitation.
     if (existingUser) {
+      // A successful OTP proves possession of the account phone number. Older
+      // versions authenticated the user but left phone_verified false, which
+      // made the SMS-reminder gate impossible to satisfy after login.
+      await db
+        .update(users)
+        .set({ phoneVerified: true, updatedAt: new Date() })
+        .where(eq(users.id, existingUser.id))
+
       let invitationResult: { accepted: boolean } = { accepted: false }
 
       if (hasUsableToken) {

--- a/src/components/profile/settings/NotificationsForm.tsx
+++ b/src/components/profile/settings/NotificationsForm.tsx
@@ -90,6 +90,10 @@ export function NotificationsForm({ initialState, phone }: Props) {
   const [savingSms, setSavingSms] = useState(false);
   const [smsNotice, setSmsNotice] = useState<string | null>(null);
   const [smsError, setSmsError] = useState<string | null>(null);
+  const [phoneVerificationStep, setPhoneVerificationStep] = useState<'idle' | 'code'>('idle');
+  const [phoneCode, setPhoneCode] = useState('');
+  const [sendingPhoneCode, setSendingPhoneCode] = useState(false);
+  const [verifyingPhoneCode, setVerifyingPhoneCode] = useState(false);
 
   const smsOn = state.smsOptIn === 'opted_in';
   const emailOn = state.emailOptIn === 'opted_in';
@@ -161,6 +165,11 @@ export function NotificationsForm({ initialState, phone }: Props) {
   }
 
   async function toggleSms(checked: boolean) {
+    if (checked && !state.phoneVerified) {
+      setSmsError('Verify your phone number before enabling SMS reminders.');
+      return;
+    }
+
     setSavingSms(true);
     setSmsError(null);
     setSmsNotice(null);
@@ -179,6 +188,68 @@ export function NotificationsForm({ initialState, phone }: Props) {
           : 'Daily SMS reminders are on.'
         : 'Daily SMS reminders are off.',
     );
+  }
+
+  async function sendPhoneVerificationCode() {
+    setSendingPhoneCode(true);
+    setSmsError(null);
+    setSmsNotice(null);
+    const response = await fetch('/api/account/phone/verify', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ action: 'send' }),
+    });
+    const json = (await response.json().catch(() => null)) as {
+      message?: string;
+      verified?: boolean;
+      state?: ReminderState;
+    } | null;
+    setSendingPhoneCode(false);
+
+    if (!response.ok) {
+      setSmsError(json?.message ?? 'Unable to send a verification code.');
+      return;
+    }
+    if (json?.verified && json.state) {
+      setState(json.state);
+      setSmsNotice('Phone number verified. You can turn on SMS reminders.');
+      return;
+    }
+    setPhoneVerificationStep('code');
+    setSmsNotice(`We sent a 6-digit code to ${phone}.`);
+  }
+
+  async function confirmPhoneVerification() {
+    const code = phoneCode.trim();
+    if (!/^\d{6}$/.test(code)) {
+      setSmsError('Enter the 6-digit verification code.');
+      return;
+    }
+
+    setVerifyingPhoneCode(true);
+    setSmsError(null);
+    const response = await fetch('/api/account/phone/verify', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ action: 'confirm', code }),
+    });
+    const json = (await response.json().catch(() => null)) as {
+      message?: string;
+      state?: ReminderState;
+    } | null;
+    setVerifyingPhoneCode(false);
+
+    if (!response.ok || !json?.state) {
+      setSmsError(json?.message ?? 'Unable to verify that code.');
+      return;
+    }
+
+    setState(json.state);
+    setPhoneCode('');
+    setPhoneVerificationStep('idle');
+    setSmsNotice('Phone number verified. You can now turn on SMS reminders.');
   }
 
   async function resendEmail() {
@@ -231,6 +302,59 @@ export function NotificationsForm({ initialState, phone }: Props) {
           <p className="text-muted-foreground mt-3 text-xs" role="status" aria-live="polite">
             Saving SMS reminder preference…
           </p>
+        ) : null}
+        {!state.phoneVerified ? (
+          <div className="mt-4 rounded-lg border border-[var(--accent-gold)]/50 bg-[var(--brand-field)] p-3">
+            <p className="text-sm font-medium">Verify your phone to turn on SMS reminders.</p>
+            {phoneVerificationStep === 'idle' ? (
+              <button
+                type="button"
+                className="btn-primary mt-3"
+                onClick={() => void sendPhoneVerificationCode()}
+                disabled={sendingPhoneCode}
+              >
+                {sendingPhoneCode ? 'Sending…' : 'Send verification code'}
+              </button>
+            ) : (
+              <div className="mt-3 space-y-2">
+                <label htmlFor="phone-verification-code" className="block text-xs font-medium">
+                  6-digit code
+                </label>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <input
+                    id="phone-verification-code"
+                    type="text"
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    maxLength={6}
+                    value={phoneCode}
+                    onChange={(event) => {
+                      setPhoneCode(event.target.value.replace(/\D/g, '').slice(0, 6));
+                      setSmsError(null);
+                    }}
+                    className="h-10 min-w-0 flex-1 rounded-lg border border-[var(--accent-gold)] bg-[var(--brand-card)] px-3 text-center tracking-[0.25em]"
+                    aria-describedby="sms-reminder-consent"
+                  />
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    onClick={() => void confirmPhoneVerification()}
+                    disabled={verifyingPhoneCode}
+                  >
+                    {verifyingPhoneCode ? 'Verifying…' : 'Verify phone'}
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  className="text-xs font-medium underline-offset-2 hover:underline disabled:opacity-50"
+                  onClick={() => void sendPhoneVerificationCode()}
+                  disabled={sendingPhoneCode}
+                >
+                  {sendingPhoneCode ? 'Sending…' : 'Send a new code'}
+                </button>
+              </div>
+            )}
+          </div>
         ) : null}
         {smsNotice ? (
           <p className="mt-3 text-xs text-[var(--success)]" role="status" aria-live="polite">

--- a/src/components/profile/settings/__tests__/NotificationsForm.sms.test.tsx
+++ b/src/components/profile/settings/__tests__/NotificationsForm.sms.test.tsx
@@ -10,6 +10,7 @@ import type { ReminderState } from '@/server/db/queries/account';
 const initialState: ReminderState = {
   smsOptIn: 'not_asked',
   emailOptIn: 'not_asked',
+  phoneVerified: false,
   emailVerified: false,
   email: null,
   pendingEmail: null,
@@ -40,6 +41,8 @@ describe('NotificationsForm SMS consent', () => {
     expect(html).toContain('Consent is not a condition of purchase');
     expect(html).toContain('href="/terms"');
     expect(html).toContain('href="/privacy"');
+    expect(html).toContain('Verify your phone to turn on SMS reminders');
+    expect(html).toContain('Send verification code');
     expect(html).not.toContain('Coming soon');
   });
 

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -201,6 +201,7 @@ export function buildSmsConsentAuditPatch(
 export type ReminderState = {
   smsOptIn: ReminderOptInState;
   emailOptIn: ReminderOptInState;
+  phoneVerified: boolean;
   emailVerified: boolean;
   email: string | null;
   pendingEmail: string | null;
@@ -221,6 +222,7 @@ export async function getReminderState(userId: string): Promise<ReminderState | 
     .select({
       smsOptIn: users.smsOptIn,
       emailOptIn: users.emailOptIn,
+      phoneVerified: users.phoneVerified,
       emailVerified: users.emailVerified,
       email: users.email,
       pendingEmail: users.pendingEmail,
@@ -241,6 +243,7 @@ export async function getReminderState(userId: string): Promise<ReminderState | 
   return {
     smsOptIn: row.smsOptIn,
     emailOptIn: row.emailOptIn,
+    phoneVerified: row.phoneVerified,
     emailVerified: row.emailVerified,
     email: row.email,
     pendingEmail: row.pendingEmail,
@@ -252,6 +255,15 @@ export async function getReminderState(userId: string): Promise<ReminderState | 
     reminderPromptDismissedAt: row.reminderPromptDismissedAt?.toISOString() ?? null,
     reminderInterstitialSeenAt: row.reminderInterstitialSeenAt?.toISOString() ?? null,
   };
+}
+
+export async function markPhoneVerified(userId: string): Promise<ReminderState | null> {
+  await db
+    .update(users)
+    .set({ phoneVerified: true, updatedAt: new Date() })
+    .where(eq(users.id, userId));
+
+  return getReminderState(userId);
 }
 
 export type ReminderPreferenceUpdate = {


### PR DESCRIPTION
## Summary
- add an inline phone verification flow to Notifications
- persist phone verification after successful OTP authentication
- add API and regression coverage

## Verification
- 27 focused tests pass
- TypeScript check passes
- ESLint passes with 4 pre-existing warnings
- mobile layout verified at 390x844