### PR TITLE
Fix the model-noun leak bug; replace lexical off-domain corroboration with a real second AI opinion

### DIFF
--- a/diagnosis/README.md
+++ b/diagnosis/README.md
@@ -64,8 +64,8 @@ Revisit once diagnosis docs settle on `main` as their normal home.
 
 | File | Status | Opened | Last reviewed | Related PR |
 |---|---|---|---|---|
-| [answer-leak-domain-drift-plan.md](answer-leak-domain-drift-plan.md) | **needs-decision** | 2026-09-05 | 2026-09-06 | #1611 |
-| [daily-build-latency-deferral-plan.md](daily-build-latency-deferral-plan.md) | **needs-decision** | 2026-09-04 | 2026-09-06 | #1612 |
+| [answer-leak-domain-drift-plan.md](answer-leak-domain-drift-plan.md) | **needs-decision** | 2026-09-05 | 2026-09-07 | #1611, #1613, #1618, #1619 |
+| [daily-build-latency-deferral-plan.md](daily-build-latency-deferral-plan.md) | **needs-decision** | 2026-09-04 | 2026-09-07 | #1601 |
 
 Keep this table in sync by hand when you add/close a file, or let
 `/diagnosis-review` do it — it rewrites this table from each file's

--- a/diagnosis/answer-leak-domain-drift-plan.md
+++ b/diagnosis/answer-leak-domain-drift-plan.md
@@ -2,9 +2,9 @@
 name: answer-leak-domain-drift-plan
 status: needs-decision
 opened: 2026-09-05
-last-reviewed: 2026-09-07
+last-reviewed: 2026-09-08
 owner: Josh
-related-pr: "#1611, #1613, #1618, #1619"
+related-pr: "#1611, #1613, #1618, #1619, #1623"
 ---
 
 # Diagnosis: answer-leak & domain-drift gate rollout

--- a/diagnosis/answer-leak-domain-drift-plan.md
+++ b/diagnosis/answer-leak-domain-drift-plan.md
@@ -785,3 +785,65 @@ before.
    22-row hand-verify above for the evidence gathered so far).
 3. Worth a separate look: why "Virginia Woolf's Novels and Essays" keeps
    generating Joyce content specifically.
+
+### 2026-09-07 (diagnosis-review) — flags unchanged; new WIP found on this branch; a GateDropStat contamination note
+
+**NEEDS DECISION (unchanged):** flip `PARTIAL_ANSWER_LEAK_ENABLED`? Flip
+`DOMAIN_DRIFT_DROP_ENABLED`? Neither has moved since the last entry.
+
+Re-checked everything this doc depends on, read-only:
+
+- **Flags** — `PARTIAL_ANSWER_LEAK_ENABLED` and `DOMAIN_DRIFT_DROP_ENABLED`
+  are still absent from `.env` (default OFF, per the code comments in
+  `generate-questions.ts`). `ANSWER_SHAPE_GATE_ENABLED` is also absent
+  (default ON). No flip since the last entry.
+- **PRs** — `#1611`, `#1613`, `#1618`, `#1619` all confirmed `MERGED` to
+  `main` via `gh pr view`. This doc's content already reflected all four as
+  of the last entry; nothing new to fold in.
+- **Bank state** — `still_servable` (is_duplicate=false) is now **2,138**,
+  up from the ~2,130 implied by the last entry's final tally (632 demoted −
+  438 recovered against a 2,324 starting corpus). Consistent with ordinary
+  generation at the documented ~13 rows/day rate; not investigated further.
+- **The 3 original `ContentReport` rows** (`800c44a3…`, `357618e3…`,
+  `139e1932…`) are all still `status='open'` — unresolved, as expected; this
+  doc doesn't own their resolution.
+- **New data-quality note on `GateDropStat`:** the `quality` gate shows
+  `failed_open: 229` on 2026-09-07, versus 0 on every prior day back to
+  2026-08-25. Traced (via `grep`, not by reading logs) to
+  `recordGateFailedOpen('quality')` living inside `findQualityFailures`
+  itself (`generate-questions.ts`), and both `scripts/sweep-bank-quality.ts`
+  and `scripts/rewrite-bank-demotions.ts` import that same function. That
+  makes it very likely today's spike is the Anthropic credit-exhaustion
+  incident from the rewrite pass (documented in the "2026-09-07 (night)"
+  entry above) writing into the **same counter** the live daily-generation
+  gate uses — not 229 real failures on player-facing traffic. Not confirmed
+  with certainty (didn't correlate individual `GateDropStat` writes to
+  script runs), but worth knowing before anyone reads that counter as a
+  live-gate health signal.
+
+**Uncommitted work-in-progress found on this branch**
+(`claude/domain-drift-safety-net`), not yet a PR, directly relevant to two
+open items here:
+
+1. `model` removed from `GENERIC_HEAD_NOUNS` in `self-answering.ts`, with a
+   new regression test — this is exactly the Phase 1 disagreement item #1
+   fix ("model year") recommended above.
+2. A new file, `src/server/quality/off-domain-second-opinion.ts`, wired into
+   `findQualityFailures`: a second, independently-worded Haiku call that
+   must ALSO confirm OFF_DOMAIN before `isDomainDriftDropEnabled` would act
+   on it (only invoked when that flag is on, so it's inert while the flag
+   stays off). Its own header notes a lexical-only corroboration attempt was
+   tried and rejected first (failed on Mrs. Dalloway/Woolf). This is a
+   direct answer to the false-positive risk the 22-row hand-verify surfaced
+   (the Mozart FP) — but it is **uncommitted, untested against the Phase 2
+   eval fixtures, and not yet a PR**, so it doesn't move decision 2 yet.
+   Flagging its existence here so it isn't lost or duplicated.
+3. Unrelated to this doc, sharing the same dirty working tree: edits to
+   `LoginPanel.tsx`, `OnboardingFlow.tsx`, the onboarding page + its test,
+   and a "fond and teasing" tone guardrail in `src/lib/llm.ts`. Noted only
+   so a future reviewer doesn't assume they're part of this gate work.
+
+**Still open, unchanged:** the 7 Phase 1 disagreement items +
+`PARTIAL_ANSWER_LEAK_ENABLED`; `DOMAIN_DRIFT_DROP_ENABLED` (now with a
+concrete in-progress mitigation, see WIP item 2 above); the "why does Woolf
+keep generating Joyce" investigation, still not started.

