### PR TITLE
Fix invite/onboarding review findings: mean asides, sparse invite topics, generic copy

### DIFF
--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -189,7 +189,7 @@ function InviteContextCard({ invite }: { invite: InviteContext }) {
   return (
     <div className="space-y-3 rounded-[var(--radius-md)] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
       <p className="text-[15px] leading-6 text-black/75">
-        {inviterFirstName(invite.inviterName)} invited you to Joshing, a new trivia game. We just
+        {inviterFirstName(invite.inviterName)} invited you to Joshing, a trivia game built for you. We just
         need to verify your phone number and then you can start playing.
       </p>
       {topics.length > 0 ? (
@@ -660,8 +660,8 @@ export default function LoginPanel({
             <>
               <div className="space-y-2 rounded-[var(--radius-md)] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
                 <p className="text-[15px] leading-6 text-black/75">
-                  {inviterFirstName(invitePrefill.inviterName)} invited you to Joshing, a new trivia
-                  game. We just need to send a text to confirm it’s you:
+                  {inviterFirstName(invitePrefill.inviterName)} invited you to Joshing, a trivia
+                  game built for you. We just need to send a text to confirm it’s you:
                 </p>
                 <p className="text-[20px] leading-7 font-semibold tracking-wide text-[var(--brand-navy)]">
                   {formatUsPhoneInput(invitePrefill.inviteePhone)}

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -20,6 +20,15 @@ export type ProposedInterest = {
   domain: string
   broadCategory: string
   rationale?: string | null
+  /**
+   * True for a topic the app added to top up a sparse invite (B-INVITE-TOPUP),
+   * never one the inviter actually typed. Must never be pre-selected — a named
+   * invite's own seeds ARE the inviter's picks and get auto-selected below, but
+   * a catalog-guessed addition is exactly the "invent personal meaning" failure
+   * mode this product avoids, so it's offered as a suggestion chip like a
+   * link-sourced seed, regardless of seedSource.
+   */
+  fromCatalog?: boolean
 }
 
 type SelectedInterest = {
@@ -275,6 +284,7 @@ export default function OnboardingFlow({
   >(() =>
     seedSource === 'named'
       ? preSeededInterests
+          .filter((interest) => !interest.fromCatalog)
           .flatMap((interest) => {
             const selected = toSelected(interest)
             return selected ? [selected] : []
@@ -820,10 +830,10 @@ export default function OnboardingFlow({
                 </h1>
                 <p className="text-muted-foreground text-base leading-7">
                   {!hasSeeds
-                    ? "A new trivia game. Add a few topics you'd want questions about, and we'll build your first round from them."
+                    ? "A trivia game built for you. Add a few topics you'd want questions about, and we'll build your first round from them."
                     : seedSource === 'link'
-                      ? `A new trivia game. Here are a few from ${displayInviterName} — take any that are yours, or add your own.`
-                      : "A new trivia game. Here are some topics we picked for you — remove any that don't fit, or add your own."}
+                      ? `A trivia game built for you. Here are a few from ${displayInviterName} — take any that are yours, or add your own.`
+                      : "A trivia game built for you. Here are some topics we picked for you — remove any that don't fit, or add your own."}
                 </p>
               </div>
 

--- a/src/app/onboarding/__tests__/page.test.ts
+++ b/src/app/onboarding/__tests__/page.test.ts
@@ -359,8 +359,8 @@ describe('OnboardingPage guard', () => {
     expect(result.props?.seedSource).toBe('link')
     expect(result.props?.preSeededInterests).toEqual([
       { domain: 'Sondheim', broadCategory: 'Music', rationale: null },
-      { domain: 'Kander & Ebb', broadCategory: 'Music', rationale: null },
-      { domain: 'Cole Porter', broadCategory: 'Music', rationale: null },
+      { domain: 'Kander & Ebb', broadCategory: 'Music', rationale: null, fromCatalog: true },
+      { domain: 'Cole Porter', broadCategory: 'Music', rationale: null, fromCatalog: true },
     ])
   })
 
@@ -450,6 +450,44 @@ describe('OnboardingPage guard', () => {
     expect(getInviteLinkSeedTopicsMock).not.toHaveBeenCalled()
     expect(result.props?.seedSource).toBe('named')
     expect(result.props?.preSeededInterests).toEqual([])
+  })
+
+  it('breaks the blank-topic wall for a thin NAMED invite too, marking the top-up as fromCatalog', async () => {
+    // AskFriendForDomain seeds the asked-about domain and leaves the other two
+    // slots genuinely optional, so a named (SMS) invite can arrive with just
+    // one topic the same way a tagged link does. The catalog top-up already
+    // built for links must also cover this path — but the added topics must
+    // carry fromCatalog so OnboardingFlow never auto-pre-selects an app guess
+    // as if the friend had chosen it.
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1', id: 's1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce({
+      id: 'u1',
+      onboardingComplete: false,
+    })
+    getPreSeededInterestsForUserMock.mockResolvedValueOnce({
+      inviterName: 'Duo',
+      inviteeDisplayName: null,
+      interests: [{ label: 'Michigan football', broadCategory: 'Sports', description: null }],
+    })
+    getCatalogSuggestionsMock.mockResolvedValueOnce([
+      { domain: 'College football rivalries', broadCategory: 'Sports' },
+      { domain: 'NFL history', broadCategory: 'Sports' },
+    ])
+
+    const result = await callPage()
+
+    expect(getInviterForUserMock).not.toHaveBeenCalled()
+    expect(getCatalogSuggestionsMock).toHaveBeenCalledWith(
+      ['Sports'],
+      new Set(['michigan football']),
+      2,
+    )
+    expect(result.props?.seedSource).toBe('named')
+    expect(result.props?.preSeededInterests).toEqual([
+      { domain: 'Michigan football', broadCategory: 'Sports', rationale: null },
+      { domain: 'College football rivalries', broadCategory: 'Sports', rationale: null, fromCatalog: true },
+      { domain: 'NFL history', broadCategory: 'Sports', rationale: null, fromCatalog: true },
+    ])
   })
 
   it('redirects to /login when there is neither a FriendInvitation nor an invite-link friendship', async () => {

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -136,13 +136,19 @@ export default async function OnboardingPage() {
       rationale: interest.description ?? null,
     }));
 
-  // A tagged invite link deliberately carries just ONE topic (seedSource
-  // 'link' never pre-selects, so this doesn't change that) — break the
-  // MIN_INTERESTS=3 blank-screen wall with a few real, verified-question
-  // domains from the SAME broad categories, not a random/invented set.
-  // Skipped when there's nothing to be adjacent to (an untagged link whose
-  // inviter also has no topics yet) — no fabricated suggestions.
-  if (seedSource === 'link' && preSeededInterests.length > 0 && preSeededInterests.length < 3) {
+  // A tagged invite link deliberately carries just ONE topic, and a named
+  // (SMS) invite can just as easily arrive with only 1-2 — AskFriendForDomain
+  // seeds the asked-about domain and leaves the other two slots genuinely
+  // optional ("add up to two more ideas if they feel right"). Either way the
+  // invitee would hit the MIN_INTERESTS=3 blank-screen wall with no seeds of
+  // their own yet, so break it with a few real, verified-question domains from
+  // the SAME broad categories, not a random/invented set. `fromCatalog: true`
+  // keeps these out of named-invite auto-pre-selection (OnboardingFlow) so an
+  // app guess is never presented as if the friend picked it — it's offered as
+  // an addable suggestion chip, same as every link-sourced seed already is.
+  // Skipped when there's nothing to be adjacent to (no topics yet at all) —
+  // no fabricated suggestions.
+  if (preSeededInterests.length > 0 && preSeededInterests.length < 3) {
     const seededKeys = new Set(preSeededInterests.map((interest) => domainKey(interest.domain)));
     const broadCategories = [
       ...new Set(preSeededInterests.map((interest) => interest.broadCategory).filter(Boolean)),
@@ -153,6 +159,7 @@ export default async function OnboardingPage() {
         domain: suggestion.domain,
         broadCategory: suggestion.broadCategory ?? 'General Knowledge',
         rationale: null,
+        fromCatalog: true,
       });
     }
   }

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1052,6 +1052,11 @@ Hard rules:
 - 1–2 sentences. No greetings, no sign-offs, no emoji.
 - Do not address the creator by name (you don't know it).
 - Do not invent fake personal history ("remember when we...").
+- Do not mock, disparage, or take a shot at the subject, the team/person/work
+  in the answer, or the player's judgment for asking or answering — "fond and
+  teasing" means warm amusement at a shared detail, never a jab at something
+  the player chose because they care about it. When in doubt, leave the joke
+  out and say something admiring or curious instead.
 - Plain prose. No quotes around the line. No "FYI" / "btw" preambles.
 
 Return JSON only, exactly:


### PR DESCRIPTION
## Summary
- `generateInsideJoke` had no rule against disparaging the subject, so a "fond and teasing" aside could read as mocking a topic the player chose because they care about it (the Michigan football dig from the 2026-09-07 walkthrough). Added a hard rule against mocking the subject/answer/player's judgment.
- The invite-link catalog top-up (fills a sparse 1-2 topic seed to 3 so an invitee never hits the `MIN_INTERESTS=3` blank-screen wall) was scoped away from named SMS invites — exactly the `AskFriendForDomain` path, which seeds one domain and leaves two more slots genuinely optional. Extended the top-up to named invites, tagging app-added topics with `fromCatalog` so `OnboardingFlow` never auto-pre-selects an app guess as if the friend had picked it.
- "a new trivia game" (4 sites: `LoginPanel.tsx` x2, `OnboardingFlow.tsx` x3) read as generic boilerplate — changed to "a trivia game built for you".

A fourth finding from the same walkthrough (a bonus slot showing 6/7 instead of the canonical 5) turned out to already be fixed by #1615/#1616 — no code change needed.

## Test plan
- [x] `npx vitest run src/app/onboarding src/app/login src/lib` — 288/289 pass (1 unrelated pre-existing timeout flake in `llm.grading.test.ts`, confirmed passing in isolation and untouched by this diff)
- [x] `npx tsc -p tsconfig.typecheck.json` — clean
- [x] `npx eslint` on all changed files — clean
- [x] Added a regression test (`page.test.ts`) covering the named-invite + sparse-seed top-up path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A