### PR TITLE
Catch answers leaked into their own questions, and off-domain drift

### DIFF
--- a/.claude/skills/diagnosis-review/SKILL.md
+++ b/.claude/skills/diagnosis-review/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: diagnosis-review
+description: Re-check every open diagnosis/*.md doc against reality (env flags, PR/merge state, DB counters, eval results), append a dated Update to each, and print a one-screen summary of anything needing Josh's decision. Run daily, or any time before/after touching something a diagnosis doc is tracking.
+argument-hint: (optional) a specific diagnosis/*.md filename to check just that one
+---
+
+# Diagnosis review: $ARGUMENTS
+
+Re-verify the standing questions in `diagnosis/` against current reality and
+log what changed. This is reconnaissance and note-taking — **never take the
+action a doc is deciding about** (don't flip an env flag, don't merge/close
+a PR, don't run a costly live eval) without asking first, even if the
+evidence clearly points that way. This skill's job is to make the decision
+easy to make, not to make it.
+
+## Steps
+
+1. Read `diagnosis/README.md` for the current conventions and index.
+2. List the target files: every `diagnosis/*.md` except `README.md` and
+   `_TEMPLATE.md`, or just the one named in `$ARGUMENTS` if given. Skip any
+   file whose frontmatter says `status: done` unless `$ARGUMENTS` names it
+   explicitly.
+3. For **each** target file:
+   a. Read it in full, including its whole `## Updates` log — the most
+      recent entries say what was still outstanding last time, which is
+      your checklist for this run.
+   b. Re-verify whatever is independently checkable, using read-only
+      lookups only:
+      - **Env flags** — any `` `ALL_CAPS_NAME` `` token that reads like a
+        flag: `grep` for it in `.env` and report its current value.
+      - **PR / merge state** — any `#NNNN` reference: `gh pr view NNNN
+        --json state,mergedAt,title,baseRefName`. If it merged since the
+        last Update, that's a significant change — the doc's file may now
+        also exist on `main`; check with `git log main -1 -- diagnosis/<file>`.
+      - **DB counters or row states** — if the doc references specific
+        rows, tables, or counters (e.g. `gate-drop-stats`, specific row
+        ids), re-run the same read-only query the doc describes via the
+        project's read-only Supabase MCP tool. Never write. If the doc's
+        own SQL was meant for Josh to run by hand (a demote, a migration),
+        just re-check whether it appears to have been applied — don't
+        apply it yourself.
+      - **Eval files** (`*.eval.test.ts`) marked "unrun" — check whether
+        `ANTHROPIC_API_KEY` is now present in `.env`. If it is and the doc
+        says the eval is still unrun, **ask Josh** before running it (it
+        costs tokens); don't run it silently.
+      - **Code/test state** — if the doc references specific functions or
+        rules, a quick `git log --oneline -5 -- <path>` shows whether
+        anything touched them since the last review, which matters even
+        before re-running any numbers.
+   c. Compare what you find to what the doc's last Update said. Three
+      outcomes:
+      - **Nothing changed** — append a short dated Update saying exactly
+        that (which flags/PRs/counters you checked and that they're
+        unchanged). Don't skip the entry; a missing entry looks like the
+        doc wasn't reviewed at all.
+      - **Something changed but doesn't resolve an open decision** — log
+        it with numbers, same as day one's Phase 1 entries.
+      - **Something now answers an open decision** — say so plainly, but
+        still don't act on it. Set `status: needs-decision` in the
+        frontmatter and state the exact question at the top of the new
+        Update entry, e.g. `**NEEDS DECISION:** eval passed both bars —
+        flip DOMAIN_DRIFT_DROP_ENABLED?`
+   d. Update the file's frontmatter: `last-reviewed: <today>`, and `status`
+      if it changed.
+4. Rewrite `diagnosis/README.md`'s index table from every file's current
+   frontmatter (status, opened, last-reviewed, related-pr).
+5. Print a summary directly to Josh, not just into the files — this is the
+   part he actually reads:
+   - One line per file: status, and the single most important thing that
+     changed (or "no change").
+   - A distinct, unmissable **NEEDS YOUR DECISION** section listing every
+     file now at `status: needs-decision`, with the exact question from
+     step 3c.
+6. Stage and commit exactly the changed `diagnosis/*.md` files (plus
+   `README.md` if its index changed) with a message like `diagnosis:
+   daily review YYYY-MM-DD`. Push to whatever branch is currently checked
+   out. **If the working tree has other, unrelated uncommitted changes,
+   stop and ask** rather than bundling them into this commit or stashing
+   them — this skill's commit should only ever contain `diagnosis/` files.
+7. If a target file's `related-pr` shows as merged in step 3b and the file
+   no longer exists on the current branch (because the branch was deleted
+   post-merge), note that in the summary and ask Josh whether to keep
+   reviewing it from `main` going forward, rather than silently switching
+   branches.
+
+## What this skill deliberately does NOT do
+
+- Flip any flag, run any migration, or apply any SQL a doc describes.
+- Run a costly live eval without asking first.
+- Delete or rewrite history in a doc's `## Updates` log — corrections are
+  new dated entries, never edits to old ones.
+- Start a new diagnosis doc — that happens when a new incident/experiment
+  starts, using `diagnosis/_TEMPLATE.md`, not as part of a routine review.

--- a/diagnosis/README.md
+++ b/diagnosis/README.md
@@ -1,0 +1,71 @@
+# diagnosis/
+
+Living tracking documents for open technical decisions that need dated
+follow-up — gate rollouts, flag flips, measurement experiments, anything
+where "ship it and measure" spans more than one sitting. Each file is a
+**standing question**, not a report: it gets edited in place and grows an
+`## Updates` log until it reaches a `done` status.
+
+## How this differs from `audits/`
+
+`audits/` is point-in-time: one dated file per run, never edited again after
+it's written (see `.claude/skills/prd-audit/SKILL.md`). A `diagnosis/` file
+is the opposite — one file per *topic*, continuously updated, until the
+open questions it tracks are resolved. If you're producing a one-shot
+findings report, it belongs in `audits/`. If you're tracking something that
+needs re-checking over days or weeks (an experiment, a flag rollout, a
+"measure before deciding" gate), it belongs here.
+
+## Conventions
+
+- **One file per topic**, not per day: `diagnosis/<slug>.md`, kebab-case,
+  named for the thing being decided (`answer-leak-domain-drift-plan.md`),
+  not the date.
+- **Frontmatter** on every file (see `_TEMPLATE.md`):
+  ```yaml
+  ---
+  name: <slug>
+  status: planning | active | needs-decision | blocked | done
+  opened: YYYY-MM-DD
+  last-reviewed: YYYY-MM-DD
+  owner: Josh
+  related-pr: "#1611"        # omit if none
+  ---
+  ```
+- **Structure inside the doc:** what triggered it, the open decisions in
+  plain language, the plan/phases, a recommendation section that gets
+  updated as evidence comes in, and an `## Updates` log at the bottom —
+  append-only, dated entries, oldest first. Never rewrite history above the
+  Updates log; correct it by adding a new dated entry, the way a lab notebook
+  works.
+- **`status: needs-decision`** means there's a specific question only Josh
+  can answer, stated explicitly near the top of the latest Update. Don't
+  bury it in prose — a reviewer scanning just the index below should be able
+  to tell something needs a decision without opening the file.
+- **`status: done`** means the open decisions are resolved (flags flipped or
+  deliberately left off, one way or the other) and nothing further is being
+  measured. Leave the file in place as a record; don't delete it.
+
+## Daily check
+
+`.claude/skills/diagnosis-review/SKILL.md` — invoke with `/diagnosis-review`.
+It re-checks every non-`done` file against whatever it depends on (env
+flags, PR/merge state, DB counters, eval results), appends a dated Update
+(even a "nothing changed" one), and prints a one-screen summary of anything
+that needs your decision. See that skill for exactly what it checks and how.
+
+**Cadence is currently manual** — run the skill yourself when you want a
+check, or ask Claude Code to run it. It is deliberately not on an unattended
+daily cron yet: these docs mostly live on feature branches until their PR
+merges, and a scheduled job would need to know which branch to check.
+Revisit once diagnosis docs settle on `main` as their normal home.
+
+## Index
+
+| File | Status | Opened | Last reviewed | Related PR |
+|---|---|---|---|---|
+| [answer-leak-domain-drift-plan.md](answer-leak-domain-drift-plan.md) | **needs-decision** | 2026-09-05 | 2026-09-06 | #1611 |
+
+Keep this table in sync by hand when you add/close a file, or let
+`/diagnosis-review` do it — it rewrites this table from each file's
+frontmatter on every run.

--- a/diagnosis/_TEMPLATE.md
+++ b/diagnosis/_TEMPLATE.md
@@ -1,0 +1,63 @@
+---
+name: <slug-matching-filename>
+status: planning
+opened: YYYY-MM-DD
+last-reviewed: YYYY-MM-DD
+owner: Josh
+related-pr: "#____"        # delete this line if there isn't one yet
+---
+
+# Diagnosis: <short title>
+
+_Started YYYY-MM-DD · Owner: Josh · Working branch: `<branch>`<if applicable, PR #____>_
+
+One or two sentences: is this a living document tracking open decisions, or
+an experiment being measured before a decision gets made? Say so explicitly
+— it changes how a reader should treat the "Recommendation" section below
+(a running best-guess vs. a final call).
+
+---
+
+## 1. What triggered this
+
+The concrete thing that started this — an incident, a question, a proposal.
+Link real evidence (commits, PR numbers, row ids, error messages), not
+paraphrases of it.
+
+## 2. Open decisions
+
+Numbered list, plain language, each one answerable with a name/number/yes-
+or-no — not "figure out the right approach to X."
+
+1. ...
+2. ...
+
+## 3. What we know so far
+
+The evidence gathered, with numbers where possible. State assumptions
+explicitly and flag which ones are load-bearing — if the assumption turns
+out wrong, say what changes.
+
+## 4. Plan
+
+Phases or steps, each with a stated **exit criterion** — the specific
+number or observation that would make the next phase (or the decision
+itself) obvious. A phase without an exit criterion isn't a phase, it's a
+task.
+
+## 5. Recommendation (as of YYYY-MM-DD)
+
+What you'd do if forced to decide today, and why — including what would
+change your mind. Update this section's date whenever the recommendation
+changes; don't leave a stale recommendation standing after new evidence.
+
+---
+
+## Updates
+
+Append-only, most recent last, dated. Every entry that changes the picture
+gets one — including a "checked, nothing changed" entry so a reader can
+tell the difference between "not yet reviewed" and "reviewed, no news."
+
+### YYYY-MM-DD
+What happened, what it means, what's still outstanding.

--- a/diagnosis/answer-leak-domain-drift-plan.md
+++ b/diagnosis/answer-leak-domain-drift-plan.md
@@ -195,3 +195,111 @@ Both labelers are running now. Next update will carry:
 (`800c44a3…`, `139e1932…`, `357618e3…`) are **still live and servable in
 prod** — re-checked today, `is_duplicate` is still `false` on all three. The
 demote SQL from PR #1611 has not been run yet.
+
+### 2026-09-06 (later still) — Phase 1 complete: both gates clear the bar
+
+Both blind labelers finished. Scored against the real flags from the blind
+sets above (raw per-occurrence basis — several corpus rows are re-generated
+duplicates of the same underlying question, noted separately below):
+
+| Gate | Flagged | Labeler agrees (TP) | Labeler disagrees (FP) | **Precision** | Controls flagged anyway (recall gap) |
+|---|---|---|---|---|---|
+| Partial leak | 13 | 12 | 1 | **92.3%** (87.5% distinct-content, 7/8) | 3 / 50 (6.0%) |
+| Answer shape | 41 | 38 | 3 | **92.7%** | 1 / 50 (2.0%) |
+
+Both clear the Phase 1 exit bar (≥ 90% precision) on the primary,
+per-occurrence metric.
+
+**Disagreement items for Josh to adjudicate** (7 distinct, not the full 154 —
+as the plan predicted):
+
+*Partial leak — rule flagged, labeler disagreed (1):*
+- `model year` for "...releasing updated vehicle styling tied to a specific
+  year..." — the rule's Rule B (generic-head-noun) has `model` in its
+  generic-noun list, but here "model" is the *substantive* jargon word, not
+  filler, and "year" (the word actually shown) is what's generic. This is
+  the mirror-image of the "dental plan" case the rule was built for. **Fix
+  candidate:** drop `model` from `GENERIC_HEAD_NOUNS` in
+  `src/server/questions/self-answering.ts`.
+
+*Partial leak — labeler flagged a control the rule missed (3, all real
+semantic leaks a lexical rule structurally cannot reach):*
+- "Credo in un Dio crudel" (Iago's aria) — stem paraphrases the Italian
+  title's meaning ("belief in a cruel God") without using its words. Needs
+  semantic understanding, not lexical overlap.
+- "The Feast of the Epiphany" — stem says the term "epiphany" was borrowed
+  from a feast day and asks which one; "feast" isn't in `GENERIC_HEAD_NOUNS`.
+- "Quilt block" — stem already says "a square block" in a quilting-themed
+  question; the labeler judged the domain context makes "quilt" redundant,
+  a contextual read a token-overlap rule can't make.
+
+*Answer shape — rule flagged, labeler disagreed (3 raw, 2 distinct — two
+are the same duplicate row):*
+- The Joyce/Woolf answer itself (`139e1932…` and an older duplicate
+  `f10644…`) — `"A petition calling for universal peace / ... (specifically,
+  the Czar Nicholas II's 1898 peace manifesto)"`. The labeler read the
+  `"(specifically, X)"` clause as an appositive narrowing down *which*
+  petition, not narration — disagreeing with the `SENTENCE_TELLS` regex,
+  which treats `specifically` as a sentence tell. **Worth noting:** this row
+  is independently caught by the partial-leak gate regardless of this
+  disagreement, so the *outcome* (drop it) is right either way — only the
+  shape gate's stated *reason* is debatable here.
+- "He floats behind them (they levitate him / he is carried out unconscious
+  on a stretcher-like levitation)" — labeler read the parenthetical as
+  alternate phrasings, not narration.
+
+*Answer shape — labeler flagged a control the rule missed (1):*
+- "He has inherited his uncle's fortune (his rich uncle has died and left
+  him wealthy)" — has the pronoun-start tell but is only ~85 characters,
+  under `ANSWER_SHAPE_MAX_CHARS` (100), so the length+tell AND doesn't
+  trigger. Suggests the length threshold may be a little high.
+
+**Recommendation:**
+- **`PARTIAL_ANSWER_LEAK_ENABLED`** — precision clears the bar; recommend
+  flipping it on. This is a Vercel environment-variable change across
+  deploy environments, which I won't make without Josh's go-ahead even with
+  the precision bar cleared (shared-infra change, not a code change this PR
+  can carry).
+- **Answer shape gate** — confirmed correct as already shipped (default on).
+  No action needed.
+- Two small rule tightenings are worth a follow-up PR, not blocking the flag
+  decision above: drop `model` from `GENERIC_HEAD_NOUNS`, and reconsider
+  whether `specifically` should stay in `SENTENCE_TELLS` given the
+  appositive-clarification counter-example.
+- The recall gaps (Credo, Epiphany, Quilt block) are the ceiling of a
+  lexical-only approach — closing them needs semantic/contextual judgment a
+  regex can't do. Relevant to Phase 4: at ~13 rows/day, worth asking whether
+  an LLM backstop is warranted before spending more effort tightening
+  regexes that are already near their lexical ceiling.
+
+### 2026-09-06 (later still) — Phase 2 fixtures built, not yet run
+
+Wrote `src/server/daily/__tests__/domain-drift.eval.test.ts`, following the
+exact conventions of the existing `quality-gate.eval.test.ts` live-eval
+harness (`RUN_LLM_EVALS=1 ANTHROPIC_API_KEY=... npx vitest run
+domain-drift.eval`, self-skips without both). Fixtures are the real rows
+named in the plan: 3 positives (Joyce + Forster under Woolf, Romantic Opera
+under Romantic Era Orchestral Music) and 4 containment negatives (Mrs.
+Dalloway under Woolf, Sesame Street under Classic Children's Television,
+Breaking Bad under Color References, a New Testament book under New
+Testament), plus one mixed-batch test matching how the gate actually runs
+in production (several questions in one call).
+
+**Not run yet** — this environment has no local `ANTHROPIC_API_KEY`, so the
+whole suite self-skips here. Someone with API access (CI, or Josh's local
+`.env`) needs to run it and log the pass/fail here before
+`DOMAIN_DRIFT_DROP_ENABLED` can be considered. Per the Phase 2 exit
+criteria: it needs to catch every positive **and** flag zero containment
+negatives — a single containment false positive disqualifies the gate from
+dropping, since that failure mode is otherwise invisible in production.
+
+### Next steps
+1. Josh: adjudicate the 7 disagreement items above, and decide whether to
+   flip `PARTIAL_ANSWER_LEAK_ENABLED`.
+2. Someone with `ANTHROPIC_API_KEY`: run `domain-drift.eval.test.ts`, log the
+   result here.
+3. If Phase 2 passes, full-corpus pass (~230 Haiku calls) for a real
+   off-domain hit rate before flipping `DOMAIN_DRIFT_DROP_ENABLED`.
+4. Phase 3 (drop-vs-refile) and Phase 4 (drift-as-demand-signal) not started.
+5. Still outstanding: the three original bad rows are still live in prod —
+   demote SQL from PR #1611 has not been run.

--- a/diagnosis/answer-leak-domain-drift-plan.md
+++ b/diagnosis/answer-leak-domain-drift-plan.md
@@ -1,3 +1,12 @@
+---
+name: answer-leak-domain-drift-plan
+status: needs-decision
+opened: 2026-09-05
+last-reviewed: 2026-09-06
+owner: Josh
+related-pr: "#1611"
+---
+
 # Diagnosis: answer-leak & domain-drift gate rollout
 
 _Started 2026-09-05 · Owner: Josh · Working branch: `claude/answer-leak-and-domain-drift-gates` (PR #1611)_
@@ -197,6 +206,10 @@ prod** — re-checked today, `is_duplicate` is still `false` on all three. The
 demote SQL from PR #1611 has not been run yet.
 
 ### 2026-09-06 (later still) — Phase 1 complete: both gates clear the bar
+
+**NEEDS DECISION:** flip `PARTIAL_ANSWER_LEAK_ENABLED` on? Precision clears
+the bar (92.3%); see the 7 disagreement items below before deciding, and
+note this is a Vercel env-var change across deploy environments.
 
 Both blind labelers finished. Scored against the real flags from the blind
 sets above (raw per-occurrence basis — several corpus rows are re-generated

--- a/diagnosis/answer-leak-domain-drift-plan.md
+++ b/diagnosis/answer-leak-domain-drift-plan.md
@@ -150,3 +150,48 @@ negative bar.
 
 ### 2026-09-06
 Folder created; plan captured as written and agreed. No phases started yet.
+
+### 2026-09-06 (later) — Phase 1 started: blind labeling in progress
+Extracted all 2,304 currently-servable (`is_duplicate = false`) rows from
+prod via a read-only SELECT, then ran the actual shipped functions from PR
+#1611 (`questionPartiallyLeaksAnswer`, `textContainsAnswer`,
+`findAnswerShapeFailures` — not a re-derivation, the real code) against every
+row to reproduce:
+
+- **13** partial-leak hits
+- **41** answer-shape hits
+- a pool of rows flagged by neither, from which **50** were sampled as
+  shared controls (deterministic shuffle, reproducible)
+
+Built two blind sets for independent labeling, each rule's hits mixed with
+the same 50 controls and shuffled so order carries no signal:
+- `leak` set: 63 items (13 flagged + 50 controls)
+- `shape` set: 91 items (41 flagged + 50 controls)
+
+Labeler-facing copies carry only `{item_id, question_text, answer}` — no
+rule tag, no flag, no row id — so the grading judgment can't be contaminated
+by knowing which rule (if any) fired.
+
+**Labeler:** two fresh, context-free subagents (no memory of this
+conversation, no knowledge of which rule wrote which candidate, no exposure
+to my reasoning about "genuine leak") — one per rule, run in parallel. This
+is the check against my own self-grading in the original PR: I wrote both
+rules and graded them against the corpus myself before shipping, which is
+the exact weakness this phase exists to close. A real Anthropic-API-backed
+Sonnet grading pass (matching how the app's own gates work) wasn't available
+in this environment — no `ANTHROPIC_API_KEY` is present in the local
+`.env` — so independent subagents stood in as the blind labeler instead.
+
+Both labelers are running now. Next update will carry:
+- LEAK / NO_LEAK and BAD_SHAPE / CLEAN counts per set
+- precision per gate (of the rule's own hits, how many the labeler agrees
+  are genuinely defective)
+- a recall proxy (of the 50 controls, how many the labeler flagged as bad
+  that neither rule caught)
+- the specific disagreement items, for Josh to adjudicate directly (this is
+  the ~10-item review the plan calls for, not the full 154)
+
+**Still outstanding, unrelated to Phase 1:** the three original bad rows
+(`800c44a3…`, `139e1932…`, `357618e3…`) are **still live and servable in
+prod** — re-checked today, `is_duplicate` is still `false` on all three. The
+demote SQL from PR #1611 has not been run yet.

--- a/diagnosis/answer-leak-domain-drift-plan.md
+++ b/diagnosis/answer-leak-domain-drift-plan.md
@@ -1,0 +1,152 @@
+# Diagnosis: answer-leak & domain-drift gate rollout
+
+_Started 2026-09-05 · Owner: Josh · Working branch: `claude/answer-leak-and-domain-drift-gates` (PR #1611)_
+
+This is a living document. It tracks the open decisions from PR #1611 (three
+new question-quality gates, two of them shipped in measure-only mode), the
+plan to resolve them, and a dated log of what actually happened. Append to
+**Updates** at the bottom rather than editing the history above it.
+
+---
+
+## 1. What triggered this
+
+Two questions served in production on 2026-09-04/05 gave their own answers
+away in the stem, and one was filed under the wrong domain:
+
+| Question (stem gives it away) | Answer | Filed under |
+|---|---|---|
+| "...What specific **dental** benefit are the workers fighting to keep?" | "Dental plan" | The Simpsons |
+| "In '**Lemon** of Troy'... recover Springfield's prized ......" | "lemon tree" | The Simpsons |
+| "...refuses to sign **a petition for universal peace**... What cause did that petition support?" | "A petition **calling** for universal peace / ..." | **Virginia Woolf** (should be Joyce) |
+
+Root causes and the three gates built to catch them are described in PR #1611.
+Two of the three gates shipped **measuring, not dropping** -- this doc is
+about how to decide whether/when to flip them on.
+
+## 2. Open decisions
+
+1. Flip `PARTIAL_ANSWER_LEAK_ENABLED` on, or keep measuring?
+2. Flip `DOMAIN_DRIFT_DROP_ENABLED` on, or keep measuring?
+3. Should the answer-shape gate (`ANSWER_SHAPE_GATE_ENABLED`, currently
+   defaulting **on**) actually default **off** instead?
+4. Is dropping the right response to drift at all, or should a drifted
+   question be **re-filed** to the domain it's actually about, or even routed
+   as an **expansion-offer signal** (the model noticing an adjacency the
+   player hasn't declared)?
+
+## 3. The reframe: shadow-mode measurement is the wrong instrument here
+
+Generation runs at roughly **13 rows/day** (~90/week, trailing 8 weeks).
+Against that throughput:
+
+| Gate | Backtest hits (2,304 live rows) | Expected shadow-mode yield |
+|---|---|---|
+| Partial leak | 13 (0.56%) | ~1 hit per 9 days |
+| Answer shape | 41 (1.78%) | ~1.6 hits per week |
+| Off-domain drift | unmeasured (no eval built yet) | unknown |
+
+Waiting a month on the counters buys ~2 partial-leak observations. The
+2,304-row corpus backtest already produced 13, today, at zero risk. So
+"measure in shadow mode" is the wrong tool for the two deterministic gates --
+it's a good *regression* detector after a decision, a poor way to *make* one.
+
+Separately: generation over-provisions and chunk-retries
+(`GENERATION_CHUNK_SIZE` + retry in `generate-questions.ts`), so at hit rates
+of 0.56% / 1.78% the **cost of a drop is close to zero**. That collapses all
+three flag decisions to one question: **is the gate right when it fires?**
+-- which is a precision question, not a volume question.
+
+That said, the three gates are not the same *kind* of decision:
+
+- **Shape + partial leak** are pure functions -- fully backtestable offline,
+  no cost, no risk. The real unknown is whether "genuine leak" as I judged it
+  matches Josh's judgment. That's a **labeling** problem. I wrote the rules
+  *and* graded them against the corpus, which is the weakest link in what
+  shipped.
+- **Off-domain drift** is an LLM judgment with **zero** precision data run
+  against it so far. It is also the gate whose false-positive mode is
+  invisible and recurring -- silently dropping a *correctly-filed* question
+  forever, with no counter that would ever surface it as wrong.
+
+## 4. Plan
+
+### Phase 1 -- Close the self-grading gap (unblocks decisions 1 and 3)
+Build a blind-labeling script:
+- Emit all 13 partial-leak hits + all 41 shape hits + ~50 unflagged controls,
+  shuffled, stripped of which rule (if any) fired.
+- An independent labeler (Sonnet, separate from the rule author) judges each:
+  "would you serve this to a player?"
+- Josh adjudicates only the **disagreements** between the rule and the
+  labeler -- expected ~10 items, not 104.
+- Output: precision per gate, plus a recall proxy from any control the
+  labeler flags as bad that neither gate caught.
+
+**Exit criteria:**
+- Partial leak >= 90% precision -> flip `PARTIAL_ANSWER_LEAK_ENABLED` on.
+- Shape >= 90% precision -> confirm default-on. Below ~75% -> default off and
+  tighten the rule instead.
+
+### Phase 2 -- Build the off-domain eval that doesn't exist yet (decision 2)
+Use the existing live-eval harness (`quality-gate.eval.test.ts`,
+`RUN_LLM_EVALS=1`, `npm run test:evals`) rather than building a new one.
+Fixture set from real rows:
+- **Positives** (should flag): 4 Joyce + 2 Forster rows filed under
+  "Virginia Woolf's Novels and Essays"; Romantic Opera rows filed under
+  "Romantic Era Orchestral Music".
+- **Negatives** (must NOT flag -- containment): Mrs. Dalloway under Woolf,
+  Sesame Street under Classic Children's Television, Breaking Bad under
+  Color References Across Film and TV, `nt-*` (New Testament book) rows
+  under New Testament.
+
+**Exit criteria:** catches every known positive **and** flags zero
+containment negatives. A single containment false positive disqualifies the
+gate from dropping -- that failure mode is otherwise invisible in production.
+Then run one full-corpus pass (~230 Haiku calls, negligible cost) for a real
+hit rate before flipping `DOMAIN_DRIFT_DROP_ENABLED`.
+
+**Until both conditions pass, this flag stays off.** This is the one gate I'd
+resist flipping on today's evidence regardless of time pressure.
+
+### Phase 3 -- Decide drop vs. re-file, on data (decision 4, first half)
+Dropping the Joyce question destroys a good question and throws away the
+taxonomy signal. But re-filing needs somewhere to put it, and that isn't
+guaranteed -- the affected user has no "Joyce" domain, only "Ulysses (Joyce
+Novel)" with 2 rows under a different `broad_category`.
+
+Measure, across all historically-drifted rows: how often does a plausible
+target domain already exist in that user's KB?
+- **High hit rate** -> re-file to the existing domain; strictly better than a
+  drop, no data model change needed.
+- **Low hit rate** -> drop remains the right default; re-filing to a
+  newly-minted domain is a bigger, riskier change (interacts with
+  `reconcileBankDomain` / territory-depth accounting) and shouldn't be built
+  speculatively.
+
+### Phase 4 -- Drift as a demand signal (decision 4, second half -- likely the highest-value option)
+The generator writing a Joyce question for a Woolf player isn't purely an
+error; it may be the model noticing a real adjacency the player hasn't
+declared. There's existing surface for this --
+`src/server/daily/expansion-offer-diagnostic.ts`,
+`src/server/db/queries/suggestion-catalog.ts`, declared interests. A
+consistently-drifting domain could route to an expansion offer instead of
+the bin. This is a product decision, not a gate-tuning exercise, and it's the
+option most likely to be worth more than any single flag flip -- but it
+should wait until Phases 1-3 establish whether drift is common enough to be
+worth building for.
+
+## 5. Recommendation (as of 2026-09-05)
+
+Do Phase 1 first -- cheap, unblocks two of three decisions, and it's the one
+place my own judgment shouldn't be the only signal. Prior: partial-leak flips
+on, shape stays on -- but that should be confirmed against an independent
+labeler, not taken on my say-so. Hold `DOMAIN_DRIFT_DROP_ENABLED` off
+regardless of time pressure until Phase 2's eval passes both a positive and a
+negative bar.
+
+---
+
+## Updates
+
+### 2026-09-06
+Folder created; plan captured as written and agreed. No phases started yet.

--- a/src/server/daily/__tests__/domain-drift.eval.test.ts
+++ b/src/server/daily/__tests__/domain-drift.eval.test.ts
@@ -1,0 +1,181 @@
+// Live domain-drift (OFF_DOMAIN) evals — these call the REAL Haiku quality
+// gate, not a mock. Mirrors the conventions of quality-gate.eval.test.ts.
+//
+// diagnosis/answer-leak-domain-drift-plan.md Phase 2: DOMAIN_DRIFT_DROP_ENABLED
+// stays off until this file passes BOTH bars — every known positive caught,
+// and every containment negative left alone. A single containment false
+// positive (a correctly-filed question silently demoted forever) is the
+// failure mode this gate can never let through, and it is otherwise
+// invisible in production — nothing would ever surface it as wrong.
+//
+// Fixtures are the REAL rows from the 2026-09-05 incident and its corpus scan
+// (see the PR #1611 description and the diagnosis doc), not invented cases.
+//
+// OPT-IN: hits the Anthropic API, costs tokens, non-deterministic. Run with:
+//
+//   RUN_LLM_EVALS=1 ANTHROPIC_API_KEY=sk-... npx vitest run domain-drift.eval
+//
+// (or `npm run test:evals`). Without RUN_LLM_EVALS=1 and a valid key, the
+// whole describe block is skipped — this environment has no local API key,
+// so these fixtures are prepared but UNRUN as of 2026-09-06. Whoever runs
+// them should log the outcome in the diagnosis doc's Updates section.
+
+import { describe, expect, it } from 'vitest';
+import { getAnthropicClient } from '@/lib/llm';
+import { findQualityFailures, type LlmQuestion } from '@/server/daily/generate-questions';
+
+const evalsEnabled = process.env.RUN_LLM_EVALS === '1' && getAnthropicClient() !== null;
+
+const EVAL_TIMEOUT_MS = 30_000;
+
+function q(domain: string, factKey: string, text: string, answer = 'answer'): LlmQuestion {
+  return {
+    canonical_subcategory: domain,
+    broad_category: 'Literature',
+    question_text: text,
+    answer,
+    explainer: 'Context for the answer.',
+    difficulty_estimate: 'moderate',
+    fact_key: factKey,
+    sub_angles: [],
+    question_shape: null,
+  };
+}
+
+const WOOLF = "Virginia Woolf's Novels and Essays";
+const ORCHESTRAL = 'Romantic Era Orchestral Music';
+
+// --- Positives: real drifted rows served in prod (should be flagged) -------
+
+const JOYCE_UNDER_WOOLF = q(
+  WOOLF,
+  'james-joyce-irish-modernism-portrait-of-the-artist-as-a-young-man-a-petition-cal',
+  "In Joyce's 'A Portrait of the Artist as a Young Man,' Stephen Dedalus famously refuses to sign a petition for universal peace circulated among students at University College Dublin. What cause did that petition support?",
+);
+
+const FORSTER_UNDER_WOOLF = q(
+  WOOLF,
+  'early-20c-british-modernist-howards-end-epigraph-only-connect',
+  "In E.M. Forster's 'Howards End,' the novel's moral vision is compressed into a two-word imperative that appears as the book's epigraph. What are those two words?",
+  'Only connect',
+);
+
+const OPERA_UNDER_ORCHESTRAL = q(
+  'Romantic Opera',
+  'donizetti-elisir-damore-dulcamara-elixir-bordeaux',
+  "In Donizetti's 'L'elisir d'amore,' the quack doctor Dulcamara sells the lovesick Nemorino a bottle of cheap Bordeaux wine, claiming it is what?",
+  "A love elixir (L'elisir d'amore)",
+);
+
+// --- Negatives: correctly-filed containment (must NOT be flagged) ----------
+
+const MRS_DALLOWAY_UNDER_WOOLF = q(
+  WOOLF,
+  'mrs-dalloway-big-ben-chimes-time-unifying-device',
+  "In 'Mrs. Dalloway,' Woolf uses a specific recurring sound — the chiming of a London clock — heard by multiple characters across the city throughout the day. What clock is it?",
+  'Big Ben',
+);
+
+const SESAME_STREET_UNDER_CHILDRENS_TV = q(
+  "Classic Children's Television",
+  'sesame-street-big-bird-imaginary-friend-snuffleupagus',
+  'On Sesame Street, what is the name of Big Bird\'s shy, imaginary friend who looks like a giant woolly mammoth?',
+  'Mr. Snuffleupagus',
+);
+
+const BREAKING_BAD_UNDER_COLOR_REFERENCES = q(
+  'Color References Across Film and TV',
+  'breaking-bad-walter-white-wardrobe-color-transformation',
+  "In Breaking Bad, Walter White's transformation into a ruthless drug lord is tracked partly through his wardrobe, which shifts from muted earth tones toward what color as he embraces the Heisenberg persona?",
+  'Black',
+);
+
+const NEW_TESTAMENT_BOOK_UNDER_NEW_TESTAMENT = q(
+  'New Testament',
+  'nt-matthew-magi-gifts-gold-frankincense-myrrh',
+  'In the Gospel of Matthew, wise men from the East follow a star to find the newborn Jesus. What three gifts do they present to him?',
+  'Gold, frankincense, and myrrh',
+);
+
+describe.skipIf(!evalsEnabled)('quality gate OFF_DOMAIN (live)', () => {
+  it(
+    'flags a Joyce question filed under Virginia Woolf (the 2026-09-05 incident row)',
+    async () => {
+      const result = await findQualityFailures([JOYCE_UNDER_WOOLF]);
+      expect(result.offDomain.has(0)).toBe(true);
+    },
+    EVAL_TIMEOUT_MS,
+  );
+
+  it(
+    'flags an E.M. Forster question filed under Virginia Woolf',
+    async () => {
+      const result = await findQualityFailures([FORSTER_UNDER_WOOLF]);
+      expect(result.offDomain.has(0)).toBe(true);
+    },
+    EVAL_TIMEOUT_MS,
+  );
+
+  it(
+    'flags a Romantic Opera question filed under Romantic Era Orchestral Music',
+    async () => {
+      const result = await findQualityFailures([OPERA_UNDER_ORCHESTRAL]);
+      expect(result.offDomain.has(0)).toBe(true);
+    },
+    EVAL_TIMEOUT_MS,
+  );
+
+  it(
+    'does NOT flag Mrs. Dalloway under Virginia Woolf — containment, not drift',
+    async () => {
+      const result = await findQualityFailures([MRS_DALLOWAY_UNDER_WOOLF]);
+      expect(result.offDomain.has(0)).toBe(false);
+    },
+    EVAL_TIMEOUT_MS,
+  );
+
+  it(
+    'does NOT flag Sesame Street under Classic Children\'s Television',
+    async () => {
+      const result = await findQualityFailures([SESAME_STREET_UNDER_CHILDRENS_TV]);
+      expect(result.offDomain.has(0)).toBe(false);
+    },
+    EVAL_TIMEOUT_MS,
+  );
+
+  it(
+    'does NOT flag Breaking Bad under Color References Across Film and TV',
+    async () => {
+      const result = await findQualityFailures([BREAKING_BAD_UNDER_COLOR_REFERENCES]);
+      expect(result.offDomain.has(0)).toBe(false);
+    },
+    EVAL_TIMEOUT_MS,
+  );
+
+  it(
+    'does NOT flag a New Testament book question under New Testament',
+    async () => {
+      const result = await findQualityFailures([NEW_TESTAMENT_BOOK_UNDER_NEW_TESTAMENT]);
+      expect(result.offDomain.has(0)).toBe(false);
+    },
+    EVAL_TIMEOUT_MS,
+  );
+
+  it(
+    'mixed batch: flags the drifted rows and spares the contained ones in the same call',
+    async () => {
+      const batch = [
+        JOYCE_UNDER_WOOLF,
+        MRS_DALLOWAY_UNDER_WOOLF,
+        OPERA_UNDER_ORCHESTRAL,
+        SESAME_STREET_UNDER_CHILDRENS_TV,
+      ];
+      const result = await findQualityFailures(batch);
+      expect(result.offDomain.has(0)).toBe(true); // Joyce
+      expect(result.offDomain.has(1)).toBe(false); // Mrs. Dalloway
+      expect(result.offDomain.has(2)).toBe(true); // Romantic Opera
+      expect(result.offDomain.has(3)).toBe(false); // Sesame Street
+    },
+    EVAL_TIMEOUT_MS,
+  );
+});

--- a/src/server/daily/__tests__/partial-answer-leak-gate.test.ts
+++ b/src/server/daily/__tests__/partial-answer-leak-gate.test.ts
@@ -1,0 +1,185 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// Regression cover for the three questions served to production on 2026-09-04
+// and 2026-09-05 whose stems gave their answers away. All three passed the
+// conjunctive `findAnswerLeaks` check because it fires only when the stem
+// contains EVERY substantive word of the answer.
+//
+// Same dynamic-import dance as answer-leak-gate.test.ts: generate-questions.ts
+// pulls in @/server/db, which throws at module load without a connection
+// string, and none of these units touch the DB.
+let findAnswerLeaks: typeof import('@/server/daily/generate-questions').findAnswerLeaks;
+let findAnswerShapeFailures: typeof import('@/server/daily/generate-questions').findAnswerShapeFailures;
+let countPartialAnswerLeaks: typeof import('@/server/daily/generate-questions').countPartialAnswerLeaks;
+let questionPartiallyLeaksAnswer: typeof import('@/server/questions/self-answering').questionPartiallyLeaksAnswer;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  ({ findAnswerLeaks, findAnswerShapeFailures, countPartialAnswerLeaks } = await import(
+    '@/server/daily/generate-questions'
+  ));
+  ({ questionPartiallyLeaksAnswer } = await import('@/server/questions/self-answering'));
+});
+
+function q(question_text: string, answer: string) {
+  return {
+    canonical_subcategory: 'The Simpsons',
+    broad_category: 'Film & Television',
+    question_text,
+    answer,
+    explainer: '',
+    difficulty_estimate: 'moderate' as const,
+    fact_key: null,
+    sub_angles: [],
+    question_shape: null,
+  };
+}
+
+// The three rows as they were actually generated and served.
+const SIMPSONS = q(
+  "In 'Last Exit to Springfield,' Homer inadvertently becomes a union negotiator when the power plant workers go on strike. What specific dental benefit are the workers fighting to keep?",
+  'Dental plan',
+);
+const LEMON = q(
+  "In 'Lemon of Troy,' Bart leads a group of Springfield kids on a mission to reclaim something stolen by Shelbyville. Fill in the blank: the kids are on a quest to recover Springfield's prized ……",
+  'lemon tree',
+);
+const JOYCE = q(
+  "In Joyce's 'A Portrait of the Artist as a Young Man,' Stephen Dedalus famously refuses to sign a petition for universal peace circulated among students at University College Dublin. What cause did that petition support?",
+  "A petition calling for universal peace / the Tsar's peace rescript (specifically, the Czar Nicholas II's 1898 peace manifesto)",
+);
+
+describe('questionPartiallyLeaksAnswer', () => {
+  it('catches the generic-head-noun leak (stem shows the modifier, withholds the category)', () => {
+    // "dental" is in the stem; the player supplies "plan" for free.
+    expect(questionPartiallyLeaksAnswer(SIMPSONS.question_text, SIMPSONS.answer)).toBe(true);
+    // The episode title hands over "lemon"; only "tree" is withheld.
+    expect(questionPartiallyLeaksAnswer(LEMON.question_text, LEMON.answer)).toBe(true);
+  });
+
+  it('catches the contiguous-run leak that one filler word used to hide', () => {
+    // The stem prints "a petition for universal peace" verbatim. Under the
+    // conjunctive rule the single gerund "calling" was enough to save it.
+    expect(questionPartiallyLeaksAnswer(JOYCE.question_text, JOYCE.answer)).toBe(true);
+  });
+
+  it('does not fire when the WITHHELD word is the substance and the shown word is the category', () => {
+    // The stem naming the category is normal; "basset" / "plagal" / "cabbage
+    // patch" are the answers and are correctly absent from the stem.
+    expect(
+      questionPartiallyLeaksAnswer(
+        "Mozart's Clarinet Concerto in A major was written for a friend who played a now-rare variant of the instrument with an extended lower range. What is that instrument called?",
+        'Basset clarinet',
+      ),
+    ).toBe(false);
+    expect(
+      questionPartiallyLeaksAnswer(
+        'In Western tonal harmony, when a chord progression moves from the subdominant (IV) chord directly to the tonic (I) chord, what is that cadence called?',
+        'Plagal cadence',
+      ),
+    ).toBe(false);
+    expect(
+      questionPartiallyLeaksAnswer(
+        'The Garbage Pail Kids cards were deliberately designed as a grotesque parody of which enormously popular 1980s doll line?',
+        'Cabbage Patch Kids',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not fire when the stem merely paraphrases the answer’s category', () => {
+    // The stem prints a real contiguous run of the answer ("tennis academy"),
+    // but withholds "Enfield" — which is the entire answer. self-answering.ts
+    // has warned about this exact case since the accepted-form gate landed, and
+    // an untightened contiguous-run rule reintroduces it.
+    expect(
+      questionPartiallyLeaksAnswer(
+        "In 'Infinite Jest,' what is the name of the elite Boston tennis academy founded by James Incandenza?",
+        'Enfield Tennis Academy',
+      ),
+    ).toBe(false);
+    // Same shape: the run is "theorem ... calculus", but "Fundamental" is the ask.
+    expect(
+      questionPartiallyLeaksAnswer(
+        'When finding the area under a curve between two x-values, you evaluate the antiderivative at the upper limit and subtract its value at the lower. Which theorem of calculus guarantees this works?',
+        'The Fundamental Theorem of Calculus',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not fire on counting questions, where the stem naming the unit is normal', () => {
+    // Structurally identical to a leak — the stem shows "bases"/"books" and the
+    // answer adds a number — but the withheld number IS the answer.
+    expect(
+      questionPartiallyLeaksAnswer(
+        'A pitcher steps off the rubber and throws to first base to attempt a pickoff, but the throw goes into the stands. How many bases are the runners awarded?',
+        'Two bases',
+      ),
+    ).toBe(false);
+    expect(
+      questionPartiallyLeaksAnswer(
+        "Bach's 'The Well-Tempered Clavier' systematically works through all 24 major and minor keys. How many books make up the complete collection?",
+        'Two books',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('findAnswerLeaks partial-leak flag', () => {
+  const cases = [SIMPSONS, LEMON, JOYCE];
+
+  it('measures the partial leaks but does not drop them by default', () => {
+    delete process.env.PARTIAL_ANSWER_LEAK_ENABLED;
+    expect(findAnswerLeaks(cases).toDrop.size).toBe(0);
+    expect(countPartialAnswerLeaks(cases)).toBe(3);
+  });
+
+  it('drops them once PARTIAL_ANSWER_LEAK_ENABLED is set', () => {
+    process.env.PARTIAL_ANSWER_LEAK_ENABLED = 'true';
+    try {
+      const result = findAnswerLeaks(cases);
+      expect([...result.toDrop].sort()).toEqual([0, 1, 2]);
+      expect(result.reasons[0]).toContain('Dental plan');
+    } finally {
+      delete process.env.PARTIAL_ANSWER_LEAK_ENABLED;
+    }
+  });
+});
+
+describe('findAnswerShapeFailures (Rule 3 — ONE CLEAN ANSWER)', () => {
+  it('drops sentence-shaped answers', () => {
+    const result = findAnswerShapeFailures([
+      q(
+        "In 'Siegfried,' the hero shatters the spear. What does that signify?",
+        "It signals the end of Wotan's power and the gods' dominion — the spear, engraved with the contracts that undergird Wotan's authority, is broken, meaning his rule over the world is finished",
+      ),
+    ]);
+    expect([...result.toDrop]).toEqual([0]);
+    expect(result.reasons[0]).toContain('one clean answer');
+  });
+
+  it('drops the Joyce answer, whose padding is what defeated the leak gate', () => {
+    expect([...findAnswerShapeFailures([JOYCE]).toDrop]).toEqual([0]);
+  });
+
+  it('spares a long answer that is genuinely one clean title', () => {
+    // 159 chars, no clause break, no leading pronoun — a real essay title and a
+    // perfectly checkable answer. A bare length cap would have killed it.
+    const result = findAnswerShapeFailures([
+      q(
+        "David Foster Wallace's profile of tennis player Michael Joyce carried what full title?",
+        'Tennis Player Michael Joyce’s Professional Artistry as a Paradigm of Certain Stuff About Choice, Freedom, Discipline, Joy, Grotesquerie, and Human Completeness',
+      ),
+    ]);
+    expect(result.toDrop.size).toBe(0);
+  });
+
+  it('spares short answers and honours the kill switch', () => {
+    expect(findAnswerShapeFailures([SIMPSONS, LEMON]).toDrop.size).toBe(0);
+    process.env.ANSWER_SHAPE_GATE_ENABLED = 'off';
+    try {
+      expect(findAnswerShapeFailures([JOYCE]).toDrop.size).toBe(0);
+    } finally {
+      delete process.env.ANSWER_SHAPE_GATE_ENABLED;
+    }
+  });
+});

--- a/src/server/daily/__tests__/quality-gate-off-domain.test.ts
+++ b/src/server/daily/__tests__/quality-gate-off-domain.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Plumbing tests for the OFF_DOMAIN defect — the "Joyce question filed under
+// Virginia Woolf" case served to production on 2026-09-05.
+//
+// The drift was invisible because `canonical_subcategory` is worthless as a
+// signal: the generation prompt tells the model to echo the domain it was
+// handed, so the field agreed with the request even though the question had
+// wandered to another author. `fact_key`, which the model derives from what it
+// actually wrote, still said "james-joyce-irish-modernism-...". These tests
+// verify that field reaches the gate and that OFF_DOMAIN verdicts are held out
+// of the drop set until DOMAIN_DRIFT_DROP_ENABLED is set. The model's actual
+// judgment (sibling flagged, containment spared) is non-deterministic and
+// belongs in the opt-in live evals.
+
+const mocks = vi.hoisted(() => ({
+  loggedMessagesCreate: vi.fn(),
+}));
+
+vi.mock('@/lib/llm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/llm')>();
+  return {
+    ...actual,
+    getAnthropicClient: () => ({}) as never,
+    loggedMessagesCreate: mocks.loggedMessagesCreate,
+  };
+});
+
+vi.mock('@/server/db', () => ({ db: {}, generatedQuestions: {} }));
+
+import { findQualityFailures, type LlmQuestion } from '@/server/daily/generate-questions';
+
+function q(domain: string, factKey: string | null, text: string): LlmQuestion {
+  return {
+    canonical_subcategory: domain,
+    broad_category: 'Literature',
+    question_text: text,
+    answer: 'answer',
+    explainer: 'explainer',
+    difficulty_estimate: 'moderate',
+    fact_key: factKey,
+    sub_angles: [],
+    question_shape: null,
+  };
+}
+
+function llmResponse(json: unknown) {
+  return { content: [{ type: 'text', text: JSON.stringify(json) }] };
+}
+
+// The row as it was actually generated: filed under Woolf, fact_key confessing Joyce.
+const DRIFTED = q(
+  "Virginia Woolf's Novels and Essays",
+  'james-joyce-irish-modernism-portrait-of-the-artist-as-a-young-man-a-petition-cal',
+  "In Joyce's 'A Portrait of the Artist as a Young Man,' Stephen Dedalus refuses to sign a petition…",
+);
+// Correctly filed: Mrs. Dalloway IS a Woolf novel. Containment, not drift.
+const CONTAINED = q(
+  "Virginia Woolf's Novels and Essays",
+  'mrs-dalloway-big-ben-chimes-time-unifying-device',
+  "In 'Mrs. Dalloway,' Woolf uses a specific recurring sound heard across London…",
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.DOMAIN_DRIFT_DROP_ENABLED;
+});
+
+describe('quality gate — OFF_DOMAIN plumbing', () => {
+  it('sends each candidate fact_key to the gate and ships the containment rubric', async () => {
+    mocks.loggedMessagesCreate.mockResolvedValue(llmResponse({ drop_indices: [], reasons: {} }));
+
+    await findQualityFailures([DRIFTED, CONTAINED]);
+
+    const [, , request] = mocks.loggedMessagesCreate.mock.calls[0];
+    const userContent = request.messages[0].content as string;
+    expect(userContent).toContain('fact=james-joyce-irish-modernism');
+    expect(userContent).toContain('fact=mrs-dalloway-big-ben-chimes');
+
+    const system = request.system as string;
+    expect(system).toContain('OFF_DOMAIN');
+    // The guard that keeps a correctly-filed work from being read as drift.
+    expect(system).toContain('containment is NOT a defect');
+  });
+
+  it('renders a null fact_key without breaking the body', async () => {
+    mocks.loggedMessagesCreate.mockResolvedValue(llmResponse({ drop_indices: [], reasons: {} }));
+    await findQualityFailures([q('Beethoven', null, 'A question')]);
+    const [, , request] = mocks.loggedMessagesCreate.mock.calls[0];
+    expect(request.messages[0].content).toContain('fact=(none)');
+  });
+
+  it('reports OFF_DOMAIN separately and does NOT drop it by default', async () => {
+    mocks.loggedMessagesCreate.mockResolvedValue(
+      llmResponse({
+        drop_indices: [0],
+        reasons: { '0': 'OFF_DOMAIN: question is about Joyce, filed under Woolf' },
+      }),
+    );
+
+    const result = await findQualityFailures([DRIFTED, CONTAINED]);
+
+    expect([...result.offDomain]).toEqual([0]);
+    expect(result.toDrop.size).toBe(0); // measure-only
+  });
+
+  it('keeps the gate’s other defects dropping exactly as before', async () => {
+    mocks.loggedMessagesCreate.mockResolvedValue(
+      llmResponse({
+        drop_indices: [0, 1],
+        reasons: {
+          '0': 'OFF_DOMAIN: about Joyce, filed under Woolf',
+          '1': 'ANSWER_LEAKED: the setup names the answer',
+        },
+      }),
+    );
+
+    const result = await findQualityFailures([DRIFTED, CONTAINED]);
+
+    // The off-domain hit is withheld; the answer-leak hit still drops.
+    expect([...result.offDomain]).toEqual([0]);
+    expect([...result.toDrop]).toEqual([1]);
+  });
+
+  it('promotes OFF_DOMAIN to a drop once DOMAIN_DRIFT_DROP_ENABLED is set', async () => {
+    // The flag is read where the drop sets are unioned, so the gate itself keeps
+    // reporting the hit separately either way — that separation is what lets the
+    // caller decide.
+    const { isDomainDriftDropEnabled } = await import('@/server/daily/generate-questions');
+    expect(isDomainDriftDropEnabled()).toBe(false);
+    process.env.DOMAIN_DRIFT_DROP_ENABLED = 'true';
+    try {
+      expect(isDomainDriftDropEnabled()).toBe(true);
+    } finally {
+      delete process.env.DOMAIN_DRIFT_DROP_ENABLED;
+    }
+  });
+
+  it('fails OPEN on a gate error — drops nothing, flags nothing', async () => {
+    mocks.loggedMessagesCreate.mockRejectedValue(new Error('anthropic 529'));
+    const result = await findQualityFailures([DRIFTED]);
+    expect(result.toDrop.size).toBe(0);
+    expect(result.offDomain.size).toBe(0);
+  });
+});

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -94,7 +94,10 @@ import { ANSWER_COOLDOWN_DAYS, answerCooldownKey } from '@/server/daily/answer-c
 import { SUBJECT_COOLDOWN_DAYS, entityKey } from '@/server/daily/subject-cooldown';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { normalizeFactKey } from '@/server/questions/fact-key';
-import { textContainsAnswer } from '@/server/questions/self-answering';
+import {
+  questionPartiallyLeaksAnswer,
+  textContainsAnswer,
+} from '@/server/questions/self-answering';
 import { embedTexts, isEmbeddingEnabled } from '@/server/llm/embeddings';
 import { resolveDailyBasePoints } from './types';
 import { STYLE_EXEMPLAR_BLOCK } from './exemplars';
@@ -812,16 +815,21 @@ const QUALITY_GATE_SYSTEM_PROMPT = `You are reviewing a small batch of just-gene
 6. MULTI_PART — the question bundles two DISTINCT asks into one, so it has no single clean answer. Tells: an "— and what…/who…/where…?" tail, or any setup that demands two separate facts (a thing AND its location, a name AND a date). E.g. "What vulnerability lets Hagen kill Siegfried — and what is the precise location of it on his body?" is MULTI_PART. This is NOT the name_multiple style (ONE ask for several items of the SAME kind, e.g. "name the three Norns"), which is fine — flag only a question asking for two DIFFERENT facts.
 7. MISLEADING_SETUP — a clause in the setup most naturally describes a DIFFERENT answer than the intended one, so a player who knows the topic is steered toward the wrong response. The intended answer may be technically defensible, but the wording conflates two things (or attaches a clue that points elsewhere), so the reader can't tell which answer is wanted. This is distinct from OPINION_OR_VAGUE (there the answer is genuinely open) — here a single answer exists but the phrasing misdirects. E.g. "In tennis, a player who has won zero points in a game is said to have this score, which is also used to describe a set won without the opponent taking a single game. What is this term for a scoreless result?" (intended answer: Love) is MISLEADING_SETUP — the clause "a set won without the opponent taking a single game" describes a *love set* (or a "bagel"), so the setup points a knowledgeable player at a different answer than the single word "love." Flag only when the misdirection is clear — never for a question that is merely wordy or that simply requires thought.
 
+8. OFF_DOMAIN — the question is not about the domain it was generated for. Each item carries the domain it was filed under and the generator's own fact_key, which the generator derives from the question's ACTUAL content: when the fact_key names a different territory than the domain, that is the generator confessing it drifted. E.g. domain="Virginia Woolf's Novels and Essays" with fact_key="james-joyce-irish-modernism-portrait-of-the-artist..." and a stem about Stephen Dedalus is OFF_DOMAIN — Joyce is Woolf's CONTEMPORARY, not part of her body of work.
+   CRITICAL — containment is NOT a defect. A question about a work, character, chapter, or episode that BELONGS to the domain is correctly filed, however different the fact_key looks: domain="Virginia Woolf's Novels and Essays" with fact_key="mrs-dalloway-big-ben-chimes" is FINE (Mrs. Dalloway is a Woolf novel), and so are "Sesame Street" under "Classic Children's Television" and "Breaking Bad" under "Color References Across Film and TV". Flag ONLY when the subject sits OUTSIDE the domain — a sibling author, a neighbouring period, an adjacent franchise. When you are unsure whether the subject belongs to the domain, do NOT flag.
+
 A high bar applies — flag a question only when one of these defects is clearly present. Subtle wordsmithing concerns are NOT defects.
 
 The following styles are explicitly ACCEPTABLE and must NOT be flagged on style grounds alone — fill-in-the-blank, complete-the-quote, name-multiple, and concise idiomatic questions all belong in Joshing. Reference exemplars:
 
 ${STYLE_EXEMPLAR_BLOCK}
 
-Only flag a question matching one of those styles if it independently exhibits ANSWER_LEAKED, OPINION_OR_VAGUE, FALSE_PREMISE, SELF_ANSWERING, MULTI_PART, MISLEADING_SETUP, or — at moderate/specialist tier only — GENERIC_AT_TIER. Style never exempts a question from the tier bar: a concise identification-style question at moderate/specialist must still clear strip-the-domain.
+Only flag a question matching one of those styles if it independently exhibits ANSWER_LEAKED, OPINION_OR_VAGUE, FALSE_PREMISE, SELF_ANSWERING, MULTI_PART, MISLEADING_SETUP, OFF_DOMAIN, or — at moderate/specialist tier only — GENERIC_AT_TIER. Style never exempts a question from the tier bar: a concise identification-style question at moderate/specialist must still clear strip-the-domain.
 
 Return JSON only:
-{ "drop_indices": [list of zero-based indices to drop], "reasons": { "<index>": "<short reason>" } }
+{ "drop_indices": [list of zero-based indices to drop], "reasons": { "<index>": "<DEFECT_NAME>: <short reason>" } }
+
+Every reason MUST begin with the defect name exactly as spelled above, followed by a colon — e.g. "OFF_DOMAIN: question is about Joyce, filed under Woolf". The caller routes on that prefix.
 
 If no questions are defective, return { "drop_indices": [], "reasons": {} }.${INSTRUCTION_USER_INPUT_GUIDANCE}`;
 
@@ -831,19 +839,30 @@ If no questions are defective, return { "drop_indices": [], "reasons": {} }.${IN
 export async function findQualityFailures(generated: LlmQuestion[]): Promise<{
   toDrop: Set<number>;
   reasons: Record<number, string>;
+  /** OFF_DOMAIN hits, held OUT of toDrop — see isDomainDriftDropEnabled. */
+  offDomain: Set<number>;
 }> {
-  if (generated.length === 0) return { toDrop: new Set(), reasons: {} };
+  const empty = { toDrop: new Set<number>(), reasons: {}, offDomain: new Set<number>() };
+  if (generated.length === 0) return empty;
   const client = getAnthropicClient();
-  if (!client) return { toDrop: new Set(), reasons: {} };
+  if (!client) return empty;
 
   // tier= feeds the GENERIC_AT_TIER defect (judged only at moderate/specialist).
   // difficulty_estimate is the same field serving and scoring treat as the
   // question's tier (resolveDailyBasePoints, bank matching), so the gate and the
   // serving path agree on what tier a question is.
+  //
+  // fact= feeds OFF_DOMAIN. `canonical_subcategory` is worthless as a drift
+  // signal on its own: the generation prompt instructs the model to echo the
+  // domain it was handed, so it is a carbon copy of the request even when the
+  // question wandered somewhere else. fact_key is the opposite — the model
+  // derives it from what it actually wrote, so a Joyce question generated for
+  // the Woolf domain still stamps "james-joyce-irish-modernism-...". Handing
+  // the gate both fields is what makes the drift visible.
   const body = generated
     .map(
       (q, i) =>
-        `[${i}] domain=${q.canonical_subcategory} tier=${q.difficulty_estimate}\n    q=${q.question_text}\n    a=${q.answer}`,
+        `[${i}] domain=${q.canonical_subcategory} tier=${q.difficulty_estimate} fact=${q.fact_key ?? '(none)'}\n    q=${q.question_text}\n    a=${q.answer}`,
     )
     .join('\n\n');
   const userMessage = wrapUserInput('batch', body);
@@ -881,15 +900,50 @@ export async function findQualityFailures(generated: LlmQuestion[]): Promise<{
         }
       }
     }
