### PR TITLE
Fix invite-link topic swap, extend OTP bypass, decouple reminder toast

### DIFF
--- a/src/app/api/account/reminders/__tests__/route.test.ts
+++ b/src/app/api/account/reminders/__tests__/route.test.ts
@@ -143,6 +143,22 @@ describe('SMS reminder opt-in confirmation', () => {
     expect(restoreSmsReminderConsentMock).toHaveBeenCalledWith('user-1', baseState);
   });
 
+  it('skips the real send for an allowlisted test phone', async () => {
+    vi.stubEnv('AUTH_OTP_BYPASS_PHONE', baseState.phoneNumber ?? '');
+    vi.stubEnv('AUTH_OTP_BYPASS_CODE', '000000');
+
+    const response = await PATCH(patchRequest({
+      smsOptIn: 'opted_in',
+      smsConsentSource: 'onboarding_web_form',
+    }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ smsConfirmationSent: true });
+    expect(sendSmsMock).not.toHaveBeenCalled();
+
+    vi.unstubAllEnvs();
+  });
+
   it('requires a source for every SMS opt-in', async () => {
     const response = await PATCH(patchRequest({ smsOptIn: 'opted_in' }));
 

--- a/src/app/api/account/reminders/route.ts
+++ b/src/app/api/account/reminders/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
+import { isBypassTestPhone } from '@/server/auth';
 import { getSession } from '@/server/auth/session';
 import {
   getReminderState,
@@ -90,12 +91,17 @@ export async function PATCH(request: Request) {
 
   let smsConfirmationSent = false;
   if (result.ok && parsed.data.smsOptIn === 'opted_in' && priorState?.smsOptIn !== 'opted_in') {
-    const sendResult = await sendSms(
-      result.state.phoneNumber,
-      buildSmsOptInConfirmationMessage(),
-      'sms_opt_in_confirmation',
-      session.userId,
-    );
+    // Allowlisted test numbers (AUTH_OTP_BYPASS_PHONE) skip the real send —
+    // same test accounts that bypass the OTP text also need to reach
+    // opted_in without a live Twilio delivery to an undeliverable number.
+    const sendResult = isBypassTestPhone(result.state.phoneNumber)
+      ? ({ ok: true } as const)
+      : await sendSms(
+          result.state.phoneNumber,
+          buildSmsOptInConfirmationMessage(),
+          'sms_opt_in_confirmation',
+          session.userId,
+        );
     if (!sendResult.ok) {
       const rollback = priorState
         ? await restoreSmsReminderConsent(session.userId, priorState)

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -22,6 +22,7 @@ import { AnswerInputBar } from '@/components/play/AnswerInputBar';
 import { NotForMeSheet } from '@/components/daily/NotForMeSheet';
 import LoadingScreen from '@/components/LoadingScreen';
 import { useLoadingMoments } from '@/components/loading-moment/useLoadingMoment';
+import { ReminderConfirmedToast } from '@/components/ReminderConfirmedToast';
 import { categoryLabel, type InsideJokeKind } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
 import {
@@ -247,10 +248,13 @@ export default function DailyPage() {
   // generation wait is in progress (the long-wait surface, C-7). Reads cached-
   // only data; empty on a cold cache → the loader just rotates the craft phrases.
   const loadingMoments = useLoadingMoments(loading && generatingAttempt != null);
-  // Set when onboarding's final reminder ask was accepted, so the crafting
-  // loader can confirm it. Read once from the one-time `remindersOn` handoff
-  // param and then stripped from the URL — a plain useEffect read (not
-  // useSearchParams) so this page doesn't need a Suspense boundary.
+  // Set when onboarding's final reminder ask was accepted, so this page can
+  // confirm it via ReminderConfirmedToast — rendered unconditionally (not
+  // tied to the crafting screen still being up), since a fast build means
+  // generation is often already done by the time the player lands here. Read
+  // once from the one-time `remindersOn` handoff param and then stripped from
+  // the URL — a plain useEffect read (not useSearchParams) so this page
+  // doesn't need a Suspense boundary.
   const [justOptedIntoReminders, setJustOptedIntoReminders] = useState(false);
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -968,6 +972,7 @@ export default function DailyPage() {
 
   return (
     <main className="relative mx-auto flex min-h-dvh max-w-lg flex-col overflow-hidden bg-[var(--surface)] bg-[url('/images/Variant4.png')] bg-repeat px-0">
+      <ReminderConfirmedToast show={justOptedIntoReminders} />
       {/* Brand triangle pattern (same artwork as the login screen / home feed)
           tiled full-strength behind the game. No cream scrim — the gameplay
           thread is entirely cards, which sit opaque on top; the sticky header
@@ -1021,11 +1026,6 @@ export default function DailyPage() {
               fullScreen
               messages={GENERATING_MESSAGES}
               loadingMoments={loadingMoments}
-              note={
-                justOptedIntoReminders
-                  ? "You're set — we'll text you when each day's five open."
-                  : undefined
-              }
             />
           ) : (
             <LoadingScreen fullScreen label="Loading today" />

--- a/src/app/dev/onboarding/building/page.tsx
+++ b/src/app/dev/onboarding/building/page.tsx
@@ -1,4 +1,5 @@
 import LoadingScreen from '@/components/LoadingScreen';
+import { ReminderConfirmedToast } from '@/components/ReminderConfirmedToast';
 
 import { WalkthroughAdvance } from './WalkthroughAdvance';
 
@@ -11,7 +12,9 @@ export const dynamic = 'force-dynamic';
  * land here — on `/daily`, whose own load path shows this same `LoadingScreen`
  * while the first queue finishes generating. `?remindersOn=1` (set by the
  * onboarding harness when the reminder ask was accepted) mirrors the real
- * `/daily?remindersOn=1` handoff and renders the confirming note. In `?walk=1`
+ * `/daily?remindersOn=1` handoff and renders the same ReminderConfirmedToast
+ * production does — unconditionally, not tied to this loading screen still
+ * being up, since a fast build often means it never shows at all. In `?walk=1`
  * (full-walkthrough) mode it pauses on the build, then advances to the
  * first-session recap — the "first time finished" stage. (Real play itself
  * can't be faithfully stubbed, so the walkthrough brackets it.)
@@ -27,15 +30,8 @@ export default async function DevBuildingPage({
 
   return (
     <main className="min-h-dvh">
-      <LoadingScreen
-        fullScreen
-        label="Building your first five…"
-        note={
-          remindersOn
-            ? "You're set — we'll text you when each day's five open."
-            : undefined
-        }
-      />
+      <ReminderConfirmedToast show={remindersOn} />
+      <LoadingScreen fullScreen label="Building your first five…" />
       {walk ? <WalkthroughAdvance nextHref="/dev/first-time-player" /> : null}
     </main>
   );

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -26,12 +26,6 @@ type LoadingScreenProps = {
    * cached-only data off the critical path; this component never fetches.
    */
   loadingMoments?: ResolvedLoadingMoment[];
-  /**
-   * A short reassurance shown below the card, outside the rotating copy slot
-   * (e.g. confirming a reminder opt-in just taken on the screen before this
-   * one). Static — never rotates, never resizes the card above it.
-   */
-  note?: string;
 };
 
 type RotationItem =
@@ -157,7 +151,6 @@ export default function LoadingScreen({
   fullScreen = false,
   loadingMoment = null,
   loadingMoments,
-  note,
 }: LoadingScreenProps) {
   const triangles = React.useMemo(() => buildTriangles(), []);
   const reducedMotion = usePrefersReducedMotion();
@@ -201,7 +194,7 @@ export default function LoadingScreen({
     currentItem.kind === "moment" ? currentItem.moment.artifact : currentItem.text;
 
   const wrapperClass = [
-    "isolate flex flex-col items-center justify-center gap-4 overflow-hidden bg-[var(--brand-cream-page)]",
+    "isolate flex items-center justify-center overflow-hidden bg-[var(--brand-cream-page)]",
     fullScreen
       ? "fixed inset-0 z-[var(--z-takeover)]"
       : "relative h-full w-full min-h-[480px]",
@@ -332,12 +325,6 @@ export default function LoadingScreen({
         </p>
         )}
       </div>
-
-      {note ? (
-        <p className="border-[var(--brand-border)] bg-[var(--brand-cream-card)] shadow-[var(--shadow-card)] relative z-10 mx-6 max-w-xs rounded-full border px-4 py-2 text-center text-xs font-semibold leading-snug text-[var(--brand-ink-700)]">
-          {note}
-        </p>
-      ) : null}
     </div>
   );
 }

--- a/src/components/ReminderConfirmedToast.tsx
+++ b/src/components/ReminderConfirmedToast.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+// The onboarding reminder-ask's confirmation, decoupled from whether the
+// crafting screen ever shows. It used to live inside LoadingScreen's
+// generating-only branch, so a fast build (generation already done by the
+// time the player lands here) meant the confirmation never rendered at all.
+// This renders unconditionally on first mount instead, then self-dismisses —
+// present whether the player is still watching the crafting screen or
+// already looking at their first question.
+export function ReminderConfirmedToast({ show }: { show: boolean }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (!show) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reacting to the parent's own one-time URL-param read, not derived render state.
+    setVisible(true)
+    const timer = window.setTimeout(() => setVisible(false), 1800)
+    return () => window.clearTimeout(timer)
+  }, [show])
+
+  if (!visible) return null
+  return (
+    <div className="fixed bottom-24 left-1/2 z-[var(--z-toast)] -translate-x-1/2 rounded-full bg-foreground px-4 py-2 text-sm text-background shadow-lg md:bottom-8">
+      You&rsquo;re set &mdash; we&rsquo;ll text you when each day&rsquo;s five open.
+    </div>
+  )
+}

--- a/src/components/friends/InviteLinksSection.tsx
+++ b/src/components/friends/InviteLinksSection.tsx
@@ -304,10 +304,10 @@ export function InviteLinksSection({ initialTopics, initialLinks }: Props) {
                     type="button"
                     disabled={locked}
                     onClick={() => void removeTopic(topic.label)}
-                    aria-label={`Swap out ${topic.label}`}
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-30 px-3 text-lg"
+                    aria-label={`Swap out ${topic.label} for something else`}
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-30 px-3 text-xs font-medium underline underline-offset-2"
                   >
-                    ×
+                    Swap
                   </button>
                 </div>
               )
@@ -334,7 +334,12 @@ export function InviteLinksSection({ initialTopics, initialLinks }: Props) {
                 ) : null}
               </span>
               <span className="text-sm font-semibold">
-                No category <span className="text-muted-foreground text-xs font-medium">carries all your topics</span>
+                No category{' '}
+                <span className="text-muted-foreground text-xs font-medium">
+                  {topics.length > 0
+                    ? `carries all ${topics.length} topic${topics.length === 1 ? '' : 's'} above`
+                    : 'carries your most-played topics'}
+                </span>
               </span>
             </button>
           </div>
@@ -361,7 +366,14 @@ export function InviteLinksSection({ initialTopics, initialLinks }: Props) {
                 + Create your own
               </button>
             )
-          ) : null}
+          ) : (
+            // At the 3-topic cap the add flow isn't gone, just one step away —
+            // say so instead of rendering nothing, since a bare "×" glyph
+            // above doesn't read as "this reopens adding."
+            <p className="text-muted-foreground text-center text-xs">
+              All 3 topics are taken. Tap Swap above to trade one for something new.
+            </p>
+          )}
 
           {createError ? <p className="text-destructive text-sm">{createError}</p> : null}
 

--- a/src/server/auth/__tests__/otp-bypass.test.ts
+++ b/src/server/auth/__tests__/otp-bypass.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getOtpBypassCodeForPhone } from '@/server/auth/otp-bypass';
+import { getOtpBypassCodeForPhone, isBypassTestPhone } from '@/server/auth/otp-bypass';
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -30,5 +30,24 @@ describe('getOtpBypassCodeForPhone', () => {
     expect(getOtpBypassCodeForPhone('+15551111111')).toBe('000000');
     expect(getOtpBypassCodeForPhone('+15552222222')).toBe('000000');
     expect(getOtpBypassCodeForPhone('+15553333333')).toBeNull();
+  });
+});
+
+describe('isBypassTestPhone', () => {
+  it('is disabled unless both a valid US phone and six-digit code are configured', () => {
+    vi.stubEnv('AUTH_OTP_BYPASS_PHONE', '+15551234567');
+    expect(isBypassTestPhone('+15551234567')).toBe(false);
+
+    vi.stubEnv('AUTH_OTP_BYPASS_CODE', 'not-a-code');
+    expect(isBypassTestPhone('+15551234567')).toBe(false);
+  });
+
+  it('matches the same allowlist as getOtpBypassCodeForPhone, without needing the code', () => {
+    vi.stubEnv('AUTH_OTP_BYPASS_PHONE', '+15551111111, (555) 222-2222');
+    vi.stubEnv('AUTH_OTP_BYPASS_CODE', '000000');
+
+    expect(isBypassTestPhone('+15551111111')).toBe(true);
+    expect(isBypassTestPhone('+15552222222')).toBe(true);
+    expect(isBypassTestPhone('+15553333333')).toBe(false);
   });
 });

--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -6,4 +6,4 @@
 export { createSession, getSession, getSessionToken, validateSessionToken, destroySession } from './session';
 export { getCurrentUser, requireUser } from './user';
 export { requestOtp, verifyOtp, getStoredCodeForPhone, isUsPhoneNumber, normalizePhone } from './otp-store';
-export { getOtpBypassCodeForPhone } from './otp-bypass';
+export { getOtpBypassCodeForPhone, isBypassTestPhone } from './otp-bypass';

--- a/src/server/auth/otp-bypass.ts
+++ b/src/server/auth/otp-bypass.ts
@@ -1,26 +1,46 @@
 import { isUsPhoneNumber, normalizePhone } from './phone';
 
-/**
- * Return the temporary OTP bypass code only for an explicitly allowlisted
- * phone. AUTH_OTP_BYPASS_PHONE takes a comma-separated list of one or more
- * numbers (a single number, the original shape, still works) so multiple test
- * accounts can share one bypass code without a real SMS ever sending. The
- * code is still required alongside at least one valid phone, so enabling the
- * bypass is deliberate and scoped to allowlisted test accounts only.
- */
-export function getOtpBypassCodeForPhone(phone: string): string | null {
-  const configuredPhones = (process.env.AUTH_OTP_BYPASS_PHONE ?? '')
+// AUTH_OTP_BYPASS_PHONE takes a comma-separated list of one or more numbers
+// (a single number, the original shape, still works), all sharing one
+// AUTH_OTP_BYPASS_CODE. The code is the single on/off switch for the whole
+// mechanism — an empty/invalid code disables it regardless of the phone list,
+// so enabling it is always a deliberate, explicit choice.
+function getBypassPhones(): string[] {
+  return (process.env.AUTH_OTP_BYPASS_PHONE ?? '')
     .split(',')
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0 && isUsPhoneNumber(entry));
-  const configuredCode = process.env.AUTH_OTP_BYPASS_CODE?.trim();
+}
 
-  if (configuredPhones.length === 0 || !configuredCode || !/^\d{6}$/.test(configuredCode)) {
-    return null;
-  }
+function bypassEnabled(): boolean {
+  const code = process.env.AUTH_OTP_BYPASS_CODE?.trim();
+  return Boolean(code && /^\d{6}$/.test(code));
+}
+
+/**
+ * Return the shared bypass code only for an explicitly allowlisted phone —
+ * lets request-otp/verify-otp skip Twilio entirely for test accounts.
+ */
+export function getOtpBypassCodeForPhone(phone: string): string | null {
+  if (!bypassEnabled()) return null;
+  const configuredPhones = getBypassPhones();
+  if (configuredPhones.length === 0) return null;
 
   const normalizedPhone = normalizePhone(phone);
-  return configuredPhones.some((configured) => normalizePhone(configured) === normalizedPhone)
-    ? configuredCode
-    : null;
+  const matches = configuredPhones.some(
+    (configured) => normalizePhone(configured) === normalizedPhone,
+  );
+  return matches ? process.env.AUTH_OTP_BYPASS_CODE!.trim() : null;
+}
+
+/**
+ * Whether `phone` is one of the allowlisted test numbers — for sends that
+ * aren't the OTP itself (e.g. the SMS opt-in confirmation) but still
+ * shouldn't hit a real, undeliverable test number. Same allowlist and same
+ * on/off switch as getOtpBypassCodeForPhone; this just skips the code.
+ */
+export function isBypassTestPhone(phone: string): boolean {
+  if (!bypassEnabled()) return false;
+  const normalizedPhone = normalizePhone(phone);
+  return getBypassPhones().some((configured) => normalizePhone(configured) === normalizedPhone);
 }


### PR DESCRIPTION
## Summary

Three follow-ups from `docs/reports/2026-09-05-reminder-ask-verification.pdf` (#1606):

- **Invite-link topic editing was effectively undiscoverable.** The add-topic control (`+ Create your own`) only rendered when under the 3-topic cap — but every user with 3+ interests opens the panel already prefilled to cap, so the control never appeared until you first deleted something. The per-topic "×" is now a labeled "Swap" button, and hitting the cap shows a line explaining that swapping is how to add another, instead of the add flow silently vanishing. Also fixes "No category — carries all your topics," which was only true when the curated set was empty — it now names the real count or describes the automatic fallback.
- **The OTP-bypass allowlist didn't cover the SMS opt-in confirmation send**, so an allowlisted test phone could complete signup but never reach `opted_in` through the real UI (a real Twilio send to a fake number always failed, correctly rolling back consent). `isBypassTestPhone()` shares the same allowlist and on/off switch as `getOtpBypassCodeForPhone`, and the reminders route now skips the real send for those numbers.
- **The reminder-ask confirmation was tied to the crafting screen still being up.** It lived inside `LoadingScreen`'s generating-only branch, so a build that finished before the player arrived (common case) meant the confirmation never rendered at all. New `ReminderConfirmedToast` renders unconditionally on `/daily` (and its dev preview, for parity) and self-dismisses after 1.8s, matching the toast pattern already used elsewhere (Friends page, bank-add action).

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json --noEmit` — clean
- [x] `npx vitest run` on all touched suites — 96/96 passing, including new cases for `isBypassTestPhone` and the confirmation-send bypass
- [x] `npm run lint` on touched files — clean
- [x] All five style ratchets — within ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A