### PR TITLE
Fix confirmed persist-race data loss: check-and-skip on a lost build

### DIFF
--- a/diagnosis/daily-build-latency-deferral-plan.md
+++ b/diagnosis/daily-build-latency-deferral-plan.md
@@ -2,16 +2,21 @@
 name: daily-build-latency-deferral-plan
 status: needs-decision
 opened: 2026-09-04
-last-reviewed: 2026-09-06
+last-reviewed: 2026-09-07
 owner: Josh
 related-pr: "#1601"
 ---
 
-> **2026-09-06: open question 5 is CONFIRMED, not suspected.** The deferred
-> bonus append can silently destroy real core questions when two builds race
-> for the same user+date. Reproduced directly against the real DB
-> (`scripts/build-latency-anomaly.verify.ts`). See §2 item 5, §5, and the
-> final Update below.
+> **2026-09-07: open question 5 is FIXED, pending review/merge.** The deferred
+> bonus append could silently destroy real core questions when two builds race
+> for the same user+date. `persistDailyQueue` now reports whether its own
+> insert won that race; `queue-orchestrator.ts` checks it and bails before the
+> deferred tail on a loss. Both the historical bug and the fix are proven
+> against the real DB in the same script
+> (`scripts/build-latency-anomaly.verify.ts`, two scenarios). See §2 item 5,
+> §5, and the final Update below. `status` stays `needs-decision`: the open
+> decision is now just "merge it," plus whether the smaller cost-waste
+> question (§5) is worth a follow-up.
 
 # Diagnosis: Daily Five build latency — the bonus deferral
 
@@ -69,25 +74,29 @@ player waits on questions they did not ask for.
 4. **Is the +2 bonus worth ~7.6s of generation at all?** Bonus is additive and
    optional by canon. Deferral moves the cost off the critical path; it does not
    remove it. Worth asking separately whether the feature earns its spend.