-    return { toDrop, reasons };
+    // OFF_DOMAIN is a NEW defect shipping in measure-only mode: pull those
+    // indices back out of the drop set so the gate's established defects keep
+    // dropping exactly as before, and a misjudged containment case ("Mrs.
+    // Dalloway" read as off-domain for the Woolf domain) costs a log line
+    // rather than a question. isDomainDriftDropEnabled promotes it to a drop.
+    const offDomain = new Set<number>();
+    for (const idx of toDrop) {
+      if (/^\s*OFF_DOMAIN\b/i.test(reasons[idx] ?? '')) offDomain.add(idx);
+    }
+    for (const idx of offDomain) toDrop.delete(idx);
+    if (offDomain.size > 0) {
+      console.warn('[daily/generate-questions] off-domain questions detected', {
+        dropping: isDomainDriftDropEnabled(),
+        indices: [...offDomain].sort((a, b) => a - b),
+        detail: [...offDomain].map((i) => ({
+          domain: generated[i].canonical_subcategory,
+          factKey: generated[i].fact_key,
+          reason: reasons[i],
+          questionPreview: generated[i].question_text.slice(0, 120),
+        })),
+      });
+    }
+    return { toDrop, reasons, offDomain };
   } catch (err) {
     // Fail open: don't block the daily queue on a Haiku outage.
     console.warn('[daily/generate-questions] quality gate failed', {
       error: err instanceof Error ? err.message : String(err),
     });
     recordGateFailedOpen('quality');
-    return { toDrop: new Set(), reasons: {} };
+    return { toDrop: new Set(), reasons: {}, offDomain: new Set() };
   }
