### PR TITLE
Allow multiple test accounts in the OTP bypass allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,11 +146,13 @@ TWILIO_ACCOUNT_SID=""
 TWILIO_AUTH_TOKEN=""
 TWILIO_MESSAGING_SERVICE_SID=""
 
-# Temporary, narrowly scoped escape hatch for a walkthrough account while SMS
-# delivery is unavailable. When BOTH values are valid, request-otp skips Twilio
-# only for this US number and verify-otp accepts only this 6-digit code. Leave
-# both unset for normal behavior, and remove them as soon as Twilio is approved.
-# AUTH_OTP_BYPASS_PHONE="+15551234567"
+# Temporary, narrowly scoped escape hatch for test/QA accounts. When BOTH
+# values are valid, request-otp skips Twilio only for these US numbers and
+# verify-otp accepts only this shared 6-digit code. AUTH_OTP_BYPASS_PHONE takes
+# a comma-separated list (a single number also still works). Leave both unset
+# for normal behavior, and remove them as soon as the accounts are no longer
+# needed for testing.
+# AUTH_OTP_BYPASS_PHONE="+15551111111,+15552222222"
 # AUTH_OTP_BYPASS_CODE="000000"
 
 # ── Email (Resend) ────────────────────────────────────────────

--- a/src/server/auth/__tests__/otp-bypass.test.ts
+++ b/src/server/auth/__tests__/otp-bypass.test.ts
@@ -22,4 +22,13 @@ describe('getOtpBypassCodeForPhone', () => {
     expect(getOtpBypassCodeForPhone('+15551234567')).toBe('654321');
     expect(getOtpBypassCodeForPhone('+15557654321')).toBeNull();
   });
+
+  it('accepts a comma-separated list of allowlisted phones sharing one code', () => {
+    vi.stubEnv('AUTH_OTP_BYPASS_PHONE', '+15551111111, (555) 222-2222');
+    vi.stubEnv('AUTH_OTP_BYPASS_CODE', '000000');
+
+    expect(getOtpBypassCodeForPhone('+15551111111')).toBe('000000');
+    expect(getOtpBypassCodeForPhone('+15552222222')).toBe('000000');
+    expect(getOtpBypassCodeForPhone('+15553333333')).toBeNull();
+  });
 });

--- a/src/server/auth/otp-bypass.ts
+++ b/src/server/auth/otp-bypass.ts
@@ -1,22 +1,26 @@
 import { isUsPhoneNumber, normalizePhone } from './phone';
 
 /**
- * Return the temporary OTP bypass code only for the explicitly allowlisted
- * phone. Both values are required so enabling the bypass is deliberate and
- * scoped to one test account.
+ * Return the temporary OTP bypass code only for an explicitly allowlisted
+ * phone. AUTH_OTP_BYPASS_PHONE takes a comma-separated list of one or more
+ * numbers (a single number, the original shape, still works) so multiple test
+ * accounts can share one bypass code without a real SMS ever sending. The
+ * code is still required alongside at least one valid phone, so enabling the
+ * bypass is deliberate and scoped to allowlisted test accounts only.
  */
 export function getOtpBypassCodeForPhone(phone: string): string | null {
-  const configuredPhone = process.env.AUTH_OTP_BYPASS_PHONE?.trim();
+  const configuredPhones = (process.env.AUTH_OTP_BYPASS_PHONE ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && isUsPhoneNumber(entry));
   const configuredCode = process.env.AUTH_OTP_BYPASS_CODE?.trim();
 
-  if (
-    !configuredPhone ||
-    !configuredCode ||
-    !isUsPhoneNumber(configuredPhone) ||
-    !/^\d{6}$/.test(configuredCode)
-  ) {
+  if (configuredPhones.length === 0 || !configuredCode || !/^\d{6}$/.test(configuredCode)) {
     return null;
   }
 
-  return normalizePhone(phone) === normalizePhone(configuredPhone) ? configuredCode : null;
+  const normalizedPhone = normalizePhone(phone);
+  return configuredPhones.some((configured) => normalizePhone(configured) === normalizedPhone)
+    ? configuredCode
+    : null;
 }


### PR DESCRIPTION
## Summary
- `AUTH_OTP_BYPASS_PHONE` now accepts a comma-separated list of US numbers (a single number, the original shape, still works), all sharing one `AUTH_OTP_BYPASS_CODE`.
- The old single-number regex rejected any comma-joined value outright, so setting `AUTH_OTP_BYPASS_PHONE` to two numbers silently disabled the bypass entirely and fell through to a real (and undeliverable, for a fake 555 test number) Twilio send.
- This surfaced live: `AUTH_OTP_BYPASS_PHONE="+15551111111,+15552222222"` was set in production for two new QA test accounts and hit exactly this failure ("Unable to send code").

## Test plan
- [x] `npx vitest run src/server/auth` — 27/27 passing, including a new case for the comma-separated list
- [x] `npx tsc -p tsconfig.typecheck.json --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A