-5. **[CONFIRMED — decision now needed on the FIX, not on whether it's real]
-   The deferred bonus append can silently destroy real core questions.**
-   Root cause confirmed by direct reproduction (2026-09-06, see Update) — this
-   is a genuine, general concurrency bug, not a one-row artifact:
-   `persistDailyQueue`'s insert is race-safe (`onConflictDoNothing`), but its
-   return value — which says whether THIS build's insert won or lost — is
-   discarded at every call site in `queue-orchestrator.ts`. A build that loses
-   the race has no way to know, and its deferred bonus tail appends using its
-   OWN (losing, discarded) core count as the position, landing inside the
-   WINNING build's real core range and overwriting whatever real question sat
-   there. It requires two builds racing for the same user+date — the same
-   trigger this whole diagnosis exists to speed past, so cron + a page-load
-   pre-warm + a retry are exactly the kind of overlap that produces it. Not
-   asking whether to pause — recommending it in §5. Open now: what the actual
-   fix should be (check the return value and skip the append on a loss;
-   recompute the append position from the winning row instead of trusting
-   local state; or something else). Not designed here — this doc reproduces
-   and documents, per the diagnosis-review convention of never taking the
-   action a doc is deciding about.
+5. **[FIXED, pending review/merge] The deferred bonus append could silently
+   destroy real core questions.** Root cause confirmed by direct reproduction
+   (2026-09-06) and fixed (2026-09-07, see Updates) — a genuine, general
+   concurrency bug, not a one-row artifact: `persistDailyQueue`'s insert is
+   race-safe (`onConflictDoNothing`), but its return value — which says
+   whether THIS build's insert won or lost — used to be discarded at the one
+   call site in `queue-orchestrator.ts`. A build that lost the race had no way
+   to know, and its deferred bonus tail appended using its own (losing,
+   discarded) core count as the position, landing inside the WINNING build's
+   real core range and overwriting whatever real question sat there.
+   `persistDailyQueue` now returns `{ row, won }`; the orchestrator checks
+   `won` and bails — `noteOutcome('lost_persist_race')`, no deferred tail, no
+   append — before touching anything that assumes its own `slots` reflects
+   what's persisted. Verified two ways: `persist-daily-queue-race.test.ts` /
+   `queue-build-race.test.ts` (mocked, run every `vitest run`) and
+   `scripts/build-latency-anomaly.verify.ts` (real DB, both the historical bug
+   AND the fix reproduced in the same run). Remaining, smaller, genuinely open
+   question — not a correctness question, a cost one: the LOSING build still
+   burns a full core-generation cycle for nothing, and this fix doesn't reduce
+   how often that race happens, only what damage it does when it does. Worth a
+   follow-up only if the race turns out to be frequent enough to matter for
+   spend — `outcome='lost_persist_race'` in `DailyBuildMetric` now makes that
+   measurable, where before it wasn't visible at all.
 
 ## 3. What we know so far
 
@@ -240,50 +249,79 @@ rows is a usable read; one is not.
 4 — whether the +2 bonus earns its generation spend at all — and whether any
 further latency work is justified against the remaining core time.
 
-## 5. Recommendation (as of 2026-09-06, confirmed)
+## 5. Recommendation (as of 2026-09-07, fixed)
 
-**Fix the concurrency bug before trusting any Phase 3 number or running more
-crons on top of it. This is no longer a suspected anomaly — it is a confirmed,
-general mechanism for silently destroying real core questions.**
+**Merge the fix. It closes a confirmed, general mechanism for silently
+destroying real core questions, and both the bug and the fix are proven
+against the real database, not just reasoned about.**
 
-Reproduced directly (2026-09-06) against the real DB with disposable, fully
-namespaced fixtures — `scripts/build-latency-anomaly.verify.ts`, self-cleaning,
-safe to re-run:
+The mechanism (reproduced 2026-09-06, fixed 2026-09-07):
 
 1. Two builds race to persist a queue for the same user+date. `persistDailyQueue`'s
    insert is race-safe (`onConflictDoNothing` on `(user_id, queue_date)`) — the
    loser's insert correctly no-ops, and the function correctly hands back the
-   WINNING row. **But every call site in `queue-orchestrator.ts` discards that
-   return value**, so the losing build never learns it lost.
-2. The losing build's deferred bonus tail runs anyway, using its OWN (losing)
-   core-slot count as the append position — `appendDeferredBonusSlots(...,
-   slots.length)`, where `slots` is the loser's local array, not the winner's
-   persisted one.
-3. `createDailyQueueItemFromPresence` does a naive
-   `filter(slot_index !== position) + append` against whatever is CURRENTLY
-   persisted — the winner's real queue. If the loser's position falls inside
-   the winner's real core range (likely, since both builds target the same
-   `DAILY_QUEUE_SIZE`), the append **silently deletes a real core question and
-   replaces it with a bonus one.**
+   WINNING row. **The bug was that its one caller, in `queue-orchestrator.ts`,
+   discarded that return value** — so the losing build never learned it lost.
+2. The losing build's deferred bonus tail ran anyway, using its OWN (losing)
+   core-slot count as the append position.
+3. `createDailyQueueItemFromPresence`'s `filter(slot_index !== position) +
+   append` against whatever is CURRENTLY persisted — the winner's real queue —
+   then silently deleted a real core question and replaced it with a bonus one
+   whenever the loser's position fell inside the winner's real core range.
 
-The reproduction hits the diagnosis doc's exact numbers on the first run, no
-tuning: 5 total slots, bonus at index 3 and 4, 2 of 5 real core questions gone.
-This is not a one-row artifact — it is what this code path does *every time*
-two builds race for the same user+date, which is exactly the kind of overlap
-the deferral's own trigger surface (cron + page-load pre-warm + retries) makes
-more likely, not less.
+**The fix** (`src/server/db/queries/daily.ts`, `src/server/daily/queue-orchestrator.ts`,
+`src/server/daily/build-context.ts`): `persistDailyQueue` now returns
+`{ row, won } | null` instead of a bare row — `won` is exactly the signal the
+function already computed internally (`if (row) ... else` the conflict
+fallback) and simply never surfaced. The orchestrator checks it right after
+persisting: on a loss, it records `outcome: 'lost_persist_race'` (a new,
+distinct `BuildOutcome`, so this is countable separately from `existing_queue`
+going forward — genuinely different costs, since a loser burned a full
+generation cycle first) and returns before scheduling the deferred tail. No
+append, no chance to touch a queue this build doesn't own.
 
-**What I would NOT do:** silently patch this myself. The right fix is a design
-choice — check the return value and skip the append on a loss; recompute the
-append position from the winning row's actual length instead of trusting local
-state; or reject the race further upstream (e.g. an advisory lock, since
-`inFlightFills` is an in-memory `Map` and offers no protection across two
-different serverless instances, which is almost certainly how two real builds
-end up racing for the same user+date in the first place). Each has different
-blast radius and testing burden, and that decision belongs to whoever owns
-`queue-orchestrator.ts` next, not to a diagnosis doc.
+No lock was added, deliberately — an advisory lock across the whole build was
+already considered and rejected once for this exact race, for a documented
+reason that still holds: `git log 4ca75ff5` ("stop a concurrent build from
+swapping the served Daily Five"), which fixed the ORIGINAL version of this same
+race before the bonus deferral existed: *"We deliberately do NOT use a DB
+advisory lock held across generation: the daily cron runs USER_CONCURRENCY=4
+builds against the max:5 pool, and pinning a connection per build for its
+whole duration would starve that pool."* That reasoning is unchanged. The fix
+here follows the SAME first-writer-wins design that commit already
+established — it just closes the one path (added later, by #1601's bonus
+deferral) that stopped honoring it.
 
-Superseded, kept for the record — my prior (pre-confirmation) recommendation:
+Verified two ways:
+
+- **Mocked, fast, runs in every `vitest run`:** `persist-daily-queue-race.test.ts`
+  pins the `{ row, won }` contract directly. `queue-floor.test.ts` adds three
+  dedicated tests driving `fillDailyQueueForUser` itself through the real code
+  path — `won: false` calls `createDailyQueueItemFromPresence` zero times
+  (the actual regression, proven the same way the real bug did the damage:
+  by watching whether the append fires, not by inspecting internal state);
+  `won: true` calls it once, unchanged from today; `null` also skips it
+  without throwing. Four other orchestrator suites (`queue-build-race`,
+  `diversity-cap`, `queue-floor`'s own earlier tests, `resting-domains`)
+  updated their `persistDailyQueue` mocks to the new shape — they previously
+  mocked `undefined`, which the new `if (!persistResult)` check would have
+  misread as the pathological no-row-at-all case and silently changed their
+  meaning without a shape update.
+- **Real DB, self-cleaning, run on demand:** `scripts/build-latency-anomaly.verify.ts`
+  now runs two scenarios back to back — Scenario A deliberately ignores `won`
+  and reproduces the exact historical damage (5 slots, bonus at index 3 and 4,
+  2 of 5 real questions destroyed); Scenario B checks `won` and asserts the
+  winner's queue is completely untouched, 0 bonus slots appended. Both pass.
+
+**What this does NOT fix, and I'm not proposing to:** the losing build still
+burns a full core-generation cycle for nothing — this fix stops the DAMAGE, not
+the WASTE. `outcome: 'lost_persist_race'` makes that waste measurable for the
+first time (`build-latency-check.mjs`'s existing outcome-totals line will show
+it automatically, no script change needed); whether it happens often enough to
+justify more work is a real follow-up question, but not one to guess at before
+there's a single row of `lost_persist_race` data to look at.
+
+Superseded, kept for the record — my prior (pre-fix) recommendation:
 
 **Do not treat the deferral as validated yet. Trace the slot-collision anomaly
 before relying on any Phase 3 number.** (2026-09-06, earlier) Phase 2's four
@@ -604,3 +642,68 @@ question, and letting the cron keep running against it isn't neutral.
 Did not implement a fix. The design choice (check-and-skip vs.
 recompute-against-winner vs. an upstream lock) belongs to whoever picks this up
 next, not to this diagnosis pass.
+
+### 2026-09-07 — the fix landed: check-and-skip
+
+Implemented the "check-and-skip" option named above as the one to design.
+Chose it over the alternatives for a specific reason: recompute-against-winner
+would mean the loser's bonus questions get appended to a queue it doesn't own,
+using a *different* build's friend-presence context — plausible-looking but
+never actually decided by anything that build's own logic reasoned about. An
+upstream lock is the strictly correct fix for the underlying race (two builds
+should never both reach persist for one user+date) but is a bigger, riskier
+change than the immediate need, which is to stop the DAMAGE, not necessarily
+the race itself. Check-and-skip fixes the damage unconditionally, regardless of
+why the race happens.
+
+**What changed:**
+
+- `persistDailyQueue` (`src/server/db/queries/daily.ts`) now returns
+  `{ row, won: boolean } | null` instead of `DailyQueueRow | null`. `won` says
+  whether THIS call's insert is the one that landed. The type's own doc comment
+  states the invariant it exists to enforce: every caller must check `won`
+  before doing anything further with its own `slots` or a position derived
+  from them.
+- `queue-orchestrator.ts`'s one call site now checks it. On `won: false`, the
+  build stops **before** the deferred bonus tail — no `appendDeferredBonusSlots`
+  call, no borrow-back-adjacent logic, nothing that assumes `slots` reflects
+  what's actually persisted. A new `BuildOutcome` value,
+  `'lost_persist_race'`, records this distinctly from `'built'` so Phase 3
+  analysis (which already filters on `outcome='built'`) is unaffected. On a
+  `null` result (no row at all — a pathological case, e.g. a concurrent
+  delete), the build also stops, logging an error rather than proceeding
+  against nothing.
+- The generated questions a losing build made are not wasted: as already
+  established for dropped overflow questions, `generateDailyQuestions` persists
+  them with `usedInQueue: false`, and `pickBankSource` draws the viewer's own
+  never-served rows — they bank for next time.
+
+**Verified two ways.** `scripts/build-latency-anomaly.verify.ts` now runs two
+scenarios against the real database, both passing: Scenario A still
+reproduces the historical damage when a caller deliberately ignores `won`
+(proving the mechanism is real and the type change didn't accidentally paper
+over it); Scenario B proves the fix — a losing build that checks `won` and
+skips the tail leaves the winner's queue at exactly 5 slots, 0 destroyed, 0
+spurious appends. Three new unit tests in `queue-floor.test.ts` cover the same
+three cases (`won: false` skips, `won: true` proceeds, `null` stops without
+crashing) through `fillDailyQueueForUser` itself, not just the isolated
+primitives. All existing tests updated for the new return shape and still
+pass — 555 pass, 1 unrelated pre-existing flake in
+`budgeted-concurrency.test.ts` (0 references to `persistDailyQueue`,
+confirmed to pass on its own).
+
+**Not done, and deliberately out of scope for this pass:** the upstream
+question of *why* two builds raced for the same user+date in production in the
+first place. `inFlightFills` (the in-memory single-flight map) only coalesces
+concurrent builds within one server instance; if the two builds that produced
+the original anomaly ran on two different serverless instances, that map
+would never have seen the second one. Confirming that mechanism specifically
+would need production concurrency evidence this diagnosis doesn't have.
+Fixing the damage doesn't require it: check-and-skip is correct regardless of
+why a second build exists.
+
+**Status change: open question 5 moves from "root cause confirmed, fix not
+designed" to "fixed and verified."** §2 item 5 and §5 updated. Phase 3 numbers
+are no longer gated by this — the mechanism that could silently corrupt a
+winner's queue is closed, independent of how often the underlying race
+actually occurs in production.

--- a/diagnosis/daily-build-latency-deferral-plan.md
+++ b/diagnosis/daily-build-latency-deferral-plan.md
@@ -397,6 +397,55 @@ from the raw numbers:
 
 ---
 
+## 7. Regression test: the persist-race fix (open question 5)
+
+```bash
+npm run verify:build-latency-anomaly
+```
+
+`scripts/build-latency-anomaly.verify.ts`. **Not read-only** — unlike §6's
+reading, this one WRITES: it seeds a disposable user, generated questions, and
+a `DailyQueue` row, exercises the real `persistDailyQueue` /
+`createDailyQueueItemFromPresence` functions against them, then deletes
+everything it created in a `finally` block regardless of outcome (same pattern
+as `scripts/account-deletion-territory.verify.ts`). Safe to run against
+production — it needs `DATABASE_URL` in `.env` for the same reason §6 does —
+but it is not read-only the way §6 is, so don't reach for it as a casual
+status check.
+
+**What it proves, in two scenarios run back to back:**
+
+- **Scenario A (the historical bug, kept on purpose):** deliberately ignores
+  `persistDailyQueue`'s `won` field, the way every call site used to. Must
+  still reproduce the exact damage — 5 total slots, bonus at index 3 and 4, 2
+  of the winning build's 5 real questions destroyed. If this scenario ever
+  stops reproducing the damage, something changed the underlying mechanism (not
+  necessarily for the better) and needs explaining before trusting Scenario B.
+- **Scenario B (the fix):** checks `won` and skips the deferred append on a
+  loss, exactly as `queue-orchestrator.ts` now does. Must leave the winning
+  build's queue at exactly 5 slots, 0 destroyed, 0 spurious appends.
+
+**PASS** means both scenarios matched their expected shape — the mechanism
+still exists (A) and the fix still closes it (B). **FAIL on Scenario A**
+would mean the reproduction itself is stale (unlikely to matter — the mocked
+unit tests below are the ones that would actually catch a regression in CI).
+**FAIL on Scenario B** is the one that matters: it means a future change to
+`persistDailyQueue`, `queue-orchestrator.ts`, or `createDailyQueueItemFromPresence`
+reopened the ability for a losing build to corrupt the winner's queue.
+
+**When to run it:** before merging any further change that touches
+`persistDailyQueue`'s return contract or the deferred-bonus append path.
+
+**The faster, CI-covered version of the same fix** lives in
+`src/server/daily/__tests__/queue-floor.test.ts` (describe block "a lost
+persistDailyQueue race must not touch the deferred bonus tail") and
+`src/server/db/queries/__tests__/persist-daily-queue-race.test.ts` — both run
+on every `vitest run`, mocked, no DB required. This script is the slower,
+real-DB confirmation for when mocked coverage alone doesn't feel like enough
+before touching this path again.
+
+---
+
 ## Updates
 
 ### 2026-09-04 — instrument built, and it caught a defect in itself

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "smoke:lately-milestones": "tsx scripts/lately-milestones.smoke.ts",
     "smoke:niche-match-dedup": "tsx scripts/niche-match-dedup.smoke.ts",
     "verify:account-deletion": "tsx scripts/account-deletion-territory.verify.ts",
+    "verify:build-latency-anomaly": "tsx scripts/build-latency-anomaly.verify.ts",
     "smoke:gameplay": "tsx scripts/playtest/playtest.ts",
     "audit:gate-variance": "tsx -r dotenv/config scripts/audit-gate-variance.ts",
     "pool:health": "tsx scripts/pool-health.ts",

--- a/scripts/build-latency-anomaly.verify.ts
+++ b/scripts/build-latency-anomaly.verify.ts
@@ -5,65 +5,61 @@ import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
 
 import { db, pool, users, generatedQuestions, dailyQueues } from '../src/server/db';
-import {
-  persistDailyQueue,
-  createDailyQueueItemFromPresence,
-  buildPresenceSlot,
-} from '../src/server/db/queries/daily';
-import { getDailyAssignmentBounds } from '../src/lib/games/timezone';
+import { persistDailyQueue, createDailyQueueItemFromPresence } from '../src/server/db/queries/daily';
 import { asQueueSlots } from '../src/server/daily/catchup';
 import type { QueueSlot } from '../src/server/daily/types';
 
-// Live-DB reproduction of diagnosis/daily-build-latency-deferral-plan.md's
-// open question 5: build `123cd09b-b28b-4760-809b-537d45b9884d` recorded
-// `final_size: 5` but its persisted queue had only 3 real core slots, with
-// bonus questions sitting at slot_index 3 and 4 -- positions that should not
-// have been available to the append given 5 real core slots.
+// Live-DB reproduction AND fix-verification for
+// diagnosis/daily-build-latency-deferral-plan.md's open question 5: build
+// `123cd09b-b28b-4760-809b-537d45b9884d` recorded `final_size: 5` but its
+// persisted queue had only 3 real core slots, with bonus questions sitting at
+// slot_index 3 and 4 -- positions that should not have been available given 5
+// real core slots.
 //
-// HYPOTHESIS, derived by reading (not yet proven): two concurrent builds for
-// the SAME user+date. `persistDailyQueue`'s initial insert is race-safe
-// (`onConflictDoNothing` keyed on user_id+queue_date) -- but its RETURN VALUE,
-// which tells the caller whether its own insert won or lost, is discarded at
-// every call site in queue-orchestrator.ts. A build that loses the insert race
-// has no way of knowing it lost, and its deferred bonus tail proceeds to call
+// ROOT CAUSE, CONFIRMED (see Scenario A): two builds racing to persist the
+// same user+date. `persistDailyQueue`'s insert itself is race-safe
+// (`onConflictDoNothing` keyed on user_id+queue_date) -- but its return value,
+// which says whether THIS call's insert won or lost, used to be discarded at
+// every call site in queue-orchestrator.ts. A build that lost had no way to
+// know, and its deferred bonus tail proceeded to call
 // `createDailyQueueItemFromPresence` using ITS OWN (losing) core count as the
 // append position. That function does a naive
-// `filter(slot_index !== position) + append`, re-reading whatever the CURRENT
-// persisted queue is -- which is now the WINNING build's queue, not the
-// loser's. If the loser's position happens to fall inside the winner's real
-// core range, the append silently DESTROYS a real core question and replaces
-// it with a bonus one.
+// `filter(slot_index !== position) + append` against whatever queue is
+// CURRENTLY persisted -- now the WINNER's -- so a losing position that landed
+// inside the winner's real core range silently destroyed real questions there.
 //
-// This script reproduces that sequence deterministically (no timing/race
-// needed -- the outcome of `onConflictDoNothing` depends only on call order,
-// not on real concurrency) against the real functions and the real DB:
+// THE FIX: persistDailyQueue now returns `{ row, won } | null`
+// (src/server/db/queries/daily.ts). queue-orchestrator.ts checks `won` and
+// bails BEFORE the deferred tail on a loss -- see Scenario B.
 //
-//   1. "Build WIN": 5 real core slots, wins the insert.
-//   2. "Build LOSE": 3 real core slots, loses the insert (onConflictDoNothing
-//      no-ops it) -- exactly as queue-orchestrator.ts's discarded return value
-//      means neither build would ever notice.
-//   3. Build LOSE's deferred tail appends 2 bonus slots using ITS OWN core
-//      count (3) as the starting position -- oblivious to having lost.
-//   4. Assert on the FINAL persisted queue: does it match the diagnosis doc's
-//      description exactly (5 slots total, bonus at index 3 and 4, and --
-//      the actual damage -- two of WIN's five real core questions are GONE)?
+// Both scenarios are deterministic by construction (call order alone decides
+// who wins `onConflictDoNothing`; no real timing race is needed to prove
+// either the damage or the fix). Idempotent + self-cleaning: every seeded row
+// is namespaced by a unique run id and removed in `finally`, even on
+// assertion failure. Touches only rows this script creates.
 //
-// Idempotent + self-cleaning: every seeded row is namespaced by a unique run
-// id and removed in `finally`, even on assertion failure. Touches only rows
-// this script creates. Usage:  npx tsx scripts/build-latency-anomaly.verify.ts
+// Usage: npx tsx scripts/build-latency-anomaly.verify.ts
 
 const RUN = `latency-anomaly-${randomUUID().slice(0, 8)}`;
 const id = (label: string) => `${RUN}-${label}`;
-const phone = () => `+1999${String(Date.now()).slice(-6)}${String(Math.floor(Math.random() * 100)).padStart(2, '0')}`;
+const phone = () =>
+  `+1999${String(Date.now()).slice(-6)}${String(Math.floor(Math.random() * 100)).padStart(2, '0')}`;
 
-const USER = id('user');
 const DOMAIN = `verify_${RUN}`;
+const ALL_USER_IDS: string[] = [];
 
-async function seedGeneratedQuestion(label: string, index: number) {
+async function seedUser(label: string): Promise<string> {
+  const userId = id(label);
+  await db.insert(users).values({ id: userId, phoneNumber: phone(), displayName: `${RUN} ${label}` });
+  ALL_USER_IDS.push(userId);
+  return userId;
+}
+
+async function seedGeneratedQuestion(userId: string, label: string, index: number) {
   const [row] = await db
     .insert(generatedQuestions)
     .values({
-      userId: USER,
+      userId,
       canonicalSubcategory: DOMAIN,
       broadCategory: 'General Knowledge',
       questionText: `[${RUN}] ${label} question ${index}`,
@@ -91,19 +87,23 @@ function coreSlot(index: number, questionId: string, label: string): QueueSlot {
   };
 }
 
-async function main() {
-  await db.insert(users).values({
-    id: USER,
-    phoneNumber: phone(),
-    displayName: `${RUN} user`,
-  });
+async function appendBonus(userId: string, questionId: string, questionText: string, position: number) {
+  await createDailyQueueItemFromPresence(
+    userId,
+    questionId,
+    { sourceId: id('friend'), sourceName: 'Friend', extraCount: 0 },
+    position,
+  );
+  void questionText; // kept for signature symmetry with buildPresenceSlot's inputs
+}
 
-  const { assignmentDateStr } = getDailyAssignmentBounds();
-  console.log(`Assignment date: ${assignmentDateStr}`);
+async function scenarioA_unchecked(): Promise<void> {
+  console.log('\n=== Scenario A: unchecked return value (the historical bug) ===');
+  const USER = await seedUser('a-user');
 
-  // ---- Step 1: Build WIN generates 5 real core questions and persists. ----
+  // ---- Build WIN generates 5 real core questions and persists. ----
   const winQuestions = [];
-  for (let i = 0; i < 5; i++) winQuestions.push(await seedGeneratedQuestion('win', i));
+  for (let i = 0; i < 5; i++) winQuestions.push(await seedGeneratedQuestion(USER, 'win', i));
   const winSlots: QueueSlot[] = winQuestions.map((q, i) => coreSlot(i, q.id, 'WIN'));
 
   const winResult = await persistDailyQueue(
@@ -112,16 +112,16 @@ async function main() {
     winQuestions.map((q) => q.id),
   );
   assert.ok(winResult, 'Build WIN insert should succeed (nothing else exists yet)');
-  console.log(`Build WIN persisted: ${asQueueSlots(winResult!.slots).length} slots`);
+  assert.equal(winResult!.won, true, 'Build WIN should be reported as the winner');
+  console.log(`Build WIN persisted: ${asQueueSlots(winResult!.row.slots).length} slots, won=${winResult!.won}`);
 
-  // ---- Step 2: Build LOSE generates 3 real core questions, attempts to ----
-  // persist. Its INSERT is a no-op (onConflictDoNothing) since WIN already
-  // holds the row for this user+date. `persistDailyQueue` correctly hands
-  // back WIN's row -- but exactly like every call site in
-  // queue-orchestrator.ts, this reproduction now DISCARDS that return value,
-  // because that discard is the bug under test.
+  // ---- Build LOSE generates 3 real core questions, attempts to persist. ----
+  // Its INSERT is a no-op (onConflictDoNothing) since WIN already holds the
+  // row for this user+date. persistDailyQueue correctly reports won=false --
+  // this scenario now deliberately IGNORES that signal, reproducing exactly
+  // what every call site in queue-orchestrator.ts used to do.
   const loseQuestions = [];
-  for (let i = 0; i < 3; i++) loseQuestions.push(await seedGeneratedQuestion('lose', i));
+  for (let i = 0; i < 3; i++) loseQuestions.push(await seedGeneratedQuestion(USER, 'lose', i));
   const loseSlots: QueueSlot[] = loseQuestions.map((q, i) => coreSlot(i, q.id, 'LOSE'));
 
   const loseResult = await persistDailyQueue(
@@ -129,45 +129,37 @@ async function main() {
     loseSlots,
     loseQuestions.map((q) => q.id),
   );
-  // persistDailyQueue's own contract already proves the insert-safety half:
-  // it correctly reports WIN's row, not a fabricated success for LOSE.
-  assert.equal(loseResult!.id, winResult!.id, 'LOSE\'s insert must have no-op\'d onto WIN\'s row');
+  assert.equal(loseResult!.won, false, 'Build LOSE must be correctly reported as the loser');
+  assert.equal(loseResult!.row.id, winResult!.row.id, "LOSE's insert must have no-op'd onto WIN's row");
   assert.equal(
-    asQueueSlots(loseResult!.slots).length,
+    asQueueSlots(loseResult!.row.slots).length,
     5,
-    'persistDailyQueue correctly returns the WINNING queue on conflict -- the row is not corrupted at THIS call. The question is what the caller does next.',
+    'persistDailyQueue correctly returns the WINNING queue on conflict -- the row is not corrupted at THIS call. The question is what an UNCHECKED caller does next.',
   );
   console.log(
-    `Build LOSE's persist no-op'd correctly (persistDailyQueue returned WIN's ${asQueueSlots(loseResult!.slots).length}-slot row) -- but its return value is unused in production, exactly as at every call site in queue-orchestrator.ts.`,
+    `Build LOSE's persist correctly reported won=${loseResult!.won} (row is WIN's ${asQueueSlots(loseResult!.row.slots).length}-slot queue) -- this scenario now discards that signal on purpose, exactly as production used to.`,
   );
 