+}
+
+/**
+ * DOMAIN_DRIFT_DROP_ENABLED — default OFF. The OFF_DOMAIN defect is detected,
+ * logged and counted (gate `domain_drift`) from the first deploy, but does not
+ * remove questions until this is set. The judgement it rests on — "is this
+ * subject INSIDE the domain, or merely adjacent to it?" — is exactly the call
+ * the reconcile prompt gets right and a lexical check cannot make at all, so it
+ * earns a measurement period before it is allowed to cost supply.
+ */
+export function isDomainDriftDropEnabled(): boolean {
+  const raw = process.env.DOMAIN_DRIFT_DROP_ENABLED?.trim().toLowerCase();
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
 }
 
 // Factual-correctness gate. The dedup and quality gates above never reliably
@@ -1083,12 +1137,121 @@ export function findAnswerLeaks(generated: LlmQuestion[]): {
 } {
   const toDrop = new Set<number>();
   const reasons: Record<number, string> = {};
+  const partialEnabled = isPartialAnswerLeakEnabled();
   for (let i = 0; i < generated.length; i += 1) {
     const q = generated[i];
     if (textContainsAnswer(q.question_text, q.answer)) {
       toDrop.add(i);
       reasons[i] = `answer "${q.answer}" appears in question text`.slice(0, 200);
+      continue;
     }
+    // Partial leak (the "dental plan" class): the stem hands over the answer's
+    // discriminating words and withholds only a generic noun or filler. Always
+    // MEASURED so the flag can be flipped on evidence; only DROPS when enabled.
+    if (questionPartiallyLeaksAnswer(q.question_text, q.answer)) {
+      if (partialEnabled) {
+        toDrop.add(i);
+        reasons[i] = `question gives away answer "${q.answer}"`.slice(0, 200);
+      } else {
+        console.warn('[daily/generate-questions] partial answer leak (measuring, not dropping)', {
+          answer: q.answer.slice(0, 80),
+          questionPreview: q.question_text.slice(0, 120),
+        });
+      }
+    }
+  }
+  return { toDrop, reasons };
+}
+
+/**
+ * PARTIAL_ANSWER_LEAK_ENABLED — default OFF. The partial-leak rules drop on a
+ * heuristic rather than on a whole-answer match, so they ship in measure-only
+ * mode: every hit is logged and counted under the `answer_leak_partial` gate,
+ * and nothing is dropped until this is set. Flip to a truthy value once the
+ * counters show the hit rate and the logged samples read as real leaks.
+ */
+export function isPartialAnswerLeakEnabled(): boolean {
+  const raw = process.env.PARTIAL_ANSWER_LEAK_ENABLED?.trim().toLowerCase();
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}
+
+/** Hits the partial-leak rules found, whether or not the flag lets them drop. */
+export function countPartialAnswerLeaks(generated: LlmQuestion[]): number {
+  let n = 0;
+  for (const q of generated) {
+    if (
+      !textContainsAnswer(q.question_text, q.answer) &&
+      questionPartiallyLeaksAnswer(q.question_text, q.answer)
+    ) {
+      n += 1;
+    }
+  }
+  return n;
+}
+
+// --- Rule 3 ("ONE CLEAN ANSWER") enforcement --------------------------------
+//
+// The generation prompt requires a single short checkable answer — "a name, a
+// title, a word, a short phrase" — and warns that paragraph-length answers
+// "grade unpredictably and must not be produced". Nothing enforced it, and the
+// live bank shows the model ignoring it regularly: "It signals the end of
+// Wotan's power and the gods' dominion — the spear, engraved with the contracts
+// that undergird Wotan's authority, is broken, meaning...".
+//
+// These are not merely ugly. A sprawling answer also DEFEATS the answer-leak
+// gate, because that gate requires the stem to contain every substantive word
+// of the answer and each extra word is another chance one is absent. The Joyce
+// question served 2026-09-05 leaked "a petition for universal peace" verbatim
+// and survived solely because its answer padded in the word "calling".
+//
+// Length alone is the wrong test — "Tennis Player Michael Joyce's Professional
+// Artistry as a Paradigm of Certain Stuff About Choice, Freedom, Discipline,
+// Joy, Grotesquerie, and Human Completeness" is a real 159-char essay title and
+// a perfectly clean answer. So we require length PLUS a sentence tell: a clause
+// break, an aside, or a leading pronoun. Measured against the live bank this
+// flags 15 of the 16 longest answers and spares that title.
+const ANSWER_SHAPE_MAX_CHARS = 100;
+// " — X" / "; X" / "(specifically, …)" are clause joins; a leading pronoun +
+// verb ("It signals…", "He gives…") is a sentence rather than a noun phrase.
+const SENTENCE_TELLS: RegExp[] = [
+  /\s[—–-]\s/,
+  /;\s/,
+  /\((?:specifically|or more precisely|i\.e\.|meaning|because)\b/i,
+  /^(?:it|he|she|they|you|we)\s+\w+/i,
+];
+
+function answerShapeMaxChars(): number {
+  const parsed = Number(process.env.ANSWER_SHAPE_MAX_CHARS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : ANSWER_SHAPE_MAX_CHARS;
+}
+
+/**
+ * ANSWER_SHAPE_GATE_ENABLED — default ON. Set to a falsy value to revert to the
+ * pre-gate behaviour without a deploy, matching the RECONCILE_BANK_DOMAINS
+ * kill-switch contract.
+ */
+export function isAnswerShapeGateEnabled(): boolean {
+  const raw = process.env.ANSWER_SHAPE_GATE_ENABLED?.trim().toLowerCase();
+  if (raw === undefined || raw === '') return true; // default ON
+  return !(raw === 'false' || raw === '0' || raw === 'no' || raw === 'off');
+}
+
+/** Answers that are sentences rather than the single clean answer Rule 3 requires. */
+export function findAnswerShapeFailures(generated: LlmQuestion[]): {
+  toDrop: Set<number>;
+  reasons: Record<number, string>;
+} {
+  const toDrop = new Set<number>();
+  const reasons: Record<number, string> = {};
+  if (!isAnswerShapeGateEnabled()) return { toDrop, reasons };
+  const maxChars = answerShapeMaxChars();
+  for (let i = 0; i < generated.length; i += 1) {
+    const answer = generated[i].answer.trim();
+    if (answer.length <= maxChars) continue;
+    const tell = SENTENCE_TELLS.find((re) => re.test(answer));
+    if (!tell) continue;
+    toDrop.add(i);
+    reasons[i] = `answer is a sentence, not one clean answer (${answer.length} chars)`.slice(0, 200);
   }
   return { toDrop, reasons };
 }
@@ -1857,6 +2020,24 @@ export async function generateDailyQuestions(
     });
   }
 