--- a/diagnosis/answer-leak-domain-drift-plan.md
+++ b/diagnosis/answer-leak-domain-drift-plan.md
@@ -847,3 +847,68 @@ open items here:
 `PARTIAL_ANSWER_LEAK_ENABLED`; `DOMAIN_DRIFT_DROP_ENABLED` (now with a
 concrete in-progress mitigation, see WIP item 2 above); the "why does Woolf
 keep generating Joyce" investigation, still not started.
+
+### 2026-09-08 — the two WIP items above finished, tested against live Phase 2 fixtures, and pushed
+
+**GateDropStat note above: worth flagging up, not just noting.** The
+229 `failed_open` spike on 2026-09-07 is very likely the credit-exhaustion
+incident's error retries writing into the same daily counter live generation
+uses, per the previous entry's tracing. Anyone reading that counter as a
+"the quality gate is failing on real player traffic" signal should discount
+2026-09-07 specifically until this is confirmed with certainty.
+
+**Item 1 (the `model` bug) and item 2 (the off-domain second opinion) are
+both finished, tested, and pushed** — no longer uncommitted WIP:
+
+- `PARTIAL_ANSWER_LEAK_ENABLED` blocker: fixed. `model` removed from
+  `GENERIC_HEAD_NOUNS`, with a regression test reproducing the exact
+  "model year" failure. This was the only one of the 7 Phase 1 items that
+  actually blocked this flag — the other 6 concern the answer-shape gate,
+  which is already on and needs no action.
+- `DOMAIN_DRIFT_DROP_ENABLED` mitigation: the lexical "corroboration"
+  attempt mentioned in the last entry was tested against the 24 real
+  off-domain hits from 2026-09-07 and **failed outright on Mrs. Dalloway**
+  — a genuinely correctly-filed row — because a specific work's fact_key
+  names the work, not its author, so "shares no words with the domain name"
+  is not a valid drift signal. Deleted rather than shipped broken.
+  Replaced with a real second, independently-worded LLM opinion
+  (`src/server/quality/off-domain-second-opinion.ts`), asked only about
+  rows the primary gate already flagged, reasoning fresh from the raw
+  question/answer text — not the fact_key, not the first gate's own
+  reasoning. Wired into both live call sites in `generate-questions.ts`
+  (`findQualityFailures` now returns `offDomainConfirmed` alongside
+  `offDomain`; `isDomainDriftDropEnabled` gates on the confirmed subset,
+  never the raw one) and into `sweep-bank-quality.ts`'s
+  `--include-off-domain` path.
+
+**Validated live against the actual production false positive, not just
+mocks or the Phase 2 fixtures**: replayed the real Mozart row
+(`fact_key="mozart-clarinet-concerto-basset-clarinet"`, the exact false
+positive the primary gate produced on 2026-09-07) through the full pipeline
+end-to-end with `DOMAIN_DRIFT_DROP_ENABLED=true` — the second opinion
+correctly overturns it, while still confirming genuine Joyce-under-Woolf
+drift in the same call. Also re-ran the full Phase 2 eval suite: still 9/11
+(the 2 failures are the same pre-existing Romantic Opera edge case from
+2026-09-07, unrelated to this change, not a regression).
+
+Full test suite: 2,627 passed. Typecheck, lint, all six ratchets clean.
+Pushed to branch `claude/domain-drift-safety-net`; PR not yet opened as of
+this entry (see Next steps).
+
+**This meaningfully de-risks `DOMAIN_DRIFT_DROP_ENABLED`** — the specific
+failure mode that made it the one gate I'd resist flipping (a wrongly
+demoted, correctly-filed question, invisible in production forever) now
+requires TWO independent LLM calls to agree before anything drops. It's
+still worth Josh's judgment call before flipping, not an autonomous
+decision, but the evidence behind it is now substantially stronger than a
+single 92%-precision number on a small sample.
+
+### Next steps
+1. Open the PR for `claude/domain-drift-safety-net`.
+2. Josh: flip `PARTIAL_ANSWER_LEAK_ENABLED` (Vercel env var, production —
+   I can't set this myself, no MCP tool exposes env var writes). The one
+   blocking bug is fixed; the other 6 disagreement items don't block it.
+3. Josh: decide on `DOMAIN_DRIFT_DROP_ENABLED` now that the false-positive
+   mitigation is built and validated against the real 2026-09-07 case.
+4. The "why does Woolf keep generating Joyce" investigation — still not
+   started.

--- a/diagnosis/daily-build-latency-deferral-plan.md
+++ b/diagnosis/daily-build-latency-deferral-plan.md
@@ -2,7 +2,7 @@
 name: daily-build-latency-deferral-plan
 status: needs-decision
 opened: 2026-09-04
-last-reviewed: 2026-09-06
+last-reviewed: 2026-09-07
 owner: Josh
 related-pr: "#1601"
 ---
@@ -604,3 +604,49 @@ question, and letting the cron keep running against it isn't neutral.
 Did not implement a fix. The design choice (check-and-skip vs.
 recompute-against-winner vs. an upstream lock) belongs to whoever picks this up
 next, not to this diagnosis pass.
+
+### 2026-09-07 (diagnosis-review) — a fourth built row, n=3; the concurrency fix still isn't built
+
+**NEEDS DECISION (unchanged):** the fix for open question 5 — check-and-skip,
+recompute-against-winner, or an upstream lock — still hasn't been designed or
+built. Nothing below changes that; it's still the gate on trusting Phase 3.
+
+Ran `npm run check:build-latency` (read-only, safe, as documented in §6):
+
+```
+DailyBuildMetric totals: carry_forward=65  existing_queue=6  built=4
+Phase 2: unchanged, still passes on the original row.
+Phase 3 (3 usable rows, up from 2):
+  2026-09-06T17:03:54  saved 1529ms  bonus  501ms  residual 1028ms  [PASS]
+  2026-09-06T17:05:14  saved 1362ms  bonus  437ms  residual  925ms  [PASS]
+  2026-09-07T17:05:14  saved 2154ms  bonus  527ms  residual 1627ms  [PASS]  <- new
+  residual spread: 925..1627ms over 3 rows -- wide; explain before relying on it.
+  3b median saving: 1529ms (was 1362ms at n=2)
+```
+
+A genuine new row landed at today's 17:05 UTC cron. `target_size` matched on
+all 3 built-since rows (3/3/0 mismatches) — **no repeat of the slot-collision
+anomaly** on this reading. That is reassuring about frequency, not about the
+mechanism: it does not mean the race was fixed, only that it didn't fire
+today. Confirmed by reading the code, not inferring from the absence of
+symptoms: `git log --oneline -- src/server/daily/queue-orchestrator.ts` still
+stops at `#1601` (the deferral itself), and the current uncommitted working
+tree (branch `claude/domain-drift-safety-net`) touches unrelated files only —
+`persistDailyQueue`'s return value is still discarded at line 1467, and
+`appendDeferredBonusSlots` still receives local `slots.length` at line 1485,
+exactly as reproduced in the 2026-09-06 entry above. §5's recommendation
+stands unaddressed.
+
+The residual (the ~1s of saving beyond the bonus generation itself) widened
+from a tight 925–1028ms band to 925–1627ms with this third row — the script's
+own output already flags this as "wide; explain before relying on it." Not
+investigated further this pass; worth watching whether it stabilizes or keeps
+spreading as more rows accumulate.
+
+**PR `#1601` reconfirmed `MERGED` to `main`** via `gh pr view` — no other PR
+is referenced by this doc.
+
+Still open: what the concurrency fix should be (not designed, not built);
+whether the ~1.5s median (n=3) holds up with more volume; open questions 3
+and 4 (phase-tagging core generation, whether the +2 bonus earns its spend)
+untouched since they were last deferred.

--- a/scripts/sweep-bank-quality.ts
+++ b/scripts/sweep-bank-quality.ts
@@ -9,6 +9,7 @@ import {
   type LlmQuestion,
 } from '../src/server/daily/generate-questions';
 import { verdictToGeneratedPatch } from '../src/server/quality/verify-question';
+import { confirmOffDomain } from '../src/server/quality/off-domain-second-opinion';
 
 // One-time hygiene sweep over EXISTING bank stock.
 //
@@ -63,7 +64,13 @@ type BankRow = {
   acceptableVariants: string[];
 };
 
-type Finding = { row: BankRow; reason: string; kind: 'deterministic' | 'llm' | 'off_domain' };
+type Finding = {
+  row: BankRow;
+  reason: string;
+  kind: 'deterministic' | 'llm' | 'off_domain';
+  /** off_domain findings only: did the second opinion also agree? */
+  confirmed?: boolean;
+};
 
 function asLlmQuestion(row: BankRow): LlmQuestion {
   const tier = (['accessible', 'moderate', 'specialist'] as const).includes(
@@ -145,6 +152,35 @@ async function main() {
     console.log('[sweep] --no-llm: skipped the quality gate (semantic defects NOT checked)');
   }
 
+  // Second opinion on every off_domain finding — a wrongly-demoted, correctly-
+  // filed question is invisible in production forever, so nothing here gets
+  // acted on off one gate's word alone. See off-domain-second-opinion.ts for
+  // why this is a real second LLM call rather than a free lexical heuristic
+  // (a first attempt at the latter was built and rejected: diagnosis/
+  // answer-leak-domain-drift-plan.md).
+  const offDomainFindings = findings.filter((f) => f.kind === 'off_domain');
+  if (offDomainFindings.length > 0 && !NO_LLM) {
+    const confirmedIdx = await confirmOffDomain(
+      offDomainFindings.map((f) => ({
+        canonicalSubcategory: f.row.canonicalSubcategory,
+        questionText: f.row.questionText,
+        answer: f.row.answer,
+      })),
+    );
+    offDomainFindings.forEach((f, i) => {
+      f.confirmed = confirmedIdx.has(i);
+    });
+    const heldBack = offDomainFindings.filter((f) => !f.confirmed);
+    console.log(
+      `[sweep] off-domain second opinion: ${confirmedIdx.size}/${offDomainFindings.length} confirmed, ${heldBack.length} held back (disagreement or check unavailable)`,
+    );
+    for (const f of heldBack) {
+      console.log(
+        `  [held back] ${f.row.id} (${f.row.canonicalSubcategory}) — first opinion said off-domain, second opinion disagreed or couldn't confirm`,
+      );
+    }
+  }
+
   const byKind = {
     deterministic: findings.filter((f) => f.kind === 'deterministic'),
     llm: findings.filter((f) => f.kind === 'llm'),
@@ -159,7 +195,12 @@ async function main() {
     );
   }
 
-  const toDemote = findings.filter((f) => f.kind !== 'off_domain' || INCLUDE_OFF_DOMAIN);
+  // off_domain requires BOTH --include-off-domain AND the second opinion's
+  // agreement (f.confirmed) — a row the first gate flagged but the second
+  // didn't confirm is never demoted by this script, flag or no flag.
+  const toDemote = findings.filter(
+    (f) => f.kind !== 'off_domain' || (INCLUDE_OFF_DOMAIN && f.confirmed),
+  );
   if (!APPLY) {
     console.log(
       `\n[sweep] DRY RUN — would demote ${toDemote.length} row(s). Re-run with --apply to write.`,

--- a/src/server/daily/__tests__/domain-drift.eval.test.ts
+++ b/src/server/daily/__tests__/domain-drift.eval.test.ts
@@ -23,6 +23,7 @@
 import { describe, expect, it } from 'vitest';
 import { getAnthropicClient } from '@/lib/llm';
 import { findQualityFailures, type LlmQuestion } from '@/server/daily/generate-questions';
+import { confirmOffDomain } from '@/server/quality/off-domain-second-opinion';
 
 const evalsEnabled = process.env.RUN_LLM_EVALS === '1' && getAnthropicClient() !== null;
 
@@ -175,6 +176,88 @@ describe.skipIf(!evalsEnabled)('quality gate OFF_DOMAIN (live)', () => {
       expect(result.offDomain.has(1)).toBe(false); // Mrs. Dalloway
       expect(result.offDomain.has(2)).toBe(true); // Romantic Opera
       expect(result.offDomain.has(3)).toBe(false); // Sesame Street
+    },
+    EVAL_TIMEOUT_MS,
+  );
+});
+
+// --- The second opinion (2026-09-08) ---------------------------------------
+//
+// A first "corroboration" attempt (comparing fact_key vocabulary against the
+// domain name) was built and REJECTED before shipping — it failed on Mrs.
+// Dalloway, because a specific work's fact_key names the work, not the
+// author. This is the replacement: a real, independently-worded second LLM
+// opinion, called only on rows the primary gate already flagged.
+//
+// The case below is not invented — it is THE actual false positive the
+// primary OFF_DOMAIN gate produced in production on 2026-09-07, found only
+// by hand-checking fact_key against domain (diagnosis/
+// answer-leak-domain-drift-plan.md): a correctly-filed Mozart row, whose
+// gate-generated reason text even admitted "correctly filed" and flagged it
+// anyway. This is the exact case the second opinion exists to catch.
+describe.skipIf(!evalsEnabled)('off-domain second opinion (live)', () => {
+  const MOZART_FALSE_POSITIVE = {
+    canonicalSubcategory: 'Mozart',
+    questionText:
+      "Mozart's Clarinet Concerto in A major was written for a friend who played a now-rare variant of the instrument with an extended lower range. What is this instrument called?",
+    answer: 'Basset clarinet',
+  };
+
+  it(
+    'overturns the real Mozart false positive — does NOT confirm it as off-domain',
+    async () => {
+      const result = await confirmOffDomain([MOZART_FALSE_POSITIVE]);
+      expect(result.has(0)).toBe(false);
+    },
+    EVAL_TIMEOUT_MS,
+  );
+
+  it(
+    'still confirms a genuine drift case (Joyce under Woolf) in the same call',
+    async () => {
+      const result = await confirmOffDomain([
+        MOZART_FALSE_POSITIVE,
+        {
+          canonicalSubcategory: WOOLF,
+          questionText:
+            "In Joyce's 'A Portrait of the Artist as a Young Man,' Stephen Dedalus famously refuses to sign a petition for universal peace circulated among students at University College Dublin. What cause did that petition support?",
+          answer: 'A petition calling for universal peace',
+        },
+      ]);
+      expect(result.has(0)).toBe(false); // Mozart still spared
+      expect(result.has(1)).toBe(true); // Joyce still caught
+    },
+    EVAL_TIMEOUT_MS,
+  );
+
+  it(
+    'end-to-end: with the flag ON, the second opinion still holds the Mozart-shaped false positive back',
+    async () => {
+      const prevFlag = process.env.DOMAIN_DRIFT_DROP_ENABLED;
+      process.env.DOMAIN_DRIFT_DROP_ENABLED = 'true';
+      try {
+        const q: LlmQuestion = {
+          canonical_subcategory: MOZART_FALSE_POSITIVE.canonicalSubcategory,
+          broad_category: 'Classical Music',
+          question_text: MOZART_FALSE_POSITIVE.questionText,
+          answer: MOZART_FALSE_POSITIVE.answer,
+          explainer: 'Context.',
+          difficulty_estimate: 'moderate',
+          fact_key: 'mozart-clarinet-concerto-basset-clarinet',
+          subject_entity: null,
+          sub_angles: [],
+          question_shape: null,
+        };
+        const result = await findQualityFailures([q]);
+        // Whether or not the primary gate even flags this one (it may not,
+        // since fact_key correctly prefixes "mozart-" here) — the load-bearing
+        // assertion is that nothing this genuinely correctly-filed ever ends
+        // up in offDomainConfirmed, which is the only thing an auto-drop acts on.
+        expect(result.offDomainConfirmed.has(0)).toBe(false);
+      } finally {
+        if (prevFlag === undefined) delete process.env.DOMAIN_DRIFT_DROP_ENABLED;
+        else process.env.DOMAIN_DRIFT_DROP_ENABLED = prevFlag;
+      }
     },
     EVAL_TIMEOUT_MS,
   );

--- a/src/server/daily/__tests__/partial-answer-leak-gate.test.ts
+++ b/src/server/daily/__tests__/partial-answer-leak-gate.test.ts
@@ -106,6 +106,20 @@ describe('questionPartiallyLeaksAnswer', () => {
     ).toBe(false);
   });
 
+  it('does not fire when the withheld word is the substance, not filler (the "model year" case)', () => {
+    // Phase 1 disagreement item (diagnosis/answer-leak-domain-drift-plan.md):
+    // 'model' used to sit in GENERIC_HEAD_NOUNS, so Rule B read this backwards
+    // -- "year" (shown, genuinely generic) was treated as the leaked substance
+    // and "model" (withheld, the actual jargon term) was waved through as
+    // filler. Removed 'model' from the generic set to fix it.
+    expect(
+      questionPartiallyLeaksAnswer(
+        'What is commonly used for the annual practice, standard among American automakers for decades, of releasing updated vehicle styling tied to a specific year?',
+        'model year',
+      ),
+    ).toBe(false);
+  });
+
   it('does not fire on counting questions, where the stem naming the unit is normal', () => {
     // Structurally identical to a leak — the stem shows "bases"/"books" and the
     // answer adds a number — but the withheld number IS the answer.

--- a/src/server/daily/__tests__/quality-gate-off-domain.test.ts
+++ b/src/server/daily/__tests__/quality-gate-off-domain.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Plumbing tests for the OFF_DOMAIN defect — the "Joyce question filed under
 // Virginia Woolf" case served to production on 2026-09-05.
@@ -141,5 +141,80 @@ describe('quality gate — OFF_DOMAIN plumbing', () => {
     const result = await findQualityFailures([DRIFTED]);
     expect(result.toDrop.size).toBe(0);
     expect(result.offDomain.size).toBe(0);
+  });
+
+  describe('offDomainConfirmed (the second opinion)', () => {
+    // A first, purely-lexical "corroboration" attempt was built and rejected
+    // before shipping (see diagnosis/answer-leak-domain-drift-plan.md) — it
+    // failed on Mrs. Dalloway, because a specific work's fact_key naturally
+    // names the work, not the author. These tests cover the real replacement:
+    // a second, independently-worded LLM call, only made when the flag is on.
+
+    afterEach(() => {
+      delete process.env.DOMAIN_DRIFT_DROP_ENABLED;
+    });
+
+    it('does NOT call the second opinion while the flag is off — nothing to act on yet', async () => {
+      mocks.loggedMessagesCreate.mockResolvedValue(
+        llmResponse({ drop_indices: [0], reasons: { '0': 'OFF_DOMAIN: about Joyce, filed under Woolf' } }),
+      );
+      const result = await findQualityFailures([DRIFTED]);
+      expect([...result.offDomain]).toEqual([0]);
+      expect(result.offDomainConfirmed.size).toBe(0);
+      // Only the quality-gate call happened — no second call to spend on.
+      expect(mocks.loggedMessagesCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('confirms the hit when the second opinion agrees, with the flag on', async () => {
+      process.env.DOMAIN_DRIFT_DROP_ENABLED = 'true';
+      mocks.loggedMessagesCreate.mockImplementation(async (_client: unknown, tag: string) => {
+        if (tag === 'quality-gate') {
+          return llmResponse({
+            drop_indices: [0],
+            reasons: { '0': 'OFF_DOMAIN: about Joyce, filed under Woolf' },
+          });
+        }
+        if (tag === 'off-domain-second-opinion') {
+          return llmResponse({ verdicts: { '0': 'OFF_DOMAIN' } });
+        }
+        throw new Error(`unexpected tag ${tag}`);
+      });
+      const result = await findQualityFailures([DRIFTED]);
+      expect([...result.offDomain]).toEqual([0]);
+      expect([...result.offDomainConfirmed]).toEqual([0]);
+    });
+
+    it('holds the hit back when the second opinion disagrees, even with the flag on', async () => {
+      process.env.DOMAIN_DRIFT_DROP_ENABLED = 'true';
+      mocks.loggedMessagesCreate.mockImplementation(async (_client: unknown, tag: string) => {
+        if (tag === 'quality-gate') {
+          // The gate flags a row exactly like the real Mozart false positive.
+          return llmResponse({
+            drop_indices: [0],
+            reasons: { '0': "OFF_DOMAIN: filed under the wrong domain" },
+          });
+        }
+        if (tag === 'off-domain-second-opinion') {
+          return llmResponse({ verdicts: { '0': 'FILED_CORRECTLY' } });
+        }
+        throw new Error(`unexpected tag ${tag}`);
+      });
+      const result = await findQualityFailures([DRIFTED]);
+      expect([...result.offDomain]).toEqual([0]); // still reported
+      expect(result.offDomainConfirmed.size).toBe(0); // but not confirmed
+    });
+
+    it('holds back rather than confirms when the second opinion itself fails', async () => {
+      process.env.DOMAIN_DRIFT_DROP_ENABLED = 'true';
+      mocks.loggedMessagesCreate.mockImplementation(async (_client: unknown, tag: string) => {
+        if (tag === 'quality-gate') {
+          return llmResponse({ drop_indices: [0], reasons: { '0': 'OFF_DOMAIN: about Joyce' } });
+        }
+        throw new Error('anthropic 529');
+      });
+      const result = await findQualityFailures([DRIFTED]);
+      expect([...result.offDomain]).toEqual([0]);
+      expect(result.offDomainConfirmed.size).toBe(0);
+    });
   });
 });

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -47,6 +47,7 @@ import {
   type RecentFactKeyEntry,
 } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
+import { confirmOffDomain } from '@/server/quality/off-domain-second-opinion';
 import { recordGateDrops, recordGateFailedOpen } from '@/server/db/queries/gate-drop-stats';
 import {
   coCalibrateRaisedEstimates,
@@ -846,8 +847,23 @@ export async function findQualityFailures(generated: LlmQuestion[]): Promise<{
   reasons: Record<number, string>;
   /** OFF_DOMAIN hits, held OUT of toDrop — see isDomainDriftDropEnabled. */
   offDomain: Set<number>;
+  /**
+   * The subset of `offDomain` a SECOND, independently-worded opinion also
+   * confirms (see off-domain-second-opinion.ts). This is what
+   * isDomainDriftDropEnabled should gate a drop on, never raw `offDomain` —
+   * a lexical-only "corroboration" attempt was tried and rejected before
+   * shipping (it failed on Mrs. Dalloway, see diagnosis doc), so this is an
+   * LLM check, not a free heuristic. Empty whenever `offDomain` is empty or
+   * the flag is off (no point paying for a check nothing will act on).
+   */
+  offDomainConfirmed: Set<number>;
 }> {
-  const empty = { toDrop: new Set<number>(), reasons: {}, offDomain: new Set<number>() };
+  const empty = {
+    toDrop: new Set<number>(),
+    reasons: {},
+    offDomain: new Set<number>(),
+    offDomainConfirmed: new Set<number>(),
+  };
   if (generated.length === 0) return empty;
   const client = getAnthropicClient();
   if (!client) return empty;
@@ -927,14 +943,43 @@ export async function findQualityFailures(generated: LlmQuestion[]): Promise<{
         })),
       });
     }
-    return { toDrop, reasons, offDomain };
+    // Second opinion, only worth paying for when the flag could actually act
+    // on the answer — while the flag is off, offDomain is measured but never
+    // dropped either way, so nothing here can change the outcome.
+    let offDomainConfirmed = new Set<number>();
+    if (offDomain.size > 0 && isDomainDriftDropEnabled()) {
+      const offDomainList = [...offDomain];
+      const confirmedLocal = await confirmOffDomain(
+        offDomainList.map((i) => ({
+          canonicalSubcategory: generated[i].canonical_subcategory,
+          questionText: generated[i].question_text,
+          answer: generated[i].answer,
+        })),
+      );
+      offDomainConfirmed = new Set(offDomainList.filter((_, localIdx) => confirmedLocal.has(localIdx)));
+      const heldBack = offDomainList.filter((i) => !offDomainConfirmed.has(i));
+      if (heldBack.length > 0) {
+        console.warn(
+          '[daily/generate-questions] second opinion disagrees — holding these back from the drop despite the flag being on',
+          {
+            indices: heldBack,
+            detail: heldBack.map((i) => ({
+              domain: generated[i].canonical_subcategory,
+              factKey: generated[i].fact_key,
+              questionPreview: generated[i].question_text.slice(0, 120),
+            })),
+          },
+        );
+      }
+    }
+    return { toDrop, reasons, offDomain, offDomainConfirmed };
   } catch (err) {
     // Fail open: don't block the daily queue on a Haiku outage.
     console.warn('[daily/generate-questions] quality gate failed', {
       error: err instanceof Error ? err.message : String(err),
     });
     recordGateFailedOpen('quality');
-    return { toDrop: new Set(), reasons: {}, offDomain: new Set() };
+    return { toDrop: new Set(), reasons: {}, offDomain: new Set(), offDomainConfirmed: new Set() };
   }
 }
 
@@ -2077,6 +2122,10 @@ export async function generateDailyQuestions(
   // Virginia Woolf" case). Held separate from qualityResult.toDrop so the new
   // defect can be measured before it is allowed to cost supply.
   const offDomain = qualityResult.offDomain;
+  // The subset a SECOND, independent opinion also agrees on — see
+  // off-domain-second-opinion.ts. This, not raw offDomain, is what
+  // isDomainDriftDropEnabled should ever be allowed to drop.
+  const offDomainConfirmed = qualityResult.offDomainConfirmed;
 
   // Rule 3 ("ONE CLEAN ANSWER") backstop. A paragraph-length answer grades
   // unpredictably AND blinds the answer-leak gate above, so it is dropped here
@@ -2173,10 +2222,12 @@ export async function generateDailyQuestions(
     ...factualResult.toDrop,
     ...answerLeaks.toDrop,
     ...answerShape.toDrop,
-    // offDomain is deliberately NOT unioned unconditionally — see the OFF_DOMAIN
-    // block above. It is measured and logged by default; flipping
-    // DOMAIN_DRIFT_DROP_ENABLED is what promotes it to a drop.
-    ...(isDomainDriftDropEnabled() ? offDomain : []),
+    // offDomainConfirmed (NOT raw offDomain) is deliberately the only thing
+    // unioned here, and only when the flag is on — a row the primary gate
+    // flags but the second opinion doesn't confirm stays measured, never
+    // dropped, regardless of the flag. See findQualityFailures /
+    // off-domain-second-opinion.ts.
+    ...(isDomainDriftDropEnabled() ? offDomainConfirmed : []),
   ]);
   if (allDrops.size > 0) {
     generated = generated.filter((_, i) => !allDrops.has(i));
@@ -3375,6 +3426,7 @@ export async function screenGroundedBatch(questions: LlmQuestion[]): Promise<Set
     ...factualResult.toDrop,
     ...answerLeaks.toDrop,
     ...answerShape.toDrop,
-    ...(isDomainDriftDropEnabled() ? qualityResult.offDomain : []),
+    // Same second-opinion gate as the per-user path — see findQualityFailures.
+    ...(isDomainDriftDropEnabled() ? qualityResult.offDomainConfirmed : []),
   ]);
 }