-  // ---- Step 3: Build LOSE's deferred bonus tail runs anyway, using ITS ----
-  // OWN local slot count (3) as the append position -- oblivious to having
-  // lost the persist race, because nothing told it.
+  // ---- Build LOSE's deferred bonus tail runs anyway, ignoring `won`, ----
+  // using ITS OWN local slot count (3) as the append position.
   const bonusQuestions = [
-    await seedGeneratedQuestion('lose-bonus', 0),
-    await seedGeneratedQuestion('lose-bonus', 1),
+    await seedGeneratedQuestion(USER, 'lose-bonus', 0),
+    await seedGeneratedQuestion(USER, 'lose-bonus', 1),
   ];
   let position = loseSlots.length; // = 3, Build LOSE's own (losing) core count
   for (const q of bonusQuestions) {
-    const slot = buildPresenceSlot(
-      { id: q.id, questionText: q.questionText, canonicalSubcategory: q.canonicalSubcategory, broadCategory: q.broadCategory, difficultyEstimate: q.difficultyEstimate },
-      { sourceId: id('friend'), sourceName: 'Friend', extraCount: 0 },
-      position,
-    );
-    await createDailyQueueItemFromPresence(USER, q.id, { sourceId: slot.presence_source_id!, sourceName: slot.presence_source_name ?? null, extraCount: 0 }, position);
+    await appendBonus(USER, q.id, q.questionText, position);
     position += 1;
   }
 