+  // OFF_DOMAIN hits from the quality gate (the "Joyce question filed under
+  // Virginia Woolf" case). Held separate from qualityResult.toDrop so the new
+  // defect can be measured before it is allowed to cost supply.
+  const offDomain = qualityResult.offDomain;
+
+  // Rule 3 ("ONE CLEAN ANSWER") backstop. A paragraph-length answer grades
+  // unpredictably AND blinds the answer-leak gate above, so it is dropped here
+  // rather than served. Deterministic and pure — cannot fail open.
+  const answerShape = findAnswerShapeFailures(generated);
+  if (answerShape.toDrop.size > 0) {
+    console.warn('[daily/generate-questions] dropping sentence-shaped answers', {
+      droppedCount: answerShape.toDrop.size,
+      droppedIndices: [...answerShape.toDrop].sort((a, b) => a - b),
+      reasons: answerShape.reasons,
+      originalCount: generated.length,
+    });
+  }
+
   // Difficulty-floor backstop: the per-domain target / fixed preference is only a
   // prompt hint, and difficulty_estimate is the model's own label of what it
   // wrote. Drop questions that came back more than one tier below what was asked
@@ -1915,6 +2096,16 @@ export async function generateDailyQuestions(
       dropped: subjectCooldownDuplicates.size,
     },
     { gate: 'answer_leak', considered: generated.length, dropped: answerLeaks.toDrop.size },