--- a/src/server/quality/__tests__/off-domain-second-opinion.test.ts
+++ b/src/server/quality/__tests__/off-domain-second-opinion.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  loggedMessagesCreate: vi.fn(),
+}));
+
+vi.mock('@/lib/llm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/llm')>();
+  return {
+    ...actual,
+    getAnthropicClient: () => ({}) as never,
+    loggedMessagesCreate: mocks.loggedMessagesCreate,
+  };
+});
+
+import { confirmOffDomain } from '@/server/quality/off-domain-second-opinion';
+
+function llmResponse(json: unknown) {
+  return { content: [{ type: 'text', text: JSON.stringify(json) }] };
+}
+
+const CANDIDATE = {
+  canonicalSubcategory: "Virginia Woolf's Novels and Essays",
+  questionText: "In Joyce's Ulysses, ...",
+  answer: 'Rhetoric',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('confirmOffDomain', () => {
+  it('returns nothing for an empty candidate list without calling the model', async () => {
+    const result = await confirmOffDomain([]);
+    expect(result.size).toBe(0);
+    expect(mocks.loggedMessagesCreate).not.toHaveBeenCalled();
+  });
+
+  it('sends the raw question/answer/domain, NOT a fact_key, so the second opinion is genuinely independent', async () => {
+    mocks.loggedMessagesCreate.mockResolvedValue(llmResponse({ verdicts: { '0': 'OFF_DOMAIN' } }));
+    await confirmOffDomain([CANDIDATE]);
+    const [, tag, request] = mocks.loggedMessagesCreate.mock.calls[0];
+    expect(tag).toBe('off-domain-second-opinion');
+    const userContent = request.messages[0].content as string;
+    expect(userContent).toContain(CANDIDATE.canonicalSubcategory);
+    expect(userContent).toContain(CANDIDATE.questionText);
+    expect(userContent).toContain(CANDIDATE.answer);
+    expect(userContent).not.toContain('fact_key');
+  });
+
+  it('confirms only the indices the model marks OFF_DOMAIN', async () => {
+    mocks.loggedMessagesCreate.mockResolvedValue(
+      llmResponse({ verdicts: { '0': 'OFF_DOMAIN', '1': 'FILED_CORRECTLY' } }),
+    );
+    const result = await confirmOffDomain([
+      CANDIDATE,
+      { canonicalSubcategory: 'Mozart', questionText: '...', answer: 'Basset clarinet' },
+    ]);
+    expect([...result]).toEqual([0]);
+  });
+
+  it('fails CLOSED (confirms nothing) on a request error — an outage must never confirm a drop', async () => {
+    mocks.loggedMessagesCreate.mockRejectedValue(new Error('anthropic 529'));
+    const result = await confirmOffDomain([CANDIDATE]);
+    expect(result.size).toBe(0);
+  });
+
+  it('fails CLOSED on an unparseable response', async () => {
+    mocks.loggedMessagesCreate.mockResolvedValue({ content: [{ type: 'text', text: 'not json' }] });
+    const result = await confirmOffDomain([CANDIDATE]);
+    expect(result.size).toBe(0);
+  });
+
+  it('ignores an out-of-range or malformed index rather than throwing', async () => {
+    mocks.loggedMessagesCreate.mockResolvedValue(
+      llmResponse({ verdicts: { '5': 'OFF_DOMAIN', 'x': 'OFF_DOMAIN' } }),
+    );
+    const result = await confirmOffDomain([CANDIDATE]);
+    expect(result.size).toBe(0);
+  });
+});

--- a/src/server/quality/off-domain-second-opinion.ts
+++ b/src/server/quality/off-domain-second-opinion.ts
@@ -1,0 +1,132 @@
+/**
+ * Second, independently-worded opinion on an OFF_DOMAIN drift finding
+ * (diagnosis/answer-leak-domain-drift-plan.md).
+ *
+ * The quality gate's own OFF_DOMAIN judgment has a measured false-positive
+ * rate: hand-verifying 24 real hits found one that was genuinely correctly
+ * filed (a Mozart row whose own gate-generated reason text admitted as much
+ * and flagged it anyway) and one defensibly ambiguous case. That failure mode
+ * is uniquely dangerous — a wrongly demoted, correctly-filed question is
+ * invisible in production forever, with no counter that would ever surface it
+ * as wrong.
+ *
+ * A first attempt at a cheap, deterministic "second opinion" (comparing the
+ * row's fact_key vocabulary against its domain's name) was built and
+ * REJECTED before shipping: it failed on a real, important case (Mrs.
+ * Dalloway under Virginia Woolf) because a specific work's fact_key
+ * naturally names the work, not the author — "does this share words with the
+ * domain name" cannot encode "is this book by that author" any more than
+ * spelling can encode knowledge. That is a genuine limitation of lexical
+ * matching, not a tunable threshold, so it was not wired in. See the
+ * 2026-09-08 entry in the diagnosis doc for the full story.
+ *
+ * This module is the corrected approach: a REAL second opinion — an
+ * independently-worded LLM call asking the containment question fresh, from
+ * the raw question/answer text (deliberately NOT the fact_key or the first
+ * gate's own reasoning), with an explicit instruction to side with
+ * "correctly filed" whenever uncertain. Only called for rows the primary
+ * gate already flagged, so cost is proportional to how often that gate
+ * fires, not to generation volume. A row is only safe to auto-drop when
+ * BOTH opinions agree.
+ */
+
+import {
+  HAIKU_MODEL,
+  INSTRUCTION_SCOPING_QUALIFIER,
+  INSTRUCTION_USER_INPUT_GUIDANCE,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+  wrapUserInput,
+} from '@/lib/llm';
+
+export type OffDomainCandidate = {
+  canonicalSubcategory: string;
+  questionText: string;
+  answer: string;
+};
+
+const SECOND_OPINION_TIMEOUT_MS = 15_000;
+
+const SYSTEM_PROMPT = `You are the SECOND, INDEPENDENT check on a claim that a trivia question was filed under the wrong category. A different automated check already suspects each item below is OFF_DOMAIN — filed under a label it doesn't actually belong to. Your job is to independently confirm or reject that suspicion. Do not assume the other check is right, and do not just agree with it by default.
+
+For each item, first work out what the question is REALLY about — the specific work, person, or subject the fact concerns — using only the question text and its answer. Then ask: does that specific subject genuinely belong within the STATED domain's scope?
+
+A subject BELONGS when it is the domain's own work, its own creator's other output, or a specific instance the domain's own category legitimately covers (a specific TV show under a TV-genre domain, a specific piece under a composer's-name domain, a specific character or chapter within a work-titled domain).
+
+A subject does NOT belong when it is a different creator's work, a different specific franchise, or an adjacent-but-separate period or movement — even when it is a close contemporary or an easily-confused neighbor.
+
+When you are not confident either way, answer FILED_CORRECTLY. This check exists specifically to catch the OTHER check's false alarms: letting a genuine drift case through costs nothing (it stays measured, not dropped), while wrongly confirming a correctly-filed question as drift costs a good question forever, silently, with nothing that would ever surface the mistake.
+
+Examples:
+- Domain "Virginia Woolf's Novels and Essays", question about Mrs. Dalloway's plot → FILED_CORRECTLY (Woolf's own novel).
+- Domain "Virginia Woolf's Novels and Essays", question about James Joyce's Ulysses → OFF_DOMAIN (Joyce is a contemporary, not part of Woolf's body of work).
+- Domain "Mozart", question about the basset clarinet written for Mozart's Clarinet Concerto → FILED_CORRECTLY (it's about a piece Mozart wrote, even though "basset clarinet" itself isn't Mozart's).
+- Domain "Classic Children's Television", question about Sesame Street → FILED_CORRECTLY (a specific show the category covers).
+- Domain "Stephen Sondheim Musicals", question about the musical "Rent" → OFF_DOMAIN (Rent is by Jonathan Larson, not Sondheim).
+
+Return JSON only: { "verdicts": { "<index>": "FILED_CORRECTLY" | "OFF_DOMAIN" } } — one entry per item index, using the exact zero-based indices given.${INSTRUCTION_USER_INPUT_GUIDANCE}${INSTRUCTION_SCOPING_QUALIFIER}`;
+
+function buildUserMessage(candidates: readonly OffDomainCandidate[]): string {
+  const body = candidates
+    .map(
+      (c, i) =>
+        `[${i}] domain=${c.canonicalSubcategory}\n    q=${c.questionText}\n    a=${c.answer}`,
+    )
+    .join('\n\n');
+  return wrapUserInput('batch', body);
+}
+
+/**
+ * Given rows the primary gate already flagged OFF_DOMAIN, returns the
+ * indices (into `candidates`) this independent check ALSO confirms are
+ * off-domain. Fails CLOSED toward safety in the direction that matters here:
+ * on any error, parse failure, or missing verdict, that index is left OUT of
+ * the confirmed set — an outage can only mean "hold back from auto-drop,"
+ * never "silently confirm a drop."
+ */
+export async function confirmOffDomain(
+  candidates: readonly OffDomainCandidate[],
+): Promise<Set<number>> {
+  if (candidates.length === 0) return new Set();
+  const client = getAnthropicClient();
+  if (!client) return new Set();
+
+  try {
+    const response = await loggedMessagesCreate(
+      client,
+      'off-domain-second-opinion',
+      {
+        model: HAIKU_MODEL,
+        max_tokens: 500,
+        temperature: 0,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: buildUserMessage(candidates) }],
+      },
+      { timeoutMs: SECOND_OPINION_TIMEOUT_MS },
+    );
+    const parsed = parseJsonObject(extractTextContent(response.content));
+    const verdicts = parsed?.verdicts;
+    const confirmed = new Set<number>();
+    if (verdicts && typeof verdicts === 'object' && !Array.isArray(verdicts)) {
+      for (const [key, value] of Object.entries(verdicts as Record<string, unknown>)) {
+        const idx = Number.parseInt(key, 10);
+        if (
+          Number.isInteger(idx) &&
+          idx >= 0 &&
+          idx < candidates.length &&
+          value === 'OFF_DOMAIN'
+        ) {
+          confirmed.add(idx);
+        }
+      }
+    }
+    return confirmed;
+  } catch (error) {
+    console.warn('[confirmOffDomain] request_failed — holding back from auto-drop', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return new Set();
+  }
+}