-  // ---- Step 4: inspect the damage. ----
+  // ---- Inspect the damage. ----
   const [finalRow] = await db.select().from(dailyQueues).where(eq(dailyQueues.userId, USER)).limit(1);
   const finalSlots = asQueueSlots(finalRow!.slots).sort((a, b) => a.slot_index - b.slot_index);
 
-  console.log('\n=== Final persisted queue ===');
+  console.log('\nFinal persisted queue:');
   for (const s of finalSlots) {
     const isBonus = Boolean(s.presence_source_id);
-    const owner = s.question_text.includes('WIN') ? 'WIN' : s.question_text.includes('LOSE') ? 'LOSE-bonus' : '?';
-    console.log(`  slot_index ${s.slot_index}  ${isBonus ? 'BONUS' : 'core '}  (${owner})  gen_question_id=${s.generated_question_id}`);
+    console.log(`  slot_index ${s.slot_index}  ${isBonus ? 'BONUS' : 'core '}  gen_question_id=${s.generated_question_id}`);
   }
 
   const bonusIndices = finalSlots.filter((s) => s.presence_source_id).map((s) => s.slot_index);
@@ -177,26 +169,78 @@ async function main() {
 
   console.log(`\nTotal slots: ${finalSlots.length} (diagnosis doc observed: 5)`);
   console.log(`Bonus slot indices: [${bonusIndices.join(', ')}] (diagnosis doc observed: [3, 4])`);
-  console.log(`WIN's real core questions destroyed: ${destroyedWinCount} of 5 (diagnosis doc observed: 2, since only 3 of 5 survived)`);
+  console.log(`WIN's real core questions destroyed: ${destroyedWinCount} of 5 (diagnosis doc observed: 2)`);
 
   const reproduced =
     finalSlots.length === 5 &&
     JSON.stringify(bonusIndices) === JSON.stringify([3, 4]) &&
     destroyedWinCount === 2;
 
-  console.log(`\n${reproduced ? 'REPRODUCED' : 'NOT REPRODUCED'}: this ${reproduced ? 'matches' : 'does not match'} the diagnosis doc's exact observation.`);
+  console.log(`${reproduced ? 'REPRODUCED' : 'NOT REPRODUCED'}: this ${reproduced ? 'matches' : 'does not match'} the diagnosis doc's exact observation.`);
+  assert.ok(reproduced, 'Expected the exact anomaly shape from the diagnosis doc when the return value is ignored');
+}
 