+    // Measure-only until PARTIAL_ANSWER_LEAK_ENABLED is set: `dropped` counts
+    // what the rules WOULD drop, so the flag can be flipped on evidence rather
+    // than on faith. Once enabled these hits also appear under `answer_leak`.
+    {
+      gate: 'answer_leak_partial',
+      considered: generated.length,
+      dropped: countPartialAnswerLeaks(generated),
+    },
+    { gate: 'answer_shape', considered: generated.length, dropped: answerShape.toDrop.size },
+    { gate: 'domain_drift', considered: generated.length, dropped: offDomain.size },
     { gate: 'difficulty_floor', considered: generated.length, dropped: underDifficulty.toDrop.size },
   ]);
 
@@ -1928,6 +2119,11 @@ export async function generateDailyQuestions(
     ...qualityResult.toDrop,
     ...factualResult.toDrop,
     ...answerLeaks.toDrop,
+    ...answerShape.toDrop,
+    // offDomain is deliberately NOT unioned unconditionally — see the OFF_DOMAIN
+    // block above. It is measured and logged by default; flipping
+    // DOMAIN_DRIFT_DROP_ENABLED is what promotes it to a drop.
+    ...(isDomainDriftDropEnabled() ? offDomain : []),
   ]);
   if (allDrops.size > 0) {
     generated = generated.filter((_, i) => !allDrops.has(i));
@@ -3077,10 +3273,13 @@ export async function screenGroundedBatch(questions: LlmQuestion[]): Promise<Set
     findFactualFailures(questions),
   ]);
   const answerLeaks = findAnswerLeaks(questions);