--- a/src/server/questions/self-answering.ts
+++ b/src/server/questions/self-answering.ts
@@ -297,8 +297,16 @@ function answerLeaksIntoQuestion(normalizedQuestion: string, candidate: string):
 // Nouns that name the CATEGORY an answer belongs to rather than its substance.
 // A stem may hand one of these over for free; what makes the answer the answer
 // is the modifier in front of it.
+// NOTE: 'model' was removed 2026-09-08 (Phase 1 disagreement item, see
+// diagnosis/answer-leak-domain-drift-plan.md). It backfires on jargon
+// compounds where "model" is the substantive term, not filler — "model
+// year" was flagged as a leak because "model" sat in this set while the
+// truly generic word ("year") was what the stem actually showed. Genuine
+// generic-filler uses of "model" (e.g. "a scale model") are rare enough,
+// and the false-positive cost real enough, that this errs toward NOT
+// treating it as generic.
 const GENERIC_HEAD_NOUNS = new Set([
-  'plan', 'tree', 'form', 'system', 'technique', 'method', 'process', 'model',
+  'plan', 'tree', 'form', 'system', 'technique', 'method', 'process',
   'theory', 'principle', 'rule', 'law', 'effect', 'style', 'period', 'era',
   'movement', 'school', 'test', 'sign', 'device', 'section', 'scene', 'act',
   'song', 'book', 'film', 'movie', 'show', 'series', 'game', 'award', 'prize',


### PR DESCRIPTION
Follow-up to the two open decisions in `diagnosis/answer-leak-domain-drift-plan.md`: `PARTIAL_ANSWER_LEAK_ENABLED` and `DOMAIN_DRIFT_DROP_ENABLED`.

## 1. `PARTIAL_ANSWER_LEAK_ENABLED` blocker fixed

Of the 7 Phase 1 disagreement items, only one actually blocked this flag: `model` sat in `GENERIC_HEAD_NOUNS`, so "model year" got flagged as a leak backwards — "model" (the substantive jargon word) was treated as filler while "year" (genuinely generic) was read as the leaked substance. Removed `model` from the set, added a regression test reproducing the exact failure. The other 6 items concern the answer-shape gate, which is already on and needs no action.

## 2. `DOMAIN_DRIFT_DROP_ENABLED` — a real safety net, after a rejected first attempt

Built a cheap lexical "corroboration" check first (compare a row's `fact_key` vocabulary against its domain name — no overlap suggests drift). **Rejected it before shipping**: it failed on Mrs. Dalloway, a genuinely correctly-filed row, because a specific work's `fact_key` naturally names the work, not its author. No amount of word-matching can encode "this book is by that author" — that's knowledge, not spelling. Deleted the module and its test rather than leave known-broken code around.

Replaced it with `src/server/quality/off-domain-second-opinion.ts` — a real second opinion: an independently-worded LLM call, asked only about rows the primary gate already flagged OFF_DOMAIN, reasoning fresh from the raw question/answer text (deliberately not the `fact_key`, not the first gate's own reasoning). Wired into both live call sites in `generate-questions.ts` — `findQualityFailures` now returns `offDomainConfirmed` alongside `offDomain`, and `isDomainDriftDropEnabled` gates the drop on the confirmed subset only — and into `sweep-bank-quality.ts`'s `--include-off-domain` path.

## Validated against the real production case, not just mocks

Replayed the actual Mozart row from the 2026-09-07 incident (`fact_key="mozart-clarinet-concerto-basset-clarinet"` — the real false positive the primary gate produced, filed correctly under "Mozart" and flagged anyway) through the full pipeline end-to-end with `DOMAIN_DRIFT_DROP_ENABLED=true`. The second opinion correctly overturns it, while still confirming genuine Joyce-under-Woolf drift in the same call.

Re-ran the full Phase 2 eval suite: 9/11 (2 failures are the same pre-existing Romantic Opera edge case from before — not a regression from this change).

## This de-risks the flag decision, doesn't make it for Josh

The failure mode that made `DOMAIN_DRIFT_DROP_ENABLED` the one gate worth resisting — a wrongly-demoted, correctly-filed question, invisible in production forever — now requires **two independent LLM calls to agree** before anything drops. Flipping the flag is still Josh's call, but the evidence behind it is now a validated mechanism, not just a 92%-precision number on a small sample.

## Not done here

- **Flipping `PARTIAL_ANSWER_LEAK_ENABLED` and `DOMAIN_DRIFT_DROP_ENABLED`** — Vercel production env vars. Checked: no MCP tool here exposes env var writes, so this genuinely needs Josh (or the Vercel dashboard/CLI directly).

## Verification

Typecheck clean, lint unchanged (2 pre-existing warnings, not from this PR), all six ratchets pass, full suite **2,627 passed**. New tests: 6 unit tests for the second-opinion module (mocked), 4 more in the existing off-domain plumbing test file covering the flag-gated wiring, 3 new live evals against real Anthropic calls (including the Mozart replay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG8TSZKng9jjkRH3UroXMS