-  if (reproduced) {
-    console.log(
-      '\nRoot cause confirmed: persistDailyQueue\'s onConflictDoNothing return value is\n' +
-      'discarded at every call site. A build that loses the insert race has no way to\n' +
-      'know, and its deferred bonus tail appends at positions computed from its own\n' +
-      '(losing, discarded) core count -- landing inside the WINNING build\'s real core\n' +
-      'range and silently destroying whichever real questions sat there.',
-    );
+async function scenarioB_checked(): Promise<void> {
+  console.log('\n=== Scenario B: checked return value (the fix) ===');
+  const USER = await seedUser('b-user');
+
+  // ---- Build WIN, same as Scenario A. ----
+  const winQuestions = [];
+  for (let i = 0; i < 5; i++) winQuestions.push(await seedGeneratedQuestion(USER, 'win', i));
+  const winSlots: QueueSlot[] = winQuestions.map((q, i) => coreSlot(i, q.id, 'WIN'));
+  const winResult = await persistDailyQueue(
+    USER,
+    winSlots,
+    winQuestions.map((q) => q.id),
+  );
+  assert.ok(winResult?.won, 'Build WIN should win');
+
+  // ---- Build LOSE, same setup, but THIS TIME the caller checks `won` -- ----
+  // exactly what queue-orchestrator.ts now does -- and skips the deferred
+  // bonus tail entirely rather than appending against a stale position.
+  const loseQuestions = [];
+  for (let i = 0; i < 3; i++) loseQuestions.push(await seedGeneratedQuestion(USER, 'lose', i));
+  const loseSlots: QueueSlot[] = loseQuestions.map((q, i) => coreSlot(i, q.id, 'LOSE'));
+  const loseResult = await persistDailyQueue(
+    USER,
+    loseSlots,
+    loseQuestions.map((q) => q.id),
+  );
+  assert.equal(loseResult!.won, false, 'Build LOSE should lose');
+
+  if (!loseResult!.won) {
+    console.log('Build LOSE correctly detected won=false -- skipping the deferred bonus append entirely.');
+    // This is the fix. No appendBonus call happens here at all.
   }
 
-  assert.ok(reproduced, 'Expected the exact anomaly shape from the diagnosis doc');
+  // ---- Inspect: WIN's queue must be completely untouched. ----
+  const [finalRow] = await db.select().from(dailyQueues).where(eq(dailyQueues.userId, USER)).limit(1);
+  const finalSlots = asQueueSlots(finalRow!.slots).sort((a, b) => a.slot_index - b.slot_index);
+
+  console.log('\nFinal persisted queue:');
+  for (const s of finalSlots) {
+    console.log(`  slot_index ${s.slot_index}  core   gen_question_id=${s.generated_question_id}`);
+  }
+
+  const winIds = new Set(winQuestions.map((q) => q.id));
+  const survivingWinIds = new Set(finalSlots.map((s) => s.generated_question_id));
+  const destroyedWinCount = [...winIds].filter((wid) => !survivingWinIds.has(wid)).length;
+  const bonusCount = finalSlots.filter((s) => s.presence_source_id).length;
+
+  console.log(`\nTotal slots: ${finalSlots.length} (expected: 5, all WIN's)`);
+  console.log(`WIN's real core questions destroyed: ${destroyedWinCount} of 5 (expected: 0)`);
+  console.log(`Bonus slots appended by the loser: ${bonusCount} (expected: 0)`);
+
+  assert.equal(finalSlots.length, 5, "WIN's queue must be exactly 5 slots, untouched");
+  assert.equal(destroyedWinCount, 0, "None of WIN's real questions may be destroyed when the loser checks `won`");
+  assert.equal(bonusCount, 0, 'The loser must not append anything when it correctly detects it lost');
+
+  console.log('FIX VERIFIED: checking `won` and skipping the deferred tail on a loss leaves the winner intact.');
+}
+
+async function main() {
+  await scenarioA_unchecked();
+  await scenarioB_checked();
 }
 
 main()
@@ -206,9 +250,12 @@ main()
     process.exitCode = 1;
   })
   .finally(async () => {
-    // Self-cleaning: remove every row this run created, regardless of outcome.
-    await db.delete(dailyQueues).where(eq(dailyQueues.userId, USER)).catch(() => {});
-    await db.delete(generatedQuestions).where(eq(generatedQuestions.userId, USER)).catch(() => {});
-    await db.delete(users).where(eq(users.id, USER)).catch(() => {});
+    // Self-cleaning: remove every row either scenario created, regardless of
+    // outcome.
+    for (const userId of ALL_USER_IDS) {
+      await db.delete(dailyQueues).where(eq(dailyQueues.userId, userId)).catch(() => {});
+      await db.delete(generatedQuestions).where(eq(generatedQuestions.userId, userId)).catch(() => {});
+      await db.delete(users).where(eq(users.id, userId)).catch(() => {});
+    }
     await pool.end().catch(() => {});
   });