+  const answerShape = findAnswerShapeFailures(questions);
   return new Set<number>([
     ...batchDuplicates,
     ...qualityResult.toDrop,
     ...factualResult.toDrop,
     ...answerLeaks.toDrop,
+    ...answerShape.toDrop,
+    ...(isDomainDriftDropEnabled() ? qualityResult.offDomain : []),
   ]);
 }

--- a/src/server/db/queries/gate-drop-stats.ts
+++ b/src/server/db/queries/gate-drop-stats.ts
@@ -24,6 +24,12 @@ export const GATE_NAMES = [
   'answer_cooldown',
   'subject_cooldown',
   'answer_leak',
+  // Measure-only until PARTIAL_ANSWER_LEAK_ENABLED / DOMAIN_DRIFT_DROP_ENABLED
+  // are set: `dropped` counts what each rule WOULD remove, so the flags get
+  // flipped on evidence. See findAnswerLeaks / findQualityFailures.
+  'answer_leak_partial',
+  'answer_shape',
+  'domain_drift',
   'difficulty_floor',
   'thin_declared',
 ] as const;

--- a/src/server/questions/self-answering.ts
+++ b/src/server/questions/self-answering.ts
@@ -249,6 +249,128 @@ function answerLeaksIntoQuestion(normalizedQuestion: string, candidate: string):
   return false;
 }
 
