### PR TITLE
Fix two summary/home contradictions: false completion, and today's questions counted as missed

### DIFF
--- a/src/app/daily/summary/FirstSessionPanel.tsx
+++ b/src/app/daily/summary/FirstSessionPanel.tsx
@@ -52,8 +52,15 @@ export function FirstSessionPanel({
 
   return (
     <section className="mt-6 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-5">
+      {/* Deliberately does NOT claim the round is finished. This panel is gated
+          on "first session with at least one answer" (computeReminderPromptState:
+          todayAnswered > 0 and no prior day with an answered slot), which a
+          player hits after a single answer — so "First five complete" announced
+          a completion that had not happened, while home simultaneously offered
+          "Resume round · 2 of 5 answered". The panel's job is orientation
+          (cadence + where to change topics), not congratulation. */}
       <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-        First five complete
+        Your first session
       </p>
       <h2 className="mt-2 font-serif text-2xl leading-tight text-[var(--brand-ink)]">
         Nice start{recap.firstName ? `, ${recap.firstName}` : ''}.

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -604,8 +604,14 @@ async function computeReminderPromptState(
     phoneNumber: null,
   };
 
-  // Today must have at least one answered slot to count as "completed" — the
-  // reminder surfaces only arrive on a summary the player actually finished.
+  // NAME IS A MISNOMER, kept for now: `isFirstCompletedRound` is true for a
+  // player's first session with AT LEAST ONE answer, not for a finished round.
+  // A single answer out of five satisfies it, which is why the first-session
+  // panel must not announce completion (it used to read "First five complete"
+  // while home still offered "Resume round · 2 of 5 answered"). Gating the
+  // first-session recap this loosely is deliberate — a new player who answers
+  // three and wanders off should still get their orientation moment — but any
+  // copy hung off this flag has to stay true of a partial session.
   if (todayAnswered <= 0) {
     return hidden;
   }

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -806,16 +806,21 @@ async function getDailyCatchupItems(
   const isRestingDomain = (domain: string | null | undefined): boolean =>
     typeof domain === 'string' && restingKeys.has(normalizeDomain(domain).toLowerCase());
 
-  const candidateSlots = queues.flatMap((queue) =>
-    asQueueSlots(queue.slots)
+  const candidateSlots = queues.flatMap((queue) => {
+    const queueDate = String(queue.queueDate);
+    // Today's own round is date-eligible (wrong answers resurface at once) but
+    // its UNANSWERED slots are still pending, not missed — see
+    // isCatchUpSlotEligible.
+    const isTodaysQueue = queueDate === assignmentDateStr;
+    return asQueueSlots(queue.slots)
       .filter(
         (slot) =>
-          isCatchUpQueueDateEligible(String(queue.queueDate), assignmentDateStr) &&
-          isCatchUpSlotEligible(slot) &&
+          isCatchUpQueueDateEligible(queueDate, assignmentDateStr) &&
+          isCatchUpSlotEligible(slot, isTodaysQueue) &&
           !isRestingDomain(slot.domain),
       )
-      .map((slot) => ({ queue, slot })),
-  );
+      .map((slot) => ({ queue, slot }));
+  });
 
   const generatedIds = candidateSlots
     .map(({ slot }) => slot.generated_question_id)

--- a/src/server/play/__tests__/catch-up-eligibility.test.ts
+++ b/src/server/play/__tests__/catch-up-eligibility.test.ts
@@ -64,4 +64,28 @@ describe('isCatchUpSlotEligible', () => {
       }),
     ).toBe(false)
   })
+
+  // Today's round is date-eligible so wrong answers resurface at once, but its
+  // unanswered slots are still pending — counting them as "missed" put the same
+  // slots behind "Resume round" and "N missed questions" simultaneously.
+  describe("today's own queue", () => {
+    it('rejects an unanswered slot from today — still pending, not missed', () => {
+      expect(isCatchUpSlotEligible(botSlot(), true)).toBe(false)
+      expect(isCatchUpSlotEligible(friendSlot(), true)).toBe(false)
+    })
+
+    it('rejects a skipped-for-now slot from today, honouring "another day"', () => {
+      expect(isCatchUpSlotEligible(botSlot({ skipped: true }), true)).toBe(false)
+    })
+
+    it('still accepts a wrong answer from today', () => {
+      expect(
+        isCatchUpSlotEligible(friendSlot({ answered: true, answer_state: 'incorrect' }), true),
+      ).toBe(true)
+    })
+
+    it('accepts the same unanswered slot once it is no longer today', () => {
+      expect(isCatchUpSlotEligible(botSlot(), false)).toBe(true)
+    })
+  })
 })