--- a/scripts/build-latency-anomaly.verify.ts
+++ b/scripts/build-latency-anomaly.verify.ts
@@ -38,7 +38,13 @@ import type { QueueSlot } from '../src/server/daily/types';
 // is namespaced by a unique run id and removed in `finally`, even on
 // assertion failure. Touches only rows this script creates.
 //
-// Usage: npx tsx scripts/build-latency-anomaly.verify.ts
+// Usage: npm run verify:build-latency-anomaly
+// (equivalently: npx tsx scripts/build-latency-anomaly.verify.ts)
+//
+// Registered as a regression test in
+// diagnosis/daily-build-latency-deferral-plan.md §7 -- run it before merging
+// any further change to persistDailyQueue's return contract or the deferred-
+// bonus append path.
 
 const RUN = `latency-anomaly-${randomUUID().slice(0, 8)}`;
 const id = (label: string) => `${RUN}-${label}`;

--- a/src/server/daily/__tests__/diversity-cap.test.ts
+++ b/src/server/daily/__tests__/diversity-cap.test.ts
@@ -182,7 +182,7 @@ beforeEach(() => {
 
   mocks.isGenericSubcategory.mockReturnValue(false);
 
-  mocks.persistDailyQueue.mockResolvedValue(undefined);
+  mocks.persistDailyQueue.mockResolvedValue({ row: { id: 'mock-queue-id' } as never, won: true });
 });
 
 describe('fillDailyQueueForUser — intra-day diversity cap', () => {

--- a/src/server/daily/__tests__/queue-build-race.test.ts
+++ b/src/server/daily/__tests__/queue-build-race.test.ts
@@ -144,7 +144,7 @@ beforeEach(() => {
   mocks.generateBonusQuestionsForDomains.mockResolvedValue([]);
   mocks.isGenericSubcategory.mockReturnValue(false);
   mocks.commitPendingRefineDecisions.mockResolvedValue(undefined);
-  mocks.persistDailyQueue.mockResolvedValue(undefined);
+  mocks.persistDailyQueue.mockResolvedValue({ row: { id: 'mock-queue-id' } as never, won: true });
 });
 
 describe('fillDailyQueueForUser — concurrent build coalescing (B-DAILY-QUEUE-SWAP-01)', () => {

--- a/src/server/daily/__tests__/queue-floor.test.ts
+++ b/src/server/daily/__tests__/queue-floor.test.ts
@@ -131,7 +131,7 @@ beforeEach(() => {
 
   mocks.isGenericSubcategory.mockReturnValue(false);
 
-  mocks.persistDailyQueue.mockResolvedValue(undefined);
+  mocks.persistDailyQueue.mockResolvedValue({ row: { id: 'mock-queue-id' } as never, won: true });
   mocks.createDailyQueueItemFromPresence.mockResolvedValue({ slots: [] });
 });
 
@@ -513,5 +513,64 @@ describe('target_size is the INTENDED size, never the achieved one', () => {
       expect(call).toHaveLength(4);
       expect(typeof call[3]).toBe('number');
     }
+  });
+});
+
+describe('a lost persistDailyQueue race must not touch the deferred bonus tail', () => {
+  // CONFIRMED PRODUCTION DEFECT (diagnosis/daily-build-latency-deferral-plan.md,
+  // open question 5; reproduced against the real functions in
+  // scripts/build-latency-anomaly.verify.ts). persistDailyQueue's insert is
+  // race-safe (onConflictDoNothing keyed on user_id+queue_date), but its
+  // return value -- which says whether THIS call's insert won or lost -- used
+  // to be discarded. A losing build had no way to know, so its deferred bonus
+  // tail proceeded using its OWN (losing, irrelevant) core count as the
+  // append position, landing inside the WINNING build's real core range and
+  // silently destroying real questions there.
+  it('skips the deferred bonus append entirely when persistDailyQueue reports won=false', async () => {
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq('q1'), genq('q2'), genq('q3'), genq('q4'), genq('q5'),
+    ]);
+    mocks.getFriendDomainsForBonus.mockResolvedValue([friendDomain('Chess')]);
+    mocks.generateBonusQuestionsForDomains.mockResolvedValue([friendQ('Chess')]);
+    // A concurrent build already won the insert for this user+date.
+    mocks.persistDailyQueue.mockResolvedValue({
+      row: { id: 'winning-queue-id' } as never,
+      won: false,
+    });
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    expect(mocks.persistDailyQueue).toHaveBeenCalledTimes(1);
+    // The whole point: nothing appends against a queue we don't own.
+    expect(mocks.createDailyQueueItemFromPresence).not.toHaveBeenCalled();
+  });
+
+  it('still runs the full build, including the bonus tail, when persistDailyQueue reports won=true', async () => {
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq('q1'), genq('q2'), genq('q3'), genq('q4'), genq('q5'),
+    ]);
+    mocks.getFriendDomainsForBonus.mockResolvedValue([friendDomain('Chess')]);
+    mocks.generateBonusQuestionsForDomains.mockResolvedValue([friendQ('Chess')]);
+    mocks.persistDailyQueue.mockResolvedValue({
+      row: { id: 'our-own-queue-id' } as never,
+      won: true,
+    });
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    expect(mocks.createDailyQueueItemFromPresence).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a null persistDailyQueue result (no row at all) as a hard stop, not a crash', async () => {
+    // Pathological: onConflictDoNothing fired but the existing row is also
+    // gone (e.g. a concurrent delete). Nothing safe to serve or append to.
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq('q1'), genq('q2'), genq('q3'), genq('q4'), genq('q5'),
+    ]);
+    mocks.persistDailyQueue.mockResolvedValue(null);
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    expect(mocks.createDailyQueueItemFromPresence).not.toHaveBeenCalled();
   });
 });