+// --- PARTIAL leak detection (the "dental plan" class) ------------------------
+//
+// acceptedFormLeaks above is CONJUNCTIVE: it fires only when the stem shows
+// EVERY substantive word of an accepted form. That is the right bar for a
+// fail-closed gate, but it is blind to the leak shape that actually dominates
+// in production — the stem hands over the answer's RARE, discriminating word
+// and withholds only a generic head noun the player can supply for free:
+//
+//   Q: "...What specific DENTAL benefit are the workers fighting to keep?"
+//   A: "Dental plan"                        (served 2026-09-05)
+//   Q: "In 'LEMON of Troy'... recover Springfield's prized ……"
+//   A: "lemon tree"                         (served 2026-09-04)
+//   Q: "...refuses to sign A PETITION FOR UNIVERSAL PEACE... What cause did
+//       that petition support?"
+//   A: "A petition CALLING for universal peace / ..."   (served 2026-09-05)
+//
+// The first two withhold one generic noun; the third withholds one filler
+// gerund out of four words the stem already prints verbatim. All three read as
+// giveaways to a player, and all three pass the conjunctive test.
+//
+// Two narrow rules cover them without touching the conjunctive gate:
+//
+//  A. CONTIGUOUS RUN — the stem prints two or more of the answer's substantive
+//     words consecutively, in order, AND every word it withholds is filler.
+//     "petition ... universal peace" is the answer read off the page; the
+//     missing "calling" changes nothing. The filler condition is what keeps
+//     this off "Enfield Tennis Academy" against a stem that says "Boston
+//     tennis academy" — there the run is real but the withheld "Enfield" is
+//     the whole answer, a false positive the module has always warned about.
+//  B. GENERIC HEAD NOUN — exactly one word is missing, it is a generic noun
+//     that names a CATEGORY rather than the answer's substance, and at least
+//     one word the stem DOES show is not generic. "dental|plan", "lemon|tree",
+//     "cyclic|form" fire; "basset|clarinet", "plagal|cadence" and
+//     "cabbage patch|kids" correctly do NOT, because there the withheld word is
+//     the substance and the shown word is the category.
+//
+// Both skip counting questions ("how many bases…" → "Two bases"), where the
+// stem naming the unit is normal and the withheld number IS the answer. This
+// is the single largest false-positive source: structurally it is identical to
+// a leak.
+//
+// Gated OFF by default (see PARTIAL_ANSWER_LEAK_ENABLED in the daily gate
+// chain) because, unlike the conjunctive test, these rules DROP on a heuristic
+// rather than on a full match.
+
+// Nouns that name the CATEGORY an answer belongs to rather than its substance.
+// A stem may hand one of these over for free; what makes the answer the answer
+// is the modifier in front of it.
+const GENERIC_HEAD_NOUNS = new Set([
+  'plan', 'tree', 'form', 'system', 'technique', 'method', 'process', 'model',
+  'theory', 'principle', 'rule', 'law', 'effect', 'style', 'period', 'era',
+  'movement', 'school', 'test', 'sign', 'device', 'section', 'scene', 'act',
+  'song', 'book', 'film', 'movie', 'show', 'series', 'game', 'award', 'prize',
+  'term', 'name', 'type', 'kind', 'group', 'set', 'unit', 'part', 'piece',
+  'shape', 'color', 'colour', 'sound', 'word', 'phrase', 'line', 'title',
+]);
+
+// Light verbs and connectives that pad an answer without being any part of it.
+// "A petition CALLING for universal peace" answers the same question as "a
+// petition for universal peace", so their absence from the stem withholds
+// nothing from the player.
+const FILLER_WORDS = new Set([
+  'calling', 'called', 'known', 'named', 'naming', 'describing', 'describes',
+  'meaning', 'means', 'being', 'involving', 'featuring', 'concerning',
+  'regarding', 'containing', 'showing', 'referring', 'relating', 'consisting',
+  'made', 'given', 'used', 'using', 'about', 'specifically', 'roughly',
+  'approximately', 'often', 'usually', 'typically', 'simply', 'literally',
+]);
+
+const COUNTING_ASK = /\bhow (?:many|much|long|old|far|tall)\b/;
+const NUMBER_WORD = new Set([
+  'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten',
+  'eleven', 'twelve', 'first', 'second', 'third', 'fourth', 'fifth', 'zero',
+  'half', 'both', 'dozen', 'hundred', 'thousand',
+]);
+const isNumeric = (token: string) => NUMBER_WORD.has(token) || /^\d+$/.test(token);
+
+/**
+ * True when the question gives away enough of the answer that the player can
+ * read it off the stem, even though the stem does not contain the whole answer.
+ *
+ * Only the PRIMARY accepted form is examined. Secondary variants after a "/" or
+ * inside parentheses are alternative phrasings, not the keyed answer, and
+ * matching against them produced false positives ("the craniosacral system"
+ * firing on a question whose real answer is "cerebrospinal fluid").
+ */
+export function questionPartiallyLeaksAnswer(text: string, answer: string): boolean {
+  const normalizedQuestion = normalize(text);
+  if (!normalizedQuestion) return false;
+  if (COUNTING_ASK.test(normalizedQuestion)) return false;
+
+  const [primary] = acceptedForms(answer);
+  if (!primary) return false;
+  const tokens = substantiveTokens(primary);
+  if (tokens.length < 2) return false;
+
+  const padded = ` ${normalizedQuestion} `;
+  const shows = (token: string) => padded.includes(` ${token} `);
+  const missing = tokens.filter((t) => !shows(t));
+  // Nothing withheld is the conjunctive gate's business, not ours.
+  if (missing.length === 0) return false;
+  // The withheld word IS the answer when it is a number — that is a counting
+  // question wearing a different stem, not a leak.
+  if (missing.some(isNumeric)) return false;
+
+  // Rule A — the stem prints a run of the answer, in order, and everything it
+  // withholds is filler. Without the filler condition this fires on a stem that
+  // paraphrases the answer's category ("Boston tennis academy" vs the answer
+  // "Enfield Tennis Academy"), where the withheld word IS the answer.
+  if (missing.every((t) => FILLER_WORDS.has(t))) {
+    let run = 0;
+    for (const token of tokens) {
+      run = shows(token) ? run + 1 : 0;
+      if (run >= 2) return true;
+    }
+  }
+
+  // Rule B — one generic head noun withheld, real substance already shown.
+  if (missing.length !== 1 || !GENERIC_HEAD_NOUNS.has(missing[0])) return false;
+  return tokens.some((t) => shows(t) && !GENERIC_HEAD_NOUNS.has(t));
+}
+
 export function textContainsAnswer(
   text: string,
   answer: string,


### PR DESCRIPTION
Three questions served on 2026-09-04/05 gave their answers away in the stem, and one was filed under the wrong domain.

| Question (stem gives it away) | Answer | Filed under |
|---|---|---|
| "…What specific **dental** benefit are the workers fighting to keep?" | "Dental plan" | The Simpsons |
| "In '**Lemon** of Troy'… recover Springfield's prized ……" | "lemon tree" | The Simpsons |
| "…refuses to sign **a petition for universal peace**… What cause did that petition support?" | "A petition **calling** for universal peace / …" | **Virginia Woolf** |

All three violate the generator's own `NEVER name the answer in the question_text` rule and passed both the Haiku quality gate and the deterministic backstop.

## Why the backstop missed them

`acceptedFormLeaks` is **conjunctive** — it fires only when the stem contains *every* substantive word of an accepted answer form. The leak shape that actually occurs is partial: the stem hands over the rare, discriminating word and withholds a generic head noun. Verified by running the real gate — deleting the single filler gerund "calling" from the Joyce answer makes the existing gate fire on it unchanged.

## Why the mis-filing was invisible

`canonical_subcategory` is useless as a drift signal: the prompt *instructs* the model to echo the domain it was handed, so it agreed with the request even though the question had wandered to another author. `fact_key`, which the model derives from what it actually wrote, still said `james-joyce-irish-modernism-…`. Nothing compared the two.

Confirmed via `LlmUsageEvent`: `reconcile-subcategory` ran once in ten days (Aug 29), not on the 5th — the fold short-circuited on an exact key match. That domain holds **6 off-domain rows out of 38** (4 Joyce, 2 Forster), recurring since May.

## Three gates, sized against all 2,304 servable rows

| Gate | Flag | Default | Live hit rate |
|---|---|---|---|
| Rule 3 answer shape | `ANSWER_SHAPE_GATE_ENABLED` | **ON** | 41 (1.78%) |
| Partial answer leak | `PARTIAL_ANSWER_LEAK_ENABLED` | OFF (measured) | 13 (0.56%) |
| Off-domain drift | `DOMAIN_DRIFT_DROP_ENABLED` | OFF (measured) | — |

- **Answer shape** drops sentence-shaped answers. Length alone is the wrong test — it would kill a real 159-char DFW essay title — so it requires length *plus* a sentence tell. This also defuses what beat the leak gate: every padding word is another chance one is absent from the stem.
- **Partial leak** — Rule A catches a contiguous run of the answer printed in the stem; Rule B catches a withheld generic head noun. Counting questions are carved out, since "How many bases?" → "Two bases" is structurally identical to a leak.
- **OFF_DOMAIN** rides the existing quality-gate batch call (**no new LLM calls**), now fed `fact_key`. Verdicts are partitioned out of the drop set and reported separately, so the gate's established defects keep dropping exactly as before. Containment (Mrs. Dalloway under Woolf, Breaking Bad under Color References) must stay legal, and the prompt says so explicitly.

## A false positive the measurement caught

Running the *shipped* rules over the live corpus caught one I'd introduced: Rule A fired on "Enfield Tennis Academy" against a stem saying "Boston tennis academy" — a case `self-answering.ts` has warned about in comments since the accepted-form gate landed. Requiring every withheld word to be filler took it from **86 hits (3.7%) to 13 (0.56%)**; all 13 read as real leaks. It's now a regression test.

## Verification

Typecheck clean, lint 0 errors, all six ratchets pass, **full suite 2,600 passed**. 16 new tests cover all three live rows plus the false-positive shapes (Enfield, Fundamental Theorem, basset clarinet, plagal cadence, Cabbage Patch Kids, counting questions).

## Not included

The three bad rows are **still servable in prod** — `is_duplicate = false`. Both write paths are closed to the agent (node+pg is denied by the auto-mode classifier; the Supabase MCP is read-only), so the demote SQL was handed over separately to run by hand.

## Review notes

The two heuristic gates default **off** because they drop on inference rather than on a full match; the new `answer_leak_partial` / `domain_drift` counters say when to flip them. The shape gate defaults **on** because its precision measured well and it drops genuinely bad questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG8TSZKng9jjkRH3UroXMS