--- a/src/server/play/catch-up-eligibility.ts
+++ b/src/server/play/catch-up-eligibility.ts
@@ -25,7 +25,23 @@ export function isCatchUpQueueDateEligible(
   return queueDate <= assignmentDate && queueDate >= oldestDate;
 }
 
-export function isCatchUpSlotEligible(slot: QueueSlot): boolean {
+/**
+ * `isTodaysQueue` narrows what today's own round contributes to catch-up.
+ *
+ * Today's queue is date-eligible on purpose, so a wrong answer resurfaces
+ * immediately instead of waiting until tomorrow. But the unanswered arm below
+ * swept in slots the player simply has not reached yet, so a round played
+ * 2-of-5 reported the other three as "missed" while home was concurrently
+ * offering "Pick up where you left off · Resume round" — the same slots
+ * counted as pending and missed at once. It also broke the promise the skip
+ * sheet makes out loud ("It'll come back another day"): a slot skipped for
+ * now reappeared as catch-up debt the same afternoon.
+ *
+ * So for TODAY only, an unanswered slot is still pending, not missed. It
+ * becomes ordinary catch-up tomorrow, when its queue is no longer today's.
+ * Wrong answers from today are unaffected and still surface immediately.
+ */
+export function isCatchUpSlotEligible(slot: QueueSlot, isTodaysQueue = false): boolean {
   if (slot.dismissed_at) return false;
   // Bot slots carry generated_question_id; friend-authored slots carry
   // question_id (the canonical Question.id). Either is sufficient to
@@ -38,7 +54,8 @@ export function isCatchUpSlotEligible(slot: QueueSlot): boolean {
   if (slot.catchup_answer_state === 'correct') return false;
   // Wrong daily-5 answers are eligible for re-attempt; correct ones are not.
   if (slot.answered) return slot.answer_state === 'incorrect';
-  return true;
+  // Unanswered: genuinely missed on a past day, still pending on today's.
+  return !isTodaysQueue;
 }
 
 export function expiresWithin24Hours(expiresAt: string, now = new Date()): boolean {


### PR DESCRIPTION
## Summary

Two UX contradictions found in a live walkthrough, where the summary and home made opposite claims about the same round at the same moment.

### 1. The first-session panel announced a completion that hadn't happened

Its eyebrow read **"First five complete"**, but the gate only requires *the player's first session with at least one answer* (`todayAnswered > 0`, no prior day with an answered slot). **One answer out of five satisfies it.**

I answered 2, skipped 3, and got "First five complete / Nice start, Trey" while home showed **"Pick up where you left off · 2 of 5 answered"** with a Resume button.

The loose gate is correct and stays — a new player who answers three and wanders off should still get their orientation moment, which is what this panel actually is (daily cadence + where to change topics), not a congratulation. The eyebrow becomes **"Your first session"**, true of a partial session. Behaviour unchanged.

### 2. Today's unplayed questions counted as "missed"

Catch-up includes today's queue on purpose, so a wrong answer resurfaces immediately rather than waiting a day. But `isCatchUpSlotEligible`'s unanswered arm returned `true` unconditionally, so slots the player **hadn't reached yet** were missed the moment the queue existed.

Same walkthrough: **"Catch up · 6 missed questions"** rendered on the same card as **"Resume round"** — the identical slots counted as pending and missed at once. It also broke a promise the product makes out loud: *"Skip for now — It'll come back another day"* came back the same afternoon.

For today's queue only, an unanswered slot is now still pending; it becomes ordinary catch-up tomorrow. Today's wrong answers are untouched.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json --noEmit` — clean
- [x] `npm run lint` on touched files — clean
- [x] `npx vitest run src/server/play src/server/db/queries/__tests__` — 246 passing, including 4 new cases for today-vs-past eligibility
- [x] `npx vitest run src/app/daily src/server/daily` — 484 passing
- [x] No test asserted on the old "First five complete" string (grepped first)

## Notes

- `isFirstCompletedRound` would be more honest as `isFirstSession` — pure rename, ~4 files plus tests, zero behaviour change. Happy to do separately.
- Unrelated dead copy spotted nearby: `NotForMeSheet`'s "No skips left in this round." never renders — both callers wire `skipDisabled` to a transient `submitting` flag, so there is no per-round skip cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A