### PR TITLE
Show the reminder toast once the crafting screen clears

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -972,7 +972,13 @@ export default function DailyPage() {
 
   return (
     <main className="relative mx-auto flex min-h-dvh max-w-lg flex-col overflow-hidden bg-[var(--surface)] bg-[url('/images/Variant4.png')] bg-repeat px-0">
-      <ReminderConfirmedToast show={justOptedIntoReminders} />
+      {/* Gated on `!loading` because the fullscreen LoadingScreen renders at
+          --z-takeover (80), above --z-toast (70) — an ungated toast is covered
+          by it while its own dismiss timer runs underneath, so it expires
+          before the player can ever see it. Waiting for load means it appears
+          when there's actually something to appear over: right after the
+          crafting screen on a slow build, immediately on a fast one. */}
+      <ReminderConfirmedToast show={justOptedIntoReminders && !loading} />
       {/* Brand triangle pattern (same artwork as the login screen / home feed)
           tiled full-strength behind the game. No cream scrim — the gameplay
           thread is entirely cards, which sit opaque on top; the sticky header

--- a/src/app/dev/onboarding/building/page.tsx
+++ b/src/app/dev/onboarding/building/page.tsx
@@ -1,5 +1,4 @@
 import LoadingScreen from '@/components/LoadingScreen';
-import { ReminderConfirmedToast } from '@/components/ReminderConfirmedToast';
 
 import { WalkthroughAdvance } from './WalkthroughAdvance';
 
@@ -10,27 +9,27 @@ export const dynamic = 'force-dynamic';
  *
  * In the real flow both onboarding exits (opted into SMS reminders or not) now
  * land here — on `/daily`, whose own load path shows this same `LoadingScreen`
- * while the first queue finishes generating. `?remindersOn=1` (set by the
- * onboarding harness when the reminder ask was accepted) mirrors the real
- * `/daily?remindersOn=1` handoff and renders the same ReminderConfirmedToast
- * production does — unconditionally, not tied to this loading screen still
- * being up, since a fast build often means it never shows at all. In `?walk=1`
- * (full-walkthrough) mode it pauses on the build, then advances to the
- * first-session recap — the "first time finished" stage. (Real play itself
- * can't be faithfully stubbed, so the walkthrough brackets it.)
+ * while the first queue finishes generating. In `?walk=1` (full-walkthrough)
+ * mode it pauses on the build, then advances to the first-session recap — the
+ * "first time finished" stage. (Real play itself can't be faithfully stubbed,
+ * so the walkthrough brackets it.)
+ *
+ * Deliberately does NOT preview ReminderConfirmedToast. That toast renders at
+ * --z-toast (70), below this screen's --z-takeover (80), so it would sit
+ * invisible behind the loader here — and in production it is gated on loading
+ * having finished for exactly that reason. It belongs to the screen AFTER this
+ * one, so previewing it here would show a state that never occurs.
  */
 export default async function DevBuildingPage({
   searchParams,
 }: {
-  searchParams: Promise<{ walk?: string; remindersOn?: string }>;
+  searchParams: Promise<{ walk?: string }>;
 }) {
   const params = await searchParams;
   const walk = params?.walk === '1';
-  const remindersOn = params?.remindersOn === '1';
 
   return (
     <main className="min-h-dvh">
-      <ReminderConfirmedToast show={remindersOn} />
       <LoadingScreen fullScreen label="Building your first five…" />
       {walk ? <WalkthroughAdvance nextHref="/dev/first-time-player" /> : null}
     </main>


### PR DESCRIPTION
## Summary

Follow-up to #1607, caught during a live production re-walkthrough: the reminder confirmation toast **still never appeared**, for a different reason than the original bug.

`ReminderConfirmedToast` renders at `--z-toast` (70), but the fullscreen `LoadingScreen` renders at `--z-takeover` (80). So on a slow build the toast was mounted but painted *underneath* the crafting screen, while its own 1.8s dismiss timer ran — expiring before the loader ever cleared. #1607 moved the confirmation out of a conditional render and into a covered layer; the player still saw nothing.

Gating on `!loading` starts its lifecycle when there is actually something to show it over: immediately on a fast build, right after the crafting screen on a slow one.

Also removes the toast from the `/dev/onboarding/building` harness — it sits below that page's takeover layer too, so the preview was showing a state that can never occur. It belongs to the screen *after* that one.

## Also in this PR

- **Round-two verification report** (`docs/reports/2026-09-06-…-round-two.{html,pdf}`) — the walkthrough that found this. Confirms the invite-link fixes from #1607 are live and correct, and records the first-ever complete SMS opt-in with a test number (the path #1605/#1607 unblocked).
- **Corrections to the round-one report.** Two claims are now known wrong: adding Final Fantasy to the inviter's own topics was never required (invite-link topics accept any label passing the specificity check), and "pixel-for-pixel" overstated a by-eye comparison. Round one now ships its HTML source too.
- **`CLAUDE.md`** records the toast-under-takeover trap beside the z-scale, since it cost two failed fixes.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json --noEmit` — clean
- [x] `npm run lint` on touched files — clean
- [x] `npx vitest run` on daily / onboarding / dev-onboarding suites — 37/37 passing
- [ ] Re-verify in production after deploy — note that both prior fixes passed CI and still failed in the browser, so this one is unproven until watched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A