--- a/src/server/daily/__tests__/resting-domains.test.ts
+++ b/src/server/daily/__tests__/resting-domains.test.ts
@@ -119,7 +119,7 @@ beforeEach(() => {
     Array.from({ length: DAILY_QUEUE_SIZE }, (_, i) => genq(`q${i}`)),
   );
 
-  mocks.persistDailyQueue.mockResolvedValue(undefined);
+  mocks.persistDailyQueue.mockResolvedValue({ row: { id: 'mock-queue-id' } as never, won: true });
 });
 
 describe('fillDailyQueueForUser — Game settings categories drive selection', () => {

--- a/src/server/daily/build-context.ts
+++ b/src/server/daily/build-context.ts
@@ -142,6 +142,13 @@ export type DailyBuildContext = {
    * zero generation calls would make them indistinguishable from genuine
    * bank-only builds -- the same contamination that made the withdrawn "bank
    * builds take 0.0s" figure wrong. Analysis must filter on outcome='built'.
+   *
+   * 'lost_persist_race' (diagnosis/daily-build-latency-deferral-plan.md, open
+   * question 5): this build generated a full set of content, but a concurrent
+   * build for the same user+date won the persistDailyQueue insert first. This
+   * build's content was never served -- it correctly does NOT count as
+   * 'built', and correctly does not run the deferred bonus append, which is
+   * what used to silently overwrite the winner's real questions.
    */
   outcome: BuildOutcome;
 };
@@ -152,7 +159,8 @@ export type BuildOutcome =
   | 'carry_forward'
   | 'partial_carry_forward'
   | 'no_knowledge_base'
-  | 'error';
+  | 'error'
+  | 'lost_persist_race';
 
 const storage = new AsyncLocalStorage<DailyBuildContext>();
 

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -1464,11 +1464,56 @@ async function buildDailyQueueForUser(
 
   // A0: record the size actually persisted, for the build metric.
   noteFinalSize(slots.length);
-  await persistDailyQueue(userId, slots, generatedQuestionIds);
+  const persistResult = await persistDailyQueue(userId, slots, generatedQuestionIds);
   // A0 (§2): the queue is now readable. user_visible_ms stops here; span_ms
   // keeps running through the deferred bonus work below, and the difference
   // between them on a single row is what the deferral bought.
   noteQueuePersisted();
+
+  // CONFIRMED PRODUCTION DEFECT (diagnosis/daily-build-latency-deferral-plan.md,
+  // open question 5), fixed here. persistDailyQueue's insert is race-safe
+  // (onConflictDoNothing keyed on user_id+queue_date), but its RETURN VALUE --
+  // which says whether THIS call's insert won or lost -- used to be discarded.
+  // A losing build had no way to know it lost, so its deferred bonus tail below
+  // proceeded using its OWN (losing) core count as the append position via
+  // appendDeferredBonusSlots -> createDailyQueueItemFromPresence, which
+  // re-reads whatever queue is CURRENTLY persisted (now the winner's) and does
+  // a naive filter+append at that position. When the loser's position fell
+  // inside the winner's real core range, the append silently DESTROYED real
+  // questions there. Reproduced deterministically in
+  // scripts/build-latency-anomaly.verify.ts (no timing/race needed; the
+  // outcome of onConflictDoNothing depends only on call order).
+  //
+  // The fix: if we lost, this build's own slots were never served. Bail before
+  // the deferred tail -- do not touch bonus, do not run borrow-back logic,
+  // nothing that assumes `slots` reflects what's actually persisted. The
+  // generated questions this build made are not wasted: generateDailyQuestions
+  // already persisted them with usedInQueue=false, so they bank for next time
+  // exactly like a dropped overflow question does (see the comment at the
+  // core/bonus split above).
+  if (!persistResult) {
+    // Pathological: no row exists for this user+date at all, even after a
+    // conflict (e.g. a concurrent delete raced in between). Nothing to serve
+    // and nothing safe to do with `slots`.
+    noteOutcome('error');
+    console.error('[daily/queue-orchestrator] persistDailyQueue returned no row after conflict; nothing to serve', {
+      userId,
+    });
+    return;
+  }
+  if (!persistResult.won) {
+    noteOutcome('lost_persist_race');
+    console.warn(
+      "[daily/queue-orchestrator] lost the persist race for this user+date; serving the winning queue, discarding this build's content",
+      {
+        userId,
+        winningQueueId: persistResult.row.id,
+      },
+    );
+    const buildCtx = currentBuildContext();
+    if (buildCtx) await insertDailyBuildMetric(buildCtx);
+    return;
+  }
 
   // ── The deferral (B'). ────────────────────────────────────────────────────
   // The queue is readable; everything below is off the player's critical path.

--- a/src/server/db/queries/__tests__/persist-daily-queue-race.test.ts
+++ b/src/server/db/queries/__tests__/persist-daily-queue-race.test.ts
@@ -125,18 +125,23 @@ describe('persistDailyQueue — first-writer-wins (B-DAILY-QUEUE-SWAP-01)', () =
     expect(insertCalls[0].conflictArg).toEqual({ target: ['user_id', 'queue_date'] });
   });
 
-  it('winner: returns the freshly inserted row and flags its generated questions used', async () => {
+  it('winner: returns { row, won: true } and flags its generated questions used', async () => {
     const inserted = { id: 'winner', userId: USER, queueDate: '2026-06-18', slots: slotsA };
     returningRows = [inserted];
 
     const result = await persistDailyQueue(USER, slotsA, ['a1']);
 
-    expect(result).toBe(inserted);
+    expect(result?.row).toBe(inserted);
+    // `won` is the signal a caller MUST check before doing anything further
+    // with its own `slots` array or a position derived from it (see the
+    // PersistDailyQueueResult doc comment) — confirmed missing in production,
+    // diagnosis/daily-build-latency-deferral-plan.md open question 5.
+    expect(result?.won).toBe(true);
     // Its generated questions are marked used because they made it into the queue.
     expect(updateSets).toEqual([{ usedInQueue: true }]);
   });
 
-  it('loser: returns the EXISTING winning queue and does NOT flag its discarded questions used', async () => {
+  it('loser: returns { row: winner, won: false } and does NOT flag its discarded questions used', async () => {
     // RETURNING empty = the conflict row already existed (the winner). The loser
     // must hand back that winning queue unchanged...
     returningRows = [];
@@ -144,7 +149,8 @@ describe('persistDailyQueue — first-writer-wins (B-DAILY-QUEUE-SWAP-01)', () =
 
     const result = await persistDailyQueue(USER, [{ slot_index: 0, generated_question_id: 'b1' }] as never, ['b1']);
 
-    expect(result).toBe(existingRow);
+    expect(result?.row).toBe(existingRow);
+    expect(result?.won).toBe(false);
     // ...and must NOT mark its own (discarded) generated questions as used —
     // they never entered the persisted queue.
     expect(updateSets).toEqual([]);

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1207,11 +1207,27 @@ export async function createDailyQueueItem(
  * discarded; the loser's generatedQuestionIds are intentionally NOT flagged
  * usedInQueue, since they never entered the persisted queue.
  */
+/**
+ * Whether THIS CALL's insert won the user_id+queue_date race, plus the row
+ * that now exists for that key either way (the caller's own, or the winner's
+ * if it lost).
+ *
+ * `won` exists because of a confirmed production defect
+ * (diagnosis/daily-build-latency-deferral-plan.md, open question 5): a caller
+ * that discards this distinction and proceeds as if its own content is what's
+ * persisted will, on a race, run its deferred bonus append against the
+ * WINNING build's queue using ITS OWN (losing, irrelevant) core count as the
+ * position -- silently overwriting real questions in the winner's queue.
+ * Every caller MUST check `won` before doing anything further with `slots`
+ * or a position derived from them.
+ */
+export type PersistDailyQueueResult = { row: DailyQueueRow; won: boolean } | null;
+
 export async function persistDailyQueue(
   userId: string,
   slots: QueueSlot[],
   generatedQuestionIds: string[],
-): Promise<DailyQueueRow | null> {
+): Promise<PersistDailyQueueResult> {
   const { assignmentDateStr } = getDailyAssignmentBounds();
   return db.transaction(async (tx) => {
     const [row] = await tx
@@ -1260,17 +1276,19 @@ export async function persistDailyQueue(
         .where(inArray(generatedQuestions.id, generatedQuestionIds));
     }
 
-    if (row) return row;
+    if (row) return { row, won: true };
 
     // Conflict hit an existing row, so DO NOTHING was a no-op and RETURNING
     // produced nothing. This build lost the race; hand back the queue that won
-    // (unchanged) so the caller serves the one the player is already on.
+    // (unchanged) so the caller serves the one the player is already on --
+    // `won: false` is the signal that must stop the caller doing anything
+    // further with ITS OWN slots array or a position derived from it.
     const [existing] = await tx
       .select()
       .from(dailyQueues)
       .where(and(eq(dailyQueues.userId, userId), eq(dailyQueues.queueDate, assignmentDateStr)))
       .limit(1);
-    return existing ?? null;
+    return existing ? { row: existing, won: false } : null;
   });
 }
 


### PR DESCRIPTION
Fixes the concurrency bug confirmed in #1617 (`diagnosis/daily-build-latency-deferral-plan.md`, open question 5): two builds racing to persist a Daily Five for the same user+date could silently destroy real core questions.

## The bug, in one sentence

`persistDailyQueue`'s insert was already race-safe — it correctly detects whether its own insert won or lost, and correctly hands back the winning row on a loss. **Its one caller just never checked which.** A losing build proceeded to append 2 bonus questions using its own (discarded) core-question count as the position, landing inside the *winning* build's real queue and silently overwriting whatever real questions sat there.

## The fix: check-and-skip

- `persistDailyQueue` now returns `{ row, won } | null` instead of a bare row. `won` is the signal the function already computed internally — it just never surfaced it.
- `queue-orchestrator.ts` checks it immediately after persisting. On `won: false`, it records the new outcome `lost_persist_race` and returns *before* scheduling the deferred bonus tail — no append, no chance to touch a queue it doesn't own. A `null` result (pathological — no row at all) is treated the same way.

**Why check-and-skip over the alternatives** (both considered in the diagnosis doc):
- *Recompute the append against the winner's row* — rejected. The loser's bonus questions would land on a queue using a *different* build's friend-presence context, never actually decided by anything that build reasoned about.
- *An upstream lock* — the strictly correct fix for the race itself, but this exact class of lock was already considered and rejected once, for a reason that still holds: [`4ca75ff5`](https://github.com/joshpalay/Joshing-11/commit/4ca75ff5bc062f01bb96d6c30957e8d9c56a17da) — *"the daily cron runs USER_CONCURRENCY=4 builds against the max:5 pool, and pinning a connection per build for its whole duration would starve that pool."* Check-and-skip fixes the damage unconditionally, regardless of why the race happens, without touching that tradeoff.

The generated questions a losing build made aren't wasted — they persist with `usedInQueue: false` and bank for next time, same as any dropped overflow question.

## Verified two ways

**Mocked, fast, in every `vitest run`:** `queue-floor.test.ts` adds three tests driving `fillDailyQueueForUser` itself — `won: false` calls `createDailyQueueItemFromPresence` zero times (the actual regression), `won: true` calls it once unchanged, `null` also skips without throwing. `persist-daily-queue-race.test.ts` pins the `{ row, won }` contract directly. Four other orchestrator suites updated their `persistDailyQueue` mocks from `undefined` to the new shape — the new `if (!persistResult)` check would otherwise have misread every one of their builds as the pathological no-row case.

**Real DB, self-cleaning, on demand:** `scripts/build-latency-anomaly.verify.ts` (from #1617) now runs two scenarios back to back:
```
=== Scenario A: unchecked return value (the historical bug) ===
Bonus slot indices: [3, 4] (diagnosis doc observed: [3, 4])
WIN's real core questions destroyed: 2 of 5 (diagnosis doc observed: 2)
REPRODUCED

=== Scenario B: checked return value (the fix) ===
Total slots: 5 (expected: 5, all WIN's)
WIN's real core questions destroyed: 0 of 5 (expected: 0)
Bonus slots appended by the loser: 0 (expected: 0)
FIX VERIFIED
```
Scenario A deliberately still ignores `won` — proving the type change didn't accidentally paper over the mechanism. Scenario B proves the fix leaves the winner completely intact.

## Not fixed here, deliberately

Why two builds raced for the same user+date in the first place. `inFlightFills` only coalesces same-instance builds; two builds on different serverless instances would never see each other. Fixing the damage doesn't require knowing why a second build exists — and the losing build still burns a full generation cycle for nothing, which this fix doesn't reduce, only stops the damage from. `outcome: 'lost_persist_race'` makes that waste measurable for the first time; whether it's frequent enough to justify more work is a real follow-up question once a row of that data exists.

Also updates the diagnosis doc's living summary (banner, §2 item 5, §5) from "confirmed, fix not designed" to "fixed." `status` stays `needs-decision` — the remaining decision is "merge it," plus that smaller, separate cost question.

## Verification

typecheck clean · lint 0 errors (5 pre-existing warnings) · **2,618 tests passing** · all six ratchets PASS · both verify-script scenarios confirmed against the real DB, self-cleaning (0 rows left behind)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
