### PR TITLE
Gate the bank re-serve path, sweep existing stock, close the accessible-tier hole

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Project-specific guidance for Claude. Keep this file short; reference, don't dup
 - `npm run format` — Prettier write
 - `npm run db:migrate` — Drizzle migrations
 - `npm run check:build-latency` — Daily Five build-latency reading (read-only; prints the Phase 2/3 checks from `diagnosis/daily-build-latency-deferral-plan.md`, with the `outcome='built'` filter applied so early returns can't be mistaken for fast builds)
+- `npm run sweep:bank-quality` — one-time hygiene sweep over EXISTING bank stock (`GeneratedQuestion` where `is_duplicate=false`). **Dry-run by default**; `--apply` writes demotions, `--no-llm` runs only the deterministic checks (no API key needed), `--include-off-domain` also demotes OFF_DOMAIN hits (off by default — that judgement has no precision data yet). Exists because the generation gate chain only ever sees FRESHLY GENERATED questions: `pickBankSource` re-serves old stock by cloning it into the queue, so anything that entered the bank before its gate existed is re-served forever. First run (2026-09-06) found 103 defective rows of 2,324 — 62 whose stem contains their own answer, 41 sentence-shaped answers.
 - `npm run smoke:daily-catchup` — daily catchup smoke test
 - `npx tsc -p tsconfig.typecheck.json` — typecheck convention (this is what produces the `tsconfig.typecheck.tsbuildinfo` churn; do not commit the `.tsbuildinfo` files)
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:typesize": "node scripts/check-typesize-ratchet.mjs",
     "check:binary": "node scripts/check-binary-sources.mjs",
     "check:build-latency": "node scripts/build-latency-check.mjs",
+    "sweep:bank-quality": "tsx scripts/sweep-bank-quality.ts",
     "smoke:daily-catchup": "tsx scripts/daily-catchup.smoke.ts",
     "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",
     "smoke:invite-first-five": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/invite-first-five.smoke.mjs",

--- a/scripts/sweep-bank-quality.ts
+++ b/scripts/sweep-bank-quality.ts
@@ -1,0 +1,194 @@
+import 'dotenv/config';
+
+import { eq, inArray } from 'drizzle-orm';
+
+import { db, pool, generatedQuestions } from '../src/server/db';
+import {
+  findBankSourceDefect,
+  findQualityFailures,
+  type LlmQuestion,
+} from '../src/server/daily/generate-questions';
+import { verdictToGeneratedPatch } from '../src/server/quality/verify-question';
+
+// One-time hygiene sweep over EXISTING bank stock.
+//
+// Why this exists: every quality gate lives inside generateDailyQuestions and
+// only ever sees FRESHLY GENERATED questions. pickBankSource re-serves old
+// stock by cloning a bank row straight into the queue, so anything that
+// entered the bank before its gate existed is re-served forever and no gate
+// tuning can reach it. Found 2026-09-06 in production: a Joyce question filed
+// under "Virginia Woolf's Novels and Essays" (generated 2026-05-09) and a
+// self-answering onion/tears question (generated 2026-08-21) were both served
+// that day having never passed through a single gate. See
+// diagnosis/answer-leak-domain-drift-plan.md.
+//
+// The companion fix (findBankSourceDefect, wired into pickBankSource) stops
+// BAD STOCK BEING RE-SERVED from here on. This script is the other half:
+// cleaning what is already in the bank. Neither substitutes for the other.
+//
+//   npx tsx scripts/sweep-bank-quality.ts                  # DRY RUN, all checks
+//   npx tsx scripts/sweep-bank-quality.ts --no-llm         # deterministic only (no API key needed)
+//   npx tsx scripts/sweep-bank-quality.ts --apply          # writes demotions to prod
+//   npx tsx scripts/sweep-bank-quality.ts --apply --include-off-domain
+//
+// Demotion is is_duplicate=true + verdict 'demoted' + a reason, exactly the
+// shape the batch verifier already uses (verdictToGeneratedPatch), so it is
+// reversible (set is_duplicate=false) and shows up wherever machine demotions
+// already show up. For a handful of individually-noticed rows, filing a
+// ContentReport is the better route — that surfaces them in /admin/reports for
+// a human. This script is bulk hygiene, so it demotes rather than flooding
+// that queue.
+//
+// OFF_DOMAIN hits are reported but NOT demoted unless --include-off-domain is
+// passed. That mirrors the DOMAIN_DRIFT_DROP_ENABLED posture: the off-domain
+// judgement has no precision data behind it yet (Phase 2's eval is still
+// unrun), and its false-positive mode — silently demoting a correctly-filed
+// question — is invisible in production.
+
+const APPLY = process.argv.includes('--apply');
+const NO_LLM = process.argv.includes('--no-llm');
+const INCLUDE_OFF_DOMAIN = process.argv.includes('--include-off-domain');
+const BATCH_SIZE = Math.max(1, Number(process.env.SWEEP_BATCH_SIZE ?? 10));
+const LIMIT = Number(process.env.SWEEP_LIMIT ?? 0); // 0 = no cap
+
+type BankRow = {
+  id: string;
+  questionText: string;
+  answer: string;
+  explainer: string;
+  canonicalSubcategory: string;
+  broadCategory: string;
+  difficultyEstimate: string;
+  factKey: string | null;
+  acceptableVariants: string[];
+};
+
+type Finding = { row: BankRow; reason: string; kind: 'deterministic' | 'llm' | 'off_domain' };
+
+function asLlmQuestion(row: BankRow): LlmQuestion {
+  const tier = (['accessible', 'moderate', 'specialist'] as const).includes(
+    row.difficultyEstimate as never,
+  )
+    ? (row.difficultyEstimate as LlmQuestion['difficulty_estimate'])
+    : 'moderate';
+  return {
+    canonical_subcategory: row.canonicalSubcategory,
+    broad_category: row.broadCategory,
+    question_text: row.questionText,
+    answer: row.answer,
+    explainer: row.explainer,
+    difficulty_estimate: tier,
+    fact_key: row.factKey,
+    subject_entity: null,
+    sub_angles: [],
+    question_shape: null,
+  };
+}
+
+async function main() {
+  const rows = (await db
+    .select({
+      id: generatedQuestions.id,
+      questionText: generatedQuestions.questionText,
+      answer: generatedQuestions.answer,
+      explainer: generatedQuestions.explainer,
+      canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+      broadCategory: generatedQuestions.broadCategory,
+      difficultyEstimate: generatedQuestions.difficultyEstimate,
+      factKey: generatedQuestions.factKey,
+      acceptableVariants: generatedQuestions.acceptableVariants,
+    })
+    .from(generatedQuestions)
+    .where(eq(generatedQuestions.isDuplicate, false))) as BankRow[];
+
+  const population = LIMIT > 0 ? rows.slice(0, LIMIT) : rows;
+  console.log(
+    `[sweep] ${population.length} servable bank rows${LIMIT > 0 ? ` (capped from ${rows.length})` : ''}`,
+  );
+
+  const findings: Finding[] = [];
+
+  // Pass 1 — deterministic. Free, no API key, catches the lexical defects.
+  const survivors: BankRow[] = [];
+  for (const row of population) {
+    const defect = findBankSourceDefect(row);
+    if (defect) findings.push({ row, reason: defect, kind: 'deterministic' });
+    else survivors.push(row);
+  }
+  console.log(`[sweep] deterministic: ${findings.length} defective / ${population.length}`);
+
+  // Pass 2 — the Haiku quality gate. This is what reaches the SEMANTIC defects
+  // (a stem that paraphrases its answer, a definition that hands the answer
+  // over, a question filed under a sibling domain) that no lexical rule can.
+  if (!NO_LLM) {
+    let batches = 0;
+    for (let i = 0; i < survivors.length; i += BATCH_SIZE) {
+      const batch = survivors.slice(i, i + BATCH_SIZE);
+      const result = await findQualityFailures(batch.map(asLlmQuestion));
+      for (const idx of result.toDrop) {
+        findings.push({ row: batch[idx], reason: result.reasons[idx] ?? 'quality gate', kind: 'llm' });
+      }
+      for (const idx of result.offDomain) {
+        findings.push({
+          row: batch[idx],
+          reason: result.reasons[idx] ?? 'OFF_DOMAIN',
+          kind: 'off_domain',
+        });
+      }
+      batches += 1;
+      if (batches % 10 === 0) {
+        console.log(`[sweep] ...${i + batch.length}/${survivors.length} through the quality gate`);
+      }
+    }
+    console.log(`[sweep] quality gate: ${batches} batches over ${survivors.length} rows`);
+  } else {
+    console.log('[sweep] --no-llm: skipped the quality gate (semantic defects NOT checked)');
+  }
+
+  const byKind = {
+    deterministic: findings.filter((f) => f.kind === 'deterministic'),
+    llm: findings.filter((f) => f.kind === 'llm'),
+    off_domain: findings.filter((f) => f.kind === 'off_domain'),
+  };
+  console.log(
+    `\n[sweep] findings: ${byKind.deterministic.length} deterministic, ${byKind.llm.length} quality-gate, ${byKind.off_domain.length} off-domain`,
+  );
+  for (const f of findings) {
+    console.log(
+      `\n  [${f.kind}] ${f.row.id}  (${f.row.canonicalSubcategory})\n    Q: ${f.row.questionText.slice(0, 130)}\n    A: ${f.row.answer.slice(0, 90)}\n    why: ${f.reason.slice(0, 160)}`,
+    );
+  }
+
+  const toDemote = findings.filter((f) => f.kind !== 'off_domain' || INCLUDE_OFF_DOMAIN);
+  if (!APPLY) {
+    console.log(
+      `\n[sweep] DRY RUN — would demote ${toDemote.length} row(s). Re-run with --apply to write.`,
+    );
+    return;
+  }
+
+  // De-dupe: a row can be flagged by more than one pass; keep the first reason.
+  const seen = new Map<string, string>();
+  for (const f of toDemote) if (!seen.has(f.row.id)) seen.set(f.row.id, f.reason);
+
+  let demoted = 0;
+  for (const [id, reason] of seen) {
+    const patch = verdictToGeneratedPatch('demoted', new Date(), `bank sweep: ${reason}`.slice(0, 400));
+    const updated = await db
+      .update(generatedQuestions)
+      .set(patch)
+      .where(inArray(generatedQuestions.id, [id]))
+      .returning({ id: generatedQuestions.id });
+    demoted += updated.length;
+  }
+  console.log(`\n[sweep] demoted ${demoted} row(s).`);
+}
+
+main()
+  .catch((err) => {
+    console.error('[sweep] failed', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/src/server/daily/__tests__/bank-pick-quality-gate.test.ts
+++ b/src/server/daily/__tests__/bank-pick-quality-gate.test.ts
@@ -1,0 +1,102 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// Cover for the bank RE-SERVE gate. Every other gate in this module runs only
+// on freshly generated questions; pickBankSource clones existing stock straight
+// into the queue, which is how a Joyce-under-Woolf row from 2026-05-09 and a
+// self-answering onion/tears row from 2026-08-21 were both re-served on
+// 2026-09-06 without passing through anything.
+//
+// Same dynamic-import dance as answer-leak-gate.test.ts: generate-questions.ts
+// imports @/server/db, which throws at module load without a connection string.
+let findBankSourceDefect: typeof import('@/server/daily/generate-questions').findBankSourceDefect;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  ({ findBankSourceDefect } = await import('@/server/daily/generate-questions'));
+});
+
+describe('findBankSourceDefect', () => {
+  it('rejects a bank row whose stem contains its own answer', () => {
+    // Real row from the live bank (Tennis Fundamentals) — the stem says "six
+    // games all and a tiebreak is about to begin" and the answer is the same words.
+    const defect = findBankSourceDefect({
+      questionText:
+        'In tennis, when a player wins the final point of a set to reach six games all and a tiebreak is about to begin, what score is typically announced?',
+      answer: 'Six all — tiebreak',
+    });
+    expect(defect).toContain('appears in question text');
+  });
+
+  it('rejects a bank row whose answer is a sentence rather than one clean answer', () => {
+    // Real row (Wagner's Ring Cycle), 172 chars of narration.
+    const defect = findBankSourceDefect({
+      questionText:
+        "In 'Götterdämmerung,' Waltraute makes a desperate journey to beg Brünnhilde to give up the ring. What does she report about Wotan?",
+      answer:
+        "Wotan sits silent and brooding, his spear shattered, surrounded by the gods; if Brünnhilde returns the ring to the Rhinemaidens, the curse will be lifted and the gods saved",
+    });
+    expect(defect).toContain('one clean answer');
+  });
+
+  it('checks acceptable_variants too, not just the primary answer', () => {
+    // "Daily Scrum" is the variant that leaks — the stem opens "In Scrum,".
+    const defect = findBankSourceDefect({
+      questionText:
+        'In Scrum, what is the name of the brief daily team meeting, typically time-boxed to fifteen minutes?',
+      answer: 'Daily standup',
+      acceptableVariants: ['Daily Scrum'],
+    });
+    expect(defect).toContain('appears in question text');
+  });
+
+  it('passes a clean bank row through untouched', () => {
+    expect(
+      findBankSourceDefect({
+        questionText:
+          "In Star Trek: The Next Generation, what is the name of Captain Picard's civilian brother, whom he visits at the family vineyard in France?",
+        answer: 'Robert Picard',
+      }),
+    ).toBeNull();
+  });
+
+  it('honours PARTIAL_ANSWER_LEAK_ENABLED, matching the generation path', () => {
+    // One flag governs both paths on purpose: a rule not trusted to drop at
+    // generation time is not trusted to reject a re-serve either.
+    const row = {
+      questionText:
+        "In 'Last Exit to Springfield,' Homer becomes a union negotiator. What specific dental benefit are the workers fighting to keep?",
+      answer: 'Dental plan',
+    };
+    delete process.env.PARTIAL_ANSWER_LEAK_ENABLED;
+    expect(findBankSourceDefect(row)).toBeNull();
+    process.env.PARTIAL_ANSWER_LEAK_ENABLED = 'true';
+    try {
+      expect(findBankSourceDefect(row)).toContain('gives away answer');
+    } finally {
+      delete process.env.PARTIAL_ANSWER_LEAK_ENABLED;
+    }
+  });
+
+  it('does NOT catch the semantic defects — that is the sweep script’s job', () => {
+    // Documenting the limitation deliberately. Both of these were re-served in
+    // production on 2026-09-06 and both pass every deterministic check: the
+    // leak is "crying"→"Tears" and "1920 + women voting"→"Nineteenth
+    // Amendment", neither of which shares a token with its answer. Only the
+    // Haiku quality gate reaches these, which is why fix 1 (this gate) and fix
+    // 2 (scripts/sweep-bank-quality.ts) are complementary, not alternatives.
+    expect(
+      findBankSourceDefect({
+        questionText:
+          'When you slice into a raw onion and start crying, a volatile compound released from damaged onion cells is what actually irritates your eyes. What everyday kitchen liquid is your body producing in response?',
+        answer: 'Tears',
+      }),
+    ).toBeNull();
+    expect(
+      findBankSourceDefect({
+        questionText:
+          'During the Progressive Era, women across the country organized and marched for the right to vote, culminating in a constitutional amendment ratified in 1920. What is this amendment commonly called?',
+        answer: 'the Nineteenth Amendment',
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/server/daily/__tests__/quality-gate.eval.test.ts
+++ b/src/server/daily/__tests__/quality-gate.eval.test.ts
@@ -171,4 +171,43 @@ describe.skipIf(!evalsEnabled)('quality gate FALSE_PREMISE (live)', () => {
     },
     EVAL_TIMEOUT_MS,
   );
+
+  // DEFINITION_SUPPLIED (added 2026-09-06). The 19th Amendment row below was
+  // generated and served in production on 2026-09-06: it passed the gate
+  // because the one defect that describes it, GENERIC_AT_TIER, is explicitly
+  // forbidden from flagging accessible-tier items. The new defect applies at
+  // every tier. See diagnosis/answer-leak-domain-drift-plan.md.
+  it(
+    'flags a stem that supplies the full definition and asks only for the name (accessible tier)',
+    async () => {
+      const result = await findQualityFailures([
+        q(
+          'During the Progressive Era, women across the country organized and marched for the right to vote, culminating in a constitutional amendment ratified in 1920. What is this amendment commonly called?',
+          'the Nineteenth Amendment',
+          'accessible',
+          'Progressive Era American Politics',
+        ),
+      ]);
+      expect([...result.toDrop]).toEqual([0]);
+    },
+    EVAL_TIMEOUT_MS,
+  );
+
+  it(
+    'does NOT flag an accessible question that still requires real recall',
+    async () => {
+      // Knowing the show, and that Picard has a brother, does not give you
+      // "Robert" -- the identification work is still the player's.
+      const result = await findQualityFailures([
+        q(
+          "In Star Trek: The Next Generation, what is the name of Captain Picard's civilian brother, whom he visits at the family vineyard in France?",
+          'Robert Picard',
+          'accessible',
+          'Star Trek: The Next Generation',
+        ),
+      ]);
+      expect(result.toDrop.size).toBe(0);
+    },
+    EVAL_TIMEOUT_MS,
+  );
 });

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -818,13 +818,18 @@ const QUALITY_GATE_SYSTEM_PROMPT = `You are reviewing a small batch of just-gene
 8. OFF_DOMAIN — the question is not about the domain it was generated for. Each item carries the domain it was filed under and the generator's own fact_key, which the generator derives from the question's ACTUAL content: when the fact_key names a different territory than the domain, that is the generator confessing it drifted. E.g. domain="Virginia Woolf's Novels and Essays" with fact_key="james-joyce-irish-modernism-portrait-of-the-artist..." and a stem about Stephen Dedalus is OFF_DOMAIN — Joyce is Woolf's CONTEMPORARY, not part of her body of work.
    CRITICAL — containment is NOT a defect. A question about a work, character, chapter, or episode that BELONGS to the domain is correctly filed, however different the fact_key looks: domain="Virginia Woolf's Novels and Essays" with fact_key="mrs-dalloway-big-ben-chimes" is FINE (Mrs. Dalloway is a Woolf novel), and so are "Sesame Street" under "Classic Children's Television" and "Breaking Bad" under "Color References Across Film and TV". Flag ONLY when the subject sits OUTSIDE the domain — a sibling author, a neighbouring period, an adjacent franchise. When you are unsure whether the subject belongs to the domain, do NOT flag.
 
+9. DEFINITION_SUPPLIED — the setup describes the answer so completely that the stem itself uniquely identifies it, and the player is only asked to attach the name. Distinct from SELF_ANSWERING (which needs the answer's own words to appear) and from ANSWER_LEAKED (which needs a paraphrase of the answer term): here every DEFINING property is handed over and the recall step has been removed. Test: strike the interrogative and ask whether the remaining sentence already picks out exactly one thing in the world. If it does, and the ask is just "what is that called?", it is DEFINITION_SUPPLIED.
+   E.g. "During the Progressive Era, women across the country organized and marched for the right to vote, culminating in a constitutional amendment ratified in 1920. What is this amendment commonly called?" — "constitutional amendment" + "1920" + "women voting" identifies the Nineteenth Amendment and nothing else; naming it is a relabel, not a recall.
+   **This defect applies at EVERY tier, accessible included.** Do not treat it as tier-gated the way GENERIC_AT_TIER is — an accessible question is allowed to be EASY, but it is not allowed to answer itself.
+   NOT this defect: a stem that supplies genuine context or narrows a field without settling it ("In Star Trek: The Next Generation, what is the name of Captain Picard's civilian brother…" — knowing the show and that he has a brother does not tell you "Robert"), or one whose defining details are exactly the fact being tested at specialist tier. When the stem leaves any real identification work to the player, do NOT flag.
+
 A high bar applies — flag a question only when one of these defects is clearly present. Subtle wordsmithing concerns are NOT defects.
 
 The following styles are explicitly ACCEPTABLE and must NOT be flagged on style grounds alone — fill-in-the-blank, complete-the-quote, name-multiple, and concise idiomatic questions all belong in Joshing. Reference exemplars:
 
 ${STYLE_EXEMPLAR_BLOCK}
 
-Only flag a question matching one of those styles if it independently exhibits ANSWER_LEAKED, OPINION_OR_VAGUE, FALSE_PREMISE, SELF_ANSWERING, MULTI_PART, MISLEADING_SETUP, OFF_DOMAIN, or — at moderate/specialist tier only — GENERIC_AT_TIER. Style never exempts a question from the tier bar: a concise identification-style question at moderate/specialist must still clear strip-the-domain.
+Only flag a question matching one of those styles if it independently exhibits ANSWER_LEAKED, OPINION_OR_VAGUE, FALSE_PREMISE, SELF_ANSWERING, MULTI_PART, MISLEADING_SETUP, OFF_DOMAIN, DEFINITION_SUPPLIED, or — at moderate/specialist tier only — GENERIC_AT_TIER. Style never exempts a question from the tier bar: a concise identification-style question at moderate/specialist must still clear strip-the-domain.
 
 Return JSON only:
 { "drop_indices": [list of zero-based indices to drop], "reasons": { "<index>": "<DEFECT_NAME>: <short reason>" } }
@@ -1255,6 +1260,54 @@ export function findAnswerShapeFailures(generated: LlmQuestion[]): {
   }
   return { toDrop, reasons };
 }
+
+// --- Bank RE-SERVE gate -----------------------------------------------------
+//
+// Every gate above runs inside generateDailyQuestions, which only ever sees
+// FRESHLY GENERATED questions. pickBankSource takes a different path: it clones
+// an existing bank row straight into the serving table. Nothing checked those
+// clones, so a defect that entered the bank before its gate existed was
+// re-served indefinitely and no amount of gate tuning could reach it.
+//
+// Found 2026-09-06 from production logs: a Joyce question filed under
+// "Virginia Woolf's Novels and Essays" (generated 2026-05-09) and a
+// self-answering onion/tears question (generated 2026-08-21, already re-served
+// on 08-30) were both served that day as `bank-pick used`, never having passed
+// through a single gate. See diagnosis/answer-leak-domain-drift-plan.md.
+//
+// This runs the DETERMINISTIC gates only — pure functions, no LLM, no network,
+// microseconds per candidate — so it is free to apply on the serving hot path.
+// The semantic defects (a stem that paraphrases its answer, a question filed
+// under a sibling domain) are NOT reachable here; clearing those out of
+// existing stock is the bank-sweep script's job (scripts/sweep-bank-quality.ts).
+//
+// Flag posture deliberately MIRRORS the generation path: a rule not trusted to
+// drop at generation time is not trusted to reject a re-serve either, so one
+// flag governs both. Flipping PARTIAL_ANSWER_LEAK_ENABLED therefore also arms
+// the partial-leak rule here.
+export function findBankSourceDefect(source: {
+  questionText: string;
+  answer: string;
+  acceptableVariants?: string[];
+}): string | null {
+  const { questionText, answer } = source;
+  if (textContainsAnswer(questionText, answer, source.acceptableVariants ?? [])) {
+    return `answer "${answer}" appears in question text`;
+  }
+  // Reuses the generation-path gate on a single-element batch so the two paths
+  // can never drift apart in what counts as a bad answer shape.
+  const shape = findAnswerShapeFailures([{ answer } as LlmQuestion]);
+  if (shape.toDrop.size > 0) return shape.reasons[0];
+  if (isPartialAnswerLeakEnabled() && questionPartiallyLeaksAnswer(questionText, answer)) {
+    return `question gives away answer "${answer}"`;
+  }
+  return null;
+}
+
+// A domain whose bank keeps offering defective rows must not spin forever:
+// after this many rejections we stop asking and let the domain fall through to
+// fresh generation, which is gated anyway.
+const MAX_BANK_QUALITY_REJECTS_PER_DOMAIN = 3;
 
 // Tier ladder shared by the difficulty-floor gate. Index = how hard, ascending.
 const DIFFICULTY_TIER_LADDER: LlmQuestion['difficulty_estimate'][] = [
@@ -3059,6 +3112,9 @@ async function pickBankPicksForDomains(
   const avoidFactKeys = new Set(previousFactKeys.map((entry) => entry.factKey));
   const picks: GeneratedQuestionRow[] = [];
   const expiresAt = getNextDailyResetBoundary();
+  // bank_pick_quality telemetry, summed across domains and recorded once below.
+  let bankCandidatesConsidered = 0;
+  let bankCandidatesRejected = 0;
 
   for (const domain of domains) {
     const difficulty = resolveDomainDifficulty(
@@ -3070,14 +3126,42 @@ async function pickBankPicksForDomains(
     if (!difficulty) continue;
     const floor = tierFallbackFloors?.get(domain);
     const ladder = floor ? bankTierLadder(difficulty, floor) : [difficulty];
+    let domainRejects = 0;
 
     let source: BankSource | null = null;
     let servedTier: BankDifficulty = difficulty;
-    for (const tier of ladder) {
-      source = await pickBankSource(userId, domain, tier, avoidFactKeys, avoidQuestionTexts).catch(() => null);
-      if (source) {
-        servedTier = tier;
-        break;
+    // Quality-reject a bank candidate and ask for the NEXT one rather than
+    // giving up on the domain: a single bad row in stock shouldn't cost the
+    // player a slot. Rejected fact_keys join avoidFactKeys, which
+    // pickBankSource already honours, so the same row can't come back and the
+    // loop always terminates (BankSource.factKey is non-nullable).
+    tierLadder: for (const tier of ladder) {
+      for (;;) {
+        const candidate = await pickBankSource(
+          userId,
+          domain,
+          tier,
+          avoidFactKeys,
+          avoidQuestionTexts,
+        ).catch(() => null);
+        if (!candidate) break; // no stock left at this tier — try the next one
+        bankCandidatesConsidered += 1;
+        const defect = findBankSourceDefect(candidate);
+        if (!defect) {
+          source = candidate;
+          servedTier = tier;
+          break tierLadder;
+        }
+        bankCandidatesRejected += 1;
+        console.warn('[daily/generate-questions] bank-pick rejected by quality gate', {
+          domain,
+          tier,
+          factKey: candidate.factKey,
+          defect,
+        });
+        avoidFactKeys.add(candidate.factKey);
+        domainRejects += 1;
+        if (domainRejects >= MAX_BANK_QUALITY_REJECTS_PER_DOMAIN) break tierLadder;
       }
     }
     // BP-7 Phase-3 telemetry: per-domain hit / fall-through, so bank hit rate
@@ -3155,6 +3239,17 @@ async function pickBankPicksForDomains(
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+  // Fire-and-forget, same contract as the generation-path gate telemetry: a
+  // counters failure must never cost the player a queue.
+  if (bankCandidatesConsidered > 0) {
+    void recordGateDrops([
+      {
+        gate: 'bank_pick_quality',
+        considered: bankCandidatesConsidered,
+        dropped: bankCandidatesRejected,
+      },
+    ]);
   }
   return picks;
 }

--- a/src/server/db/queries/gate-drop-stats.ts
+++ b/src/server/db/queries/gate-drop-stats.ts
@@ -30,6 +30,13 @@ export const GATE_NAMES = [
   'answer_leak_partial',
   'answer_shape',
   'domain_drift',
+  // Bank RE-SERVE path, not generation. Every gate above runs only on freshly
+  // generated questions; pickBankSource cloned old stock into the queue
+  // ungated, so a defect that entered the bank before a gate existed was
+  // re-served forever (2026-09-06: a Joyce-under-Woolf row from 2026-05-09 and
+  // a self-answering onion/tears row from 2026-08-21, both re-served that day).
+  // `considered` counts bank candidates examined, `dropped` counts rejected.
+  'bank_pick_quality',
   'difficulty_floor',
   'thin_declared',
 ] as const;


### PR DESCRIPTION
Fixes the root cause found on 2026-09-06 (diagnosis: `diagnosis/answer-leak-domain-drift-plan.md`, tracked in #1613).

## The hole

Every quality gate lives inside `generateDailyQuestions` and only ever sees **freshly generated** questions. `pickBankSource` re-serves old stock by cloning a bank row straight into the queue — **ungated**. So anything that entered the bank before its gate existed is re-served forever, and no amount of gate tuning reaches it.

Confirmed from production runtime logs, not inferred:

```
[daily/generate-questions] bank-pick used {
  domain: "Virginia Woolf's Novels and Essays",
  factKey: 'james-joyce-irish-modernism-...-claritas' }
```

| Row served 2026-09-06 | Originally generated |
|---|---|
| Joyce question filed under Woolf | **2026-05-09** |
| Self-answering onion/tears question | **2026-08-21** (re-served 08-30 too) |

Neither had passed through a single gate. Worth noting the gates **do** work where they run — that same batch dropped 4 of 6 freshly generated questions, two for `ANSWER_LEAKED`. This is a hole beside the chain, not a broken chain.

## The three fixes

**1. Gate the re-serve path.** `findBankSourceDefect`, wired into `pickBankPicksForDomains`. Deterministic gates only — pure functions, no LLM, no network, microseconds — so it's free on the serving hot path. A rejected candidate is skipped and the *next* one requested (rejects join `avoidFactKeys`, which `pickBankSource` already honours, so it terminates), capped at 3 per domain before falling through to fresh generation. New `bank_pick_quality` counter measures how often it fires.

Flag posture deliberately mirrors the generation path: `PARTIAL_ANSWER_LEAK_ENABLED` governs both, on the principle that a rule not trusted to drop at generation isn't trusted to reject a re-serve either.

**2. Sweep existing stock.** `npm run sweep:bank-quality`, dry-run by default. Fix 1 only prevents *future* re-serves; this cleans what's already there. First run against live data:

| | |
|---|---|
| Servable bank rows | 2,324 |
| **Defective** | **103 (4.4%)** |
| — stem contains its own answer | 62 |
| — sentence-shaped answer | 41 |

Those 62 would be rejected outright if generated today — they predate the gate. `--no-llm` runs the deterministic half with no API key; `--include-off-domain` is required to demote OFF_DOMAIN hits, mirroring `DOMAIN_DRIFT_DROP_ENABLED`, since that judgement still has no precision data behind it.

**3. `DEFINITION_SUPPLIED`.** A new quality-gate defect for a stem that hands over every defining property and asks only for the name. The 19th Amendment row served 2026-09-06 *was* freshly generated and *did* pass the gate — because the one defect describing it, `GENERIC_AT_TIER`, is explicitly forbidden from flagging accessible-tier items. This defect applies at **every** tier, and ships with a counter-example in the rubric so it doesn't eat questions that still require real recall.

## Honesty about scope

Fixes 1 and 2 are complementary, **not** alternatives. The tears and 19th Amendment rows pass every deterministic check — verified, and asserted in the tests — because their leaks are semantic ("crying"→"Tears", "1920 + women voting"→"Nineteenth Amendment"). Only the Haiku gate reaches those, which is what fix 2 is for.

This also **clears OFF_DOMAIN of the charge** raised earlier: it never ran on the Joyce row, so nothing here says whether that prompt works. The Phase 2 eval remains unrun and is still the only thing that can settle `DOMAIN_DRIFT_DROP_ENABLED`.

## Verification

Typecheck clean, lint 0 errors, all six ratchets pass, **2,615 tests pass**. 6 new tests on the bank gate (including one asserting the semantic limitation), plus 2 new live evals for `DEFINITION_SUPPLIED` (opt-in, `RUN_LLM_EVALS=1`).

**Not run:** the sweep's `--apply`, and the LLM half of the sweep — no `ANTHROPIC_API_KEY` in my environment, and applying 103 demotions to prod is yours to trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG8TSZKng9jjkRH3UroXMS
