### PR TITLE
Redesign Invite via link experience

### DIFF
--- a/drizzle/0141_invite_link_categories.sql
+++ b/drizzle/0141_invite_link_categories.sql
@@ -1,0 +1,5 @@
+-- Each managed invite link now owns its recommendation set. NULL preserves
+-- the legacy slot-based resolver for links created before this migration;
+-- once a creator edits one, the exact corrected set is written here.
+ALTER TABLE "UserInviteLink"
+  ADD COLUMN IF NOT EXISTS "categories" jsonb;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -988,6 +988,13 @@
       "when": 1788400823476,
       "tag": "0140_build_metric_domain_counts",
       "breakpoints": true
+    },
+    {
+      "idx": 141,
+      "version": "7",
+      "when": 1788757200000,
+      "tag": "0141_invite_link_categories",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/account/invite-links/[linkId]/__tests__/route.test.ts
+++ b/src/app/api/account/invite-links/[linkId]/__tests__/route.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { getSessionMock, updateInviteLinkCategoriesMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  updateInviteLinkCategoriesMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/db/queries/invite-links', () => ({
+  updateInviteLinkCategories: updateInviteLinkCategoriesMock,
+}));
+
+import { PATCH } from '@/app/api/account/invite-links/[linkId]/route';
+
+function request(categories: unknown) {
+  return new Request('https://example.com/api/account/invite-links/link-1', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ categories }),
+  });
+}
+
+const context = { params: Promise.resolve({ linkId: 'link-1' }) };
+
+describe('PATCH /api/account/invite-links/[linkId]', () => {
+  it('requires at least one valid category during edit', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' });
+
+    const response = await PATCH(request(['No category']), context);
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toBe('invalid_categories');
+    expect(updateInviteLinkCategoriesMock).not.toHaveBeenCalled();
+  });
+
+  it('updates only the requested link with the validated category set', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' });
+    updateInviteLinkCategoriesMock.mockResolvedValueOnce({
+      ok: true,
+      categories: [{ label: 'Jazz', broadCategory: 'Music', description: null }],
+    });
+
+    const response = await PATCH(request([{ label: 'Jazz', broadCategory: 'Music' }]), context);
+
+    expect(response.status).toBe(200);
+    expect(updateInviteLinkCategoriesMock).toHaveBeenCalledWith('u1', 'link-1', [
+      { label: 'Jazz', broadCategory: 'Music' },
+    ]);
+  });
+});

--- a/src/app/api/account/invite-links/[linkId]/route.ts
+++ b/src/app/api/account/invite-links/[linkId]/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { MAX_INVITE_LINK_CATEGORIES, sanitizeInviteLinkCategories } from '@/lib/invite-links';
+import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
+import { getSession } from '@/server/auth/session';
+import { updateInviteLinkCategories } from '@/server/db/queries/invite-links';
+
+export const dynamic = 'force-dynamic';
+
+const categorySchema = z.union([
+  z.string(),
+  z.object({
+    label: z.string(),
+    broadCategory: z.string().nullable().optional(),
+  }),
+]);
+
+const bodySchema = z.object({
+  categories: z.array(categorySchema).min(1).max(MAX_INVITE_LINK_CATEGORIES),
+});
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ linkId: string }> }) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_body', message: `Choose 1–${MAX_INVITE_LINK_CATEGORIES} categories.` },
+      { status: 400 },
+    );
+  }
+
+  const categories = sanitizeInviteLinkCategories(parsed.data.categories);
+  if (categories.length !== parsed.data.categories.length || categories.length === 0) {
+    return NextResponse.json(
+      { error: 'invalid_categories', message: 'Choose at least one valid category for this link.' },
+      { status: 400 },
+    );
+  }
+
+  const tooBroad = categories.find((category) => isTooBroadInterest(category.label));
+  if (tooBroad) {
+    return NextResponse.json(
+      {
+        error: 'too_broad',
+        message: `“${tooBroad.label}” is too broad — try something more specific.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const { linkId } = await params;
+  const result = await updateInviteLinkCategories(session.userId, linkId, categories);
+  if (!result.ok) {
+    const status = result.error === 'not_found' ? 404 : 400;
+    const message =
+      result.error === 'not_found'
+        ? 'That link is no longer available.'
+        : 'Choose at least one category for this link.';
+    return NextResponse.json({ error: result.error, message }, { status });
+  }
+
+  return NextResponse.json({ categories: result.categories });
+}

--- a/src/app/api/account/invite-links/__tests__/route.test.ts
+++ b/src/app/api/account/invite-links/__tests__/route.test.ts
@@ -1,27 +1,40 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getSessionMock, listLiveInviteLinksMock, createInviteLinkMock, dbSelectMock } = vi.hoisted(() => ({
+const {
+  getSessionMock,
+  listLiveInviteLinksMock,
+  createInviteLinkMock,
+  dbSelectMock,
+  getInviteLinkSeedTopicsMock,
+} = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
   listLiveInviteLinksMock: vi.fn(),
   createInviteLinkMock: vi.fn(),
   dbSelectMock: vi.fn(),
-}))
+  getInviteLinkSeedTopicsMock: vi.fn(),
+}));
 
-vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }))
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
 vi.mock('@/server/db/queries/invite-links', () => ({
   listLiveInviteLinks: listLiveInviteLinksMock,
   createInviteLink: createInviteLinkMock,
-}))
+}));
 vi.mock('@/server/friends/user-invite-token', () => ({
-  buildInviteUrl: (baseUrl: string, handle: string, token: string) => `${baseUrl}/u/${handle}/${token}`,
+  buildInviteUrl: (baseUrl: string, handle: string, token: string) =>
+    `${baseUrl}/u/${handle}/${token}`,
   getBaseUrl: () => 'https://example.com',
-}))
+  getInviteLinkSeedTopics: getInviteLinkSeedTopicsMock,
+}));
 vi.mock('@/server/db', () => ({
   db: { select: dbSelectMock },
   users: { handle: 'handle', id: 'id' },
-}))
+}));
 
-import { GET, POST } from '@/app/api/account/invite-links/route'
+import { GET, POST } from '@/app/api/account/invite-links/route';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 function mockHandleRow(handle: string | null) {
   dbSelectMock.mockReturnValue({
@@ -30,7 +43,7 @@ function mockHandleRow(handle: string | null) {
         limit: () => Promise.resolve(handle ? [{ handle }] : []),
       }),
     }),
-  })
+  });
 }
 
 function jsonRequest(body: unknown) {
@@ -38,85 +51,146 @@ function jsonRequest(body: unknown) {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
-  })
+  });
 }
 
 describe('GET /api/account/invite-links', () => {
   it('returns 401 when signed out', async () => {
-    getSessionMock.mockResolvedValueOnce(null)
-    const response = await GET(new Request('https://example.com/api/account/invite-links'))
-    expect(response.status).toBe(401)
-  })
+    getSessionMock.mockResolvedValueOnce(null);
+    const response = await GET(new Request('https://example.com/api/account/invite-links'));
+    expect(response.status).toBe(401);
+  });
 
   it('returns handle_required when the caller has no handle', async () => {
-    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
-    mockHandleRow(null)
-    const response = await GET(new Request('https://example.com/api/account/invite-links'))
-    expect(response.status).toBe(409)
-    const body = await response.json()
-    expect(body.error).toBe('handle_required')
-  })
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' });
+    mockHandleRow(null);
+    const response = await GET(new Request('https://example.com/api/account/invite-links'));
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toBe('handle_required');
+  });
 
   it('lists live links with built share URLs', async () => {
-    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
-    mockHandleRow('joshp')
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' });
+    mockHandleRow('joshp');
     listLiveInviteLinksMock.mockResolvedValueOnce([
-      { id: 'lk1', token: 'tok1', slot: 1, createdAt: new Date('2026-01-01T00:00:00Z'), joinedCount: 4 },
-    ])
-    const response = await GET(new Request('https://example.com/api/account/invite-links'))
-    const body = await response.json()
+      {
+        id: 'lk1',
+        token: 'tok1',
+        slot: 0,
+        categories: [{ label: 'Jazz', broadCategory: 'Music' }],
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        joinedCount: 4,
+      },
+    ]);
+    const response = await GET(new Request('https://example.com/api/account/invite-links'));
+    const body = await response.json();
     expect(body.links).toEqual([
       {
         id: 'lk1',
-        slot: 1,
+        slot: 0,
+        categories: [{ label: 'Jazz', broadCategory: 'Music' }],
         url: 'https://example.com/u/joshp/tok1',
         createdAt: '2026-01-01T00:00:00.000Z',
         joinedCount: 4,
       },
-    ])
-  })
-})
+    ]);
+  });
+});
 
 describe('POST /api/account/invite-links', () => {
   it('returns 401 when signed out', async () => {
-    getSessionMock.mockResolvedValueOnce(null)
-    const response = await POST(jsonRequest({ slot: 1 }))
-    expect(response.status).toBe(401)
-  })
+    getSessionMock.mockResolvedValueOnce(null);
+    const response = await POST(jsonRequest({ slot: 1 }));
+    expect(response.status).toBe(401);
+  });
 
   it('rejects an invalid body', async () => {
-    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
-    mockHandleRow('joshp')
-    const response = await POST(jsonRequest({ slot: 'not-a-number' }))
-    expect(response.status).toBe(400)
-  })
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' });
+    mockHandleRow('joshp');
+    const response = await POST(jsonRequest({ slot: 'not-a-number' }));
+    expect(response.status).toBe(400);
+  });
 
   it('surfaces limit_reached as 409', async () => {
-    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
-    mockHandleRow('joshp')
-    createInviteLinkMock.mockResolvedValueOnce({ ok: false, error: 'limit_reached' })
-    const response = await POST(jsonRequest({ slot: 0 }))
-    expect(response.status).toBe(409)
-    const body = await response.json()
-    expect(body.error).toBe('limit_reached')
-  })
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' });
+    mockHandleRow('joshp');
+    createInviteLinkMock.mockResolvedValueOnce({ ok: false, error: 'limit_reached' });
+    const response = await POST(jsonRequest({ categories: [{ label: 'Sondheim' }] }));
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toBe('limit_reached');
+  });
 
   it('creates a link and returns its share URL', async () => {
-    getSessionMock.mockResolvedValueOnce({ userId: 'u1' })
-    mockHandleRow('joshp')
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' });
+    mockHandleRow('joshp');
     createInviteLinkMock.mockResolvedValueOnce({
       ok: true,
-      link: { id: 'lk2', token: 'tok2', slot: 2, createdAt: new Date('2026-01-02T00:00:00Z'), joinedCount: 0 },
-    })
-    const response = await POST(jsonRequest({ slot: 2 }))
-    expect(response.status).toBe(200)
-    const body = await response.json()
+      link: {
+        id: 'lk2',
+        token: 'tok2',
+        slot: 0,
+        categories: [{ label: 'Sondheim' }],
+        createdAt: new Date('2026-01-02T00:00:00Z'),
+        joinedCount: 0,
+      },
+    });
+    const response = await POST(jsonRequest({ categories: [{ label: 'Sondheim' }] }));
+    expect(response.status).toBe(200);
+    const body = await response.json();
     expect(body.link).toEqual({
       id: 'lk2',
-      slot: 2,
+      slot: 0,
+      categories: [{ label: 'Sondheim' }],
       url: 'https://example.com/u/joshp/tok2',
       createdAt: '2026-01-02T00:00:00.000Z',
       joinedCount: 0,
-    })
-  })
-})
+    });
+    expect(createInviteLinkMock).toHaveBeenCalledWith('u1', [
+      { label: 'Sondheim', broadCategory: null },
+    ]);
+  });
+
+  it('requires at least one valid category', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' });
+    mockHandleRow('joshp');
+
+    const response = await POST(jsonRequest({ categories: ['No category'] }));
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toBe('invalid_categories');
+    expect(createInviteLinkMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps two links with different category sets isolated', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1' });
+    mockHandleRow('joshp');
+    listLiveInviteLinksMock.mockResolvedValueOnce([
+      {
+        id: 'a',
+        token: 'ta',
+        slot: 0,
+        categories: [{ label: 'Jazz' }],
+        createdAt: new Date(),
+        joinedCount: 0,
+      },
+      {
+        id: 'b',
+        token: 'tb',
+        slot: 0,
+        categories: [{ label: 'Poetry' }],
+        createdAt: new Date(),
+        joinedCount: 1,
+      },
+    ]);
+
+    const response = await GET(new Request('https://example.com/api/account/invite-links'));
+    const body = await response.json();
+
+    expect(body.links[0].categories.map((item: { label: string }) => item.label)).toEqual(['Jazz']);
+    expect(body.links[1].categories.map((item: { label: string }) => item.label)).toEqual([
+      'Poetry',
+    ]);
+  });
+});

--- a/src/app/api/account/invite-links/route.ts
+++ b/src/app/api/account/invite-links/route.ts
@@ -1,91 +1,145 @@
-import { eq } from 'drizzle-orm'
-import { NextResponse } from 'next/server'
-import { z } from 'zod'
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 
-import { getSession } from '@/server/auth/session'
-import { db, users } from '@/server/db'
-import { createInviteLink, listLiveInviteLinks } from '@/server/db/queries/invite-links'
-import { buildInviteUrl, getBaseUrl } from '@/server/friends/user-invite-token'
+import { getSession } from '@/server/auth/session';
+import { db, users } from '@/server/db';
+import { createInviteLink, listLiveInviteLinks } from '@/server/db/queries/invite-links';
+import { MAX_INVITE_LINK_CATEGORIES, sanitizeInviteLinkCategories } from '@/lib/invite-links';
+import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
+import {
+  buildInviteUrl,
+  getBaseUrl,
+  getInviteLinkSeedTopics,
+} from '@/server/friends/user-invite-token';
 
-export const dynamic = 'force-dynamic'
+export const dynamic = 'force-dynamic';
 
 const CREATE_ERROR_COPY: Record<string, { status: number; message: string }> = {
   limit_reached: { status: 409, message: 'You already have 3 links. Delete one to make another.' },
-  slot_taken: { status: 409, message: 'That topic already has a link. Delete it first to reuse the slot.' },
-  invalid_slot: { status: 400, message: 'Choose a topic slot or no category.' },
-}
+  invalid_categories: { status: 400, message: 'Choose at least one category for this link.' },
+};
 
 async function requireHandle(userId: string, request: Request) {
-  const [row] = await db.select({ handle: users.handle }).from(users).where(eq(users.id, userId)).limit(1)
-  if (!row?.handle) return null
-  const baseUrl = getBaseUrl(request)
-  return { handle: row.handle, baseUrl }
+  const [row] = await db
+    .select({ handle: users.handle })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (!row?.handle) return null;
+  const baseUrl = getBaseUrl(request);
+  return { handle: row.handle, baseUrl };
 }
 
 // Lists the caller's live invite links, each with its share URL and current
 // join count.
 export async function GET(request: Request) {
-  const session = await getSession()
-  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const identity = await requireHandle(session.userId, request)
+  const identity = await requireHandle(session.userId, request);
   if (!identity) {
     return NextResponse.json(
-      { error: 'handle_required', message: 'Set a handle in your profile before generating an invite link.' },
+      {
+        error: 'handle_required',
+        message: 'Set a handle in your profile before generating an invite link.',
+      },
       { status: 409 },
-    )
+    );
   }
 
-  const links = await listLiveInviteLinks(session.userId)
+  const links = await listLiveInviteLinks(session.userId);
+  const resolvedLinks = await Promise.all(
+    links.map(async (link) => ({
+      ...link,
+      categories: link.categories ?? (await getInviteLinkSeedTopics(session.userId, link.slot)),
+    })),
+  );
   return NextResponse.json({
-    links: links.map((link) => ({
+    links: resolvedLinks.map((link) => ({
       id: link.id,
       slot: link.slot,
+      categories: sanitizeInviteLinkCategories(link.categories),
       url: buildInviteUrl(identity.baseUrl, identity.handle, link.token),
       createdAt: link.createdAt.toISOString(),
       joinedCount: link.joinedCount,
     })),
-  })
+  });
 }
 
+const categorySchema = z.union([
+  z.string(),
+  z.object({
+    label: z.string(),
+    broadCategory: z.string().nullable().optional(),
+  }),
+]);
+
 const bodySchema = z.object({
-  slot: z.number().int().min(0).max(3),
-})
+  categories: z.array(categorySchema).min(1).max(MAX_INVITE_LINK_CATEGORIES),
+});
 
-// Creates a new live link tagged with `slot` (0 = untagged, 1-3 = a standing
-// topic slot). Capped at 3 live links and at one live link per named slot —
-// see createInviteLink.
+// Creates a new live link with its own exact category set, capped at 3 live
+// links and 3 categories per link.
 export async function POST(request: Request) {
-  const session = await getSession()
-  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const identity = await requireHandle(session.userId, request)
+  const identity = await requireHandle(session.userId, request);
   if (!identity) {
     return NextResponse.json(
-      { error: 'handle_required', message: 'Set a handle in your profile before generating an invite link.' },
+      {
+        error: 'handle_required',
+        message: 'Set a handle in your profile before generating an invite link.',
+      },
       { status: 409 },
-    )
+    );
   }
 
-  const json = await request.json().catch(() => null)
-  const parsed = bodySchema.safeParse(json)
+  const json = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: 'invalid_body', message: 'A topic slot (0-3) is required.' }, { status: 400 })
+    return NextResponse.json(
+      { error: 'invalid_body', message: `Choose 1–${MAX_INVITE_LINK_CATEGORIES} categories.` },
+      { status: 400 },
+    );
   }
 
-  const result = await createInviteLink(session.userId, parsed.data.slot)
+  const categories = sanitizeInviteLinkCategories(parsed.data.categories);
+  if (categories.length !== parsed.data.categories.length || categories.length === 0) {
+    return NextResponse.json(
+      { error: 'invalid_categories', message: 'Choose at least one valid category for this link.' },
+      { status: 400 },
+    );
+  }
+  const tooBroad = categories.find((category) => isTooBroadInterest(category.label));
+  if (tooBroad) {
+    return NextResponse.json(
+      {
+        error: 'too_broad',
+        message: `“${tooBroad.label}” is too broad — try something more specific.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await createInviteLink(session.userId, categories);
   if (!result.ok) {
-    const copy = CREATE_ERROR_COPY[result.error]
-    return NextResponse.json({ error: result.error, message: copy.message }, { status: copy.status })
+    const copy = CREATE_ERROR_COPY[result.error];
+    return NextResponse.json(
+      { error: result.error, message: copy.message },
+      { status: copy.status },
+    );
   }
 
   return NextResponse.json({
     link: {
       id: result.link.id,
       slot: result.link.slot,
+      categories: result.link.categories ?? [],
       url: buildInviteUrl(identity.baseUrl, identity.handle, result.link.token),
       createdAt: result.link.createdAt.toISOString(),
       joinedCount: result.link.joinedCount,
     },
-  })
+  });
 }

--- a/src/app/api/auth/verify-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/verify-otp/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   acceptFriendInvitationMock,
@@ -11,13 +11,11 @@ const {
   getInvitePrefillByTokenMock,
   provisionUserInsertMock,
   verifyOtpMock,
+  acceptUserInviteLinkMock,
+  resolveInviteLinkMock,
 } = vi.hoisted(() => {
-  const findUserSelectMock = vi.fn(
-    async () => [] as Array<Record<string, unknown>>
-  )
-  const provisionUserInsertMock = vi.fn(
-    async () => [] as Array<Record<string, unknown>>
-  )
+  const findUserSelectMock = vi.fn(async () => [] as Array<Record<string, unknown>>);
+  const provisionUserInsertMock = vi.fn(async () => [] as Array<Record<string, unknown>>);
   const dbMock = {
     update: vi.fn(() => ({
       set: vi.fn(() => ({
@@ -38,7 +36,7 @@ const {
         })),
       })),
     })),
-  }
+  };
   return {
     acceptFriendInvitationMock: vi.fn(),
     createSessionMock: vi.fn(async () => 'session-token'),
@@ -49,19 +47,19 @@ const {
     getValidPendingInvitationForPhoneMock: vi.fn(async () => null as unknown),
     getInvitePrefillByTokenMock: vi.fn(async () => null as unknown),
     provisionUserInsertMock,
-    verifyOtpMock: vi.fn(async (phone: string, code: string) =>
-      code === '000000' ? phone : null
-    ),
-  }
-})
+    verifyOtpMock: vi.fn(async (phone: string, code: string) => (code === '000000' ? phone : null)),
+    acceptUserInviteLinkMock: vi.fn(async () => ({ accepted: true })),
+    resolveInviteLinkMock: vi.fn(async () => ({ inviterUserId: 'inviter-1' })),
+  };
+});
 
 vi.mock('@/server/auth', () => ({
   verifyOtp: verifyOtpMock,
-}))
+}));
 
 vi.mock('@/server/auth/session', () => ({
   createSession: createSessionMock,
-}))
+}));
 
 vi.mock('@/server/db', () => ({
   db: dbMock,
@@ -75,7 +73,7 @@ vi.mock('@/server/db', () => ({
     phoneVerified: 'users.phoneVerified',
     updatedAt: 'users.updatedAt',
   },
-}))
+}));
 
 vi.mock('@/server/friends/invitations', () => ({
   acceptFriendInvitation: acceptFriendInvitationMock,
@@ -88,9 +86,14 @@ vi.mock('@/server/friends/invitations', () => ({
   // no token) path; mock must expose it or that branch throws.
   INVITE_REQUIRED_MESSAGE:
     "Joshing is invite-only. Ask a friend who's already on Joshing to send you an invite.",
-}))
+}));
 
-import { POST } from '@/app/api/auth/verify-otp/route'
+vi.mock('@/server/friends/user-invite-token', () => ({
+  acceptUserInviteLink: acceptUserInviteLinkMock,
+  resolveInviteLink: resolveInviteLinkMock,
+}));
+
+import { POST } from '@/app/api/auth/verify-otp/route';
 
 const EXISTING_USER = {
   id: 'user-1',
@@ -99,7 +102,7 @@ const EXISTING_USER = {
   handle: null,
   timezone: 'America/New_York',
   onboardingComplete: false,
-}
+};
 
 const NEW_USER = {
   id: 'user-2',
@@ -108,7 +111,7 @@ const NEW_USER = {
   handle: null,
   timezone: 'America/New_York',
   onboardingComplete: false,
-}
+};
 
 const VALID_INVITATION = {
   id: 'inv-1',
@@ -123,166 +126,160 @@ const VALID_INVITATION = {
   acceptedAt: null,
   cancelledAt: null,
   expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
-}
+};
 
 function jsonRequest(body: unknown) {
   return new Request('http://localhost/api/auth/verify-otp', {
     method: 'POST',
     body: JSON.stringify(body),
-  })
+  });
 }
 
 describe('/api/auth/verify-otp invitation gate', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    findUserSelectMock.mockReset()
-    provisionUserInsertMock.mockReset()
-    hasAcceptedInvitationForUserMock.mockReset()
-    getValidInvitationForPhoneMock.mockReset()
-    getValidPendingInvitationForPhoneMock.mockReset()
-    getInvitePrefillByTokenMock.mockReset()
-    acceptFriendInvitationMock.mockReset()
+    vi.clearAllMocks();
+    findUserSelectMock.mockReset();
+    provisionUserInsertMock.mockReset();
+    hasAcceptedInvitationForUserMock.mockReset();
+    getValidInvitationForPhoneMock.mockReset();
+    getValidPendingInvitationForPhoneMock.mockReset();
+    getInvitePrefillByTokenMock.mockReset();
+    acceptFriendInvitationMock.mockReset();
+    acceptUserInviteLinkMock.mockReset();
+    resolveInviteLinkMock.mockReset();
 
-    findUserSelectMock.mockResolvedValue([])
-    provisionUserInsertMock.mockResolvedValue([])
-    hasAcceptedInvitationForUserMock.mockResolvedValue(false)
-    getValidInvitationForPhoneMock.mockResolvedValue(null)
-    getValidPendingInvitationForPhoneMock.mockResolvedValue(null)
-    getInvitePrefillByTokenMock.mockResolvedValue(null)
-    acceptFriendInvitationMock.mockResolvedValue({ accepted: true })
-  })
+    findUserSelectMock.mockResolvedValue([]);
+    provisionUserInsertMock.mockResolvedValue([]);
+    hasAcceptedInvitationForUserMock.mockResolvedValue(false);
+    getValidInvitationForPhoneMock.mockResolvedValue(null);
+    getValidPendingInvitationForPhoneMock.mockResolvedValue(null);
+    getInvitePrefillByTokenMock.mockResolvedValue(null);
+    acceptFriendInvitationMock.mockResolvedValue({ accepted: true });
+    acceptUserInviteLinkMock.mockResolvedValue({ accepted: true });
+    resolveInviteLinkMock.mockResolvedValue({ inviterUserId: 'inviter-1' });
+  });
 
   describe('re-login (existing user)', () => {
     it('allows re-login with no token when the user has a prior accepted invitation', async () => {
-      findUserSelectMock.mockResolvedValueOnce([EXISTING_USER])
+      findUserSelectMock.mockResolvedValueOnce([EXISTING_USER]);
 
-      const response = await POST(
-        jsonRequest({ phone: '+15551234567', code: '000000' })
-      )
-      const body = await response.json()
+      const response = await POST(jsonRequest({ phone: '+15551234567', code: '000000' }));
+      const body = await response.json();
 
-      expect(response.status).toBe(200)
-      expect(body.user.id).toBe('user-1')
-      expect(body.user.handle).toBeNull()
-      expect(body.invitation).toEqual({ accepted: false })
+      expect(response.status).toBe(200);
+      expect(body.user.id).toBe('user-1');
+      expect(body.user.handle).toBeNull();
+      expect(body.invitation).toEqual({ accepted: false });
       expect(createSessionMock).toHaveBeenCalledWith('user-1', {
         invitationAccepted: true,
         onboardingComplete: false,
-      })
-      expect(acceptFriendInvitationMock).not.toHaveBeenCalled()
-    })
+      });
+      expect(acceptFriendInvitationMock).not.toHaveBeenCalled();
+    });
 
     it('allows re-login with no token even when the user has no prior accepted invitation (legacy/grandfathered account)', async () => {
-      findUserSelectMock.mockResolvedValueOnce([EXISTING_USER])
+      findUserSelectMock.mockResolvedValueOnce([EXISTING_USER]);
 
-      const response = await POST(
-        jsonRequest({ phone: '+15551234567', code: '000000' })
-      )
-      const body = await response.json()
+      const response = await POST(jsonRequest({ phone: '+15551234567', code: '000000' }));
+      const body = await response.json();
 
-      expect(response.status).toBe(200)
-      expect(body.user.id).toBe('user-1')
-      expect(body.invitation).toEqual({ accepted: false })
+      expect(response.status).toBe(200);
+      expect(body.user.id).toBe('user-1');
+      expect(body.invitation).toEqual({ accepted: false });
       expect(createSessionMock).toHaveBeenCalledWith('user-1', {
         invitationAccepted: true,
         onboardingComplete: false,
-      })
-      expect(hasAcceptedInvitationForUserMock).not.toHaveBeenCalled()
-    })
+      });
+      expect(hasAcceptedInvitationForUserMock).not.toHaveBeenCalled();
+    });
 
     it('mints the session with the user real onboardingComplete on re-login (B-ROOT-404: avoids the refresh-onboarding-claim redirect hop on /)', async () => {
       // A fully-onboarded user re-logging in must get onb:true straight away.
       // Previously the route hardcoded onboardingComplete:false, so the first
       // post-login GET / was bounced through /api/auth/refresh-onboarding-claim
       // to re-mint the claim — a redirect hop that intermittently 404'd on /.
-      findUserSelectMock.mockResolvedValueOnce([
-        { ...EXISTING_USER, onboardingComplete: true },
-      ])
+      findUserSelectMock.mockResolvedValueOnce([{ ...EXISTING_USER, onboardingComplete: true }]);
 
-      const response = await POST(
-        jsonRequest({ phone: '+15551234567', code: '000000' })
-      )
-      const body = await response.json()
+      const response = await POST(jsonRequest({ phone: '+15551234567', code: '000000' }));
+      const body = await response.json();
 
-      expect(response.status).toBe(200)
-      expect(body.user.onboardingComplete).toBe(true)
+      expect(response.status).toBe(200);
+      expect(body.user.onboardingComplete).toBe(true);
       expect(createSessionMock).toHaveBeenCalledWith('user-1', {
         invitationAccepted: true,
         onboardingComplete: true,
-      })
-    })
+      });
+    });
 
     it('allows re-login when accepting a new invitation', async () => {
-      findUserSelectMock.mockResolvedValueOnce([EXISTING_USER])
-      acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true })
+      findUserSelectMock.mockResolvedValueOnce([EXISTING_USER]);
+      acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true });
 
       const response = await POST(
         jsonRequest({
           phone: '+15551234567',
           code: '000000',
           invitationToken: 'invite-token',
-        })
-      )
-      const body = await response.json()
+        }),
+      );
+      const body = await response.json();
 
-      expect(response.status).toBe(200)
-      expect(body.invitation).toEqual({ accepted: true })
+      expect(response.status).toBe(200);
+      expect(body.invitation).toEqual({ accepted: true });
       expect(acceptFriendInvitationMock).toHaveBeenCalledWith({
         token: 'invite-token',
         inviteeUserId: 'user-1',
         verifiedPhone: '+15551234567',
-      })
+      });
       expect(createSessionMock).toHaveBeenCalledWith('user-1', {
         invitationAccepted: true,
         onboardingComplete: false,
-      })
-    })
+      });
+    });
 
     it('still logs in when a supplied invitation token fails to accept', async () => {
-      findUserSelectMock.mockResolvedValueOnce([EXISTING_USER])
+      findUserSelectMock.mockResolvedValueOnce([EXISTING_USER]);
       acceptFriendInvitationMock.mockResolvedValueOnce({
         accepted: false,
         reason: 'expired',
-      })
+      });
 
       const response = await POST(
         jsonRequest({
           phone: '+15551234567',
           code: '000000',
           invitationToken: 'invite-token',
-        })
-      )
+        }),
+      );
 
-      expect(response.status).toBe(200)
+      expect(response.status).toBe(200);
       expect(createSessionMock).toHaveBeenCalledWith('user-1', {
         invitationAccepted: true,
         onboardingComplete: false,
-      })
-    })
-  })
+      });
+    });
+  });
 
   describe('new signup', () => {
     it('rejects a brand new phone number with no invitation token', async () => {
-      findUserSelectMock.mockResolvedValueOnce([])
+      findUserSelectMock.mockResolvedValueOnce([]);
 
-      const response = await POST(
-        jsonRequest({ phone: '+15559876543', code: '000000' })
-      )
-      const body = await response.json()
+      const response = await POST(jsonRequest({ phone: '+15559876543', code: '000000' }));
+      const body = await response.json();
 
       // New signup with no token is gated by inviteRequiredRejection() →
       // 403 invite_required (not the 400 invalid_invitation used for bad/empty
       // tokens). This is the invite-only signup gate.
-      expect(response.status).toBe(403)
+      expect(response.status).toBe(403);
       expect(body).toEqual({
         error: 'invite_required',
         message:
           "Joshing is invite-only. Ask a friend who's already on Joshing to send you an invite.",
-      })
-      expect(createSessionMock).not.toHaveBeenCalled()
+      });
+      expect(createSessionMock).not.toHaveBeenCalled();
       // No user should be created.
-      expect(provisionUserInsertMock).not.toHaveBeenCalled()
-    })
+      expect(provisionUserInsertMock).not.toHaveBeenCalled();
+    });
 
     it('rejects an empty-string invitation token (closes the {"invitationToken": ""} bypass)', async () => {
       const response = await POST(
@@ -290,19 +287,19 @@ describe('/api/auth/verify-otp invitation gate', () => {
           phone: '+15559876543',
           code: '000000',
           invitationToken: '',
-        })
-      )
-      const body = await response.json()
+        }),
+      );
+      const body = await response.json();
 
-      expect(response.status).toBe(400)
+      expect(response.status).toBe(400);
       expect(body).toEqual({
         error: 'invalid_invitation',
         message: 'This invitation could not be accepted.',
-      })
-      expect(verifyOtpMock).not.toHaveBeenCalled()
-      expect(createSessionMock).not.toHaveBeenCalled()
-      expect(provisionUserInsertMock).not.toHaveBeenCalled()
-    })
+      });
+      expect(verifyOtpMock).not.toHaveBeenCalled();
+      expect(createSessionMock).not.toHaveBeenCalled();
+      expect(provisionUserInsertMock).not.toHaveBeenCalled();
+    });
 
     it('rejects a whitespace-only invitation token', async () => {
       const response = await POST(
@@ -310,159 +307,198 @@ describe('/api/auth/verify-otp invitation gate', () => {
           phone: '+15559876543',
           code: '000000',
           invitationToken: '   ',
-        })
-      )
+        }),
+      );
 
-      expect(response.status).toBe(400)
-      expect(createSessionMock).not.toHaveBeenCalled()
-      expect(provisionUserInsertMock).not.toHaveBeenCalled()
-    })
+      expect(response.status).toBe(400);
+      expect(createSessionMock).not.toHaveBeenCalled();
+      expect(provisionUserInsertMock).not.toHaveBeenCalled();
+    });
 
     it('rejects a new phone with a token that does not match an invitation', async () => {
-      findUserSelectMock.mockResolvedValueOnce([])
-      getValidInvitationForPhoneMock.mockResolvedValueOnce(null)
+      findUserSelectMock.mockResolvedValueOnce([]);
+      getValidInvitationForPhoneMock.mockResolvedValueOnce(null);
 
       const response = await POST(
         jsonRequest({
           phone: '+15559876543',
           code: '000000',
           invitationToken: 'bogus-token',
-        })
-      )
-      const body = await response.json()
+        }),
+      );
+      const body = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(body.error).toBe('invalid_invitation')
-      expect(createSessionMock).not.toHaveBeenCalled()
-      expect(provisionUserInsertMock).not.toHaveBeenCalled()
-      expect(acceptFriendInvitationMock).not.toHaveBeenCalled()
-    })
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('invalid_invitation');
+      expect(createSessionMock).not.toHaveBeenCalled();
+      expect(provisionUserInsertMock).not.toHaveBeenCalled();
+      expect(acceptFriendInvitationMock).not.toHaveBeenCalled();
+    });
 
     it('rejects a new phone when the invitation token does not match the verified phone', async () => {
-      findUserSelectMock.mockResolvedValueOnce([])
+      findUserSelectMock.mockResolvedValueOnce([]);
       // Pre-validation rejects because phone doesn't match invitee phone.
-      getValidInvitationForPhoneMock.mockResolvedValueOnce(null)
+      getValidInvitationForPhoneMock.mockResolvedValueOnce(null);
 
       const response = await POST(
         jsonRequest({
           phone: '+15550000000',
           code: '000000',
           invitationToken: 'invite-token',
-        })
-      )
+        }),
+      );
 
-      expect(response.status).toBe(400)
-      expect(provisionUserInsertMock).not.toHaveBeenCalled()
-      expect(acceptFriendInvitationMock).not.toHaveBeenCalled()
-    })
+      expect(response.status).toBe(400);
+      expect(provisionUserInsertMock).not.toHaveBeenCalled();
+      expect(acceptFriendInvitationMock).not.toHaveBeenCalled();
+    });
 
     it('provisions a user and accepts the invitation when token + phone match', async () => {
-      findUserSelectMock.mockResolvedValueOnce([])
-      getValidInvitationForPhoneMock.mockResolvedValueOnce(VALID_INVITATION)
-      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER])
-      acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true })
+      findUserSelectMock.mockResolvedValueOnce([]);
+      getValidInvitationForPhoneMock.mockResolvedValueOnce(VALID_INVITATION);
+      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER]);
+      acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true });
 
       const response = await POST(
         jsonRequest({
           phone: '+15559876543',
           code: '000000',
           invitationToken: 'invite-token',
-        })
-      )
-      const body = await response.json()
+        }),
+      );
+      const body = await response.json();
 
-      expect(response.status).toBe(200)
-      expect(body.user.id).toBe('user-2')
-      expect(body.user.handle).toBeNull()
-      expect(body.invitation).toEqual({ accepted: true })
-      expect(provisionUserInsertMock).toHaveBeenCalled()
+      expect(response.status).toBe(200);
+      expect(body.user.id).toBe('user-2');
+      expect(body.user.handle).toBeNull();
+      expect(body.invitation).toEqual({ accepted: true });
+      expect(provisionUserInsertMock).toHaveBeenCalled();
       expect(acceptFriendInvitationMock).toHaveBeenCalledWith({
         token: 'invite-token',
         inviteeUserId: 'user-2',
         verifiedPhone: '+15559876543',
-      })
+      });
       expect(createSessionMock).toHaveBeenCalledWith('user-2', {
         invitationAccepted: true,
         onboardingComplete: false,
-      })
-    })
+      });
+    });
 
     it('rejects new signup when accept races and fails after provisioning', async () => {
-      findUserSelectMock.mockResolvedValueOnce([])
-      getValidInvitationForPhoneMock.mockResolvedValueOnce(VALID_INVITATION)
-      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER])
+      findUserSelectMock.mockResolvedValueOnce([]);
+      getValidInvitationForPhoneMock.mockResolvedValueOnce(VALID_INVITATION);
+      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER]);
       acceptFriendInvitationMock.mockResolvedValueOnce({
         accepted: false,
         reason: 'claim_failed',
-      })
+      });
 
       const response = await POST(
         jsonRequest({
           phone: '+15559876543',
           code: '000000',
           invitationToken: 'invite-token',
-        })
-      )
-      const body = await response.json()
+        }),
+      );
+      const body = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(body.error).toBe('invalid_invitation')
-      expect(createSessionMock).not.toHaveBeenCalled()
-    })
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('invalid_invitation');
+      expect(createSessionMock).not.toHaveBeenCalled();
+    });
 
     it('provisions and accepts a phone-matched pending invite when no token or link rode along (B-AUTH-INVITE-PHONEMATCH)', async () => {
       // Contact-invited user who opened the app directly and typed their
       // number: request-otp let them through on the phone-match, so they must
       // clear verify-otp too even with no token/link in the request body.
-      findUserSelectMock.mockResolvedValueOnce([])
-      getValidPendingInvitationForPhoneMock.mockResolvedValueOnce(
-        VALID_INVITATION
-      )
-      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER])
-      acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true })
+      findUserSelectMock.mockResolvedValueOnce([]);
+      getValidPendingInvitationForPhoneMock.mockResolvedValueOnce(VALID_INVITATION);
+      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER]);
+      acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true });
 
-      const response = await POST(
-        jsonRequest({ phone: '+15559876543', code: '000000' })
-      )
-      const body = await response.json()
+      const response = await POST(jsonRequest({ phone: '+15559876543', code: '000000' }));
+      const body = await response.json();
 
-      expect(response.status).toBe(200)
-      expect(body.user.id).toBe('user-2')
-      expect(body.invitation).toEqual({ accepted: true })
-      expect(provisionUserInsertMock).toHaveBeenCalled()
+      expect(response.status).toBe(200);
+      expect(body.user.id).toBe('user-2');
+      expect(body.invitation).toEqual({ accepted: true });
+      expect(provisionUserInsertMock).toHaveBeenCalled();
       // Claims the resolved invitation by ITS token — the body carried none.
       expect(acceptFriendInvitationMock).toHaveBeenCalledWith({
         token: 'invite-token',
         inviteeUserId: 'user-2',
         verifiedPhone: '+15559876543',
-      })
+      });
       expect(createSessionMock).toHaveBeenCalledWith('user-2', {
         invitationAccepted: true,
         onboardingComplete: false,
-      })
-    })
+      });
+    });
 
     it('rejects the phone-match path when the accept races and fails after provisioning', async () => {
-      findUserSelectMock.mockResolvedValueOnce([])
-      getValidPendingInvitationForPhoneMock.mockResolvedValueOnce(
-        VALID_INVITATION
-      )
-      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER])
+      findUserSelectMock.mockResolvedValueOnce([]);
+      getValidPendingInvitationForPhoneMock.mockResolvedValueOnce(VALID_INVITATION);
+      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER]);
       acceptFriendInvitationMock.mockResolvedValueOnce({
         accepted: false,
         reason: 'claim_failed',
-      })
+      });
+
+      const response = await POST(jsonRequest({ phone: '+15559876543', code: '000000' }));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('invalid_invitation');
+      expect(createSessionMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('per-user invite-link signup', () => {
+    it('preserves the exact link through OTP and attributes the new user', async () => {
+      findUserSelectMock.mockResolvedValueOnce([]);
+      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER]);
+      resolveInviteLinkMock.mockResolvedValueOnce({ inviterUserId: 'inviter-1' });
+      acceptUserInviteLinkMock.mockResolvedValueOnce({ accepted: true });
 
       const response = await POST(
-        jsonRequest({ phone: '+15559876543', code: '000000' })
-      )
-      const body = await response.json()
+        jsonRequest({
+          phone: '+15559876543',
+          code: '000000',
+          userInvite: { handle: 'josh', token: 'link-token' },
+        }),
+      );
 
-      expect(response.status).toBe(400)
-      expect(body.error).toBe('invalid_invitation')
-      expect(createSessionMock).not.toHaveBeenCalled()
-    })
-  })
+      expect(response.status).toBe(200);
+      expect(resolveInviteLinkMock).toHaveBeenCalledWith('josh', 'link-token');
+      expect(acceptUserInviteLinkMock).toHaveBeenCalledWith({
+        handle: 'josh',
+        token: 'link-token',
+        inviteeUserId: 'user-2',
+      });
+      expect(createSessionMock).toHaveBeenCalledWith('user-2', {
+        invitationAccepted: true,
+        onboardingComplete: false,
+      });
+    });
+
+    it('does not provision a user when the link was invalidated before OTP verification', async () => {
+      findUserSelectMock.mockResolvedValueOnce([]);
+      resolveInviteLinkMock.mockResolvedValueOnce(null);
+
+      const response = await POST(
+        jsonRequest({
+          phone: '+15559876543',
+          code: '000000',
+          userInvite: { handle: 'josh', token: 'deleted-token' },
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe('invalid_invitation');
+      expect(provisionUserInsertMock).not.toHaveBeenCalled();
+      expect(createSessionMock).not.toHaveBeenCalled();
+    });
+  });
 
   describe('invite-phone prefill (no phone sent)', () => {
     it('resolves the phone from the token, verifies, provisions, and accepts the invitation', async () => {
@@ -470,54 +506,54 @@ describe('/api/auth/verify-otp invitation gate', () => {
         inviterName: 'Alex',
         inviteePhone: '+15559876543',
         maskedPhone: '•••-•••-6543',
-      })
-      findUserSelectMock.mockResolvedValueOnce([])
-      getValidInvitationForPhoneMock.mockResolvedValueOnce(VALID_INVITATION)
-      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER])
-      acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true })
+      });
+      findUserSelectMock.mockResolvedValueOnce([]);
+      getValidInvitationForPhoneMock.mockResolvedValueOnce(VALID_INVITATION);
+      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER]);
+      acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true });
 
       const response = await POST(
         jsonRequest({
           code: '000000',
           invitationToken: 'invite-token',
           useInvitePhone: true,
-        })
-      )
-      const body = await response.json()
+        }),
+      );
+      const body = await response.json();
 
-      expect(response.status).toBe(200)
-      expect(body.invitation).toEqual({ accepted: true })
+      expect(response.status).toBe(200);
+      expect(body.invitation).toEqual({ accepted: true });
       // 000000 bypass works against the server-resolved phone.
-      expect(verifyOtpMock).toHaveBeenCalledWith('+15559876543', '000000')
+      expect(verifyOtpMock).toHaveBeenCalledWith('+15559876543', '000000');
       expect(acceptFriendInvitationMock).toHaveBeenCalledWith({
         token: 'invite-token',
         inviteeUserId: 'user-2',
         verifiedPhone: '+15559876543',
-      })
+      });
       expect(createSessionMock).toHaveBeenCalledWith('user-2', {
         invitationAccepted: true,
         onboardingComplete: false,
-      })
-    })
+      });
+    });
 
     it('rejects when the invite token no longer resolves to a phone', async () => {
-      getInvitePrefillByTokenMock.mockResolvedValue(null)
+      getInvitePrefillByTokenMock.mockResolvedValue(null);
 
       const response = await POST(
         jsonRequest({
           code: '000000',
           invitationToken: 'stale-token',
           useInvitePhone: true,
-        })
-      )
-      const body = await response.json()
+        }),
+      );
+      const body = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(body.error).toBe('invalid_invitation')
-      expect(verifyOtpMock).not.toHaveBeenCalled()
-      expect(createSessionMock).not.toHaveBeenCalled()
-    })
-  })
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('invalid_invitation');
+      expect(verifyOtpMock).not.toHaveBeenCalled();
+      expect(createSessionMock).not.toHaveBeenCalled();
+    });
+  });
 
   describe('OTP failure short-circuits', () => {
     it('rejects non-000000 OTP codes before any user lookup or invitation work', async () => {
@@ -526,15 +562,15 @@ describe('/api/auth/verify-otp invitation gate', () => {
           phone: '+15551234567',
           code: '123456',
           invitationToken: 'invite-token',
-        })
-      )
-      const body = await response.json()
+        }),
+      );
+      const body = await response.json();
 
-      expect(response.status).toBe(401)
-      expect(body).toEqual(expect.objectContaining({ error: 'invalid_code' }))
-      expect(findUserSelectMock).not.toHaveBeenCalled()
-      expect(acceptFriendInvitationMock).not.toHaveBeenCalled()
-      expect(createSessionMock).not.toHaveBeenCalled()
-    })
-  })
-})
+      expect(response.status).toBe(401);
+      expect(body).toEqual(expect.objectContaining({ error: 'invalid_code' }));
+      expect(findUserSelectMock).not.toHaveBeenCalled();
+      expect(acceptFriendInvitationMock).not.toHaveBeenCalled();
+      expect(createSessionMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -1,15 +1,15 @@
-import { randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto';
 
-import { eq } from 'drizzle-orm'
-import { NextResponse } from 'next/server'
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
 
-import { colorForUser } from '@/components/feed/visual'
-import { normalizeToE164 } from '@/lib/phone-e164'
-import { verifyOtp } from '@/server/auth'
-import { createSession } from '@/server/auth/session'
-import { prewarmDailyQueue } from '@/server/daily/prewarm'
-import { db, users } from '@/server/db'
-import { hashPhoneNumber } from '@/server/lib/phone-hashing'
+import { colorForUser } from '@/components/feed/visual';
+import { normalizeToE164 } from '@/lib/phone-e164';
+import { verifyOtp } from '@/server/auth';
+import { createSession } from '@/server/auth/session';
+import { prewarmDailyQueue } from '@/server/daily/prewarm';
+import { db, users } from '@/server/db';
+import { hashPhoneNumber } from '@/server/lib/phone-hashing';
 import {
   acceptFriendInvitation,
   getInvitePrefillByToken,
@@ -17,41 +17,41 @@ import {
   getValidPendingInvitationForPhone,
   INVITATION_ACCEPTANCE_ERROR_MESSAGE,
   INVITE_REQUIRED_MESSAGE,
-} from '@/server/friends/invitations'
-import { acceptUserInviteLink } from '@/server/friends/user-invite-token'
+} from '@/server/friends/invitations';
+import { acceptUserInviteLink, resolveInviteLink } from '@/server/friends/user-invite-token';
 
 // Headroom for the post-response Daily Five pre-warm (prewarmDailyQueue) on the
 // returning-user path. The background build can take seconds of Sonnet
 // generation, and on Vercel `after()` work counts toward this function's
 // duration budget — the default ceiling would kill the build mid-flight. The
 // login response itself still returns immediately; this is only a ceiling.
-export const maxDuration = 90
+export const maxDuration = 90;
 
 type VerifyOtpBody = {
-  phone?: unknown
-  code?: unknown
-  invitationToken?: unknown
-  useInvitePhone?: unknown
-  userInvite?: unknown
-}
+  phone?: unknown;
+  code?: unknown;
+  invitationToken?: unknown;
+  useInvitePhone?: unknown;
+  userInvite?: unknown;
+};
 
 function parseUserInvite(value: unknown): { handle: string; token: string } | null {
-  if (!value || typeof value !== 'object') return null
-  const candidate = value as { handle?: unknown; token?: unknown }
-  const handle = typeof candidate.handle === 'string' ? candidate.handle.trim() : ''
-  const token = typeof candidate.token === 'string' ? candidate.token.trim() : ''
-  if (!handle || !token) return null
-  return { handle, token }
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as { handle?: unknown; token?: unknown };
+  const handle = typeof candidate.handle === 'string' ? candidate.handle.trim() : '';
+  const token = typeof candidate.token === 'string' ? candidate.token.trim() : '';
+  if (!handle || !token) return null;
+  return { handle, token };
 }
 
 type AuthUser = {
-  id: string
-  phoneNumber: string
-  displayName: string | null
-  handle: string | null
-  timezone: string
-  onboardingComplete: boolean
-}
+  id: string;
+  phoneNumber: string;
+  displayName: string | null;
+  handle: string | null;
+  timezone: string;
+  onboardingComplete: boolean;
+};
 
 const USER_SELECTION = {
   id: users.id,
@@ -65,38 +65,34 @@ const USER_SELECTION = {
   // /api/auth/refresh-onboarding-claim route handler to re-mint the claim —
   // a redirect hop that opened an intermittent 404 window on / (B-ROOT-404).
   onboardingComplete: users.onboardingComplete,
-}
+};
 
-async function findUserByPhone(
-  phoneNumber: string
-): Promise<AuthUser | null> {
+async function findUserByPhone(phoneNumber: string): Promise<AuthUser | null> {
   const [existing] = await db
     .select(USER_SELECTION)
     .from(users)
     .where(eq(users.phoneNumber, phoneNumber))
-    .limit(1)
+    .limit(1);
 
-  return existing ?? null
+  return existing ?? null;
 }
 
 function computePhoneHash(phoneNumber: string): string | null {
   // Skip when the salt is unset (dev environments without
   // PHONE_HASH_SALT — production sets it). The hash can be filled in
   // later via scripts/backfill-phone-hashes.ts once the salt is set.
-  if (!process.env.PHONE_HASH_SALT) return null
-  const e164 = normalizeToE164(phoneNumber)
-  if (!e164) return null
-  return hashPhoneNumber(e164)
+  if (!process.env.PHONE_HASH_SALT) return null;
+  const e164 = normalizeToE164(phoneNumber);
+  if (!e164) return null;
+  return hashPhoneNumber(e164);
 }
 
-async function provisionUserForPhone(
-  phoneNumber: string
-): Promise<AuthUser> {
+async function provisionUserForPhone(phoneNumber: string): Promise<AuthUser> {
   // Pre-generate the id so we can persist a deterministic avatar_color in the
   // same insert (colorForUser hashes the id). Without this, avatar_color
   // would be NULL until the next signup backfill.
-  const id = randomUUID()
-  const phoneHash = computePhoneHash(phoneNumber)
+  const id = randomUUID();
+  const phoneHash = computePhoneHash(phoneNumber);
   const [created] = await db
     .insert(users)
     .values({
@@ -107,16 +103,16 @@ async function provisionUserForPhone(
       phoneHash,
     })
     .onConflictDoNothing({ target: users.phoneNumber })
-    .returning(USER_SELECTION)
+    .returning(USER_SELECTION);
 
-  if (created) return created
+  if (created) return created;
 
   // Conflict: another request created the user between findUserByPhone and now.
-  const existing = await findUserByPhone(phoneNumber)
+  const existing = await findUserByPhone(phoneNumber);
   if (!existing) {
-    throw new Error('Unable to find or create user for verified phone number.')
+    throw new Error('Unable to find or create user for verified phone number.');
   }
-  return existing
+  return existing;
 }
 
 function invitationRejection() {
@@ -125,8 +121,8 @@ function invitationRejection() {
       error: 'invalid_invitation',
       message: INVITATION_ACCEPTANCE_ERROR_MESSAGE,
     },
-    { status: 400 }
-  )
+    { status: 400 },
+  );
 }
 
 function inviteRequiredRejection() {
@@ -135,31 +131,26 @@ function inviteRequiredRejection() {
       error: 'invite_required',
       message: INVITE_REQUIRED_MESSAGE,
     },
-    { status: 403 }
-  )
+    { status: 403 },
+  );
 }
 
 export async function POST(request: Request) {
   try {
-    const body = (await request
-      .json()
-      .catch(() => null)) as VerifyOtpBody | null
-    let phone = typeof body?.phone === 'string' ? body.phone.trim() : ''
-    const code = typeof body?.code === 'string' ? body.code.trim() : ''
-    const tokenProvided =
-      body?.invitationToken !== undefined && body?.invitationToken !== null
+    const body = (await request.json().catch(() => null)) as VerifyOtpBody | null;
+    let phone = typeof body?.phone === 'string' ? body.phone.trim() : '';
+    const code = typeof body?.code === 'string' ? body.code.trim() : '';
+    const tokenProvided = body?.invitationToken !== undefined && body?.invitationToken !== null;
     const invitationToken =
-      typeof body?.invitationToken === 'string'
-        ? body.invitationToken.trim()
-        : ''
-    const hasUsableToken = tokenProvided && invitationToken.length > 0
-    const useInvitePhone = body?.useInvitePhone === true
-    const userInvite = parseUserInvite(body?.userInvite)
+      typeof body?.invitationToken === 'string' ? body.invitationToken.trim() : '';
+    const hasUsableToken = tokenProvided && invitationToken.length > 0;
+    const useInvitePhone = body?.useInvitePhone === true;
+    const userInvite = parseUserInvite(body?.userInvite);
 
     // A token field was supplied but it's empty/whitespace — reject before
     // anything else. This closes the `{"invitationToken": ""}` bypass.
     if (tokenProvided && !hasUsableToken) {
-      return invitationRejection()
+      return invitationRejection();
     }
 
     // Invite-prefill flow: no phone is sent — resolve the recipient phone from
@@ -167,30 +158,30 @@ export async function POST(request: Request) {
     // acceptFriendInvitation, which requires inviteePhone === verifiedPhone)
     // works exactly as the manual path.
     if (useInvitePhone && hasUsableToken && !phone) {
-      const prefill = await getInvitePrefillByToken(invitationToken)
+      const prefill = await getInvitePrefillByToken(invitationToken);
       if (!prefill) {
-        return invitationRejection()
+        return invitationRejection();
       }
-      phone = prefill.inviteePhone
+      phone = prefill.inviteePhone;
     }
 
     if (!phone || !code) {
       return NextResponse.json(
         { error: 'invalid_request', message: 'phone and code are required' },
-        { status: 400 }
-      )
+        { status: 400 },
+      );
     }
 
-    const normalizedPhone = await verifyOtp(phone, code)
+    const normalizedPhone = await verifyOtp(phone, code);
 
     if (!normalizedPhone) {
       return NextResponse.json(
         { error: 'invalid_code', message: 'Code invalid or expired' },
-        { status: 401 }
-      )
+        { status: 401 },
+      );
     }
 
-    const existingUser = await findUserByPhone(normalizedPhone)
+    const existingUser = await findUserByPhone(normalizedPhone);
 
     // Re-login path: any existing user can re-authenticate after OTP. The
     // invitation gate only applies to new-account creation below. This is
@@ -204,16 +195,16 @@ export async function POST(request: Request) {
       await db
         .update(users)
         .set({ phoneVerified: true, updatedAt: new Date() })
-        .where(eq(users.id, existingUser.id))
+        .where(eq(users.id, existingUser.id));
 
-      let invitationResult: { accepted: boolean } = { accepted: false }
+      let invitationResult: { accepted: boolean } = { accepted: false };
 
       if (hasUsableToken) {
         invitationResult = await acceptFriendInvitation({
           token: invitationToken,
           inviteeUserId: existingUser.id,
           verifiedPhone: normalizedPhone,
-        })
+        });
       }
 
       // Per-user invite-link flow (B-Friends-3): when the visitor arrived
@@ -225,13 +216,13 @@ export async function POST(request: Request) {
           handle: userInvite.handle,
           token: userInvite.token,
           inviteeUserId: existingUser.id,
-        })
+        });
       }
 
       await createSession(existingUser.id, {
         invitationAccepted: true,
         onboardingComplete: existingUser.onboardingComplete,
-      })
+      });
 
       // Returning, onboarded users: pre-warm today's Daily Five in the
       // background so /daily is already built by the time they tap in. Usually a
@@ -241,7 +232,7 @@ export async function POST(request: Request) {
       // false) are skipped here — they have no knowledge base to build from yet,
       // and are pre-warmed at onboarding completion instead.
       if (existingUser.onboardingComplete) {
-        prewarmDailyQueue(existingUser.id, 'login')
+        prewarmDailyQueue(existingUser.id, 'login');
       }
 
       return NextResponse.json({
@@ -254,7 +245,7 @@ export async function POST(request: Request) {
           onboardingComplete: existingUser.onboardingComplete,
         },
         invitation: invitationResult,
-      })
+      });
     }
 
     // New-user path: an invitation is a hard precondition. It can be
@@ -269,10 +260,10 @@ export async function POST(request: Request) {
     const phoneInvitation =
       !hasUsableToken && !userInvite
         ? await getValidPendingInvitationForPhone(normalizedPhone)
-        : null
+        : null;
 
     if (!hasUsableToken && !userInvite && !phoneInvitation) {
-      return inviteRequiredRejection()
+      return inviteRequiredRejection();
     }
 
     // Pre-validate the FriendInvitation read-only so we don't provision a
@@ -282,30 +273,37 @@ export async function POST(request: Request) {
       const candidateInvitation = await getValidInvitationForPhone({
         token: invitationToken,
         verifiedPhone: normalizedPhone,
-      })
+      });
 
       if (!candidateInvitation) {
-        return invitationRejection()
+        return invitationRejection();
       }
     }
 
-    const user = await provisionUserForPhone(normalizedPhone)
+    // The link may have been deleted after request-otp sent the code. Recheck
+    // before provisioning so an invalidated link can never create an account
+    // or a friendship merely because the URL was opened earlier.
+    if (userInvite && !(await resolveInviteLink(userInvite.handle, userInvite.token))) {
+      return invitationRejection();
+    }
 
-    let invitation: { accepted: boolean } = { accepted: false }
+    const user = await provisionUserForPhone(normalizedPhone);
+
+    let invitation: { accepted: boolean } = { accepted: false };
 
     if (hasUsableToken) {
       invitation = await acceptFriendInvitation({
         token: invitationToken,
         inviteeUserId: user.id,
         verifiedPhone: normalizedPhone,
-      })
+      });
 
       if (!invitation.accepted) {
         // Race condition: the invitation was claimed between our pre-validate
         // and accept. The user row already exists but has no accepted
         // invitation — future logins will hit the orphan-rejection branch
         // above, so the access surface is closed.
-        return invitationRejection()
+        return invitationRejection();
       }
     } else if (userInvite) {
       // Per-user invite link path: create the active friendship now. If
@@ -315,7 +313,7 @@ export async function POST(request: Request) {
         handle: userInvite.handle,
         token: userInvite.token,
         inviteeUserId: user.id,
-      })
+      });
     } else if (phoneInvitation) {
       // Phone-matched invite path: claim the specific pending invitation we
       // resolved above by its token, reusing the same acceptance +
@@ -324,20 +322,20 @@ export async function POST(request: Request) {
         token: phoneInvitation.token,
         inviteeUserId: user.id,
         verifiedPhone: normalizedPhone,
-      })
+      });
 
       if (!invitation.accepted) {
         // The invitation was claimed or cancelled between resolve and accept.
         // Same posture as the token path: reject rather than mint a session
         // for a new account with no accepted invitation.
-        return invitationRejection()
+        return invitationRejection();
       }
     }
 
     await createSession(user.id, {
       invitationAccepted: true,
       onboardingComplete: false,
-    })
+    });
 
     return NextResponse.json({
       user: {
@@ -349,12 +347,12 @@ export async function POST(request: Request) {
         onboardingComplete: false,
       },
       invitation,
-    })
+    });
   } catch (error) {
-    console.error('[auth/verify-otp] failed', error)
+    console.error('[auth/verify-otp] failed', error);
     return NextResponse.json(
       { error: 'server_error', message: 'Unable to verify code.' },
-      { status: 500 }
-    )
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/friend-invitations/accept-token/__tests__/route.test.ts
+++ b/src/app/api/friend-invitations/accept-token/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { getSessionMock, acceptFriendInvitationMock, dbSelectMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  acceptFriendInvitationMock: vi.fn(),
+  dbSelectMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/friends/invitations', () => ({
+  acceptFriendInvitation: acceptFriendInvitationMock,
+}));
+vi.mock('@/server/db', () => ({
+  db: { select: dbSelectMock },
+  users: {
+    id: 'id',
+    phoneNumber: 'phoneNumber',
+    phoneVerified: 'phoneVerified',
+    onboardingComplete: 'onboardingComplete',
+  },
+}));
+
+import { POST } from '@/app/api/friend-invitations/accept-token/route';
+
+function request(token = 'token-1') {
+  return new Request('https://example.com/api/friend-invitations/accept-token', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ token }),
+  });
+}
+
+function mockUser(onboardingComplete: boolean) {
+  dbSelectMock.mockReturnValue({
+    from: () => ({
+      where: () => ({
+        limit: async () => [
+          { phoneNumber: '+17345550123', phoneVerified: true, onboardingComplete },
+        ],
+      }),
+    }),
+  });
+}
+
+describe('POST /api/friend-invitations/accept-token', () => {
+  it('uses the authenticated user’s verified phone without sending them through login again', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'recipient-1' });
+    mockUser(false);
+    acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ nextHref: '/onboarding' });
+    expect(acceptFriendInvitationMock).toHaveBeenCalledWith({
+      token: 'token-1',
+      inviteeUserId: 'recipient-1',
+      verifiedPhone: '+17345550123',
+    });
+  });
+});

--- a/src/app/api/friend-invitations/accept-token/route.ts
+++ b/src/app/api/friend-invitations/accept-token/route.ts
@@ -1,0 +1,62 @@
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { db, users } from '@/server/db';
+import { acceptFriendInvitation } from '@/server/friends/invitations';
+
+const bodySchema = z.object({ token: z.string().trim().min(1).max(200) });
+
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_body', message: 'That invitation is not valid.' },
+      { status: 400 },
+    );
+  }
+
+  const [user] = await db
+    .select({
+      phoneNumber: users.phoneNumber,
+      phoneVerified: users.phoneVerified,
+      onboardingComplete: users.onboardingComplete,
+    })
+    .from(users)
+    .where(eq(users.id, session.userId))
+    .limit(1);
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  if (!user.phoneVerified) {
+    return NextResponse.json(
+      {
+        error: 'verification_required',
+        message: 'Verify your phone number to continue this invitation.',
+      },
+      { status: 403 },
+    );
+  }
+
+  const result = await acceptFriendInvitation({
+    token: parsed.data.token,
+    inviteeUserId: session.userId,
+    verifiedPhone: user.phoneNumber,
+  });
+  if (!result.accepted) {
+    return NextResponse.json(
+      {
+        error: 'invalid_invitation',
+        message: 'This invitation is no longer available for this account.',
+      },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    nextHref: user.onboardingComplete ? '/' : '/onboarding',
+  });
+}

--- a/src/app/api/invite-links/accept/__tests__/route.test.ts
+++ b/src/app/api/invite-links/accept/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { getSessionMock, acceptUserInviteLinkMock, dbSelectMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  acceptUserInviteLinkMock: vi.fn(),
+  dbSelectMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/friends/user-invite-token', () => ({
+  acceptUserInviteLink: acceptUserInviteLinkMock,
+}));
+vi.mock('@/server/db', () => ({
+  db: { select: dbSelectMock },
+  users: { id: 'id', onboardingComplete: 'onboardingComplete' },
+}));
+
+import { POST } from '@/app/api/invite-links/accept/route';
+
+function request(body: unknown) {
+  return new Request('https://example.com/api/invite-links/accept', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockUser(onboardingComplete: boolean) {
+  dbSelectMock.mockReturnValue({
+    from: () => ({ where: () => ({ limit: async () => [{ onboardingComplete }] }) }),
+  });
+}
+
+describe('POST /api/invite-links/accept', () => {
+  it('accepts for the signed-in user and sends unfinished accounts to onboarding', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'recipient-1' });
+    mockUser(false);
+    acceptUserInviteLinkMock.mockResolvedValueOnce({ accepted: true });
+
+    const response = await POST(request({ handle: 'josh', token: 'token-1' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ nextHref: '/onboarding' });
+    expect(acceptUserInviteLinkMock).toHaveBeenCalledWith({
+      handle: 'josh',
+      token: 'token-1',
+      inviteeUserId: 'recipient-1',
+    });
+  });
+
+  it('does not require authentication again for an onboarded returning user', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'recipient-1' });
+    mockUser(true);
+    acceptUserInviteLinkMock.mockResolvedValueOnce({ accepted: true });
+
+    const response = await POST(request({ handle: 'josh', token: 'token-1' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ nextHref: '/' });
+  });
+});

--- a/src/app/api/invite-links/accept/route.ts
+++ b/src/app/api/invite-links/accept/route.ts
@@ -1,0 +1,49 @@
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { db, users } from '@/server/db';
+import { acceptUserInviteLink } from '@/server/friends/user-invite-token';
+
+const bodySchema = z.object({
+  handle: z.string().trim().min(1).max(80),
+  token: z.string().trim().min(1).max(200),
+});
+
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_body', message: 'That invitation is not valid.' },
+      { status: 400 },
+    );
+  }
+
+  const [user] = await db
+    .select({ onboardingComplete: users.onboardingComplete })
+    .from(users)
+    .where(eq(users.id, session.userId))
+    .limit(1);
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const result = await acceptUserInviteLink({
+    handle: parsed.data.handle,
+    token: parsed.data.token,
+    inviteeUserId: session.userId,
+  });
+  if (!result.accepted) {
+    return NextResponse.json(
+      { error: 'invalid_invitation', message: 'This invitation is no longer available.' },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    nextHref: user.onboardingComplete ? '/' : '/onboarding',
+  });
+}

--- a/src/app/dev/invite-redesign/creator/page.tsx
+++ b/src/app/dev/invite-redesign/creator/page.tsx
@@ -1,0 +1,57 @@
+import { InviteLinksSection } from '@/components/friends/InviteLinksSection';
+
+const previewTopics = [
+  { label: 'Ancient History', broadCategory: 'History' },
+  { label: 'Cinema', broadCategory: 'Arts & Culture' },
+  { label: 'Space Exploration', broadCategory: 'Science' },
+  { label: 'World Cuisine', broadCategory: 'Food & Drink' },
+];
+
+const previewLinks = [
+  {
+    id: 'preview-history',
+    slot: 1,
+    categories: [previewTopics[0]!, previewTopics[2]!],
+    url: '/dev/invite-redesign/recipient',
+    createdAt: '2026-09-01T12:00:00.000Z',
+    joinedCount: 1,
+  },
+  {
+    id: 'preview-culture',
+    slot: 2,
+    categories: [previewTopics[1]!, previewTopics[3]!],
+    url: '/dev/invite-redesign/recipient',
+    createdAt: '2026-09-02T12:00:00.000Z',
+    joinedCount: 2,
+  },
+];
+
+export default function InviteCreatorPreviewPage() {
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5 pb-28">
+      <header className="mb-5">
+        <h1 className="text-foreground font-serif text-3xl font-semibold">Friends</h1>
+      </header>
+
+      <div className="mb-5">
+        <InviteLinksSection
+          creatorName="Josh"
+          initialTopics={previewTopics}
+          initialLinks={previewLinks}
+        />
+      </div>
+
+      <section aria-label="Friends list preview" className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="font-serif text-xl font-semibold">Your friends</h2>
+          <button
+            type="button"
+            className="min-h-11 text-sm font-medium text-[var(--brand-navy)] underline underline-offset-4"
+          >
+            Sort friends
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/dev/invite-redesign/recipient/page.tsx
+++ b/src/app/dev/invite-redesign/recipient/page.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+import {
+  InvitationLandingContent,
+  InvitationPageShell,
+} from '@/components/invite/InvitationLanding';
+
+export default function InviteRecipientPreviewPage() {
+  return (
+    <InvitationPageShell>
+      <InvitationLandingContent
+        inviterName="Josh"
+        categories={[
+          { label: 'Ancient History', broadCategory: 'History' },
+          { label: 'Space Exploration', broadCategory: 'Science' },
+        ]}
+        action={
+          <Link href="#" className="btn-primary min-h-11 w-full">
+            Continue with Josh
+          </Link>
+        }
+      />
+    </InvitationPageShell>
+  );
+}

--- a/src/app/friends/__tests__/page.test.tsx
+++ b/src/app/friends/__tests__/page.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import { renderToStaticMarkup } from 'react-dom/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   getSessionMock,
@@ -20,87 +20,87 @@ const {
   listLiveInviteLinksMock: vi.fn(async () => [] as unknown[]),
   getInviteLinkSeedTopicsMock: vi.fn(async () => [] as unknown[]),
   redirectMock: vi.fn(() => {
-    throw new Error('__REDIRECT__')
+    throw new Error('__REDIRECT__');
   }),
-}))
+}));
 
-vi.mock('next/navigation', () => ({ redirect: redirectMock }))
-vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
-vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }))
+vi.mock('next/navigation', () => ({ redirect: redirectMock }));
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }));
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
 vi.mock('@/server/db', () => ({
   db: { select: dbSelectMock },
-  users: { id: 'id', handle: 'handle', discoverableByContacts: 'dbc' },
-}))
+  users: { id: 'id', handle: 'handle', displayName: 'displayName', discoverableByContacts: 'dbc' },
+}));
 vi.mock('@/server/db/queries/contact-hashes', () => ({
   listContactMatches: listContactMatchesMock,
   getLastContactHashUpload: getLastContactHashUploadMock,
   isRefreshDue: () => false,
   markDiscoveryChecked: vi.fn(async () => {}),
-}))
+}));
 vi.mock('@/server/db/queries/friend-invitations', () => ({
   listInviteReflections: listInviteReflectionsMock,
-}))
+}));
 vi.mock('@/server/db/queries/invite-links', () => ({
   listLiveInviteLinks: listLiveInviteLinksMock,
-}))
+}));
 vi.mock('@/server/friends/user-invite-token', () => ({
   getInviteLinkSeedTopics: getInviteLinkSeedTopicsMock,
   buildInviteUrl: (base: string, handle: string, token: string) => `${base}/u/${handle}/${token}`,
   getBaseUrl: () => 'https://example.com',
-}))
+}));
 // Client islands are stubbed: this test is about which SECTIONS the server
 // component renders, not their internals.
 vi.mock('@/components/friends/ContactMatchBlock', () => ({
   ContactMatchBlock: () => <div data-stub="contact-match" />,
-}))
+}));
 vi.mock('@/components/friends/FindFriendsSearch', () => ({
   FindFriendsSearch: () => <div data-stub="find-friends-search" />,
-}))
+}));
 vi.mock('@/components/friends/InviteLinksSection', () => ({
   InviteLinksSection: () => <div data-stub="invite-links" />,
-}))
-vi.mock('@/components/FriendsList', () => ({ default: () => <div data-stub="friends-list" /> }))
+}));
+vi.mock('@/components/FriendsList', () => ({ default: () => <div data-stub="friends-list" /> }));
 
-import FriendsPage from '@/app/friends/page'
+import FriendsPage from '@/app/friends/page';
 
 function mockViewer(discoverableByContacts = true) {
   dbSelectMock.mockReturnValue({
     from: () => ({
       where: () => ({
-        limit: async () => [{ handle: 'jpalay', discoverableByContacts }],
+        limit: async () => [{ handle: 'jpalay', displayName: 'Josh', discoverableByContacts }],
       }),
     }),
-  })
+  });
 }
 
 async function render() {
-  const element = await FriendsPage()
-  return renderToStaticMarkup(element)
+  const element = await FriendsPage();
+  return renderToStaticMarkup(element);
 }
 
 describe('/friends page sections', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    listInviteReflectionsMock.mockResolvedValue([])
-    listContactMatchesMock.mockResolvedValue([])
-    getLastContactHashUploadMock.mockResolvedValue(null)
-    listLiveInviteLinksMock.mockResolvedValue([])
-    getInviteLinkSeedTopicsMock.mockResolvedValue([])
-    getSessionMock.mockResolvedValue({ userId: 'u1' })
-    mockViewer()
-  })
+    vi.clearAllMocks();
+    listInviteReflectionsMock.mockResolvedValue([]);
+    listContactMatchesMock.mockResolvedValue([]);
+    getLastContactHashUploadMock.mockResolvedValue(null);
+    listLiveInviteLinksMock.mockResolvedValue([]);
+    getInviteLinkSeedTopicsMock.mockResolvedValue([]);
+    getSessionMock.mockResolvedValue({ userId: 'u1' });
+    mockViewer();
+  });
 
   it('omits the Suggested section ENTIRELY when there is nothing to suggest', async () => {
     // The heading used to render unconditionally, so with no contact matches
     // and no invite reflections the section was a title over a "Coming soon"
     // card -- roughly a third of the first screen saying nothing.
-    const html = await render()
-    expect(html).not.toContain('Suggested')
+    const html = await render();
+    expect(html).not.toContain('Suggested');
     // The rest of the page is unaffected.
-    expect(html).toContain('data-stub="find-friends-search"')
-    expect(html).toContain('data-stub="invite-links"')
-    expect(html).toContain('data-stub="friends-list"')
-  })
+    expect(html).toContain('data-stub="find-friends-search"');
+    expect(html).toContain('data-stub="invite-links"');
+    expect(html).toContain('data-stub="friends-list"');
+  });
 
   it('renders the Suggested section WITH its heading when reflections exist', async () => {
     // The guard must hide an empty section, not delete the label -- otherwise
@@ -118,24 +118,24 @@ describe('/friends page sections', () => {
         acceptedAt: new Date('2026-09-01T00:00:00Z'),
         relationship: { state: 'none', friendshipId: null, formedAt: null, isBlocked: false },
       },
-    ])
+    ]);
 
-    const html = await render()
-    expect(html).toContain('Suggested')
-    expect(html).toContain('Robyn')
+    const html = await render();
+    expect(html).toContain('Suggested');
+    expect(html).toContain('Robyn');
     // Provenance chip: a suggestion must never read as unexplained.
-    expect(html).toContain('Joined from your invite')
-  })
+    expect(html).toContain('Joined from your invite');
+  });
 
   it('never renders the retired "Coming soon" mutual-friends placeholder', async () => {
-    listInviteReflectionsMock.mockResolvedValue([])
-    const html = await render()
-    expect(html).not.toContain('Coming soon')
-    expect(html).not.toContain('Suggested via mutual friends')
-  })
+    listInviteReflectionsMock.mockResolvedValue([]);
+    const html = await render();
+    expect(html).not.toContain('Coming soon');
+    expect(html).not.toContain('Suggested via mutual friends');
+  });
 
   it('redirects a signed-out visitor', async () => {
-    getSessionMock.mockResolvedValue(null)
-    await expect(render()).rejects.toThrow('__REDIRECT__')
-  })
-})
+    getSessionMock.mockResolvedValue(null);
+    await expect(render()).rejects.toThrow('__REDIRECT__');
+  });
+});

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -1,75 +1,91 @@
-import { eq } from 'drizzle-orm'
-import { headers } from 'next/headers'
-import { redirect } from 'next/navigation'
+import { eq } from 'drizzle-orm';
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
 
-import { ContactMatchBlock } from '@/components/friends/ContactMatchBlock'
-import { FindFriendsSearch } from '@/components/friends/FindFriendsSearch'
-import { InviteLinksSection } from '@/components/friends/InviteLinksSection'
-import { colorForUser, formatRelativeTime } from '@/components/feed/visual'
-import FriendsList from '@/components/FriendsList'
-import { getSession } from '@/server/auth/session'
-import { db, users } from '@/server/db'
+import { ContactMatchBlock } from '@/components/friends/ContactMatchBlock';
+import { FindFriendsSearch } from '@/components/friends/FindFriendsSearch';
+import { InviteLinksSection } from '@/components/friends/InviteLinksSection';
+import { colorForUser, formatRelativeTime } from '@/components/feed/visual';
+import FriendsList from '@/components/FriendsList';
+import { getSession } from '@/server/auth/session';
+import { db, users } from '@/server/db';
 import {
   getLastContactHashUpload,
   isRefreshDue,
   listContactMatches,
   markDiscoveryChecked,
-} from '@/server/db/queries/contact-hashes'
-import { listInviteReflections } from '@/server/db/queries/friend-invitations'
-import { listLiveInviteLinks } from '@/server/db/queries/invite-links'
-import { buildInviteUrl, getBaseUrl, getInviteLinkSeedTopics } from '@/server/friends/user-invite-token'
+} from '@/server/db/queries/contact-hashes';
+import { listInviteReflections } from '@/server/db/queries/friend-invitations';
+import { listLiveInviteLinks } from '@/server/db/queries/invite-links';
+import { sanitizeInviteLinkCategories } from '@/lib/invite-links';
+import {
+  buildInviteUrl,
+  getBaseUrl,
+  getInviteLinkSeedTopics,
+} from '@/server/friends/user-invite-token';
 
-export const dynamic = 'force-dynamic'
+export const dynamic = 'force-dynamic';
 
 function initialsFor(name: string | null, fallback: string): string {
-  const source = (name?.trim() || fallback).replace(/[^a-zA-Z]+/g, ' ').trim()
-  if (!source) return '??'
-  const parts = source.split(/\s+/)
-  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase()
-  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase()
+  const source = (name?.trim() || fallback).replace(/[^a-zA-Z]+/g, ' ').trim();
+  if (!source) return '??';
+  const parts = source.split(/\s+/);
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase();
 }
 
 export default async function FriendsPage() {
-  const session = await getSession()
-  if (!session) redirect('/login')
+  const session = await getSession();
+  if (!session) redirect('/login');
 
   const [viewer] = await db
     .select({
       handle: users.handle,
+      displayName: users.displayName,
       discoverableByContacts: users.discoverableByContacts,
     })
     .from(users)
     .where(eq(users.id, session.userId))
-    .limit(1)
+    .limit(1);
 
-  if (!viewer) redirect('/login')
+  if (!viewer) redirect('/login');
 
   // Stamp the discovery threshold AS the user lands here — clears the
   // Nav-tab dot and the Invitations-tab passive row on next render.
-  await markDiscoveryChecked(session.userId)
+  await markDiscoveryChecked(session.userId);
 
-  const [reflections, contactMatches, lastContactUpload, resolvedTopics, liveLinks] = await Promise.all([
-    listInviteReflections(session.userId),
-    viewer.discoverableByContacts ? listContactMatches(session.userId) : Promise.resolve([]),
-    viewer.discoverableByContacts ? getLastContactHashUpload(session.userId) : Promise.resolve(null),
-    getInviteLinkSeedTopics(session.userId),
-    listLiveInviteLinks(session.userId),
-  ])
-  const contactRefreshDue = isRefreshDue(lastContactUpload)
+  const [reflections, contactMatches, lastContactUpload, resolvedTopics, liveLinks] =
+    await Promise.all([
+      listInviteReflections(session.userId),
+      viewer.discoverableByContacts ? listContactMatches(session.userId) : Promise.resolve([]),
+      viewer.discoverableByContacts
+        ? getLastContactHashUpload(session.userId)
+        : Promise.resolve(null),
+      getInviteLinkSeedTopics(session.userId),
+      listLiveInviteLinks(session.userId),
+    ]);
+  const contactRefreshDue = isRefreshDue(lastContactUpload);
 
-  const requestHeaders = await headers()
-  const baseUrl = getBaseUrl(requestHeaders)
+  const requestHeaders = await headers();
+  const baseUrl = getBaseUrl(requestHeaders);
+  const resolvedLinks = await Promise.all(
+    liveLinks.map(async (link) => ({
+      ...link,
+      categories: link.categories ?? (await getInviteLinkSeedTopics(session.userId, link.slot)),
+    })),
+  );
   const initialLinks = viewer.handle
-    ? liveLinks.map((link) => ({
+    ? resolvedLinks.map((link) => ({
         id: link.id,
         slot: link.slot,
+        categories: sanitizeInviteLinkCategories(link.categories),
         url: buildInviteUrl(baseUrl, viewer.handle!, link.token),
         createdAt: link.createdAt.toISOString(),
         joinedCount: link.joinedCount,
       }))
-    : []
+    : [];
 
-  const hasSuggestions = contactMatches.length > 0 || reflections.length > 0
+  const hasSuggestions = contactMatches.length > 0 || reflections.length > 0;
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5 pb-28">
@@ -109,11 +125,14 @@ export default async function FriendsPage() {
           <h2 className="text-foreground font-serif text-xl font-semibold">Suggested</h2>
           <div className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
             {reflections.map((reflection) => {
-              const displayName = reflection.displayName?.trim() || `@${reflection.handle ?? ''}`
-              const initials = initialsFor(reflection.displayName, reflection.handle ?? '?')
-              const swatch = reflection.avatarColor || colorForUser(reflection.inviteeUserId)
+              const displayName = reflection.displayName?.trim() || `@${reflection.handle ?? ''}`;
+              const initials = initialsFor(reflection.displayName, reflection.handle ?? '?');
+              const swatch = reflection.avatarColor || colorForUser(reflection.inviteeUserId);
               return (
-                <article key={reflection.invitationId} className="flex items-start gap-3 border-b py-3 last:border-0 last:pb-0">
+                <article
+                  key={reflection.invitationId}
+                  className="flex items-start gap-3 border-b py-3 last:border-0 last:pb-0"
+                >
                   <span
                     aria-hidden
                     className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold text-white"
@@ -132,7 +151,7 @@ export default async function FriendsPage() {
                     </p>
                   </div>
                 </article>
-              )
+              );
             })}
           </div>
         </section>
@@ -141,7 +160,11 @@ export default async function FriendsPage() {
       {/* Invite via link. An action rather than a destination, so it sits above
           the roster but below the lookup. */}
       <div className="mb-5">
-        <InviteLinksSection initialTopics={resolvedTopics} initialLinks={initialLinks} />
+        <InviteLinksSection
+          creatorName={viewer.displayName}
+          initialTopics={resolvedTopics}
+          initialLinks={initialLinks}
+        />
       </div>
 
       {/* The roster is what people come back for, so it moves up: with the dead
@@ -149,5 +172,5 @@ export default async function FriendsPage() {
           first screen instead of the third. */}
       <FriendsList />
     </main>
-  )
+  );
 }

--- a/src/app/invite/[token]/__tests__/page.test.tsx
+++ b/src/app/invite/[token]/__tests__/page.test.tsx
@@ -1,10 +1,10 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getFriendInvitationLandingByTokenMock, redirectMock } = vi.hoisted(() => ({
+const { getFriendInvitationLandingByTokenMock, getSessionMock, redirectMock } = vi.hoisted(() => ({
   getFriendInvitationLandingByTokenMock: vi.fn(),
+  getSessionMock: vi.fn(),
   redirectMock: vi.fn((url: string) => {
-    // Mirror Next's real redirect(): throw to halt rendering.
     throw new Error(`NEXT_REDIRECT:${url}`);
   }),
 }));
@@ -12,9 +12,10 @@ const { getFriendInvitationLandingByTokenMock, redirectMock } = vi.hoisted(() =>
 vi.mock('@/server/friends/invitations', () => ({
   getFriendInvitationLandingByToken: getFriendInvitationLandingByTokenMock,
 }));
-
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
 vi.mock('next/navigation', () => ({
   redirect: redirectMock,
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 
 import InvitePage from '@/app/invite/[token]/page';
@@ -27,20 +28,44 @@ async function renderInvite(token = 'safe-token') {
 describe('/invite/[token] landing QA states', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getSessionMock.mockResolvedValue(null);
   });
 
-  it('sends a valid invite straight to the login screen with the invite context attached (no interstitial)', async () => {
+  it('shows personalized context before a signed-out recipient continues to authentication', async () => {
     getFriendInvitationLandingByTokenMock.mockResolvedValueOnce({
       status: 'valid',
-      inviterName: 'Alex Inviter',
+      inviterName: 'Alex',
+      inviterUserId: 'u1',
+      inviterAvatarColor: null,
+      categories: ['Jazz', 'Poetry'],
     });
 
-    await expect(renderInvite('valid-token')).rejects.toThrow(
-      'NEXT_REDIRECT:/login?invitationToken=valid-token',
-    );
+    const html = await renderInvite('valid-token');
 
+    expect(html).toContain('Alex invited you to Joshing');
+    expect(html).toContain('Play Alex’s greatest hits');
+    expect(html).toContain('Alex picked a few categories');
+    expect(html).toContain('Jazz');
+    expect(html).toContain('Poetry');
+    expect(html).toContain('Continue with Alex');
+    expect(html).toContain('href="/login?invitationToken=valid-token"');
     expect(getFriendInvitationLandingByTokenMock).toHaveBeenCalledWith('valid-token');
-    expect(redirectMock).toHaveBeenCalledWith('/login?invitationToken=valid-token');
+  });
+
+  it('lets a signed-in recipient continue without a login link', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'recipient-1' });
+    getFriendInvitationLandingByTokenMock.mockResolvedValueOnce({
+      status: 'valid',
+      inviterName: 'Alex',
+      inviterUserId: 'u1',
+      inviterAvatarColor: null,
+      categories: ['Jazz'],
+    });
+
+    const html = await renderInvite('valid-token');
+
+    expect(html).toContain('Continue with Alex');
+    expect(html).not.toContain('href="/login?invitationToken=valid-token"');
   });
 
   it.each([
@@ -57,14 +82,17 @@ describe('/invite/[token] landing QA states', () => {
     {
       status: 'invalid',
       expectedHeading: 'This invitation link is not valid.',
-      expectedEyebrow: 'Invalid invitation',
+      expectedEyebrow: 'Invitation unavailable',
     },
   ])(
     'renders the $status invite state safely',
     async ({ status, expectedHeading, expectedEyebrow }) => {
       getFriendInvitationLandingByTokenMock.mockResolvedValueOnce({
         status,
-        inviterName: 'Alex Inviter',
+        inviterName: 'Secret Inviter',
+        inviterUserId: null,
+        inviterAvatarColor: null,
+        categories: ['Secret Category'],
       });
 
       const html = await renderInvite(`${status}-token`);
@@ -73,6 +101,25 @@ describe('/invite/[token] landing QA states', () => {
       expect(html).toContain(expectedHeading);
       expect(html).toContain('href="/login"');
       expect(html).not.toContain(`${status}-token`);
+      expect(html).not.toContain('Secret Inviter');
+      expect(html).not.toContain('Secret Category');
     },
   );
+
+  it('uses neutral fallback copy when the inviter has no safe public name', async () => {
+    getFriendInvitationLandingByTokenMock.mockResolvedValueOnce({
+      status: 'valid',
+      inviterName: '+1 (734) 555-0123',
+      inviterUserId: 'u1',
+      inviterAvatarColor: null,
+      categories: ['Jazz'],
+    });
+
+    const html = await renderInvite('valid-token');
+
+    expect(html).toContain('You’ve been invited to Joshing');
+    expect(html).toContain('Play the greatest hits');
+    expect(html).toContain('Someone picked a few categories to get you started.');
+    expect(html).not.toContain('734');
+  });
 });

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,7 +1,13 @@
-import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
+import { AcceptFriendInvitationButton } from '@/components/invite/AcceptFriendInvitationButton';
+import {
+  InvitationLandingContent,
+  InvitationPageShell,
+} from '@/components/invite/InvitationLanding';
+import { safeInviteName } from '@/lib/invite-links';
+import { getSession } from '@/server/auth/session';
 import { getFriendInvitationLandingByToken } from '@/server/friends/invitations';
 
 type InvitePageProps = {
@@ -12,87 +18,70 @@ function inviteLoginHref(token: string) {
   return `/login?invitationToken=${encodeURIComponent(token)}`;
 }
 
-function InviteShell({ children }: { children: ReactNode }) {
-  return (
-    <main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4 py-10">
-      <section className="bg-card w-full max-w-sm rounded-[var(--radius-card)] border p-5 shadow-[var(--shadow-card)]">
-        {children}
-      </section>
-    </main>
-  );
-}
-
 export default async function InvitePage({ params }: InvitePageProps) {
   const { token } = await params;
   const invitation = await getFriendInvitationLandingByToken(token);
+  const session = await getSession();
 
   if (invitation.status === 'valid') {
-    // Skip the interstitial — drop the invitee straight onto the login screen,
-    // which carries the invite context (the reworded "verify your phone" card).
-    redirect(inviteLoginHref(token));
-  }
+    if (session?.userId === invitation.inviterUserId) redirect('/friends');
+    const inviterName = safeInviteName(invitation.inviterName);
 
-  if (invitation.status === 'expired') {
     return (
-      <InviteShell>
-        <div className="space-y-4 text-center">
-          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-            Invitation expired
-          </p>
-          <h1 className="font-serif text-2xl leading-tight font-semibold">
-            This invitation has expired. Ask {invitation.inviterName} to send you a new one.
-          </h1>
-          <Link
-            href="/login"
-            className="btn-ghost w-full"
-          >
-            Go to login
-          </Link>
-        </div>
-      </InviteShell>
+      <InvitationPageShell>
+        <InvitationLandingContent
+          inviterName={inviterName}
+          categories={invitation.categories}
+          action={
+            session ? (
+              <AcceptFriendInvitationButton token={token} inviterName={inviterName} />
+            ) : (
+              <Link href={inviteLoginHref(token)} className="btn-primary min-h-11 w-full">
+                {inviterName ? `Continue with ${inviterName}` : 'Continue'}
+              </Link>
+            )
+          }
+        />
+      </InvitationPageShell>
     );
   }
 
   if (invitation.status === 'accepted') {
     return (
-      <InviteShell>
+      <InvitationPageShell>
         <div className="space-y-4 text-center">
-          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-            Invitation already used
-          </p>
-          <h1 className="font-serif text-2xl leading-tight font-semibold">
+          <p className="text-muted-foreground text-sm font-medium">Invitation already used</p>
+          <h1 className="font-serif text-3xl leading-tight font-semibold">
             This invitation has already been used.
           </h1>
           <p className="text-muted-foreground text-sm leading-6">
-            Log in with your phone number to continue to Joshing.
+            Continue to Joshing with the account that accepted it.
           </p>
-          <Link href="/login" className="btn-primary w-full">
-            Go to login
+          <Link href={session ? '/' : '/login'} className="btn-primary min-h-11 w-full">
+            {session ? 'Continue to Joshing' : 'Go to login'}
           </Link>
         </div>
-      </InviteShell>
+      </InvitationPageShell>
     );
   }
 
+  const expired = invitation.status === 'expired';
   return (
-    <InviteShell>
+    <InvitationPageShell>
       <div className="space-y-4 text-center">
-        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-          Invalid invitation
+        <p className="text-muted-foreground text-sm font-medium">
+          {expired ? 'Invitation expired' : 'Invitation unavailable'}
         </p>
-        <h1 className="text-2xl font-semibold tracking-normal">
-          This invitation link is not valid.
+        <h1 className="font-serif text-3xl leading-tight font-semibold">
+          {expired ? 'This invitation has expired.' : 'This invitation link is not valid.'}
         </h1>
         <p className="text-muted-foreground text-sm leading-6">
           Ask your friend to send you a new Joshing invitation.
         </p>
-        <Link
-          href="/login"
-          className="inline-flex h-11 w-full items-center justify-center rounded-md border px-4 text-sm font-medium"
-        >
+        <Link href="/login" className="btn-ghost min-h-11 w-full">
           Go to login
         </Link>
       </div>
-    </InviteShell>
+    </InvitationPageShell>
   );
 }

--- a/src/app/login/__tests__/build-invite-views.test.ts
+++ b/src/app/login/__tests__/build-invite-views.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest';
 
-import { buildLoginInviteViews } from '@/app/login/build-invite-views'
+import { buildLoginInviteViews } from '@/app/login/build-invite-views';
 
 describe('buildLoginInviteViews', () => {
   it('returns both null when neither a prefill nor a link resolution exists', () => {
-    const result = buildLoginInviteViews(null, null)
-    expect(result).toEqual({ invitePrefill: null, inviteContext: null })
-  })
+    const result = buildLoginInviteViews(null, null);
+    expect(result).toEqual({ invitePrefill: null, inviteContext: null });
+  });
 
   it('the named (FriendInvitation) prefill builds both invitePrefill and a topic-free inviteContext', () => {
     const prefill = {
@@ -14,20 +14,20 @@ describe('buildLoginInviteViews', () => {
       inviterUserId: 'inviter-1',
       inviterAvatarColor: '#abc',
       inviteePhone: '+17345550123',
-    }
+    };
 
-    const result = buildLoginInviteViews(prefill, null)
+    const result = buildLoginInviteViews(prefill, null);
 
-    expect(result.invitePrefill).toEqual(prefill)
+    expect(result.invitePrefill).toEqual(prefill);
     expect(result.inviteContext).toEqual({
       inviterName: 'Alex Inviter',
       inviterUserId: 'inviter-1',
       inviterAvatarColor: '#abc',
-    })
+    });
     // Boundary-level check per the Stage 4 audit's rule ("Do not touch the
     // named path"): the named path never carries topics.
-    expect(result.inviteContext).not.toHaveProperty('topics')
-  })
+    expect(result.inviteContext).not.toHaveProperty('topics');
+  });
 
   it('the per-user invite-link resolution builds only inviteContext, with its seedTopics as topics', () => {
     const userInviteResolution = {
@@ -36,33 +36,33 @@ describe('buildLoginInviteViews', () => {
       inviterUserId: 'inviter-2',
       inviterAvatarColor: '#def',
       seedTopics: ['Jazz', 'Poetry'],
-    }
+    };
 
-    const result = buildLoginInviteViews(null, userInviteResolution)
+    const result = buildLoginInviteViews(null, userInviteResolution);
 
-    expect(result.invitePrefill).toBeNull()
+    expect(result.invitePrefill).toBeNull();
     expect(result.inviteContext).toEqual({
       inviterName: 'Jaime Rivera',
       inviterUserId: 'inviter-2',
       inviterAvatarColor: '#def',
       topics: ['Jazz', 'Poetry'],
-    })
-  })
+    });
+  });
 
-  it('falls back to "@handle" when the link inviter has no display name', () => {
+  it('uses a neutral fallback when the link inviter has no safe display name', () => {
     const userInviteResolution = {
       inviterDisplayName: null,
       inviterHandle: 'jaime',
       inviterUserId: 'inviter-2',
       inviterAvatarColor: null,
       seedTopics: [],
-    }
+    };
 
-    const result = buildLoginInviteViews(null, userInviteResolution)
+    const result = buildLoginInviteViews(null, userInviteResolution);
 
-    expect(result.inviteContext?.inviterName).toBe('@jaime')
-    expect(result.inviteContext?.topics).toEqual([])
-  })
+    expect(result.inviteContext?.inviterName).toBe('A friend');
+    expect(result.inviteContext?.topics).toEqual([]);
+  });
 
   it('the named prefill wins over a simultaneous link resolution', () => {
     const prefill = {
@@ -70,19 +70,19 @@ describe('buildLoginInviteViews', () => {
       inviterUserId: 'inviter-1',
       inviterAvatarColor: null,
       inviteePhone: '+17345550123',
-    }
+    };
     const userInviteResolution = {
       inviterDisplayName: 'Jaime Rivera',
       inviterHandle: 'jaime',
       inviterUserId: 'inviter-2',
       inviterAvatarColor: null,
       seedTopics: ['Jazz'],
-    }
+    };
 
-    const result = buildLoginInviteViews(prefill, userInviteResolution)
+    const result = buildLoginInviteViews(prefill, userInviteResolution);
 
-    expect(result.invitePrefill?.inviterUserId).toBe('inviter-1')
-    expect(result.inviteContext?.inviterUserId).toBe('inviter-1')
-    expect(result.inviteContext).not.toHaveProperty('topics')
-  })
-})
+    expect(result.invitePrefill?.inviterUserId).toBe('inviter-1');
+    expect(result.inviteContext?.inviterUserId).toBe('inviter-1');
+    expect(result.inviteContext).not.toHaveProperty('topics');
+  });
+});

--- a/src/app/login/build-invite-views.ts
+++ b/src/app/login/build-invite-views.ts
@@ -6,6 +6,8 @@
  * are the already-resolved query results, not the queries themselves.
  */
 
+import { safeInviteName } from '@/lib/invite-links';
+
 export type InvitePrefillView = {
   inviterName: string;
   inviterUserId: string;
@@ -65,9 +67,7 @@ export function buildLoginInviteViews(
       }
     : userInviteResolution
       ? {
-          inviterName:
-            userInviteResolution.inviterDisplayName?.trim() ||
-            `@${userInviteResolution.inviterHandle}`,
+          inviterName: safeInviteName(userInviteResolution.inviterDisplayName) || 'A friend',
           inviterUserId: userInviteResolution.inviterUserId,
           inviterAvatarColor: userInviteResolution.inviterAvatarColor,
           topics: userInviteResolution.seedTopics,

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -19,6 +19,7 @@ import { assessInterestAnswerability } from '@/server/llm/interests';
 import { convergeDomain } from '@/server/knowledge/converge-domain';
 import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
 import { domainKey } from '@/lib/knowledge/domain-key';
+import { safeInviteName, sanitizeInviteLinkCategories } from '@/lib/invite-links';
 import { getReminderState } from '@/server/db/queries/account';
 import { shouldOfferReminderAcquisition } from '@/server/reminders/acquisition';
 
@@ -41,9 +42,7 @@ export default async function OnboardingPage() {
   }
 
   const reminderState = await getReminderState(session.userId);
-  const showReminderOffer = reminderState
-    ? shouldOfferReminderAcquisition(reminderState)
-    : false;
+  const showReminderOffer = reminderState ? shouldOfferReminderAcquisition(reminderState) : false;
 
   // Belt-and-suspenders invitation check: the middleware JWT gate runs first,
   // but this protects the onboarding route against any future session path
@@ -58,10 +57,12 @@ export default async function OnboardingPage() {
   const hasInvitation = await db
     .select({ id: friendInvitations.id })
     .from(friendInvitations)
-    .where(and(
-      eq(friendInvitations.inviteeUserId, session.userId),
-      isNotNull(friendInvitations.acceptedAt),
-    ))
+    .where(
+      and(
+        eq(friendInvitations.inviteeUserId, session.userId),
+        isNotNull(friendInvitations.acceptedAt),
+      ),
+    )
     .limit(1);
 
   if (hasInvitation.length === 0 && !(await hasInviteLinkFriendship(session.userId))) {
@@ -95,12 +96,17 @@ export default async function OnboardingPage() {
         (await getInviteLinkSeedTopics(inviter.inviterUserId));
       seeded = {
         interests: topics,
-        inviterName: normalizePersonName(inviter.inviterName),
+        inviterName: safeInviteName(normalizePersonName(inviter.inviterName)),
         inviteeDisplayName: seeded.inviteeDisplayName,
       };
       seedSource = 'link';
     }
   }
+
+  seeded = {
+    ...seeded,
+    interests: sanitizeInviteLinkCategories(seeded.interests),
+  };
 
   // Validate the inviter's free-text suggestions at the invitee's first login,
   // before the interests step renders. The inviter can seed anything ("your
@@ -124,7 +130,11 @@ export default async function OnboardingPage() {
       const { candidates } = await convergeDomain(interest.label);
       const exact = candidates.find((candidate) => candidate.kind === 'exact');
       return exact
-        ? { ...interest, label: exact.label, broadCategory: exact.broadCategory ?? interest.broadCategory }
+        ? {
+            ...interest,
+            label: exact.label,
+            broadCategory: exact.broadCategory ?? interest.broadCategory,
+          }
         : interest;
     }),
   );
@@ -153,7 +163,11 @@ export default async function OnboardingPage() {
     const broadCategories = [
       ...new Set(preSeededInterests.map((interest) => interest.broadCategory).filter(Boolean)),
     ];
-    const adjacent = await getCatalogSuggestions(broadCategories, seededKeys, 3 - preSeededInterests.length);
+    const adjacent = await getCatalogSuggestions(
+      broadCategories,
+      seededKeys,
+      3 - preSeededInterests.length,
+    );
     for (const suggestion of adjacent) {
       preSeededInterests.push({
         domain: suggestion.domain,
@@ -168,7 +182,7 @@ export default async function OnboardingPage() {
     <OnboardingFlow
       preSeededInterests={preSeededInterests}
       seedSource={seedSource}
-      inviterName={seeded.inviterName}
+      inviterName={safeInviteName(seeded.inviterName)}
       inviteeDisplayName={seeded.inviteeDisplayName}
       initialDisplayName={user.displayName}
       initialHandle={user.handle}

--- a/src/app/u/[handle]/[token]/__tests__/page.test.tsx
+++ b/src/app/u/[handle]/[token]/__tests__/page.test.tsx
@@ -1,0 +1,119 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { resolveInviteLinkMock, getSessionMock, redirectMock } = vi.hoisted(() => ({
+  resolveInviteLinkMock: vi.fn(),
+  getSessionMock: vi.fn(),
+  redirectMock: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock('@/server/friends/user-invite-token', () => ({ resolveInviteLink: resolveInviteLinkMock }));
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+import UserInvitePage from '@/app/u/[handle]/[token]/page';
+
+function resolution(overrides: Record<string, unknown> = {}) {
+  return {
+    inviterUserId: 'inviter-1',
+    inviterHandle: 'josh',
+    inviterDisplayName: 'Josh',
+    inviterAvatarColor: null,
+    linkId: 'link-1',
+    slot: 0,
+    seedTopics: ['Sondheim', 'Jazz'],
+    ...overrides,
+  };
+}
+
+async function render(handle = 'josh', token = 'safe-token') {
+  const element = await UserInvitePage({ params: Promise.resolve({ handle, token }) });
+  return renderToStaticMarkup(element);
+}
+
+describe('/u/[handle]/[token] personalized invitation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue(null);
+  });
+
+  it('uses the inviter identity and exact categories resolved from the server record', async () => {
+    resolveInviteLinkMock.mockResolvedValueOnce(resolution());
+
+    const html = await render();
+
+    expect(resolveInviteLinkMock).toHaveBeenCalledWith('josh', 'safe-token');
+    expect(html).toContain('Josh invited you to Joshing');
+    expect(html).toContain('Play Josh’s greatest hits');
+    expect(html).toContain('Sondheim');
+    expect(html).toContain('Jazz');
+    expect(html).toContain('Continue with Josh');
+    expect(html).toContain('inviteHandle=josh');
+    expect(html).toContain('inviteUserToken=safe-token');
+  });
+
+  it('cannot spoof the inviter name through URL query data', async () => {
+    resolveInviteLinkMock.mockResolvedValueOnce(resolution({ inviterDisplayName: 'Josh' }));
+
+    const element = await UserInvitePage({
+      params: Promise.resolve({ handle: 'josh', token: 'safe-token' }),
+      searchParams: Promise.resolve({ inviterName: 'Mallory' }),
+    } as never);
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('Josh invited you to Joshing');
+    expect(html).not.toContain('Mallory');
+  });
+
+  it('keeps category sets isolated between two links', async () => {
+    resolveInviteLinkMock
+      .mockResolvedValueOnce(resolution({ linkId: 'a', seedTopics: ['Jazz'] }))
+      .mockResolvedValueOnce(resolution({ linkId: 'b', seedTopics: ['Poetry'] }));
+
+    const first = await render('josh', 'token-a');
+    const second = await render('josh', 'token-b');
+
+    expect(first).toContain('Jazz');
+    expect(first).not.toContain('Poetry');
+    expect(second).toContain('Poetry');
+    expect(second).not.toContain('Jazz');
+  });
+
+  it('shows personalized context to a signed-in recipient without a login link', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'recipient-1' });
+    resolveInviteLinkMock.mockResolvedValueOnce(resolution());
+
+    const html = await render();
+
+    expect(html).toContain('Josh invited you to Joshing');
+    expect(html).toContain('Continue with Josh');
+    expect(html).not.toContain('inviteHandle=');
+  });
+
+  it('reveals no inviter or categories for an invalid link', async () => {
+    resolveInviteLinkMock.mockResolvedValueOnce(null);
+
+    const html = await render('josh', 'bad-token');
+
+    expect(html).toContain('This invitation link is no longer valid.');
+    expect(html).not.toContain('Josh invited');
+    expect(html).not.toContain('Sondheim');
+    expect(html).not.toContain('bad-token');
+  });
+
+  it('uses neutral copy when the inviter has no safe public name', async () => {
+    resolveInviteLinkMock.mockResolvedValueOnce(resolution({ inviterDisplayName: null }));
+
+    const html = await render();
+
+    expect(html).toContain('You’ve been invited to Joshing');
+    expect(html).toContain('Play the greatest hits');
+    expect(html).toContain('Someone picked a few categories to get you started.');
+    expect(html).toContain('>Continue<');
+  });
+});

--- a/src/app/u/[handle]/[token]/page.tsx
+++ b/src/app/u/[handle]/[token]/page.tsx
@@ -1,115 +1,78 @@
-// Per-user invite link handler (B-Friends-3).
-//
-// Lives at /u/[handle]/[token] rather than /invite/[handle]/[token] because
-// /invite/[token] already owns the /invite/<dynamic> slot — Next.js refuses
-// to build the route trie when two sibling dynamic segments use different
-// slug names ('handle' vs 'token'), and the resulting unhandled rejection
-// hangs every cold-start lambda until the 15-minute task timeout. See the
-// commit that moved this file.
-//
-// /invite/[token]/page.tsx still resolves FriendInvitation.token
-// (per-invitation, expires, may pre-seed interests). THIS route resolves
-// the inviter's evergreen users.invite_token, generated on demand at
-// /api/account/invite-token and rotatable from /account/privacy.
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
 
-import type { ReactNode } from 'react'
-import { redirect } from 'next/navigation'
-import Link from 'next/link'
-
-import { AddFriendButton } from '@/components/friends/AddFriendButton'
-import { getSession } from '@/server/auth/session'
-import { getRelationship } from '@/server/db/queries/friend-requests'
-import { resolveInviteLink } from '@/server/friends/user-invite-token'
+import { AcceptInviteLinkButton } from '@/components/invite/AcceptInviteLinkButton';
+import {
+  InvitationLandingContent,
+  InvitationPageShell,
+} from '@/components/invite/InvitationLanding';
+import { safeInviteName } from '@/lib/invite-links';
+import { getSession } from '@/server/auth/session';
+import { resolveInviteLink } from '@/server/friends/user-invite-token';
 
 type InvitePageProps = {
-  params: Promise<{ handle: string; token: string }>
-}
-
-function InviteShell({ children }: { children: ReactNode }) {
-  return (
-    <main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4 py-10">
-      <section className="bg-card w-full max-w-sm rounded-[var(--radius-card)] border p-5 shadow-[var(--shadow-card)]">
-        {children}
-      </section>
-    </main>
-  )
-}
+  params: Promise<{ handle: string; token: string }>;
+};
 
 function loginHref(handle: string, token: string): string {
   const params = new URLSearchParams({
     inviteHandle: handle,
     inviteUserToken: token,
-  })
-  return `/login?${params.toString()}`
+  });
+  return `/login?${params.toString()}`;
 }
 
 export default async function UserInvitePage({ params }: InvitePageProps) {
-  const { handle, token } = await params
-  const inviter = await resolveInviteLink(handle, token)
+  const { handle, token } = await params;
+  const inviter = await resolveInviteLink(handle, token);
 
   if (!inviter) {
     return (
-      <InviteShell>
+      <InvitationPageShell>
         <div className="space-y-4 text-center">
-          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-            Link not valid
-          </p>
-          <h1 className="font-serif text-2xl font-semibold leading-tight">
-            This invite link is no longer valid.
+          <p className="text-muted-foreground text-sm font-medium">Invitation unavailable</p>
+          <h1 className="font-serif text-3xl leading-tight font-semibold text-balance">
+            This invitation link is no longer valid.
           </h1>
           <p className="text-muted-foreground text-sm leading-6">
-            Ask your friend for a fresh link.
+            Ask your friend for a fresh link, or continue to Joshing if you already have an account.
           </p>
-          <Link
-            href="/login"
-            className="inline-flex h-11 w-full items-center justify-center rounded-md border px-4 text-sm font-medium"
-          >
+          <Link href="/login" className="btn-ghost min-h-11 w-full">
             Go to login
           </Link>
         </div>
-      </InviteShell>
-    )
+      </InvitationPageShell>
+    );
   }
 
-  const session = await getSession()
-  const displayName = inviter.inviterDisplayName?.trim() || `@${inviter.inviterHandle}`
+  const session = await getSession();
+  if (session?.userId === inviter.inviterUserId) redirect('/friends');
 
-  // Logged-in as the inviter themselves — bounce to /friends.
-  if (session?.userId === inviter.inviterUserId) {
-    redirect('/friends')
-  }
+  const inviterName = safeInviteName(inviter.inviterDisplayName);
+  const continueLabel = inviterName ? `Continue with ${inviterName}` : 'Continue';
 
-  // Logged-in as someone else — render an inline send-friend-request UI.
-  if (session) {
-    const relationship = await getRelationship(session.userId, inviter.inviterUserId)
-    return (
-      <InviteShell>
-        <div className="space-y-5">
-          <div>
-            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-              You were invited
-            </p>
-            <h1 className="mt-2 font-serif text-3xl font-semibold leading-tight">
-              {displayName} invited you to connect on Joshing.
-            </h1>
-          </div>
-          <AddFriendButton
-            targetUserId={inviter.inviterUserId}
-            targetDisplayName={displayName}
-            relationship={relationship}
-          />
-          <Link
-            href={`/users/${inviter.inviterUserId}`}
-            className="text-muted-foreground inline-flex text-sm underline underline-offset-4"
-          >
-            View {displayName}&rsquo;s profile
-          </Link>
-        </div>
-      </InviteShell>
-    )
-  }
-
-  // Logged-out — skip the interstitial and drop the invitee straight onto the
-  // login screen, with the invite params attached so it shows the invite card.
-  redirect(loginHref(inviter.inviterHandle, token))
+  return (
+    <InvitationPageShell>
+      <InvitationLandingContent
+        inviterName={inviterName}
+        categories={inviter.seedTopics}
+        action={
+          session ? (
+            <AcceptInviteLinkButton
+              handle={inviter.inviterHandle}
+              token={token}
+              inviterName={inviterName}
+            />
+          ) : (
+            <Link
+              href={loginHref(inviter.inviterHandle, token)}
+              className="btn-primary min-h-11 w-full"
+            >
+              {continueLabel}
+            </Link>
+          )
+        }
+      />
+    </InvitationPageShell>
+  );
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -25,13 +25,7 @@ function formatBadgeCount(count: number): string {
   return String(count);
 }
 
-function AccountIcon({
-  active,
-  initials,
-}: {
-  active: boolean;
-  initials: string | null;
-}) {
+function AccountIcon({ active, initials }: { active: boolean; initials: string | null }) {
   if (!initials) {
     return <User className="size-5" strokeWidth={active ? 2.4 : 1.8} />;
   }
@@ -93,7 +87,9 @@ export function Nav({
           if (!active || !data) return;
           setDisplayName(data.displayName ?? null);
           setBadgeCount(typeof data.bellBadgeCount === 'number' ? data.bellBadgeCount : 0);
-          setFriendRequests(typeof data.friendRequestCount === 'number' ? data.friendRequestCount : 0);
+          setFriendRequests(
+            typeof data.friendRequestCount === 'number' ? data.friendRequestCount : 0,
+          );
           setFriendsDot(Boolean(data.friendsDotVisible));
         },
       )
@@ -125,6 +121,7 @@ export function Nav({
     pathname.startsWith('/admin') ||
     pathname.startsWith('/knowledge') ||
     pathname === '/friends' ||
+    pathname === '/dev/invite-redesign/creator' ||
     isOtherUserProfilePath;
   const showCreateShortcut = !hidesCreateShortcut;
 
@@ -144,18 +141,21 @@ export function Nav({
   // `/dev/onboarding/` prefix now only matches the self-contained stage replays.
   const isOnboardingHarnessPreview =
     pathname === '/dev/welcome-tour' || pathname.startsWith('/dev/onboarding/');
+  const isInviteLanding =
+    pathname.startsWith('/invite/') ||
+    pathname.startsWith('/u/') ||
+    pathname === '/dev/invite-redesign/recipient';
 
   if (
     pathname === '/onboarding' ||
     pathname.startsWith('/daily') ||
     pathname === '/login' ||
-    pathname.startsWith('/invite/') ||
+    isInviteLanding ||
     isCeremonyScreen ||
     isOnboardingHarnessPreview
   ) {
     return null;
   }
-
 
   // The Profile tab is active for both the canonical /users/<self-id>
   // route and the /users/me alias before it redirects.
@@ -175,13 +175,13 @@ export function Nav({
     <>
       <header
         data-app-chrome
-        className="z-40 border-b bg-background/95 backdrop-blur"
+        className="bg-background/95 z-40 border-b backdrop-blur"
         aria-label="Primary header"
       >
         <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-3">
           <Link
             href="/"
-            className="font-wordmark text-[22px] font-semibold uppercase leading-none tracking-[0.05em] text-foreground"
+            className="font-wordmark text-foreground text-[22px] leading-none font-semibold tracking-[0.05em] uppercase"
           >
             Joshing
           </Link>
@@ -193,12 +193,12 @@ export function Nav({
                   ? `Lately, ${badgeCount} new update${badgeCount === 1 ? '' : 's'}`
                   : 'Lately'
               }
-              className="relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-md transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
               <Bell className="size-5" strokeWidth={1.9} />
               {showBadge ? (
                 <span
-                  className="absolute right-1 top-1 grid min-w-[18px] items-center rounded-full px-1.5 text-center font-mono text-[9px] font-semibold leading-[14px] text-[var(--brand-card)]"
+                  className="absolute top-1 right-1 grid min-w-[18px] items-center rounded-full px-1.5 text-center font-mono text-[9px] leading-[14px] font-semibold text-[var(--brand-card)]"
                   style={{ backgroundColor: 'var(--destructive)' }}
                   aria-hidden="true"
                 >
@@ -210,7 +210,7 @@ export function Nav({
               href="/users/me"
               aria-label="Account and settings"
               aria-current={isProfileTabActive('/users/me') ? 'page' : undefined}
-              className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring inline-flex min-h-11 min-w-11 items-center justify-center rounded-md transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
               <AccountIcon active={isProfileTabActive('/users/me')} initials={accountInitials} />
             </Link>
@@ -222,7 +222,7 @@ export function Nav({
           type="button"
           data-app-chrome
           className={[
-            'fixed bottom-24 right-5 z-50 grid size-14 place-items-center rounded-full bg-primary text-primary-foreground shadow-lg',
+            'bg-primary text-primary-foreground fixed right-5 bottom-24 z-50 grid size-14 place-items-center rounded-full shadow-lg',
             // The dedicated add-a-question FAB shows on every viewport; the
             // generic Create chooser FAB stays mobile-only as before.
             isQuestionComposerShortcut ? '' : 'md:hidden',
@@ -239,7 +239,7 @@ export function Nav({
       ) : null}
       <nav
         data-app-chrome
-        className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur"
+        className="bg-background/95 fixed inset-x-0 bottom-0 z-40 border-t backdrop-blur"
         aria-label="Primary navigation"
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
@@ -277,7 +277,7 @@ export function Nav({
                   // Inactive tabs use a legible secondary navy (--brand-ink-700,
                   // ~7:1 on cream) rather than the old text-foreground/55, which
                   // dimmed to ~2.5:1 and failed AA.
-                  active ? 'text-foreground' : 'text-[var(--brand-ink-700)] hover:text-foreground',
+                  active ? 'text-foreground' : 'hover:text-foreground text-[var(--brand-ink-700)]',
                 ].join(' ')}
               >
                 <span aria-hidden="true" className="relative grid place-items-center">
@@ -297,7 +297,7 @@ export function Nav({
                       find — never both, so the tab corner stays uncluttered. */}
                   {showFriendRequests ? (
                     <span
-                      className="absolute -right-2 -top-1 grid min-w-[18px] items-center rounded-full px-1.5 text-center font-mono text-[9px] font-semibold leading-[14px] text-[var(--brand-card)]"
+                      className="absolute -top-1 -right-2 grid min-w-[18px] items-center rounded-full px-1.5 text-center font-mono text-[9px] leading-[14px] font-semibold text-[var(--brand-card)]"
                       style={{ backgroundColor: 'var(--destructive)' }}
                       aria-hidden="true"
                     >
@@ -305,14 +305,14 @@ export function Nav({
                     </span>
                   ) : friendsDot && label === 'Friends' ? (
                     <span
-                      className="absolute -right-1 -top-1 size-2 rounded-full"
+                      className="absolute -top-1 -right-1 size-2 rounded-full"
                       style={{ backgroundColor: 'var(--brand-ink-400)' }}
                     />
                   ) : null}
                 </span>
                 <span
                   className={[
-                    'font-mono text-[10px] uppercase tracking-[0.06em]',
+                    'font-mono text-[10px] tracking-[0.06em] uppercase',
                     active ? 'font-semibold' : 'font-medium',
                   ].join(' ')}
                 >

--- a/src/components/friends/InviteLinksSection.tsx
+++ b/src/components/friends/InviteLinksSection.tsx
@@ -1,442 +1,466 @@
-'use client'
+'use client';
 
-import { useState } from 'react'
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
 
-import { AddTopicField, type AddTopicCandidate, type AddTopicError } from '@/components/interests/AddTopicField'
-import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles'
+import {
+  AddTopicField,
+  type AddTopicCandidate,
+  type AddTopicError,
+} from '@/components/interests/AddTopicField';
+import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
+import {
+  inviteGreatestHitsTitle,
+  MAX_INVITE_LINK_CATEGORIES,
+  sanitizeInviteLinkCategories,
+  type InviteLinkCategory,
+} from '@/lib/invite-links';
 
-const SEED_TOPIC_CAP = 3
-const SHARE_TEXT = "I'm playing Joshing — come be my friend."
+const SHARE_TEXT = "I'm playing Joshing — come be my friend.";
 
-export type InviteLinkTopic = {
-  label: string
-  broadCategory?: string | null
-}
+export type InviteLinkTopic = InviteLinkCategory;
 
 export type InviteLinkRowData = {
-  id: string
-  slot: number
-  url: string
-  createdAt: string
-  joinedCount: number
-}
+  id: string;
+  slot: number;
+  categories: InviteLinkTopic[];
+  url: string;
+  createdAt: string;
+  joinedCount: number;
+};
 
 type Props = {
-  initialTopics: InviteLinkTopic[]
-  initialLinks: InviteLinkRowData[]
-}
+  creatorName?: string | null;
+  initialTopics: InviteLinkTopic[];
+  initialLinks: InviteLinkRowData[];
+};
 
-type TopicsResponse = { topics?: InviteLinkTopic[]; message?: string }
-type LinkResponse = { link?: InviteLinkRowData; message?: string }
+type LinkResponse = { link?: InviteLinkRowData; message?: string };
+type EditResponse = { categories?: InviteLinkTopic[]; message?: string };
+type EditorState = { kind: 'create' } | { kind: 'edit'; linkId: string };
 
 function topicColor(topic: InviteLinkTopic | null): { primary: string; text: string } {
-  if (!topic) return { primary: 'var(--brand-ink-400)', text: 'var(--brand-ink-700)' }
-  return getPortraitDomainColor(topic.broadCategory ?? topic.label)
+  if (!topic) return { primary: 'var(--brand-ink-400)', text: 'var(--brand-ink-700)' };
+  return getPortraitDomainColor(topic.broadCategory ?? topic.label);
 }
 
-// The tag a specific link carries — 0 (untagged) or the topic at that
-// standing slot, 1-indexed against `topics`.
-function slotLabel(slot: number, topics: InviteLinkTopic[]): string {
-  if (slot === 0) return 'No category'
-  return topics[slot - 1]?.label ?? 'No category'
+export function joinedFriendsCopy(count: number): string {
+  return `${count} ${count === 1 ? 'friend' : 'friends'} joined`;
+}
+
+export function createInviteLinkControlCopy(activeCount: number): string {
+  return activeCount === 0 ? 'Create an invite link' : 'Create a link with different categories';
 }
 
 async function shareUrl(url: string, onCopied: () => void) {
   if (typeof navigator.share === 'function') {
     try {
-      await navigator.share({ text: SHARE_TEXT, url })
-      return
+      await navigator.share({ text: SHARE_TEXT, url });
+      return;
     } catch (shareError) {
-      if (shareError instanceof Error && shareError.name === 'AbortError') return
+      if (shareError instanceof Error && shareError.name === 'AbortError') return;
     }
   }
-  await navigator.clipboard.writeText(url)
-  onCopied()
+  await navigator.clipboard.writeText(url);
+  onCopied();
 }
 
-export function InviteLinksSection({ initialTopics, initialLinks }: Props) {
-  const [topics, setTopics] = useState<InviteLinkTopic[]>(initialTopics)
-  const [links, setLinks] = useState<InviteLinkRowData[]>(initialLinks)
-  const [draftSlot, setDraftSlot] = useState<number | null>(null)
-  const [showCreate, setShowCreate] = useState(false)
-  const [creatingTopic, setCreatingTopic] = useState(false)
-  const [creatingLink, setCreatingLink] = useState(false)
-  const [createError, setCreateError] = useState<string | null>(null)
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
-  const [deleting, setDeleting] = useState(false)
-  const [toast, setToast] = useState<string | null>(null)
+function CategoryChip({ topic, onRemove }: { topic: InviteLinkTopic; onRemove?: () => void }) {
+  const color = topicColor(topic);
+  return (
+    <span
+      className="inline-flex min-h-8 max-w-full items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold whitespace-normal"
+      style={{
+        borderColor: `color-mix(in srgb, ${color.primary} 40%, transparent)`,
+        color: color.text,
+        overflowWrap: 'anywhere',
+      }}
+    >
+      <span
+        aria-hidden
+        className="size-1.5 shrink-0 rounded-full"
+        style={{ background: color.primary }}
+      />
+      <span>{topic.label}</span>
+      {onRemove ? (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="ml-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-full text-base leading-none hover:bg-[var(--brand-navy)]/5 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--brand-navy)]"
+          aria-label={`Remove ${topic.label}`}
+        >
+          ×
+        </button>
+      ) : null}
+    </span>
+  );
+}
 
-  const usedSlots = new Set(links.map((link) => link.slot).filter((slot) => slot !== 0))
+export function InviteLinksSection({ creatorName, initialTopics, initialLinks }: Props) {
+  const suggestions = sanitizeInviteLinkCategories(initialTopics);
+  const [links, setLinks] = useState<InviteLinkRowData[]>(() =>
+    initialLinks.map((link) => ({
+      ...link,
+      categories: sanitizeInviteLinkCategories(link.categories),
+    })),
+  );
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [draftCategories, setDraftCategories] = useState<InviteLinkTopic[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
 
   function flashToast(message: string) {
-    setToast(message)
-    window.setTimeout(() => setToast((current) => (current === message ? null : current)), 1800)
+    setToast(message);
+    window.setTimeout(() => setToast((current) => (current === message ? null : current)), 1800);
+  }
+
+  function closeEditor() {
+    setEditor(null);
+    setDraftCategories([]);
+    setSaveError(null);
+  }
+
+  function openCreate() {
+    setDraftCategories([]);
+    setSaveError(null);
+    setEditor({ kind: 'create' });
+  }
+
+  function openEdit(link: InviteLinkRowData) {
+    setDraftCategories(sanitizeInviteLinkCategories(link.categories));
+    setSaveError(null);
+    setEditor({ kind: 'edit', linkId: link.id });
   }
 
   async function handleAddTopic(candidate: AddTopicCandidate) {
-    const label = candidate.label.trim()
-    if (topics.some((topic) => topic.label.toLowerCase() === label.toLowerCase())) {
-      const err: AddTopicError = new Error('You already added that one.')
-      throw err
+    if (draftCategories.length >= MAX_INVITE_LINK_CATEGORIES) {
+      const error = new Error(
+        `You can choose up to ${MAX_INVITE_LINK_CATEGORIES} categories per link.`,
+      ) as AddTopicError;
+      error.code = 'limit_reached';
+      throw error;
     }
-    if (topics.length >= SEED_TOPIC_CAP) {
-      const err: AddTopicError = new Error(`You already have ${SEED_TOPIC_CAP}. Remove one to add another.`)
-      err.code = 'limit_reached'
-      throw err
+    const next = sanitizeInviteLinkCategories([...draftCategories, candidate]);
+    if (next.length === draftCategories.length) {
+      throw new Error('You already added that category.');
     }
-
-    const next = [...topics, { label, broadCategory: candidate.broadCategory ?? null }]
-    const response = await fetch('/api/account/invite-links/topics', {
-      method: 'PATCH',
-      credentials: 'include',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ topics: next.map((topic) => topic.label) }),
-    })
-    const body = (await response.json().catch(() => null)) as TopicsResponse | null
-    if (!response.ok) {
-      const err: AddTopicError = new Error(body?.message ?? 'Could not add that topic.')
-      if (body?.message?.includes('too broad')) err.code = 'too_broad'
-      throw err
-    }
-    // Keep the broadCategory this add just resolved (AddTopicField already ran
-    // it through expansion/convergence) — the PATCH response only echoes
-    // labels, since curated storage doesn't persist category.
-    setTopics(next)
+    setDraftCategories(next);
+    setSaveError(null);
   }
 
-  async function removeTopic(label: string) {
-    const next = topics.filter((topic) => topic.label !== label)
-    setTopics(next)
-    setDraftSlot(null)
-    setShowCreate(true)
-    await fetch('/api/account/invite-links/topics', {
-      method: 'PATCH',
-      credentials: 'include',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ topics: next.map((topic) => topic.label) }),
-    }).catch(() => undefined)
+  function addSuggestedTopic(topic: InviteLinkTopic) {
+    if (draftCategories.length >= MAX_INVITE_LINK_CATEGORIES) return;
+    setDraftCategories((current) => sanitizeInviteLinkCategories([...current, topic]));
+    setSaveError(null);
   }
 
-  async function createLink() {
-    if (draftSlot === null || creatingLink) return
-    setCreatingLink(true)
-    setCreateError(null)
+  function removeDraftTopic(label: string) {
+    setDraftCategories((current) => current.filter((topic) => topic.label !== label));
+  }
+
+  async function saveCategories() {
+    const categories = sanitizeInviteLinkCategories(draftCategories);
+    if (categories.length === 0) {
+      setSaveError('Choose at least one category before saving this link.');
+      return;
+    }
+    if (!editor || saving) return;
+
+    setSaving(true);
+    setSaveError(null);
     try {
-      const response = await fetch('/api/account/invite-links', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ slot: draftSlot }),
-      })
-      const body = (await response.json().catch(() => null)) as LinkResponse | null
-      if (!response.ok || !body?.link) {
-        setCreateError(body?.message ?? 'Could not create that link.')
-        return
+      if (editor.kind === 'create') {
+        const response = await fetch('/api/account/invite-links', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ categories }),
+        });
+        const body = (await response.json().catch(() => null)) as LinkResponse | null;
+        if (!response.ok || !body?.link) {
+          setSaveError(body?.message ?? 'Could not create that link.');
+          return;
+        }
+        setLinks((current) => [
+          ...current,
+          { ...body.link!, categories: sanitizeInviteLinkCategories(body.link!.categories) },
+        ]);
+        flashToast('Link created.');
+      } else {
+        const response = await fetch(`/api/account/invite-links/${editor.linkId}`, {
+          method: 'PATCH',
+          credentials: 'include',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ categories }),
+        });
+        const body = (await response.json().catch(() => null)) as EditResponse | null;
+        if (!response.ok || !body?.categories) {
+          setSaveError(body?.message ?? 'Could not save those categories.');
+          return;
+        }
+        setLinks((current) =>
+          current.map((link) =>
+            link.id === editor.linkId
+              ? { ...link, categories: sanitizeInviteLinkCategories(body.categories) }
+              : link,
+          ),
+        );
+        flashToast('Link updated.');
       }
-      setLinks((current) => [...current, body.link!])
-      setDraftSlot(null)
-      setShowCreate(false)
-      flashToast('Link created.')
+      closeEditor();
     } catch {
-      setCreateError('Network error. Try again.')
+      setSaveError('Network error. Try again.');
     } finally {
-      setCreatingLink(false)
+      setSaving(false);
     }
   }
 
   async function confirmDelete() {
-    if (!pendingDeleteId || deleting) return
-    setDeleting(true)
+    if (!pendingDeleteId || deleting) return;
+    setDeleting(true);
     try {
       const response = await fetch(`/api/account/invite-links/${pendingDeleteId}/delete`, {
         method: 'POST',
         credentials: 'include',
-      })
+      });
       if (response.ok) {
-        setLinks((current) => current.filter((link) => link.id !== pendingDeleteId))
-        flashToast('Link deleted. Friends kept.')
+        setLinks((current) => current.filter((link) => link.id !== pendingDeleteId));
+        if (editor?.kind === 'edit' && editor.linkId === pendingDeleteId) closeEditor();
+        flashToast('Link deleted. Friends kept.');
       }
     } finally {
-      setDeleting(false)
-      setPendingDeleteId(null)
+      setDeleting(false);
+      setPendingDeleteId(null);
     }
   }
 
-  const pendingDeleteLink = links.find((link) => link.id === pendingDeleteId) ?? null
+  const pendingDeleteLink = links.find((link) => link.id === pendingDeleteId) ?? null;
+  const availableSuggestions = suggestions.filter(
+    (suggestion) =>
+      !draftCategories.some(
+        (selected) =>
+          selected.label.toLocaleLowerCase('en-US') === suggestion.label.toLocaleLowerCase('en-US'),
+      ),
+  );
 
   return (
-    <section id="invite-links" className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
-      <h2 className="font-serif text-lg font-semibold">Invite via link</h2>
-      <p className="text-muted-foreground mt-1 text-sm">
-        Up to 3 at a time. Anyone with a link can join — deleting one never removes a friend.
+    <section
+      id="invite-links"
+      className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]"
+    >
+      <h2 className="font-serif text-xl font-semibold">Invite via link</h2>
+      <p className="text-muted-foreground mt-1 text-sm leading-5">
+        Create a personal invitation with a few categories to get the two of you playing.
       </p>
 
-      <div className="mt-3 space-y-2">
+      <div className="mt-4 space-y-3">
         {links.map((link) => {
-          const topic = link.slot === 0 ? null : (topics[link.slot - 1] ?? null)
-          const color = topicColor(topic)
-          const label = slotLabel(link.slot, topics)
-          // An untagged link carries every standing topic; a tagged one carries
-          // exactly its slot. Same resolution the server uses in
-          // getInviteLinkSeedTopics(userId, slot).
-          const carriedTopics = link.slot === 0 ? topics : topic ? [topic] : []
+          const categories = sanitizeInviteLinkCategories(link.categories);
+          const accent = topicColor(categories[0] ?? null);
           return (
             <article
               key={link.id}
-              className="relative overflow-hidden rounded-[var(--radius-card)] border bg-background pl-4 pr-3 py-3"
+              className="bg-background relative min-w-0 overflow-hidden rounded-[var(--radius-card)] border py-3 pr-3 pl-4"
               style={{ borderColor: 'var(--brand-border)' }}
             >
               <span
                 aria-hidden
-                className="absolute left-0 top-0 h-full w-[5px]"
-                style={{ background: color.primary }}
+                className="absolute top-0 left-0 h-full w-[5px]"
+                style={{ background: accent.primary }}
               />
-              <span
-                className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-bold"
-                style={{ background: `color-mix(in srgb, ${color.primary} 12%, transparent)`, color: color.text }}
-              >
-                <span className="size-1.5 rounded-full" style={{ background: color.primary }} />
-                {label}
-              </span>
-              {/* The raw share URL is deliberately NOT rendered. It was 60+
-                  characters of base64 wrapping onto two lines -- the loudest
-                  thing on the card, and unreadable by design (nobody reads a
-                  token). What a person actually needs to recognise a link is
-                  what it CARRIES and how it has done, so the topic chips and
-                  the join count take that space instead. The URL still reaches
-                  the clipboard and the share sheet via the buttons below. */}
-              <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                {carriedTopics.length > 0 ? (
-                  carriedTopics.map((topic) => {
-                    const chipColor = topicColor(topic)
-                    return (
-                      <span
-                        key={topic.label}
-                        className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
-                        style={{ borderColor: `color-mix(in srgb, ${chipColor.primary} 40%, transparent)`, color: chipColor.text }}
-                      >
-                        <span className="size-1 rounded-full" style={{ background: chipColor.primary }} />
-                        {topic.label}
-                      </span>
-                    )
-                  })
-                ) : (
-                  <span className="text-muted-foreground text-xs">No topics yet</span>
-                )}
-              </div>
-              <p className="text-muted-foreground/80 mt-1.5 text-xs">
-                {link.joinedCount} joined
+              <h3 className="font-serif text-xl leading-tight font-semibold break-words text-[var(--brand-navy)]">
+                {inviteGreatestHitsTitle(creatorName, true)}
+              </h3>
+              <p className="text-muted-foreground mt-1 text-sm leading-5">
+                We’ll recommend these categories to anyone who uses this link.
               </p>
-              <div className="mt-2 flex gap-2">
+              {categories.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {categories.map((topic) => (
+                    <CategoryChip key={topic.label} topic={topic} />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-destructive mt-2 text-xs leading-5">
+                  This legacy link needs at least one category. Use Edit to choose one.
+                </p>
+              )}
+              <p className="text-muted-foreground/80 mt-2 text-xs">
+                {joinedFriendsCopy(link.joinedCount)}
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1">
                 <button
                   type="button"
                   onClick={() => void shareUrl(link.url, () => flashToast('Link copied.'))}
-                  className="btn-ghost h-8 px-3 text-xs"
+                  className="inline-flex min-h-10 items-center justify-center rounded-md bg-[var(--brand-navy)] px-3 text-xs font-semibold text-[var(--brand-card)] transition hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-navy)]"
                 >
-                  Share
+                  Share link
+                </button>
+                <button
+                  type="button"
+                  onClick={() => openEdit(link)}
+                  className="min-h-10 text-sm font-medium text-[var(--brand-navy)] underline decoration-transparent underline-offset-4 transition hover:decoration-current focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-navy)]"
+                >
+                  Edit
                 </button>
                 <button
                   type="button"
                   onClick={() => setPendingDeleteId(link.id)}
-                  className="btn-ghost text-destructive h-8 px-3 text-xs"
+                  className="text-destructive focus-visible:outline-destructive min-h-10 text-sm font-medium underline decoration-transparent underline-offset-4 transition hover:decoration-current focus-visible:outline-2 focus-visible:outline-offset-2"
                 >
                   Delete
                 </button>
               </div>
             </article>
-          )
+          );
         })}
-        {links.length === 0 ? (
-          <p className="text-muted-foreground text-sm">
-            No invite links yet. Make one and share it anywhere — a text, a group chat, your bio.
-          </p>
-        ) : null}
       </div>
 
-      {links.length >= 3 ? (
-        <p className="text-muted-foreground mt-3 text-xs">
-          You have all 3 links. Delete one to make another.
-        </p>
-      ) : showCreate ? (
-        <div className="mt-3 space-y-3 rounded-xl border p-3" style={{ borderColor: 'var(--brand-border)' }}>
-          <p className="text-sm font-medium">Tag the new link</p>
-          <div className="space-y-2">
-            {topics.map((topic, index) => {
-              const slot = index + 1
-              const color = topicColor(topic)
-              const locked = usedSlots.has(slot)
-              const selected = draftSlot === slot
-              return (
-                <div
-                  key={topic.label}
-                  className="flex items-stretch overflow-hidden rounded-full border-2"
-                  style={{
-                    borderColor: selected ? color.primary : 'var(--brand-border)',
-                    background: selected ? `color-mix(in srgb, ${color.primary} 8%, transparent)` : 'var(--brand-field)',
-                  }}
-                >
-                  <button
-                    type="button"
-                    disabled={locked}
-                    onClick={() => setDraftSlot(slot)}
-                    aria-pressed={selected}
-                    className="flex flex-1 items-center gap-2.5 px-3 py-2.5 text-left disabled:opacity-45"
-                  >
-                    <span
-                      className="size-4 rounded-full border-2"
-                      style={{ borderColor: selected ? color.primary : 'var(--brand-border)' }}
-                    >
-                      {selected ? (
-                        <span
-                          className="block size-full scale-50 rounded-full"
-                          style={{ background: color.primary }}
-                        />
-                      ) : null}
-                    </span>
-                    <span className="text-sm font-semibold">
-                      {topic.label}{' '}
-                      <span className="text-muted-foreground text-xs font-medium">
-                        {locked ? '— link exists' : topic.broadCategory ?? ''}
-                      </span>
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    disabled={locked}
-                    onClick={() => void removeTopic(topic.label)}
-                    aria-label={`Swap out ${topic.label} for something else`}
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-30 px-3 text-xs font-medium underline underline-offset-2"
-                  >
-                    Swap
-                  </button>
-                </div>
-              )
-            })}
-            <button
-              type="button"
-              onClick={() => setDraftSlot(0)}
-              aria-pressed={draftSlot === 0}
-              className="flex w-full items-center gap-2.5 rounded-full border-2 px-3 py-2.5 text-left"
-              style={{
-                borderColor: draftSlot === 0 ? 'var(--accent-gold)' : 'var(--brand-border)',
-                background:
-                  draftSlot === 0
-                    ? 'color-mix(in srgb, var(--accent-gold) 12%, transparent)'
-                    : 'var(--brand-field)',
-              }}
-            >
-              <span
-                className="size-4 rounded-full border-2"
-                style={{ borderColor: draftSlot === 0 ? 'var(--accent-gold)' : 'var(--brand-border)' }}
-              >
-                {draftSlot === 0 ? (
-                  <span className="block size-full scale-50 rounded-full" style={{ background: 'var(--accent-gold)' }} />
-                ) : null}
-              </span>
-              <span className="text-sm font-semibold">
-                No category{' '}
-                <span className="text-muted-foreground text-xs font-medium">
-                  {topics.length > 0
-                    ? `carries all ${topics.length} topic${topics.length === 1 ? '' : 's'} above`
-                    : 'carries your most-played topics'}
-                </span>
-              </span>
-            </button>
+      {editor ? (
+        <div
+          className="mt-4 space-y-3 rounded-[var(--radius-card)] border p-3"
+          style={{ borderColor: 'var(--brand-border)' }}
+        >
+          <div>
+            <h3 className="font-serif text-lg font-semibold">
+              {editor.kind === 'create' ? 'Choose categories' : 'Edit categories'}
+            </h3>
+            <p className="text-muted-foreground mt-1 text-sm leading-5">
+              Choose up to {MAX_INVITE_LINK_CATEGORIES}. Your friend can keep, change, or ignore
+              them during setup.
+            </p>
           </div>
 
-          {topics.length < SEED_TOPIC_CAP ? (
-            creatingTopic ? (
-              <div className="rounded-xl border p-3" style={{ borderColor: 'var(--brand-border)', background: 'var(--brand-cream-card)' }}>
-                <AddTopicField
-                  onAdd={handleAddTopic}
-                  existingLabels={topics.map((topic) => topic.label)}
-                  convergeBeforeAdd
-                  placeholder="e.g. Byzantine Coinage"
+          {draftCategories.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {draftCategories.map((topic) => (
+                <CategoryChip
+                  key={topic.label}
+                  topic={topic}
+                  onRemove={() => removeDraftTopic(topic.label)}
                 />
-                <button
-                  type="button"
-                  onClick={() => setCreatingTopic(false)}
-                  className="text-muted-foreground hover:text-foreground mt-2 text-xs underline underline-offset-2"
-                >
-                  Done
-                </button>
-              </div>
-            ) : (
-              <button type="button" onClick={() => setCreatingTopic(true)} className="btn-ghost w-full">
-                + Create your own
-              </button>
-            )
+              ))}
+            </div>
           ) : (
-            // At the 3-topic cap the add flow isn't gone, just one step away —
-            // say so instead of rendering nothing, since a bare "×" glyph
-            // above doesn't read as "this reopens adding."
-            <p className="text-muted-foreground text-center text-xs">
-              All 3 topics are taken. Tap Swap above to trade one for something new.
+            <p className="text-destructive text-sm" role="status">
+              Choose at least one category to save.
             </p>
           )}
 
-          {createError ? <p className="text-destructive text-sm">{createError}</p> : null}
+          {availableSuggestions.length > 0 &&
+          draftCategories.length < MAX_INVITE_LINK_CATEGORIES ? (
+            <div>
+              <p className="text-muted-foreground mb-2 text-xs font-medium">Your categories</p>
+              <div className="flex flex-wrap gap-2">
+                {availableSuggestions.map((topic) => (
+                  <button
+                    key={topic.label}
+                    type="button"
+                    onClick={() => addSuggestedTopic(topic)}
+                    className="hover:bg-muted inline-flex min-h-9 max-w-full items-center gap-1 rounded-full border px-3 py-1 text-left text-xs font-medium focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-navy)]"
+                  >
+                    <Plus className="size-3.5 shrink-0" aria-hidden />
+                    <span style={{ overflowWrap: 'anywhere' }}>{topic.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
 
-          <div className="flex gap-2">
+          {draftCategories.length < MAX_INVITE_LINK_CATEGORIES ? (
+            <AddTopicField
+              heading="Add a different category"
+              onAdd={handleAddTopic}
+              existingLabels={draftCategories.map((topic) => topic.label)}
+              convergeBeforeAdd
+              placeholder="e.g. Byzantine Coinage"
+              multiAddHint={false}
+            />
+          ) : (
+            <p className="text-muted-foreground text-xs">
+              You’ve chosen the maximum of {MAX_INVITE_LINK_CATEGORIES} categories.
+            </p>
+          )}
+
+          {saveError ? (
+            <p className="text-destructive text-sm" role="alert">
+              {saveError}
+            </p>
+          ) : null}
+
+          <div className="flex flex-wrap items-center gap-3">
             <button
               type="button"
-              onClick={() => void createLink()}
-              disabled={draftSlot === null || creatingLink}
-              className="btn-primary flex-1"
+              onClick={() => void saveCategories()}
+              disabled={draftCategories.length === 0 || saving}
+              className="btn-primary min-h-11 px-4 disabled:opacity-45"
             >
-              {creatingLink ? 'Creating…' : 'Create link'}
+              {saving ? 'Saving…' : editor.kind === 'create' ? 'Create link' : 'Save changes'}
             </button>
-            <button
-              type="button"
-              onClick={() => {
-                setShowCreate(false)
-                setDraftSlot(null)
-                setCreateError(null)
-              }}
-              className="btn-ghost"
-            >
+            <button type="button" onClick={closeEditor} className="btn-ghost min-h-11 px-3">
               Cancel
             </button>
           </div>
         </div>
-      ) : (
-        <button type="button" onClick={() => setShowCreate(true)} className="btn-primary mt-3 w-full">
-          Create an invite link
+      ) : null}
+
+      {links.length < 3 && !editor ? (
+        <button
+          type="button"
+          onClick={openCreate}
+          className="mt-4 inline-flex min-h-11 items-center gap-1.5 text-left text-sm font-semibold text-[var(--brand-navy)] underline decoration-transparent underline-offset-4 transition hover:decoration-current focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-navy)]"
+        >
+          <Plus className="size-4 shrink-0" aria-hidden />
+          {createInviteLinkControlCopy(links.length)}
         </button>
-      )}
+      ) : null}
+      <p className="text-muted-foreground mt-1 text-xs leading-5">
+        You can keep up to three active invitation links.
+      </p>
 
       {pendingDeleteLink ? (
         <div
           className="fixed inset-0 z-[var(--z-modal)] flex items-end justify-center sm:items-center"
           style={{ background: 'var(--scrim)' }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-invite-link-title"
         >
-          <div className="w-full max-w-sm rounded-t-2xl bg-card p-5 text-card-foreground sm:rounded-2xl">
-            <h3 className="font-serif text-xl font-semibold">
-              Delete your {slotLabel(pendingDeleteLink.slot, topics)} link?
+          <div className="bg-card text-card-foreground w-full max-w-sm rounded-t-2xl p-5 sm:rounded-2xl">
+            <h3 id="delete-invite-link-title" className="font-serif text-xl font-semibold">
+              Delete this invitation link?
             </h3>
             <p
               className="mt-3 rounded-lg p-2.5 text-sm"
               style={{ background: 'var(--success-surface)', color: 'var(--success)' }}
             >
-              The {pendingDeleteLink.joinedCount} {pendingDeleteLink.joinedCount === 1 ? 'person' : 'people'} who
-              already joined through this link stay your friends. Nothing changes for them.
+              The {pendingDeleteLink.joinedCount}{' '}
+              {pendingDeleteLink.joinedCount === 1 ? 'person' : 'people'} who already joined through
+              this link stay your friends. Nothing changes for them.
             </p>
             <p
               className="mt-2 rounded-lg p-2.5 text-sm"
               style={{ background: 'var(--warning-surface)', color: 'var(--warning)' }}
             >
-              The link stops working right away. A new link gets a new address, so you&rsquo;d need to
+              The link stops working right away. A new link gets a new address, so you’d need to
               send it again.
             </p>
             <div className="mt-4 flex gap-2">
-              <button type="button" onClick={() => setPendingDeleteId(null)} className="btn-ghost flex-1">
+              <button
+                type="button"
+                onClick={() => setPendingDeleteId(null)}
+                className="btn-ghost min-h-11 flex-1"
+              >
                 Keep it
               </button>
               <button
                 type="button"
                 onClick={() => void confirmDelete()}
                 disabled={deleting}
-                className="btn-primary flex-1 bg-[var(--destructive)]"
+                className="btn-primary min-h-11 flex-1 bg-[var(--destructive)]"
               >
                 {deleting ? 'Deleting…' : 'Delete link'}
               </button>
@@ -446,10 +470,13 @@ export function InviteLinksSection({ initialTopics, initialLinks }: Props) {
       ) : null}
 
       {toast ? (
-        <div className="fixed bottom-24 left-1/2 z-[var(--z-toast)] -translate-x-1/2 rounded-full bg-foreground px-4 py-2 text-sm text-background shadow-lg">
+        <div
+          className="bg-foreground text-background fixed bottom-24 left-1/2 z-[var(--z-toast)] -translate-x-1/2 rounded-full px-4 py-2 text-sm whitespace-nowrap shadow-lg"
+          role="status"
+        >
           {toast}
         </div>
       ) : null}
     </section>
-  )
+  );
 }

--- a/src/components/friends/__tests__/InviteLinksSection.test.tsx
+++ b/src/components/friends/__tests__/InviteLinksSection.test.tsx
@@ -1,0 +1,103 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import {
+  InviteLinksSection,
+  type InviteLinkRowData,
+} from '@/components/friends/InviteLinksSection';
+
+function link(id: string, categories: unknown, joinedCount = 0): InviteLinkRowData {
+  return {
+    id,
+    slot: 0,
+    categories: categories as InviteLinkRowData['categories'],
+    url: `https://example.com/u/josh/${id}`,
+    createdAt: '2026-09-07T00:00:00.000Z',
+    joinedCount,
+  };
+}
+
+function render(links: InviteLinkRowData[], creatorName: string | null = 'Josh') {
+  return renderToStaticMarkup(
+    <InviteLinksSection
+      creatorName={creatorName}
+      initialTopics={[{ label: 'Sondheim', broadCategory: 'Theater' }]}
+      initialLinks={links}
+    />,
+  );
+}
+
+describe('InviteLinksSection', () => {
+  it('renders the dynamic creator title and required supporting copy', () => {
+    const html = render([link('one', [{ label: 'Jazz' }])]);
+
+    expect(html).toContain('Play Josh’s greatest hits');
+    expect(html).toContain('We’ll recommend these categories to anyone who uses this link.');
+  });
+
+  it('uses the creator fallback without exposing a phone-like value', () => {
+    const html = render([link('one', [{ label: 'Jazz' }])], '+1 (734) 555-0123');
+
+    expect(html).toContain('Play your greatest hits');
+    expect(html).not.toContain('734');
+  });
+
+  it('filters blank, sentinel, malformed, and duplicate categories', () => {
+    const html = render([
+      link('one', [
+        null,
+        '',
+        'No category',
+        { label: 'Jazz' },
+        { label: ' jazz ' },
+        { nope: true },
+      ]),
+    ]);
+
+    expect(html).toContain('Jazz');
+    expect(html).not.toContain('No category');
+    expect(html.match(/>Jazz</g) ?? []).toHaveLength(1);
+  });
+
+  it('keeps each link’s categories separate', () => {
+    const html = render([link('one', [{ label: 'Jazz' }]), link('two', [{ label: 'Poetry' }])]);
+
+    expect(html).toContain('Jazz');
+    expect(html).toContain('Poetry');
+    expect(html.match(/Play Josh’s greatest hits/g) ?? []).toHaveLength(2);
+  });
+
+  it('pluralizes joined counts correctly', () => {
+    const html = render([
+      link('zero', [{ label: 'Jazz' }], 0),
+      link('one', [{ label: 'Poetry' }], 1),
+      link('two', [{ label: 'Chess' }], 2),
+    ]);
+
+    expect(html).toContain('0 friends joined');
+    expect(html).toContain('1 friend joined');
+    expect(html).toContain('2 friends joined');
+  });
+
+  it('uses the zero-link create copy', () => {
+    expect(render([])).toContain('Create an invite link');
+  });
+
+  it.each([1, 2])('uses the alternate create copy with %i active link(s)', (count) => {
+    const links = Array.from({ length: count }, (_, index) =>
+      link(`${index}`, [{ label: `Topic ${index}` }]),
+    );
+    expect(render(links)).toContain('Create a link with different categories');
+  });
+
+  it('does not offer a fourth link when three are active', () => {
+    const html = render([
+      link('one', [{ label: 'Jazz' }]),
+      link('two', [{ label: 'Poetry' }]),
+      link('three', [{ label: 'Chess' }]),
+    ]);
+
+    expect(html).not.toContain('Create a link with different categories');
+    expect(html).toContain('You can keep up to three active invitation links.');
+  });
+});

--- a/src/components/invite/AcceptFriendInvitationButton.tsx
+++ b/src/components/invite/AcceptFriendInvitationButton.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { safeInviteName } from '@/lib/invite-links';
+
+export function AcceptFriendInvitationButton({
+  token,
+  inviterName,
+}: {
+  token: string;
+  inviterName?: string | null;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const name = safeInviteName(inviterName);
+
+  async function continueInvite() {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/friend-invitations/accept-token', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || typeof body?.nextHref !== 'string') {
+        setError(body?.message ?? 'This invitation could not be continued.');
+        return;
+      }
+      router.push(body.nextHref);
+      router.refresh();
+    } catch {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        onClick={() => void continueInvite()}
+        disabled={busy}
+        className="btn-primary min-h-11 w-full"
+      >
+        {busy ? 'Continuing…' : name ? `Continue with ${name}` : 'Continue'}
+      </button>
+      {error ? (
+        <p className="text-destructive text-sm leading-5" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/invite/AcceptInviteLinkButton.tsx
+++ b/src/components/invite/AcceptInviteLinkButton.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { safeInviteName } from '@/lib/invite-links';
+
+export function AcceptInviteLinkButton({
+  handle,
+  token,
+  inviterName,
+}: {
+  handle: string;
+  token: string;
+  inviterName?: string | null;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const name = safeInviteName(inviterName);
+
+  async function continueInvite() {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/invite-links/accept', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ handle, token }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || typeof body?.nextHref !== 'string') {
+        setError(
+          body?.message ??
+            'This invitation could not be continued. Ask your friend for a fresh link.',
+        );
+        return;
+      }
+      router.push(body.nextHref);
+      router.refresh();
+    } catch {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        onClick={() => void continueInvite()}
+        disabled={busy}
+        className="btn-primary min-h-11 w-full"
+      >
+        {busy ? 'Continuing…' : name ? `Continue with ${name}` : 'Continue'}
+      </button>
+      {error ? (
+        <p className="text-destructive text-sm leading-5" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/invite/InvitationLanding.tsx
+++ b/src/components/invite/InvitationLanding.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+
+import { InviteCategoryChips } from '@/components/invite/InviteCategoryChips';
+import { inviteGreatestHitsTitle, safeInviteName } from '@/lib/invite-links';
+
+export function InvitationPageShell({ children }: { children: ReactNode }) {
+  return (
+    <main className="bg-background text-foreground flex min-h-dvh items-center justify-center px-4 py-8 sm:py-12">
+      <section className="bg-card w-full max-w-md overflow-hidden rounded-[var(--radius-card)] border shadow-[var(--shadow-card)]">
+        <div className="h-1.5 bg-[var(--accent-gold)]" aria-hidden />
+        <div className="p-5 sm:p-7">{children}</div>
+      </section>
+    </main>
+  );
+}
+
+export function InvitationLandingContent({
+  inviterName: inputName,
+  categories,
+  action,
+}: {
+  inviterName?: string | null;
+  categories: unknown;
+  action: ReactNode;
+}) {
+  const inviterName = safeInviteName(inputName);
+  const invitationLine = inviterName
+    ? `${inviterName} invited you to Joshing`
+    : 'You’ve been invited to Joshing';
+  const explanation = inviterName
+    ? `${inviterName} picked a few categories to get you started. We’ll recommend them during setup—you can keep, change, or ignore them.`
+    : 'Someone picked a few categories to get you started.';
+
+  return (
+    <div className="space-y-5 text-center">
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-sm font-medium break-words">{invitationLine}</p>
+        <h1 className="font-serif text-3xl leading-tight font-semibold text-balance break-words text-[var(--brand-navy)] sm:text-4xl">
+          {inviteGreatestHitsTitle(inviterName)}
+        </h1>
+        <p className="text-muted-foreground text-sm leading-6 break-words">{explanation}</p>
+      </div>
+      <InviteCategoryChips categories={categories} />
+      {action}
+    </div>
+  );
+}

--- a/src/components/invite/InviteCategoryChips.tsx
+++ b/src/components/invite/InviteCategoryChips.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
+import { sanitizeInviteLinkCategories } from '@/lib/invite-links';
+
+export function InviteCategoryChips({ categories }: { categories: unknown }) {
+  const safeCategories = sanitizeInviteLinkCategories(categories);
+  if (safeCategories.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap justify-center gap-2" aria-label="Recommended categories">
+      {safeCategories.map((category) => {
+        const color = getPortraitDomainColor(category.broadCategory ?? category.label);
+        return (
+          <span
+            key={category.label}
+            className="inline-flex min-h-8 max-w-full items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold whitespace-normal"
+            style={{
+              borderColor: `color-mix(in srgb, ${color.primary} 40%, transparent)`,
+              color: color.text,
+              overflowWrap: 'anywhere',
+            }}
+          >
+            <span
+              aria-hidden
+              className="size-1.5 shrink-0 rounded-full"
+              style={{ background: color.primary }}
+            />
+            {category.label}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/__tests__/invite-links.test.ts
+++ b/src/lib/__tests__/invite-links.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hasValidInviteLinkCategories,
+  inviteGreatestHitsTitle,
+  safeInviteName,
+  sanitizeInviteLinkCategories,
+} from '@/lib/invite-links';
+
+describe('invite-link presentation guards', () => {
+  it('removes placeholders, blanks, malformed entries, and duplicates', () => {
+    expect(
+      sanitizeInviteLinkCategories([
+        null,
+        '',
+        'No category',
+        'undefined',
+        { label: ' Jazz ', broad_category: 'Music' },
+        { label: 'jazz' },
+        { nope: 'Poetry' },
+      ]),
+    ).toEqual([{ label: 'Jazz', broadCategory: 'Music' }]);
+  });
+
+  it('requires at least one valid category', () => {
+    expect(hasValidInviteLinkCategories(['No category', ' '])).toBe(false);
+    expect(hasValidInviteLinkCategories([{ label: 'Sondheim' }])).toBe(true);
+  });
+
+  it('never treats a phone or handle as an inviter name', () => {
+    expect(safeInviteName('+1 (734) 555-0123')).toBeNull();
+    expect(safeInviteName('@private-id')).toBeNull();
+    expect(inviteGreatestHitsTitle('+1 (734) 555-0123')).toBe('Play the greatest hits');
+    expect(inviteGreatestHitsTitle(null, true)).toBe('Play your greatest hits');
+  });
+});

--- a/src/lib/invite-links.ts
+++ b/src/lib/invite-links.ts
@@ -1,0 +1,83 @@
+export const MAX_INVITE_LINK_CATEGORIES = 3;
+
+export type InviteLinkCategory = {
+  label: string;
+  broadCategory?: string | null;
+  description?: string | null;
+};
+
+const INVALID_CATEGORY_KEYS = new Set([
+  'no category',
+  'none',
+  'null',
+  'undefined',
+  'n/a',
+  'na',
+  'placeholder',
+  'select a category',
+  'uncategorized',
+]);
+
+function cleanText(value: unknown, maxLength: number): string {
+  return typeof value === 'string' ? value.trim().replace(/\s+/g, ' ').slice(0, maxLength) : '';
+}
+
+/**
+ * Invitation categories cross a legacy JSON boundary, so every read is
+ * defensive. Blank values, the retired "No category" sentinel, malformed
+ * records, and duplicates are omitted without invalidating the link itself.
+ */
+export function sanitizeInviteLinkCategories(value: unknown): InviteLinkCategory[] {
+  if (!Array.isArray(value)) return [];
+
+  const seen = new Set<string>();
+  const categories: InviteLinkCategory[] = [];
+
+  for (const item of value) {
+    const record =
+      item && typeof item === 'object' && !Array.isArray(item)
+        ? (item as Record<string, unknown>)
+        : null;
+    const label = cleanText(typeof item === 'string' ? item : record?.label, 80);
+    const key = label.toLocaleLowerCase('en-US');
+    if (!label || INVALID_CATEGORY_KEYS.has(key) || seen.has(key)) continue;
+
+    const broadCategory = cleanText(record?.broadCategory ?? record?.broad_category, 80);
+    const hasDescription = Boolean(
+      record && Object.prototype.hasOwnProperty.call(record, 'description'),
+    );
+    const description = cleanText(record?.description, 180);
+    seen.add(key);
+    categories.push({
+      label,
+      broadCategory: broadCategory || null,
+      ...(hasDescription ? { description: description || null } : {}),
+    });
+    if (categories.length === MAX_INVITE_LINK_CATEGORIES) break;
+  }
+
+  return categories;
+}
+
+export function hasValidInviteLinkCategories(value: unknown): boolean {
+  return sanitizeInviteLinkCategories(value).length > 0;
+}
+
+/** A public display name only; never fall back to a handle, phone, or id. */
+export function safeInviteName(value: unknown): string | null {
+  const name = cleanText(value, 80);
+  if (!name) return null;
+
+  const key = name.toLocaleLowerCase('en-US');
+  if (INVALID_CATEGORY_KEYS.has(key)) return null;
+  // Phone-like strings and email/handle-shaped identifiers are account data,
+  // not a friendly public name. Use the neutral product fallback instead.
+  if (/^\+?[\d\s().-]{7,}$/.test(name) || name.includes('@')) return null;
+  return name;
+}
+
+export function inviteGreatestHitsTitle(name: unknown, creatorView = false): string {
+  const safeName = safeInviteName(name);
+  if (!safeName) return creatorView ? 'Play your greatest hits' : 'Play the greatest hits';
+  return `Play ${safeName}’s greatest hits`;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -43,6 +43,7 @@ export async function middleware(request: NextRequest) {
     pathname === '/privacy' ||
     pathname === '/sms-consent' ||
     pathname === '/dev/invite-login' ||
+    pathname.startsWith('/dev/invite-redesign/') ||
     pathname === '/dev/onboarding/intro' ||
     pathname === '/dev/welcome-tour' ||
     pathname.startsWith('/compliance/')

--- a/src/server/db/queries/invite-links.ts
+++ b/src/server/db/queries/invite-links.ts
@@ -1,39 +1,43 @@
-import { randomBytes } from 'node:crypto'
+import { randomBytes } from 'node:crypto';
 
-import { and, count, eq, isNull } from 'drizzle-orm'
+import { and, count, eq, isNull } from 'drizzle-orm';
 
-import { db, userInviteLinks, users } from '@/server/db'
+import { db, userInviteLinks, users } from '@/server/db';
+import { sanitizeInviteLinkCategories, type InviteLinkCategory } from '@/lib/invite-links';
 
 // B-FRIENDS-INVITE-LINKS-01 — up to 3 named links per user, replacing the
 // single evergreen users.invite_token. See the comment on userInviteLinks in
 // schema.ts for the slot model (0 = untagged, 1-3 = a specific standing
 // topic slot).
-export const MAX_LIVE_INVITE_LINKS = 3
+export const MAX_LIVE_INVITE_LINKS = 3;
 
 // Same primitive as the pre-existing FriendInvitation tokens
 // (src/server/friends/invitations.ts) and the single-token model this
 // replaces: randomBytes(32).toString('base64url') yields a 43-char
 // URL-safe string.
 export function generateUserInviteToken(): string {
-  return randomBytes(32).toString('base64url')
+  return randomBytes(32).toString('base64url');
 }
 
 export type InviteLinkRow = {
-  id: string
-  token: string
-  slot: number
-  createdAt: Date
-  joinedCount: number
-}
+  id: string;
+  token: string;
+  slot: number;
+  /** null means a legacy slot-based link; [] means stored legacy junk was filtered. */
+  categories: InviteLinkCategory[] | null;
+  createdAt: Date;
+  joinedCount: number;
+};
 
 // Live (non-deleted) links for a user, oldest first — slot 0 (untagged) may
 // repeat; slots 1-3 cannot, enforced by UserInviteLink_user_id_slot_live_key.
 export async function listLiveInviteLinks(userId: string): Promise<InviteLinkRow[]> {
-  return db
+  const rows = await db
     .select({
       id: userInviteLinks.id,
       token: userInviteLinks.token,
       slot: userInviteLinks.slot,
+      categories: userInviteLinks.categories,
       createdAt: userInviteLinks.createdAt,
       joinedCount: count(users.id),
     })
@@ -41,43 +45,90 @@ export async function listLiveInviteLinks(userId: string): Promise<InviteLinkRow
     .leftJoin(users, eq(users.joinedViaInviteLinkId, userInviteLinks.id))
     .where(and(eq(userInviteLinks.userId, userId), isNull(userInviteLinks.deletedAt)))
     .groupBy(userInviteLinks.id)
-    .orderBy(userInviteLinks.createdAt)
+    .orderBy(userInviteLinks.createdAt);
+
+  return rows.map((row) => ({
+    ...row,
+    categories: row.categories === null ? null : sanitizeInviteLinkCategories(row.categories),
+  }));
 }
 
 export type CreateInviteLinkResult =
   | { ok: true; link: InviteLinkRow }
-  | { ok: false; error: 'limit_reached' | 'slot_taken' | 'invalid_slot' }
+  | { ok: false; error: 'limit_reached' | 'invalid_categories' };
 
-// Creates a new live link in `slot` (0 = untagged, 1-3 = a standing topic
-// slot). Rejects at MAX_LIVE_INVITE_LINKS live links, and — for a named slot
-// — at one live link per slot (UserInviteLink_user_id_slot_live_key catches
-// the race; the pre-check here is just the fast, friendly path).
-export async function createInviteLink(userId: string, slot: number): Promise<CreateInviteLinkResult> {
-  if (!Number.isInteger(slot) || slot < 0 || slot > 3) return { ok: false, error: 'invalid_slot' }
+// New links own an exact category set. We still allocate one of slots 1–3 as a
+// concurrency-safe active-link position: the existing partial unique index
+// makes two simultaneous creators race for the same free position instead of
+// silently creating a fourth link. The categories themselves no longer depend
+// on what occupies the creator's legacy global topic slot.
+export async function createInviteLink(
+  userId: string,
+  inputCategories: unknown,
+): Promise<CreateInviteLinkResult> {
+  const categories = sanitizeInviteLinkCategories(inputCategories);
+  if (categories.length === 0) return { ok: false, error: 'invalid_categories' };
 
-  const live = await listLiveInviteLinks(userId)
-  if (live.length >= MAX_LIVE_INVITE_LINKS) return { ok: false, error: 'limit_reached' }
-  if (slot !== 0 && live.some((link) => link.slot === slot)) return { ok: false, error: 'slot_taken' }
+  const live = await listLiveInviteLinks(userId);
+  if (live.length >= MAX_LIVE_INVITE_LINKS) return { ok: false, error: 'limit_reached' };
+  const allocatedSlot = [1, 2, 3].find((slot) => !live.some((link) => link.slot === slot));
+  if (!allocatedSlot) return { ok: false, error: 'limit_reached' };
 
-  const token = generateUserInviteToken()
+  const token = generateUserInviteToken();
   try {
     const [row] = await db
       .insert(userInviteLinks)
-      .values({ userId, token, slot })
+      .values({ userId, token, slot: allocatedSlot, categories })
       .returning({
         id: userInviteLinks.id,
         token: userInviteLinks.token,
         slot: userInviteLinks.slot,
+        categories: userInviteLinks.categories,
         createdAt: userInviteLinks.createdAt,
-      })
+      });
 
-    if (!row) return { ok: false, error: 'limit_reached' }
-    return { ok: true, link: { ...row, joinedCount: 0 } }
+    if (!row) return { ok: false, error: 'limit_reached' };
+    return {
+      ok: true,
+      link: {
+        ...row,
+        categories: sanitizeInviteLinkCategories(row.categories),
+        joinedCount: 0,
+      },
+    };
   } catch {
-    // Unique-violation race on the partial (user_id, slot) index — someone
-    // created a link in this slot between the pre-check above and the insert.
-    return { ok: false, error: 'slot_taken' }
+    // A concurrent request can race the app-layer live-link cap. Keep the
+    // public error bounded and actionable rather than leaking a DB failure.
+    return { ok: false, error: 'limit_reached' };
   }
+}
+
+export type UpdateInviteLinkCategoriesResult =
+  | { ok: true; categories: InviteLinkCategory[] }
+  | { ok: false; error: 'invalid_categories' | 'not_found' };
+
+export async function updateInviteLinkCategories(
+  userId: string,
+  linkId: string,
+  inputCategories: unknown,
+): Promise<UpdateInviteLinkCategoriesResult> {
+  const categories = sanitizeInviteLinkCategories(inputCategories);
+  if (categories.length === 0) return { ok: false, error: 'invalid_categories' };
+
+  const [row] = await db
+    .update(userInviteLinks)
+    .set({ categories })
+    .where(
+      and(
+        eq(userInviteLinks.id, linkId),
+        eq(userInviteLinks.userId, userId),
+        isNull(userInviteLinks.deletedAt),
+      ),
+    )
+    .returning({ categories: userInviteLinks.categories });
+
+  if (!row) return { ok: false, error: 'not_found' };
+  return { ok: true, categories: sanitizeInviteLinkCategories(row.categories) };
 }
 
 // Soft-deletes a live link the caller owns. No-op (returns false) if the link
@@ -95,16 +146,17 @@ export async function softDeleteInviteLink(userId: string, linkId: string): Prom
         isNull(userInviteLinks.deletedAt),
       ),
     )
-    .returning({ id: userInviteLinks.id })
+    .returning({ id: userInviteLinks.id });
 
-  return result.length > 0
+  return result.length > 0;
 }
 
 export type LiveInviteLinkLookup = {
-  id: string
-  userId: string
-  slot: number
-}
+  id: string;
+  userId: string;
+  slot: number;
+  categories: InviteLinkCategory[] | null;
+};
 
 // The /u/<handle>/<token> and accept-time resolution primitive: the specific
 // LIVE link for this user+token pair, or null if it doesn't exist, belongs to
@@ -116,7 +168,12 @@ export async function findLiveInviteLinkByToken(
   token: string,
 ): Promise<LiveInviteLinkLookup | null> {
   const [row] = await db
-    .select({ id: userInviteLinks.id, userId: userInviteLinks.userId, slot: userInviteLinks.slot })
+    .select({
+      id: userInviteLinks.id,
+      userId: userInviteLinks.userId,
+      slot: userInviteLinks.slot,
+      categories: userInviteLinks.categories,
+    })
     .from(userInviteLinks)
     .where(
       and(
@@ -125,23 +182,34 @@ export async function findLiveInviteLinkByToken(
         isNull(userInviteLinks.deletedAt),
       ),
     )
-    .limit(1)
+    .limit(1);
 
-  return row ?? null
+  if (!row) return null;
+  return {
+    ...row,
+    categories: row.categories === null ? null : sanitizeInviteLinkCategories(row.categories),
+  };
 }
 
 // Records which link an invitee joined through. Called once, at accept time
 // (acceptUserInviteLink) — never overwritten afterward, so it survives the
 // link being later deleted (the row stays; only deletedAt is set) and stays
 // meaningful even if the inviter's topics change under the slot later.
-export async function attributeInviteLinkJoin(inviteeUserId: string, linkId: string): Promise<void> {
-  await db.update(users).set({ joinedViaInviteLinkId: linkId }).where(eq(users.id, inviteeUserId))
+export async function attributeInviteLinkJoin(
+  inviteeUserId: string,
+  linkId: string,
+): Promise<void> {
+  await db
+    .update(users)
+    .set({ joinedViaInviteLinkId: linkId })
+    .where(and(eq(users.id, inviteeUserId), isNull(users.joinedViaInviteLinkId)));
 }
 
 export type JoinedLinkInfo = {
-  inviterUserId: string
-  slot: number
-}
+  inviterUserId: string;
+  slot: number;
+  categories: InviteLinkCategory[] | null;
+};
 
 // The link a user joined through, if any and if attributed. NULL for anyone
 // who joined before this table existed, joined via the named FriendInvitation
@@ -150,11 +218,21 @@ export type JoinedLinkInfo = {
 // the unslotted "all curated/declared topics" resolution in that case.
 export async function getJoinedInviteLink(inviteeUserId: string): Promise<JoinedLinkInfo | null> {
   const [row] = await db
-    .select({ userId: userInviteLinks.userId, slot: userInviteLinks.slot })
+    .select({
+      userId: userInviteLinks.userId,
+      slot: userInviteLinks.slot,
+      categories: userInviteLinks.categories,
+    })
     .from(users)
     .innerJoin(userInviteLinks, eq(userInviteLinks.id, users.joinedViaInviteLinkId))
     .where(eq(users.id, inviteeUserId))
-    .limit(1)
+    .limit(1);
 
-  return row ? { inviterUserId: row.userId, slot: row.slot } : null
+  return row
+    ? {
+        inviterUserId: row.userId,
+        slot: row.slot,
+        categories: row.categories === null ? null : sanitizeInviteLinkCategories(row.categories),
+      }
+    : null;
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -2058,9 +2058,10 @@ export const friendInvitations = pgTable(
 // user, replacing the single evergreen users.invite_token. slot is the
 // identity a link carries: 0 = untagged (carries all 3 seed topics), 1-3 = a
 // specific slot in the user's standing invite_seed_interests. slot is an
-// INTEGER, not the topic label itself, so renaming a topic never orphans a
-// link or changes its color — the UI resolves slot -> topic -> category at
-// render time.
+// New links persist their own category JSON so two links remain isolated even
+// when the creator later edits another link. `slot` remains for legacy rows:
+// categories=NULL resolves through the former slot model until the creator
+// edits that link, at which point an exact category set is stored.
 //
 // Deletion is soft (deletedAt). A deleted link 404s immediately on
 // /u/<handle>/<token>, but never touches the Follow edge upsertInvitationFriendship
@@ -2081,15 +2082,16 @@ export const userInviteLinks = pgTable(
       .references(() => users.id, { onDelete: 'cascade' }),
     token: text('token').notNull(),
     slot: integer('slot').notNull().default(0),
+    categories: jsonb('categories'),
     createdAt: createdAt(),
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (table) => [
     uniqueIndex('UserInviteLink_token_key').on(table.token),
     index('UserInviteLink_user_id_idx').on(table.userId),
-    // A user can hold several untagged (slot 0) links at once, but at most one
-    // LIVE link per named slot — tagging a second link with the same topic
-    // would make "which link is Sondheim" ambiguous.
+    // Legacy untagged rows may share slot 0. New category-owning links allocate
+    // slots 1–3, so this existing index also makes the three-link cap robust to
+    // concurrent creates.
     uniqueIndex('UserInviteLink_user_id_slot_live_key')
       .on(table.userId, table.slot)
       .where(sql`${table.slot} <> 0 AND ${table.deletedAt} IS NULL`),
@@ -2192,7 +2194,9 @@ export const llmUsageEvent = pgTable(
     index('LlmUsageEvent_provider_created_at_idx').on(table.provider, table.createdAt),
     // Partial: only build-scoped calls are ever queried this way, and they're a
     // minority of the table.
-    index('LlmUsageEvent_build_id_idx').on(table.buildId).where(sql`build_id IS NOT NULL`),
+    index('LlmUsageEvent_build_id_idx')
+      .on(table.buildId)
+      .where(sql`build_id IS NOT NULL`),
   ],
 );
 

--- a/src/server/friends/__tests__/invitations.test.ts
+++ b/src/server/friends/__tests__/invitations.test.ts
@@ -1,19 +1,19 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 type Invitation = {
-  id: string
-  inviterUserId: string
-  inviteePhone: string
-  inviteeUserId: string | null
-  inviteeDisplayName: string | null
-  preSeededInterests: unknown
-  personalMessage: string | null
-  token: string
-  sentAt: Date
-  acceptedAt: Date | null
-  cancelledAt: Date | null
-  expiresAt: Date
-}
+  id: string;
+  inviterUserId: string;
+  inviteePhone: string;
+  inviteeUserId: string | null;
+  inviteeDisplayName: string | null;
+  preSeededInterests: unknown;
+  personalMessage: string | null;
+  token: string;
+  sentAt: Date;
+  acceptedAt: Date | null;
+  cancelledAt: Date | null;
+  expiresAt: Date;
+};
 
 const { dbMock, state } = vi.hoisted(() => {
   const state = {
@@ -23,13 +23,13 @@ const { dbMock, state } = vi.hoisted(() => {
     invitationValues: undefined as Record<string, unknown> | undefined,
     updateValues: undefined as Record<string, unknown> | undefined,
     inviterName: 'Alex Inviter' as string | null,
-  }
+  };
 
   function makeSelectBuilder(selection?: Record<string, unknown>) {
-    const isLandingSelect = Boolean(selection && 'inviterName' in selection)
+    const isLandingSelect = Boolean(selection && 'inviterName' in selection);
     const rows = () => {
-      if (!state.invitation) return []
-      if (!isLandingSelect) return [state.invitation]
+      if (!state.invitation) return [];
+      if (!isLandingSelect) return [state.invitation];
 
       // Joined select (landing + prefill both leftJoin users). Superset of
       // both selections; the real query only reads the columns it selected, so
@@ -43,93 +43,89 @@ const { dbMock, state } = vi.hoisted(() => {
           inviteePhone: state.invitation.inviteePhone,
           inviterName: state.inviterName,
         },
-      ]
-    }
+      ];
+    };
     const limited = {
       limit: vi.fn(async () => rows()),
-    }
+    };
     const whereable = {
       where: vi.fn(() => ({
         ...limited,
         orderBy: vi.fn(() => limited),
       })),
-    }
+    };
     return {
       from: vi.fn(() => ({
         ...whereable,
         leftJoin: vi.fn(() => whereable),
       })),
-    }
+    };
   }
 
   function makeUpdateBuilder({ claimOnly = false } = {}) {
     return {
       set: vi.fn((values: Record<string, unknown>) => {
-        state.updateValues = values
+        state.updateValues = values;
         return {
           where: vi.fn(() => ({
             returning: vi.fn(async () => {
               if (claimOnly) {
-                if (!state.updateReturnsClaim || !state.invitation) return []
-                state.invitation = { ...state.invitation, ...values }
-                return [{ id: state.invitation.id }]
+                if (!state.updateReturnsClaim || !state.invitation) return [];
+                state.invitation = { ...state.invitation, ...values };
+                return [{ id: state.invitation.id }];
               }
 
-              if (!state.invitation) return []
-              state.invitation = { ...state.invitation, ...values }
-              return [state.invitation]
+              if (!state.invitation) return [];
+              state.invitation = { ...state.invitation, ...values };
+              return [state.invitation];
             }),
           })),
-        }
+        };
       }),
-    }
+    };
   }
 
   function makeInsertBuilder({ friendshipOnly = false } = {}) {
     return {
       values: vi.fn((values: Record<string, unknown>) => {
         if (friendshipOnly) {
-          state.friendshipValues.push(values)
+          state.friendshipValues.push(values);
           return {
             onConflictDoUpdate: vi.fn(async () => undefined),
-          }
+          };
         }
 
-        state.invitationValues = values
+        state.invitationValues = values;
         const created = {
           id: 'inv-created',
           inviteeUserId: null,
           acceptedAt: null,
           cancelledAt: null,
           ...values,
-        } as Invitation
-        state.invitation = created
+        } as Invitation;
+        state.invitation = created;
         return {
           returning: vi.fn(async () => [created]),
-        }
+        };
       }),
-    }
+    };
   }
 
   const tx = {
     update: vi.fn(() => makeUpdateBuilder({ claimOnly: true })),
     insert: vi.fn(() => makeInsertBuilder({ friendshipOnly: true })),
-  }
+  };
 
   const dbMock = {
-    select: vi.fn((selection?: Record<string, unknown>) =>
-      makeSelectBuilder(selection)
-    ),
+    select: vi.fn((selection?: Record<string, unknown>) => makeSelectBuilder(selection)),
     update: vi.fn(() => makeUpdateBuilder()),
     insert: vi.fn(() => makeInsertBuilder()),
-    transaction: vi.fn(async (callback: (tx: typeof tx) => unknown) =>
-      callback(tx)
-    ),
+    transaction: vi.fn(async (callback: (tx: typeof tx) => unknown) => callback(tx)),
     tx,
-  }
+  };
 
-  return { dbMock, state }
-})
+  return { dbMock, state };
+});
 
 vi.mock('@/server/db', () => ({
   db: dbMock,
@@ -157,14 +153,14 @@ vi.mock('@/server/db', () => ({
     followerId: 'follows.followerId',
     followeeId: 'follows.followeeId',
   },
-}))
+}));
 
 // The one-time inviter feed backfill (B-HomeSeed-1) fires inside
 // acceptFriendInvitation; it has its own dedicated test, so stub it here to keep
 // these tests focused on the acceptance logic.
 vi.mock('@/server/feed/backfill-inviter-feed', () => ({
   backfillInviterFeedItems: vi.fn(async () => ({ created: 0 })),
-}))
+}));
 
 import {
   acceptFriendInvitation,
@@ -175,11 +171,11 @@ import {
   getInvitePrefillByToken,
   getPendingInvitationForPhone,
   updateFriendInvitation,
-} from '@/server/friends/invitations'
-import { parsePreSeededInterests } from '@/server/db/queries/users'
+} from '@/server/friends/invitations';
+import { parsePreSeededInterests } from '@/server/db/queries/users';
 
-const now = new Date('2026-05-13T12:00:00.000Z')
-const matchingPhone = '+15551234567'
+const now = new Date('2026-05-13T12:00:00.000Z');
+const matchingPhone = '+15551234567';
 
 function setInvitation(overrides: Partial<Invitation> = {}) {
   state.invitation = {
@@ -196,37 +192,37 @@ function setInvitation(overrides: Partial<Invitation> = {}) {
     cancelledAt: null,
     expiresAt: new Date('2026-05-14T12:00:00.000Z'),
     ...overrides,
-  }
+  };
 }
 
 describe('acceptFriendInvitation', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    state.invitation = undefined
-    state.updateReturnsClaim = true
-    state.friendshipValues = []
-    state.invitationValues = undefined
-    state.updateValues = undefined
-  })
+    vi.clearAllMocks();
+    state.invitation = undefined;
+    state.updateReturnsClaim = true;
+    state.friendshipValues = [];
+    state.invitationValues = undefined;
+    state.updateValues = undefined;
+  });
 
   it('accepts a valid token for the matching verified phone and creates an invitation friendship', async () => {
-    setInvitation()
+    setInvitation();
 
     const result = await acceptFriendInvitation({
       token: 'valid-token',
       inviteeUserId: 'user-invitee',
       verifiedPhone: matchingPhone,
       now,
-    })
+    });
 
-    expect(result).toEqual({ accepted: true })
+    expect(result).toEqual({ accepted: true });
     expect(state.invitation).toEqual(
       expect.objectContaining({
         acceptedAt: now,
         inviteeUserId: 'user-invitee',
-      })
-    )
-    expect(dbMock.transaction).toHaveBeenCalledTimes(1)
+      }),
+    );
+    expect(dbMock.transaction).toHaveBeenCalledTimes(1);
     // Invitation creates a mutual follow: two approved edges, both directions.
     expect(state.friendshipValues).toEqual([
       expect.objectContaining({
@@ -241,8 +237,8 @@ describe('acceptFriendInvitation', () => {
         state: 'approved',
         approvedAt: now,
       }),
-    ])
-  })
+    ]);
+  });
 
   it("accepts Jaime's 000000-verified matching phone once and rejects wrong-phone or reused claims without duplicate friendship rows", async () => {
     setInvitation({
@@ -250,7 +246,7 @@ describe('acceptFriendInvitation', () => {
       inviteeDisplayName: 'Jaime',
       inviteePhone: '+17345550002',
       token: 'jaime-token',
-    })
+    });
 
     await expect(
       acceptFriendInvitation({
@@ -258,9 +254,9 @@ describe('acceptFriendInvitation', () => {
         inviteeUserId: 'user-jaime-wrong-phone',
         verifiedPhone: '+17345559999',
         now,
-      })
-    ).resolves.toEqual({ accepted: false, reason: 'phone_mismatch' })
-    expect(state.friendshipValues).toHaveLength(0)
+      }),
+    ).resolves.toEqual({ accepted: false, reason: 'phone_mismatch' });
+    expect(state.friendshipValues).toHaveLength(0);
 
     await expect(
       acceptFriendInvitation({
@@ -268,14 +264,14 @@ describe('acceptFriendInvitation', () => {
         inviteeUserId: 'user-jaime',
         verifiedPhone: '+17345550002',
         now,
-      })
-    ).resolves.toEqual({ accepted: true })
+      }),
+    ).resolves.toEqual({ accepted: true });
     expect(state.invitation).toEqual(
       expect.objectContaining({
         acceptedAt: now,
         inviteeUserId: 'user-jaime',
-      })
-    )
+      }),
+    );
     expect(state.friendshipValues).toEqual([
       expect.objectContaining({
         followerId: 'user-josh',
@@ -289,7 +285,7 @@ describe('acceptFriendInvitation', () => {
         state: 'approved',
         approvedAt: now,
       }),
-    ])
+    ]);
 
     await expect(
       acceptFriendInvitation({
@@ -297,31 +293,29 @@ describe('acceptFriendInvitation', () => {
         inviteeUserId: 'user-jaime',
         verifiedPhone: '+17345550002',
         now,
-      })
-    ).resolves.toEqual({ accepted: false, reason: 'accepted' })
+      }),
+    ).resolves.toEqual({ accepted: false, reason: 'accepted' });
     // The already-accepted re-attempt writes no further edges: still exactly
     // the two approved edges from the single successful acceptance.
     expect(
-      state.friendshipValues.filter(
-        (edge) => (edge as { state?: string }).state === 'approved'
-      )
-    ).toHaveLength(2)
-  })
+      state.friendshipValues.filter((edge) => (edge as { state?: string }).state === 'approved'),
+    ).toHaveLength(2);
+  });
 
   it('rejects a valid token when the verified phone does not match the invitation phone', async () => {
-    setInvitation()
+    setInvitation();
 
     const result = await acceptFriendInvitation({
       token: 'valid-token',
       inviteeUserId: 'user-invitee',
       verifiedPhone: '+15557654321',
       now,
-    })
+    });
 
-    expect(result).toEqual({ accepted: false, reason: 'phone_mismatch' })
-    expect(dbMock.transaction).not.toHaveBeenCalled()
-    expect(state.friendshipValues).toEqual([])
-  })
+    expect(result).toEqual({ accepted: false, reason: 'phone_mismatch' });
+    expect(dbMock.transaction).not.toHaveBeenCalled();
+    expect(state.friendshipValues).toEqual([]);
+  });
 
   it('rejects invalid or missing tokens without claiming an invitation', async () => {
     await expect(
@@ -330,14 +324,14 @@ describe('acceptFriendInvitation', () => {
         inviteeUserId: 'user-invitee',
         verifiedPhone: matchingPhone,
         now,
-      })
-    ).resolves.toEqual({ accepted: false, reason: 'missing' })
-    expect(dbMock.transaction).not.toHaveBeenCalled()
-    expect(state.friendshipValues).toEqual([])
-  })
+      }),
+    ).resolves.toEqual({ accepted: false, reason: 'missing' });
+    expect(dbMock.transaction).not.toHaveBeenCalled();
+    expect(state.friendshipValues).toEqual([]);
+  });
 
   it('rejects expired invitations', async () => {
-    setInvitation({ expiresAt: new Date('2026-05-12T12:00:00.000Z') })
+    setInvitation({ expiresAt: new Date('2026-05-12T12:00:00.000Z') });
 
     await expect(
       acceptFriendInvitation({
@@ -345,13 +339,13 @@ describe('acceptFriendInvitation', () => {
         inviteeUserId: 'user-invitee',
         verifiedPhone: matchingPhone,
         now,
-      })
-    ).resolves.toEqual({ accepted: false, reason: 'expired' })
-    expect(state.friendshipValues).toEqual([])
-  })
+      }),
+    ).resolves.toEqual({ accepted: false, reason: 'expired' });
+    expect(state.friendshipValues).toEqual([]);
+  });
 
   it('rejects invitations at the exact expiration instant', async () => {
-    setInvitation({ expiresAt: now })
+    setInvitation({ expiresAt: now });
 
     await expect(
       acceptFriendInvitation({
@@ -359,14 +353,14 @@ describe('acceptFriendInvitation', () => {
         inviteeUserId: 'user-invitee',
         verifiedPhone: matchingPhone,
         now,
-      })
-    ).resolves.toEqual({ accepted: false, reason: 'expired' })
-    expect(dbMock.transaction).not.toHaveBeenCalled()
-    expect(state.friendshipValues).toEqual([])
-  })
+      }),
+    ).resolves.toEqual({ accepted: false, reason: 'expired' });
+    expect(dbMock.transaction).not.toHaveBeenCalled();
+    expect(state.friendshipValues).toEqual([]);
+  });
 
   it('rejects already accepted invitations', async () => {
-    setInvitation({ acceptedAt: new Date('2026-05-13T11:00:00.000Z') })
+    setInvitation({ acceptedAt: new Date('2026-05-13T11:00:00.000Z') });
 
     await expect(
       acceptFriendInvitation({
@@ -374,13 +368,13 @@ describe('acceptFriendInvitation', () => {
         inviteeUserId: 'user-invitee',
         verifiedPhone: matchingPhone,
         now,
-      })
-    ).resolves.toEqual({ accepted: false, reason: 'accepted' })
-    expect(state.friendshipValues).toEqual([])
-  })
+      }),
+    ).resolves.toEqual({ accepted: false, reason: 'accepted' });
+    expect(state.friendshipValues).toEqual([]);
+  });
 
   it('rejects self-invites', async () => {
-    setInvitation({ inviterUserId: 'same-user' })
+    setInvitation({ inviterUserId: 'same-user' });
 
     await expect(
       acceptFriendInvitation({
@@ -388,14 +382,14 @@ describe('acceptFriendInvitation', () => {
         inviteeUserId: 'same-user',
         verifiedPhone: matchingPhone,
         now,
-      })
-    ).resolves.toEqual({ accepted: false, reason: 'self' })
-    expect(state.friendshipValues).toEqual([])
-  })
+      }),
+    ).resolves.toEqual({ accepted: false, reason: 'self' });
+    expect(state.friendshipValues).toEqual([]);
+  });
 
   it('does not create a friendship when the invitation claim update fails', async () => {
-    setInvitation()
-    state.updateReturnsClaim = false
+    setInvitation();
+    state.updateReturnsClaim = false;
 
     await expect(
       acceptFriendInvitation({
@@ -403,69 +397,63 @@ describe('acceptFriendInvitation', () => {
         inviteeUserId: 'user-invitee',
         verifiedPhone: matchingPhone,
         now,
-      })
-    ).resolves.toEqual({ accepted: false, reason: 'claim_failed' })
-    expect(state.friendshipValues).toEqual([])
-  })
-})
+      }),
+    ).resolves.toEqual({ accepted: false, reason: 'claim_failed' });
+    expect(state.friendshipValues).toEqual([]);
+  });
+});
 
 describe('friend invitation helpers', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    state.invitation = undefined
-    state.updateReturnsClaim = true
-    state.friendshipValues = []
-    state.invitationValues = undefined
-    state.updateValues = undefined
-    state.inviterName = 'Alex Inviter'
-  })
+    vi.clearAllMocks();
+    state.invitation = undefined;
+    state.updateReturnsClaim = true;
+    state.friendshipValues = [];
+    state.invitationValues = undefined;
+    state.updateValues = undefined;
+    state.inviterName = 'Alex Inviter';
+  });
 
-  it('returns a safe valid landing state with inviter display name and suggested interest chips', async () => {
+  it('returns a safe valid landing state with inviter display name and suggested category chips', async () => {
     setInvitation({
-      preSeededInterests: [
-        ' Jazz ',
-        { label: 'Poetry' },
-        'jazz',
-        'Film',
-        'Extra ignored',
-      ],
-    })
+      preSeededInterests: [' Jazz ', { label: 'Poetry' }, 'jazz', 'Film', 'Extra ignored'],
+    });
 
-    // F1.5: pre-seeded interest labels MUST NOT appear in the public
-    // landing payload. They are still stored on the invitation row and
-    // surfaced to the recipient post-OTP via getPreSeededInterestsForUser.
-    await expect(
-      getFriendInvitationLandingByToken('valid-token', now)
-    ).resolves.toEqual({
+    await expect(getFriendInvitationLandingByToken('valid-token', now)).resolves.toEqual({
       status: 'valid',
       inviterName: 'Alex Inviter',
-    })
-  })
+      inviterUserId: undefined,
+      inviterAvatarColor: undefined,
+      categories: ['Jazz', 'Poetry', 'Film'],
+    });
+  });
 
   it('returns an expired landing state with no leaked interest labels', async () => {
     setInvitation({
       expiresAt: new Date('2026-05-12T12:00:00.000Z'),
       preSeededInterests: ['Jazz'],
-    })
+    });
 
-    await expect(
-      getFriendInvitationLandingByToken('expired-token', now)
-    ).resolves.toEqual({
+    await expect(getFriendInvitationLandingByToken('expired-token', now)).resolves.toEqual({
       status: 'expired',
-      inviterName: 'Alex Inviter',
-    })
-  })
+      inviterName: 'Someone',
+      inviterUserId: null,
+      inviterAvatarColor: null,
+      categories: [],
+    });
+  });
 
   it('returns an already accepted landing state that can route safely to login', async () => {
-    setInvitation({ acceptedAt: new Date('2026-05-13T11:00:00.000Z') })
+    setInvitation({ acceptedAt: new Date('2026-05-13T11:00:00.000Z') });
 
-    await expect(
-      getFriendInvitationLandingByToken('accepted-token', now)
-    ).resolves.toEqual({
+    await expect(getFriendInvitationLandingByToken('accepted-token', now)).resolves.toEqual({
       status: 'accepted',
       inviterName: 'Alex Inviter',
-    })
-  })
+      inviterUserId: undefined,
+      inviterAvatarColor: undefined,
+      categories: [],
+    });
+  });
 
   it('returns a generic invalid landing state for missing, cancelled, or blank tokens', async () => {
     await expect(getFriendInvitationLandingByToken('', now)).resolves.toEqual({
@@ -473,21 +461,21 @@ describe('friend invitation helpers', () => {
       inviterName: 'Someone',
       inviterUserId: null,
       inviterAvatarColor: null,
-    })
+      categories: [],
+    });
 
-    setInvitation({ cancelledAt: new Date('2026-05-13T11:00:00.000Z') })
-    await expect(
-      getFriendInvitationLandingByToken('cancelled-token', now)
-    ).resolves.toEqual({
+    setInvitation({ cancelledAt: new Date('2026-05-13T11:00:00.000Z') });
+    await expect(getFriendInvitationLandingByToken('cancelled-token', now)).resolves.toEqual({
       status: 'invalid',
       inviterName: 'Someone',
       inviterUserId: null,
       inviterAvatarColor: null,
-    })
-  })
+      categories: [],
+    });
+  });
 
   it('creates an Add Friend invitation with invitee display name, phone, and suggested interests', async () => {
-    const preSeededInterests = [{ label: 'Jazz', broadCategory: 'music' }]
+    const preSeededInterests = [{ label: 'Jazz', broadCategory: 'music' }];
 
     const invitation = await createFriendInvitation({
       inviterUserId: 'user-inviter',
@@ -496,7 +484,7 @@ describe('friend invitation helpers', () => {
       preSeededInterests,
       personalMessage: 'Join me?',
       now,
-    })
+    });
 
     expect(invitation).toEqual(
       expect.objectContaining({
@@ -504,8 +492,8 @@ describe('friend invitation helpers', () => {
         inviteeDisplayName: 'Morgan Lee',
         preSeededInterests,
         personalMessage: 'Join me?',
-      })
-    )
+      }),
+    );
     expect(state.invitationValues).toEqual(
       expect.objectContaining({
         inviterUserId: 'user-inviter',
@@ -513,27 +501,27 @@ describe('friend invitation helpers', () => {
         inviteeDisplayName: 'Morgan Lee',
         preSeededInterests,
         sentAt: now,
-      })
-    )
-    expect(typeof state.invitationValues?.token).toBe('string')
-  })
+      }),
+    );
+    expect(typeof state.invitationValues?.token).toBe('string');
+  });
 
   it('uses the inviteePhone lookup helper for pending invitations', async () => {
-    setInvitation({ inviteeDisplayName: 'Morgan' })
+    setInvitation({ inviteeDisplayName: 'Morgan' });
 
     await expect(
       getPendingInvitationForPhone({
         inviterUserId: 'user-inviter',
         inviteePhone: matchingPhone,
         now,
-      })
-    ).resolves.toEqual(expect.objectContaining({ inviteePhone: matchingPhone }))
+      }),
+    ).resolves.toEqual(expect.objectContaining({ inviteePhone: matchingPhone }));
 
-    expect(dbMock.select).toHaveBeenCalledTimes(1)
-  })
+    expect(dbMock.select).toHaveBeenCalledTimes(1);
+  });
 
   it('updates an existing pending invite instead of creating a duplicate', async () => {
-    setInvitation({ preSeededInterests: [{ label: 'Jazz' }] })
+    setInvitation({ preSeededInterests: [{ label: 'Jazz' }] });
 
     const invitation = await createFriendInvitation({
       inviterUserId: 'user-inviter',
@@ -541,31 +529,31 @@ describe('friend invitation helpers', () => {
       inviteeDisplayName: 'Morgan Updated',
       preSeededInterests: [{ label: 'Poetry' }],
       now,
-    })
+    });
 
-    expect(dbMock.insert).not.toHaveBeenCalled()
+    expect(dbMock.insert).not.toHaveBeenCalled();
     expect(invitation).toEqual(
       expect.objectContaining({
         id: 'inv-1',
         inviteeDisplayName: 'Morgan Updated',
         preSeededInterests: [{ label: 'Poetry' }],
-      })
-    )
-  })
+      }),
+    );
+  });
 
   it('keeps existing invitation rows readable when display name is absent', async () => {
-    setInvitation({ inviteeDisplayName: null })
+    setInvitation({ inviteeDisplayName: null });
 
     await expect(getInvitationByToken('valid-token')).resolves.toEqual(
       expect.objectContaining({
         id: 'inv-1',
         inviteeDisplayName: null,
-      })
-    )
-  })
+      }),
+    );
+  });
 
   it('edits a pending invitation in place, normalizing name and preserving the token', async () => {
-    setInvitation({ token: 'keep-this-token' })
+    setInvitation({ token: 'keep-this-token' });
 
     const updated = await updateFriendInvitation({
       invitationId: 'inv-1',
@@ -574,7 +562,7 @@ describe('friend invitation helpers', () => {
       inviteeDisplayName: '  Dad  Palay ',
       preSeededInterests: [{ label: 'Sondheim' }],
       now,
-    })
+    });
 
     expect(updated).toEqual(
       expect.objectContaining({
@@ -583,67 +571,65 @@ describe('friend invitation helpers', () => {
         inviteePhone: '+17345559999',
         inviteeDisplayName: 'Dad Palay',
         preSeededInterests: [{ label: 'Sondheim' }],
-      })
-    )
+      }),
+    );
     expect(state.updateValues).toEqual(
       expect.objectContaining({
         inviteePhone: '+17345559999',
         inviteeDisplayName: 'Dad Palay',
-      })
-    )
-  })
+      }),
+    );
+  });
 
   it('can cancel a pending invitation when cancellation is supported', async () => {
-    setInvitation()
+    setInvitation();
 
     await expect(
       cancelFriendInvitation({
         invitationId: 'inv-1',
         inviterUserId: 'user-inviter',
         now,
-      })
-    ).resolves.toEqual(expect.objectContaining({ cancelledAt: now }))
-  })
+      }),
+    ).resolves.toEqual(expect.objectContaining({ cancelledAt: now }));
+  });
 
   it('resolves a valid pending invite to inviter name, raw phone, and masked phone', async () => {
-    setInvitation({ inviteePhone: '+17345556819' })
+    setInvitation({ inviteePhone: '+17345556819' });
 
     await expect(getInvitePrefillByToken('valid-token', now)).resolves.toEqual({
       inviterName: 'Alex Inviter',
       inviterUserId: 'friend-invite',
       inviteePhone: '+17345556819',
       maskedPhone: '•••-•••-6819',
-    })
-  })
+    });
+  });
 
   it('falls back to "Someone" when the inviter has no display name', async () => {
-    state.inviterName = null
-    setInvitation({ inviteePhone: '+17345556819' })
+    state.inviterName = null;
+    setInvitation({ inviteePhone: '+17345556819' });
 
     await expect(getInvitePrefillByToken('valid-token', now)).resolves.toEqual(
-      expect.objectContaining({ inviterName: 'Someone' })
-    )
-  })
+      expect.objectContaining({ inviterName: 'Someone' }),
+    );
+  });
 
   it('returns null for blank, accepted, cancelled, or expired invites', async () => {
-    await expect(getInvitePrefillByToken('', now)).resolves.toBeNull()
+    await expect(getInvitePrefillByToken('', now)).resolves.toBeNull();
 
-    setInvitation({ acceptedAt: new Date('2026-05-13T11:00:00.000Z') })
-    await expect(getInvitePrefillByToken('accepted-token', now)).resolves.toBeNull()
+    setInvitation({ acceptedAt: new Date('2026-05-13T11:00:00.000Z') });
+    await expect(getInvitePrefillByToken('accepted-token', now)).resolves.toBeNull();
 
-    setInvitation({ cancelledAt: new Date('2026-05-13T11:00:00.000Z') })
-    await expect(
-      getInvitePrefillByToken('cancelled-token', now)
-    ).resolves.toBeNull()
+    setInvitation({ cancelledAt: new Date('2026-05-13T11:00:00.000Z') });
+    await expect(getInvitePrefillByToken('cancelled-token', now)).resolves.toBeNull();
 
-    setInvitation({ expiresAt: new Date('2026-05-12T12:00:00.000Z') })
-    await expect(getInvitePrefillByToken('expired-token', now)).resolves.toBeNull()
-  })
+    setInvitation({ expiresAt: new Date('2026-05-12T12:00:00.000Z') });
+    await expect(getInvitePrefillByToken('expired-token', now)).resolves.toBeNull();
+  });
 
   it('returns null when the invite has no recipient phone', async () => {
-    setInvitation({ inviteePhone: '' })
-    await expect(getInvitePrefillByToken('valid-token', now)).resolves.toBeNull()
-  })
+    setInvitation({ inviteePhone: '' });
+    await expect(getInvitePrefillByToken('valid-token', now)).resolves.toBeNull();
+  });
 
   it('still parses existing onboarding pre-seeded interests', () => {
     expect(
@@ -651,11 +637,11 @@ describe('friend invitation helpers', () => {
         'Film',
         { label: 'Jazz', description: 'Blue Note', broad_category: 'music' },
         { label: 'Poetry', broadCategory: 'literature' },
-      ])
+      ]),
     ).toEqual([
       { label: 'Film' },
       { label: 'Jazz', description: 'Blue Note', broadCategory: 'music' },
       { label: 'Poetry', description: null, broadCategory: 'literature' },
-    ])
-  })
-})
+    ]);
+  });
+});

--- a/src/server/friends/__tests__/user-invite-token.test.ts
+++ b/src/server/friends/__tests__/user-invite-token.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Table-keyed queues: each table gets its own FIFO result queue so tests don't
 // have to track cross-table call interleaving (resolveInviteLink runs its
@@ -8,84 +8,91 @@ const { dbMock, state, users, profileDomainVisibility } = vi.hoisted(() => {
     usersQueue: [] as unknown[][],
     profileDomainVisibilityQueue: [] as unknown[][],
     updateSetCalls: [] as unknown[],
-  }
+  };
 
-  const users = { __table: 'users' }
-  const profileDomainVisibility = { __table: 'profileDomainVisibility' }
+  const users = { __table: 'users' };
+  const profileDomainVisibility = { __table: 'profileDomainVisibility' };
 
   const dbMock = {
     select: vi.fn(() => {
       // `from(table)` determines which queue this call reads from; capture
       // it via a chain whose `from` remembers the table before resolving.
-      let selectedTable: unknown
+      let selectedTable: unknown;
       const chain: Record<string, unknown> = {
         from: vi.fn((table: unknown) => {
-          selectedTable = table
-          return chain
+          selectedTable = table;
+          return chain;
         }),
         where: vi.fn(() => chain),
         limit: vi.fn(() => chain),
-      }
+      };
       chain.then = (resolve: (rows: unknown[]) => unknown) => {
-        const queue = selectedTable === users ? state.usersQueue : state.profileDomainVisibilityQueue
-        return resolve(queue.shift() ?? [])
-      }
-      return chain
+        const queue =
+          selectedTable === users ? state.usersQueue : state.profileDomainVisibilityQueue;
+        return resolve(queue.shift() ?? []);
+      };
+      return chain;
     }),
     update: vi.fn(() => ({
       set: vi.fn((values: unknown) => {
-        state.updateSetCalls.push(values)
-        return { where: vi.fn(async () => {}) }
+        state.updateSetCalls.push(values);
+        return { where: vi.fn(async () => {}) };
       }),
     })),
-  }
+  };
 
-  return { dbMock, state, users, profileDomainVisibility }
-})
+  return { dbMock, state, users, profileDomainVisibility };
+});
 
 const { getActiveDeclaredInterestsMock, getDailyPreferencesMock } = vi.hoisted(() => ({
-  getActiveDeclaredInterestsMock: vi.fn(async () => [] as Array<{ domain: string; broadCategory: string | null }>),
-  getDailyPreferencesMock: vi.fn(async () => ({ domainPreferenceFrequency: {} as Record<string, string> })),
-}))
+  getActiveDeclaredInterestsMock: vi.fn(
+    async () => [] as Array<{ domain: string; broadCategory: string | null }>,
+  ),
+  getDailyPreferencesMock: vi.fn(async () => ({
+    domainPreferenceFrequency: {} as Record<string, string>,
+  })),
+}));
 
 const {
   findLiveInviteLinkByTokenMock,
   attributeInviteLinkJoinMock,
   getJoinedInviteLinkMock,
+  upsertInvitationFriendshipMock,
 } = vi.hoisted(() => ({
   findLiveInviteLinkByTokenMock: vi.fn(),
   attributeInviteLinkJoinMock: vi.fn(async () => {}),
   getJoinedInviteLinkMock: vi.fn(),
-}))
+  upsertInvitationFriendshipMock: vi.fn(async () => {}),
+}));
 
 vi.mock('@/server/db', () => ({
   db: dbMock,
   users,
   follows: {},
   profileDomainVisibility,
-}))
+}));
 
 vi.mock('@/server/db/queries/declared-interests', () => ({
   getActiveDeclaredInterests: getActiveDeclaredInterestsMock,
-}))
+}));
 
 vi.mock('@/server/db/queries/daily-preferences', () => ({
   getDailyPreferences: getDailyPreferencesMock,
-}))
+}));
 
 vi.mock('@/server/db/queries/invite-links', () => ({
   findLiveInviteLinkByToken: findLiveInviteLinkByTokenMock,
   attributeInviteLinkJoin: attributeInviteLinkJoinMock,
   getJoinedInviteLink: getJoinedInviteLinkMock,
-}))
+}));
 
 vi.mock('@/server/feed/backfill-inviter-feed', () => ({
   backfillInviterFeedItems: vi.fn(async () => {}),
-}))
+}));
 
 vi.mock('@/server/friends/friendships', () => ({
-  upsertInvitationFriendship: vi.fn(async () => {}),
-}))
+  upsertInvitationFriendship: upsertInvitationFriendshipMock,
+}));
 
 import {
   acceptUserInviteLink,
@@ -94,39 +101,39 @@ import {
   getSeedTopicsForJoinedLink,
   resolveInviteLink,
   setCuratedInviteSeedTopics,
-} from '@/server/friends/user-invite-token'
+} from '@/server/friends/user-invite-token';
 
 function resetAll() {
-  vi.clearAllMocks()
-  state.usersQueue = []
-  state.profileDomainVisibilityQueue = []
-  state.updateSetCalls = []
-  getDailyPreferencesMock.mockResolvedValue({ domainPreferenceFrequency: {} })
+  vi.clearAllMocks();
+  state.usersQueue = [];
+  state.profileDomainVisibilityQueue = [];
+  state.updateSetCalls = [];
+  getDailyPreferencesMock.mockResolvedValue({ domainPreferenceFrequency: {} });
 }
 
 describe('getInviteLinkSeedTopics', () => {
-  beforeEach(resetAll)
+  beforeEach(resetAll);
 
   it('returns the curated set when present, without touching declared interests', async () => {
-    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }] }]]
+    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }] }]];
 
-    const topics = await getInviteLinkSeedTopics('inviter-1')
+    const topics = await getInviteLinkSeedTopics('inviter-1');
 
-    expect(topics.map((topic) => topic.label)).toEqual(['Sondheim', 'Jazz'])
-    expect(getActiveDeclaredInterestsMock).not.toHaveBeenCalled()
-  })
+    expect(topics.map((topic) => topic.label)).toEqual(['Sondheim', 'Jazz']);
+    expect(getActiveDeclaredInterestsMock).not.toHaveBeenCalled();
+  });
 
   it('falls back to declared interests, most-played (often) first', async () => {
-    state.usersQueue = [[{ inviteSeedInterests: null }]]
+    state.usersQueue = [[{ inviteSeedInterests: null }]];
     getActiveDeclaredInterestsMock.mockResolvedValueOnce([
       { domain: 'History', broadCategory: 'Humanities' },
       { domain: 'Jazz', broadCategory: 'Music' },
       { domain: 'Poetry', broadCategory: 'Literature' },
       { domain: 'Chess', broadCategory: 'Games' },
-    ])
+    ]);
     getDailyPreferencesMock.mockResolvedValueOnce({
       domainPreferenceFrequency: { Jazz: 'often', Chess: 'often' },
-    })
+    });
 
     // Jazz and Chess are 'often' -> lead, in their original relative order;
     // then the rest (History, Poetry) in first-picked order; capped at 3.
@@ -134,104 +141,121 @@ describe('getInviteLinkSeedTopics', () => {
       { label: 'Jazz', broadCategory: 'Music' },
       { label: 'Chess', broadCategory: 'Games' },
       { label: 'History', broadCategory: 'Humanities' },
-    ])
-  })
+    ]);
+  });
 
   it('slot 0 (or default) returns the full resolved set', async () => {
-    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }] }]]
-    await expect(getInviteLinkSeedTopics('inviter-1', 0)).resolves.toHaveLength(2)
-  })
+    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }] }]];
+    await expect(getInviteLinkSeedTopics('inviter-1', 0)).resolves.toHaveLength(2);
+  });
 
   it('a named slot (1-3) returns just the one topic at that position', async () => {
-    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }] }]]
+    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }] }]];
     await expect(getInviteLinkSeedTopics('inviter-1', 2)).resolves.toEqual([
       { label: 'Jazz', broadCategory: null, description: null },
-    ])
-  })
+    ]);
+  });
 
   it('a slot beyond the resolved set returns empty, not an out-of-range crash', async () => {
-    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }] }]]
-    await expect(getInviteLinkSeedTopics('inviter-1', 3)).resolves.toEqual([])
-  })
-})
+    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }] }]];
+    await expect(getInviteLinkSeedTopics('inviter-1', 3)).resolves.toEqual([]);
+  });
+});
 
 describe('getSeedTopicsForJoinedLink', () => {
-  beforeEach(resetAll)
+  beforeEach(resetAll);
 
   it('returns null when the invitee has no attributed link', async () => {
-    getJoinedInviteLinkMock.mockResolvedValueOnce(null)
-    await expect(getSeedTopicsForJoinedLink('invitee-1')).resolves.toBeNull()
-  })
+    getJoinedInviteLinkMock.mockResolvedValueOnce(null);
+    await expect(getSeedTopicsForJoinedLink('invitee-1')).resolves.toBeNull();
+  });
 
   it('resolves the specific link the invitee joined through', async () => {
-    getJoinedInviteLinkMock.mockResolvedValueOnce({ inviterUserId: 'inviter-1', slot: 1 })
-    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }] }]]
+    getJoinedInviteLinkMock.mockResolvedValueOnce({ inviterUserId: 'inviter-1', slot: 1 });
+    state.usersQueue = [[{ inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }] }]];
 
     await expect(getSeedTopicsForJoinedLink('invitee-1')).resolves.toEqual([
       { label: 'Sondheim', broadCategory: null, description: null },
-    ])
-  })
-})
+    ]);
+  });
+
+  it('uses the stored per-link categories without consulting a mutable legacy slot', async () => {
+    getJoinedInviteLinkMock.mockResolvedValueOnce({
+      inviterUserId: 'inviter-1',
+      slot: 2,
+      categories: [{ label: 'Poetry', broadCategory: 'Literature' }],
+    });
+
+    await expect(getSeedTopicsForJoinedLink('invitee-1')).resolves.toEqual([
+      { label: 'Poetry', broadCategory: 'Literature' },
+    ]);
+    expect(state.usersQueue).toHaveLength(0);
+  });
+});
 
 describe('getCuratedInviteSeedTopics / setCuratedInviteSeedTopics', () => {
-  beforeEach(resetAll)
+  beforeEach(resetAll);
 
   it('reads back only the curated labels, capped at 3', async () => {
     state.usersQueue = [
       [{ inviteSeedInterests: [{ label: 'A' }, { label: 'B' }, { label: 'C' }, { label: 'D' }] }],
-    ]
+    ];
 
-    await expect(getCuratedInviteSeedTopics('user-1')).resolves.toEqual(['A', 'B', 'C'])
-  })
+    await expect(getCuratedInviteSeedTopics('user-1')).resolves.toEqual(['A', 'B', 'C']);
+  });
 
   it('cleans, dedupes, and caps before writing', async () => {
-    await setCuratedInviteSeedTopics('user-1', ['  Jazz ', 'jazz', 'Poetry', 'Chess', 'Extra'])
+    await setCuratedInviteSeedTopics('user-1', ['  Jazz ', 'jazz', 'Poetry', 'Chess', 'Extra']);
 
-    expect(state.updateSetCalls).toHaveLength(1)
-    expect((state.updateSetCalls[0] as { inviteSeedInterests: unknown }).inviteSeedInterests).toEqual([
-      { label: 'Jazz' },
-      { label: 'Poetry' },
-      { label: 'Chess' },
-    ])
-  })
+    expect(state.updateSetCalls).toHaveLength(1);
+    expect(
+      (state.updateSetCalls[0] as { inviteSeedInterests: unknown }).inviteSeedInterests,
+    ).toEqual([{ label: 'Jazz' }, { label: 'Poetry' }, { label: 'Chess' }]);
+  });
 
   it('clearing to an empty array reverts to the automatic fallback', async () => {
-    await setCuratedInviteSeedTopics('user-1', [])
+    await setCuratedInviteSeedTopics('user-1', []);
 
-    expect((state.updateSetCalls[0] as { inviteSeedInterests: unknown }).inviteSeedInterests).toEqual([])
-  })
-})
+    expect(
+      (state.updateSetCalls[0] as { inviteSeedInterests: unknown }).inviteSeedInterests,
+    ).toEqual([]);
+  });
+});
 
 describe('resolveInviteLink — link lookup, seed topics, visibility', () => {
-  beforeEach(resetAll)
+  beforeEach(resetAll);
 
   function seedHandle() {
     state.usersQueue.push([
       { id: 'inviter-1', handle: 'josh', displayName: 'Josh', avatarColor: '#fff' },
-    ])
+    ]);
   }
 
   it('returns null when the handle does not resolve', async () => {
-    state.usersQueue.push([])
-    await expect(resolveInviteLink('nobody', 'tok123')).resolves.toBeNull()
-    expect(findLiveInviteLinkByTokenMock).not.toHaveBeenCalled()
-  })
+    state.usersQueue.push([]);
+    await expect(resolveInviteLink('nobody', 'tok123')).resolves.toBeNull();
+    expect(findLiveInviteLinkByTokenMock).not.toHaveBeenCalled();
+  });
 
   it('returns null when no live link matches the token (deleted, wrong owner, or never existed)', async () => {
-    seedHandle()
-    findLiveInviteLinkByTokenMock.mockResolvedValueOnce(null)
+    seedHandle();
+    findLiveInviteLinkByTokenMock.mockResolvedValueOnce(null);
 
-    await expect(resolveInviteLink('josh', 'wrong-token')).resolves.toBeNull()
-    expect(findLiveInviteLinkByTokenMock).toHaveBeenCalledWith('inviter-1', 'wrong-token')
-  })
+    await expect(resolveInviteLink('josh', 'wrong-token')).resolves.toBeNull();
+    expect(findLiveInviteLinkByTokenMock).toHaveBeenCalledWith('inviter-1', 'wrong-token');
+  });
 
   it('includes a public topic and excludes a private one', async () => {
-    seedHandle()
-    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({ id: 'link-1', userId: 'inviter-1', slot: 0 })
+    seedHandle();
+    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({
+      id: 'link-1',
+      userId: 'inviter-1',
+      slot: 0,
+    });
     // getInviteLinkSeedTopics: curated set present.
     state.usersQueue.push([
       { inviteSeedInterests: [{ label: 'Jazz' }, { label: 'Secret Hobby' }] },
-    ])
+    ]);
     // getPubliclyHiddenDomainKeys: one row marking "Secret Hobby" private.
     state.profileDomainVisibilityQueue.push([
       {
@@ -240,80 +264,161 @@ describe('resolveInviteLink — link lookup, seed topics, visibility', () => {
         visibility: 'private',
         isVisible: false,
       },
-    ])
+    ]);
 
-    const result = await resolveInviteLink('josh', 'tok123')
+    const result = await resolveInviteLink('josh', 'tok123');
 
-    expect(result?.seedTopics).toEqual(['Jazz'])
-    expect(result?.linkId).toBe('link-1')
-    expect(result?.slot).toBe(0)
-  })
+    expect(result?.seedTopics).toEqual(['Jazz']);
+    expect(result?.linkId).toBe('link-1');
+    expect(result?.slot).toBe(0);
+  });
 
   it('shows a topic with no PROFILE_DOMAIN_VISIBILITY row at all (default public)', async () => {
-    seedHandle()
-    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({ id: 'link-1', userId: 'inviter-1', slot: 0 })
-    state.usersQueue.push([{ inviteSeedInterests: [{ label: 'Jazz' }] }])
-    state.profileDomainVisibilityQueue.push([]) // no rows for this user
+    seedHandle();
+    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({
+      id: 'link-1',
+      userId: 'inviter-1',
+      slot: 0,
+    });
+    state.usersQueue.push([{ inviteSeedInterests: [{ label: 'Jazz' }] }]);
+    state.profileDomainVisibilityQueue.push([]); // no rows for this user
 
-    const result = await resolveInviteLink('josh', 'tok123')
+    const result = await resolveInviteLink('josh', 'tok123');
 
-    expect(result?.seedTopics).toEqual(['Jazz'])
-  })
+    expect(result?.seedTopics).toEqual(['Jazz']);
+  });
 
   it('a tagged link only carries the one topic at its slot', async () => {
-    seedHandle()
-    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({ id: 'link-2', userId: 'inviter-1', slot: 2 })
-    state.usersQueue.push([{ inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }, { label: 'Chess' }] }])
-    state.profileDomainVisibilityQueue.push([])
+    seedHandle();
+    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({
+      id: 'link-2',
+      userId: 'inviter-1',
+      slot: 2,
+    });
+    state.usersQueue.push([
+      { inviteSeedInterests: [{ label: 'Sondheim' }, { label: 'Jazz' }, { label: 'Chess' }] },
+    ]);
+    state.profileDomainVisibilityQueue.push([]);
 
-    const result = await resolveInviteLink('josh', 'tok-slot2')
+    const result = await resolveInviteLink('josh', 'tok-slot2');
 
-    expect(result?.seedTopics).toEqual(['Jazz'])
-  })
-})
+    expect(result?.seedTopics).toEqual(['Jazz']);
+  });
+
+  it('keeps two stored category sets isolated even when both use legacy-independent slots', async () => {
+    seedHandle();
+    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({
+      id: 'link-a',
+      userId: 'inviter-1',
+      slot: 1,
+      categories: [{ label: 'Jazz' }],
+    });
+    state.profileDomainVisibilityQueue.push([]);
+    await expect(resolveInviteLink('josh', 'token-a')).resolves.toMatchObject({
+      seedTopics: ['Jazz'],
+    });
+
+    seedHandle();
+    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({
+      id: 'link-b',
+      userId: 'inviter-1',
+      slot: 2,
+      categories: [{ label: 'Poetry' }],
+    });
+    state.profileDomainVisibilityQueue.push([]);
+    await expect(resolveInviteLink('josh', 'token-b')).resolves.toMatchObject({
+      seedTopics: ['Poetry'],
+    });
+  });
+});
 
 describe('acceptUserInviteLink', () => {
-  beforeEach(resetAll)
+  beforeEach(resetAll);
 
   function seedHandle() {
     state.usersQueue.push([
       { id: 'inviter-1', handle: 'josh', displayName: 'Josh', avatarColor: '#fff' },
-    ])
+    ]);
   }
 
   it('rejects self-invites without attributing anything', async () => {
-    seedHandle()
-    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({ id: 'link-1', userId: 'inviter-1', slot: 0 })
-    state.usersQueue.push([{ inviteSeedInterests: [] }])
-    state.profileDomainVisibilityQueue.push([])
+    seedHandle();
+    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({
+      id: 'link-1',
+      userId: 'inviter-1',
+      slot: 0,
+    });
+    state.usersQueue.push([{ inviteSeedInterests: [] }]);
+    state.profileDomainVisibilityQueue.push([]);
 
-    const result = await acceptUserInviteLink({ handle: 'josh', token: 'tok123', inviteeUserId: 'inviter-1' })
+    const result = await acceptUserInviteLink({
+      handle: 'josh',
+      token: 'tok123',
+      inviteeUserId: 'inviter-1',
+    });
 
-    expect(result).toEqual({ accepted: false })
-    expect(attributeInviteLinkJoinMock).not.toHaveBeenCalled()
-  })
+    expect(result).toEqual({ accepted: false });
+    expect(attributeInviteLinkJoinMock).not.toHaveBeenCalled();
+  });
 
   it('accepts and attributes the join to the specific link clicked', async () => {
-    seedHandle()
-    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({ id: 'link-1', userId: 'inviter-1', slot: 1 })
-    state.usersQueue.push([{ inviteSeedInterests: [{ label: 'Sondheim' }] }])
-    state.profileDomainVisibilityQueue.push([])
+    seedHandle();
+    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({
+      id: 'link-1',
+      userId: 'inviter-1',
+      slot: 1,
+    });
+    state.usersQueue.push([{ inviteSeedInterests: [{ label: 'Sondheim' }] }]);
+    state.profileDomainVisibilityQueue.push([]);
 
-    const result = await acceptUserInviteLink({ handle: 'josh', token: 'tok123', inviteeUserId: 'invitee-1' })
+    const result = await acceptUserInviteLink({
+      handle: 'josh',
+      token: 'tok123',
+      inviteeUserId: 'invitee-1',
+    });
 
-    expect(result).toEqual({ accepted: true })
-    expect(attributeInviteLinkJoinMock).toHaveBeenCalledWith('invitee-1', 'link-1')
-  })
+    expect(result).toEqual({ accepted: true });
+    expect(attributeInviteLinkJoinMock).toHaveBeenCalledWith('invitee-1', 'link-1');
+  });
 
   it('a failed attribution never undoes an otherwise-successful accept', async () => {
-    seedHandle()
-    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({ id: 'link-1', userId: 'inviter-1', slot: 0 })
-    state.usersQueue.push([{ inviteSeedInterests: [] }])
-    state.profileDomainVisibilityQueue.push([])
-    attributeInviteLinkJoinMock.mockRejectedValueOnce(new Error('boom'))
+    seedHandle();
+    findLiveInviteLinkByTokenMock.mockResolvedValueOnce({
+      id: 'link-1',
+      userId: 'inviter-1',
+      slot: 0,
+    });
+    state.usersQueue.push([{ inviteSeedInterests: [] }]);
+    state.profileDomainVisibilityQueue.push([]);
+    attributeInviteLinkJoinMock.mockRejectedValueOnce(new Error('boom'));
 
-    const result = await acceptUserInviteLink({ handle: 'josh', token: 'tok123', inviteeUserId: 'invitee-1' })
+    const result = await acceptUserInviteLink({
+      handle: 'josh',
+      token: 'tok123',
+      inviteeUserId: 'invitee-1',
+    });
 
-    expect(result).toEqual({ accepted: true })
-  })
-})
+    expect(result).toEqual({ accepted: true });
+  });
+
+  it('reopening an accepted reusable link remains idempotent at the friendship boundary', async () => {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      seedHandle();
+      findLiveInviteLinkByTokenMock.mockResolvedValueOnce({
+        id: 'link-1',
+        userId: 'inviter-1',
+        slot: 1,
+        categories: [{ label: 'Sondheim' }],
+      });
+      state.profileDomainVisibilityQueue.push([]);
+      await expect(
+        acceptUserInviteLink({ handle: 'josh', token: 'tok123', inviteeUserId: 'invitee-1' }),
+      ).resolves.toEqual({ accepted: true });
+    }
+
+    // The helper is an ON-CONFLICT upsert, not an insert-only friendship path;
+    // category data is read from the link and never inserted for the recipient.
+    expect(upsertInvitationFriendshipMock).toHaveBeenCalledTimes(2);
+    expect(attributeInviteLinkJoinMock).toHaveBeenCalledWith('invitee-1', 'link-1');
+  });
+});

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -1,18 +1,18 @@
-import { randomBytes } from 'crypto'
+import { randomBytes } from 'crypto';
 
-import { and, desc, eq, gt, inArray, isNotNull, isNull, lte, or } from 'drizzle-orm'
+import { and, desc, eq, gt, inArray, isNotNull, isNull, lte, or } from 'drizzle-orm';
 
-import { maskPhoneE164 } from '@/lib/phone-e164'
-import { activityItems, db, friendInvitations, users } from '@/server/db'
-import { backfillInviterFeedItems } from '@/server/feed/backfill-inviter-feed'
-import { upsertInvitationFriendship } from '@/server/friends/friendships'
-import { hashTelemetryValue, logTelemetry } from '@/server/telemetry'
+import { maskPhoneE164 } from '@/lib/phone-e164';
+import { safeInviteName, sanitizeInviteLinkCategories } from '@/lib/invite-links';
+import { activityItems, db, friendInvitations, users } from '@/server/db';
+import { backfillInviterFeedItems } from '@/server/feed/backfill-inviter-feed';
+import { upsertInvitationFriendship } from '@/server/friends/friendships';
+import { hashTelemetryValue, logTelemetry } from '@/server/telemetry';
 
-export const INVITATION_ACCEPTANCE_ERROR_MESSAGE =
-  'This invitation could not be accepted.'
+export const INVITATION_ACCEPTANCE_ERROR_MESSAGE = 'This invitation could not be accepted.';
 
 export const INVITE_REQUIRED_MESSAGE =
-  "Joshing is invite-only. Ask a friend who's already on Joshing to send you an invite."
+  "Joshing is invite-only. Ask a friend who's already on Joshing to send you an invite.";
 
 // 30 days (was 14). Kept well inside the ~90-day window US carriers wait
 // before recycling an unused phone number — the risk a perpetual invite would
@@ -20,56 +20,53 @@ export const INVITE_REQUIRED_MESSAGE =
 // on their behalf. The friend-invitation-reminders cron fires at this same
 // 30-day mark for still-unaccepted invites, so expiry and "nudge the inviter"
 // land together.
-const DEFAULT_INVITATION_TTL_MS = 1000 * 60 * 60 * 24 * 30
+const DEFAULT_INVITATION_TTL_MS = 1000 * 60 * 60 * 24 * 30;
 
-export type FriendInvitation = typeof friendInvitations.$inferSelect
+export type FriendInvitation = typeof friendInvitations.$inferSelect;
 
-export type OutgoingFriendInvitationStatus =
-  | 'pending'
-  | 'accepted'
-  | 'expired'
-  | 'cancelled'
+export type OutgoingFriendInvitationStatus = 'pending' | 'accepted' | 'expired' | 'cancelled';
 
 export type OutgoingFriendInvitation = FriendInvitation & {
-  status: OutgoingFriendInvitationStatus
-  suggestedInterests: string[]
-}
+  status: OutgoingFriendInvitationStatus;
+  suggestedInterests: string[];
+};
 
 export type FriendInvitationLanding = {
-  status: 'valid' | 'expired' | 'accepted' | 'invalid'
-  inviterName: string
-  inviterUserId: string | null
-  inviterAvatarColor: string | null
-}
+  status: 'valid' | 'expired' | 'accepted' | 'invalid';
+  inviterName: string;
+  inviterUserId: string | null;
+  inviterAvatarColor: string | null;
+  categories: string[];
+};
 
 export type InvitePrefill = {
-  inviterName: string
-  inviterUserId: string
-  inviterAvatarColor: string | null
+  inviterName: string;
+  inviterUserId: string;
+  inviterAvatarColor: string | null;
   // Recipient's E.164 phone resolved from the invite token. Default posture is
   // server-only (surface `maskedPhone` instead). Deliberate exception
   // (D-AUTH-INVITE-PHONE-FIRST §2.3): the phone-first FriendInvitation login
   // path pre-fills this full number into an editable field, so `login/page.tsx`
   // crosses it to the client — but ONLY for that invite-token-gated case. The
   // invitee's own number is not a secret from them. Do not widen this exposure.
-  inviteePhone: string
-  maskedPhone: string
-}
+  inviteePhone: string;
+  maskedPhone: string;
+};
 
 export type CreateFriendInvitationInput = {
-  inviterUserId: string
-  inviteePhone: string
-  inviteeDisplayName: string
-  preSeededInterests?: unknown
-  personalMessage?: string | null
-  now?: Date
-  expiresAt?: Date
-}
+  inviterUserId: string;
+  inviteePhone: string;
+  inviteeDisplayName: string;
+  preSeededInterests?: unknown;
+  personalMessage?: string | null;
+  now?: Date;
+  expiresAt?: Date;
+};
 
 export type AcceptFriendInvitationResult =
   | { accepted: true }
   | {
-      accepted: false
+      accepted: false;
       reason:
         | 'missing'
         | 'expired'
@@ -77,19 +74,18 @@ export type AcceptFriendInvitationResult =
         | 'cancelled'
         | 'self'
         | 'phone_mismatch'
-        | 'claim_failed'
-    }
+        | 'claim_failed';
+    };
 
 function displayInviterName(value: string | null | undefined) {
-  const normalized = value?.trim().replace(/\s+/g, ' ')
-  return normalized ? normalized.slice(0, 80) : 'Someone'
+  return safeInviteName(value) ?? 'Someone';
 }
 
 export function parseInvitationInterests(value: unknown): string[] {
-  if (!Array.isArray(value)) return []
+  if (!Array.isArray(value)) return [];
 
-  const seen = new Set<string>()
-  const interests: string[] = []
+  const seen = new Set<string>();
+  const interests: string[] = [];
 
   for (const item of value) {
     const rawLabel =
@@ -97,29 +93,34 @@ export function parseInvitationInterests(value: unknown): string[] {
         ? item
         : item && typeof item === 'object' && !Array.isArray(item)
           ? (item as Record<string, unknown>).label
-          : null
-    const label =
-      typeof rawLabel === 'string' ? rawLabel.trim().replace(/\s+/g, ' ') : ''
-    if (!label) continue
+          : null;
+    const label = typeof rawLabel === 'string' ? rawLabel.trim().replace(/\s+/g, ' ') : '';
+    if (!label) continue;
 
-    const key = label.toLocaleLowerCase('en-US')
-    if (seen.has(key)) continue
+    const key = label.toLocaleLowerCase('en-US');
+    if (seen.has(key)) continue;
 
-    seen.add(key)
-    interests.push(label.slice(0, 80))
-    if (interests.length === 3) break
+    seen.add(key);
+    interests.push(label.slice(0, 80));
+    if (interests.length === 3) break;
   }
 
-  return interests
+  return interests;
 }
 
 export async function getFriendInvitationLandingByToken(
   token: string,
-  now = new Date()
+  now = new Date(),
 ): Promise<FriendInvitationLanding> {
-  const normalizedToken = token.trim()
+  const normalizedToken = token.trim();
   if (!normalizedToken) {
-    return { status: 'invalid', inviterName: 'Someone', inviterUserId: null, inviterAvatarColor: null }
+    return {
+      status: 'invalid',
+      inviterName: 'Someone',
+      inviterUserId: null,
+      inviterAvatarColor: null,
+      categories: [],
+    };
   }
 
   const [row] = await db
@@ -135,36 +136,44 @@ export async function getFriendInvitationLandingByToken(
     .from(friendInvitations)
     .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
     .where(eq(friendInvitations.token, normalizedToken))
-    .limit(1)
+    .limit(1);
 
   if (!row || row.cancelledAt) {
     logTelemetry('friend_invite_link_opened', {
       status: 'invalid',
       invite_hash: hashTelemetryValue(normalizedToken),
-    })
-    return { status: 'invalid', inviterName: 'Someone', inviterUserId: null, inviterAvatarColor: null }
+    });
+    return {
+      status: 'invalid',
+      inviterName: 'Someone',
+      inviterUserId: null,
+      inviterAvatarColor: null,
+      categories: [],
+    };
   }
 
-  const inviterName = displayInviterName(row.inviterName)
-  // Pre-seeded interests are NEVER returned to the public landing payload:
-  // anyone with the link could otherwise view the inviter's notes for the
-  // intended recipient. The labels are still surfaced to the recipient
-  // post-OTP via getPreSeededInterestsForUser(). We count them here only
-  // for telemetry.
-  const interestCount = parseInvitationInterests(row.preSeededInterests).length
+  const inviterName = displayInviterName(row.inviterName);
+  // The invitation URL is the capability. Surface only the validated labels
+  // promised on the personalized landing page; descriptions/personal notes
+  // remain server-only and never cross this boundary.
+  const categories = sanitizeInviteLinkCategories(
+    parseInvitationInterests(row.preSeededInterests),
+  ).map((category) => category.label);
+  const interestCount = categories.length;
 
   if (row.acceptedAt) {
     logTelemetry('friend_invite_link_opened', {
       status: 'accepted',
       invite_hash: hashTelemetryValue(normalizedToken),
       suggested_interest_count: 0,
-    })
+    });
     return {
       status: 'accepted',
       inviterName,
       inviterUserId: row.inviterUserId,
       inviterAvatarColor: row.inviterAvatarColor,
-    }
+      categories: [],
+    };
   }
 
   if (row.expiresAt <= now) {
@@ -172,27 +181,29 @@ export async function getFriendInvitationLandingByToken(
       status: 'expired',
       invite_hash: hashTelemetryValue(normalizedToken),
       suggested_interest_count: 0,
-    })
+    });
     return {
       status: 'expired',
-      inviterName,
-      inviterUserId: row.inviterUserId,
-      inviterAvatarColor: row.inviterAvatarColor,
-    }
+      inviterName: 'Someone',
+      inviterUserId: null,
+      inviterAvatarColor: null,
+      categories: [],
+    };
   }
 
   logTelemetry('friend_invite_link_opened', {
     status: 'valid',
     invite_hash: hashTelemetryValue(normalizedToken),
     suggested_interest_count: interestCount,
-  })
+  });
 
   return {
     status: 'valid',
     inviterName,
     inviterUserId: row.inviterUserId,
     inviterAvatarColor: row.inviterAvatarColor,
-  }
+    categories,
+  };
 }
 
 /**
@@ -205,10 +216,10 @@ export async function getFriendInvitationLandingByToken(
  */
 export async function getInvitePrefillByToken(
   token: string,
-  now = new Date()
+  now = new Date(),
 ): Promise<InvitePrefill | null> {
-  const normalizedToken = token.trim()
-  if (!normalizedToken) return null
+  const normalizedToken = token.trim();
+  if (!normalizedToken) return null;
 
   const [row] = await db
     .select({
@@ -223,14 +234,14 @@ export async function getInvitePrefillByToken(
     .from(friendInvitations)
     .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
     .where(eq(friendInvitations.token, normalizedToken))
-    .limit(1)
+    .limit(1);
 
-  if (!row) return null
-  if (row.acceptedAt || row.cancelledAt) return null
-  if (row.expiresAt <= now) return null
+  if (!row) return null;
+  if (row.acceptedAt || row.cancelledAt) return null;
+  if (row.expiresAt <= now) return null;
 
-  const inviteePhone = row.inviteePhone?.trim()
-  if (!inviteePhone) return null
+  const inviteePhone = row.inviteePhone?.trim();
+  if (!inviteePhone) return null;
 
   return {
     inviterName: displayInviterName(row.inviterName),
@@ -238,19 +249,19 @@ export async function getInvitePrefillByToken(
     inviterAvatarColor: row.inviterAvatarColor,
     inviteePhone,
     maskedPhone: maskPhoneE164(inviteePhone),
-  }
+  };
 }
 
 function normalizeRequiredText(value: string, fieldName: string) {
-  const normalized = value.trim().replace(/\s+/g, ' ')
+  const normalized = value.trim().replace(/\s+/g, ' ');
   if (!normalized) {
-    throw new Error(`${fieldName} is required`)
+    throw new Error(`${fieldName} is required`);
   }
-  return normalized
+  return normalized;
 }
 
 function generateInvitationToken() {
-  return randomBytes(32).toString('base64url')
+  return randomBytes(32).toString('base64url');
 }
 
 export async function createFriendInvitation({
@@ -262,20 +273,17 @@ export async function createFriendInvitation({
   now = new Date(),
   expiresAt = new Date(now.getTime() + DEFAULT_INVITATION_TTL_MS),
 }: CreateFriendInvitationInput): Promise<FriendInvitation> {
-  const normalizedInviteePhone = normalizeRequiredText(
-    inviteePhone,
-    'inviteePhone'
-  )
+  const normalizedInviteePhone = normalizeRequiredText(inviteePhone, 'inviteePhone');
   const normalizedInviteeDisplayName = normalizeRequiredText(
     inviteeDisplayName,
-    'inviteeDisplayName'
-  )
+    'inviteeDisplayName',
+  );
 
   const existingInvitation = await getPendingInvitationForPhone({
     inviterUserId,
     inviteePhone: normalizedInviteePhone,
     now,
-  })
+  });
 
   if (existingInvitation) {
     const [updatedInvitation] = await db
@@ -291,12 +299,12 @@ export async function createFriendInvitation({
           eq(friendInvitations.id, existingInvitation.id),
           isNull(friendInvitations.acceptedAt),
           isNull(friendInvitations.cancelledAt),
-          gt(friendInvitations.expiresAt, now)
-        )
+          gt(friendInvitations.expiresAt, now),
+        ),
       )
-      .returning()
+      .returning();
 
-    if (updatedInvitation) return updatedInvitation
+    if (updatedInvitation) return updatedInvitation;
   }
 
   const [createdInvitation] = await db
@@ -311,37 +319,35 @@ export async function createFriendInvitation({
       sentAt: now,
       expiresAt,
     })
-    .returning()
+    .returning();
 
   if (!createdInvitation) {
-    throw new Error('Friend invitation could not be created')
+    throw new Error('Friend invitation could not be created');
   }
 
-  return createdInvitation
+  return createdInvitation;
 }
 
-export async function hasAcceptedInvitationForUser(
-  inviteeUserId: string
-): Promise<boolean> {
+export async function hasAcceptedInvitationForUser(inviteeUserId: string): Promise<boolean> {
   const [row] = await db
     .select({ id: friendInvitations.id })
     .from(friendInvitations)
     .where(
       and(
         eq(friendInvitations.inviteeUserId, inviteeUserId),
-        isNotNull(friendInvitations.acceptedAt)
-      )
+        isNotNull(friendInvitations.acceptedAt),
+      ),
     )
-    .limit(1)
+    .limit(1);
 
-  return !!row
+  return !!row;
 }
 
 export async function getValidPendingInvitationForPhone(
   phoneNumber: string,
-  now: Date = new Date()
+  now: Date = new Date(),
 ): Promise<FriendInvitation | null> {
-  if (!phoneNumber) return null
+  if (!phoneNumber) return null;
 
   const [invitation] = await db
     .select()
@@ -351,22 +357,22 @@ export async function getValidPendingInvitationForPhone(
         eq(friendInvitations.inviteePhone, phoneNumber),
         isNull(friendInvitations.acceptedAt),
         isNull(friendInvitations.cancelledAt),
-        gt(friendInvitations.expiresAt, now)
-      )
+        gt(friendInvitations.expiresAt, now),
+      ),
     )
     // Deterministic pick when the same number was invited more than once:
     // the invite that lives longest is the most recently sent one.
     .orderBy(desc(friendInvitations.expiresAt))
-    .limit(1)
+    .limit(1);
 
-  return invitation ?? null
+  return invitation ?? null;
 }
 
 // Reuses the invitation TTL: the reminder fires at the same 30-day mark the
 // invite itself lapses at, so "nudge the inviter" and "this link stopped
 // working" land together instead of the inviter finding out only when Stan
 // tells them the link is dead.
-const REMINDER_THRESHOLD_MS = DEFAULT_INVITATION_TTL_MS
+const REMINDER_THRESHOLD_MS = DEFAULT_INVITATION_TTL_MS;
 
 // Candidates for the friend-invitation-reminders cron: sent >= 30 days ago,
 // still neither accepted nor cancelled, and not already reminded (a prior
@@ -376,9 +382,9 @@ const REMINDER_THRESHOLD_MS = DEFAULT_INVITATION_TTL_MS
 // marker). One-shot per invitation: resending creates a fresh row (see
 // createFriendInvitation), so a resent invite gets its own 30-day clock.
 export async function getInvitationsNeedingReminder(
-  now: Date = new Date()
+  now: Date = new Date(),
 ): Promise<FriendInvitation[]> {
-  const cutoff = new Date(now.getTime() - REMINDER_THRESHOLD_MS)
+  const cutoff = new Date(now.getTime() - REMINDER_THRESHOLD_MS);
 
   const candidates = await db
     .select()
@@ -387,11 +393,11 @@ export async function getInvitationsNeedingReminder(
       and(
         isNull(friendInvitations.acceptedAt),
         isNull(friendInvitations.cancelledAt),
-        lte(friendInvitations.sentAt, cutoff)
-      )
-    )
+        lte(friendInvitations.sentAt, cutoff),
+      ),
+    );
 
-  if (candidates.length === 0) return []
+  if (candidates.length === 0) return [];
 
   const alreadyReminded = await db
     .select({ referenceId: activityItems.referenceId })
@@ -402,20 +408,20 @@ export async function getInvitationsNeedingReminder(
         isNull(activityItems.deletedAt),
         inArray(
           activityItems.referenceId,
-          candidates.map((c) => c.id)
-        )
-      )
-    )
-  const remindedIds = new Set(alreadyReminded.map((r) => r.referenceId))
+          candidates.map((c) => c.id),
+        ),
+      ),
+    );
+  const remindedIds = new Set(alreadyReminded.map((r) => r.referenceId));
 
-  return candidates.filter((c) => !remindedIds.has(c.id))
+  return candidates.filter((c) => !remindedIds.has(c.id));
 }
 
 export async function hasValidPendingInvitationForPhone(
   phoneNumber: string,
-  now: Date = new Date()
+  now: Date = new Date(),
 ): Promise<boolean> {
-  return Boolean(await getValidPendingInvitationForPhone(phoneNumber, now))
+  return Boolean(await getValidPendingInvitationForPhone(phoneNumber, now));
 }
 
 export async function getValidInvitationForPhone({
@@ -423,11 +429,11 @@ export async function getValidInvitationForPhone({
   verifiedPhone,
   now = new Date(),
 }: {
-  token: string
-  verifiedPhone: string
-  now?: Date
+  token: string;
+  verifiedPhone: string;
+  now?: Date;
 }): Promise<FriendInvitation | null> {
-  if (!token || !verifiedPhone) return null
+  if (!token || !verifiedPhone) return null;
 
   const [invitation] = await db
     .select()
@@ -438,26 +444,24 @@ export async function getValidInvitationForPhone({
         eq(friendInvitations.inviteePhone, verifiedPhone),
         isNull(friendInvitations.acceptedAt),
         isNull(friendInvitations.cancelledAt),
-        gt(friendInvitations.expiresAt, now)
-      )
+        gt(friendInvitations.expiresAt, now),
+      ),
     )
-    .limit(1)
+    .limit(1);
 
-  return invitation ?? null
+  return invitation ?? null;
 }
 
-export async function getInvitationByToken(
-  token: string
-): Promise<FriendInvitation | null> {
-  if (!token) return null
+export async function getInvitationByToken(token: string): Promise<FriendInvitation | null> {
+  if (!token) return null;
 
   const [invitation] = await db
     .select()
     .from(friendInvitations)
     .where(eq(friendInvitations.token, token))
-    .limit(1)
+    .limit(1);
 
-  return invitation ?? null
+  return invitation ?? null;
 }
 
 export async function getPendingInvitationForPhone({
@@ -465,9 +469,9 @@ export async function getPendingInvitationForPhone({
   inviteePhone,
   now = new Date(),
 }: {
-  inviterUserId: string
-  inviteePhone: string
-  now?: Date
+  inviterUserId: string;
+  inviteePhone: string;
+  now?: Date;
 }): Promise<FriendInvitation | null> {
   const [invitation] = await db
     .select()
@@ -478,57 +482,54 @@ export async function getPendingInvitationForPhone({
         eq(friendInvitations.inviteePhone, inviteePhone),
         isNull(friendInvitations.acceptedAt),
         isNull(friendInvitations.cancelledAt),
-        gt(friendInvitations.expiresAt, now)
-      )
+        gt(friendInvitations.expiresAt, now),
+      ),
     )
     .orderBy(desc(friendInvitations.sentAt))
-    .limit(1)
+    .limit(1);
 
-  return invitation ?? null
+  return invitation ?? null;
 }
 
 export function getOutgoingFriendInvitationStatus(
-  invitation: Pick<
-    FriendInvitation,
-    'acceptedAt' | 'cancelledAt' | 'expiresAt'
-  >,
-  now = new Date()
+  invitation: Pick<FriendInvitation, 'acceptedAt' | 'cancelledAt' | 'expiresAt'>,
+  now = new Date(),
 ): OutgoingFriendInvitationStatus {
-  if (invitation.cancelledAt) return 'cancelled'
-  if (invitation.acceptedAt) return 'accepted'
-  if (invitation.expiresAt <= now) return 'expired'
-  return 'pending'
+  if (invitation.cancelledAt) return 'cancelled';
+  if (invitation.acceptedAt) return 'accepted';
+  if (invitation.expiresAt <= now) return 'expired';
+  return 'pending';
 }
 
 export async function listOutgoingFriendInvitations({
   inviterUserId,
   now = new Date(),
 }: {
-  inviterUserId: string
-  now?: Date
+  inviterUserId: string;
+  now?: Date;
 }): Promise<OutgoingFriendInvitation[]> {
   const invitations = await db
     .select()
     .from(friendInvitations)
     .where(eq(friendInvitations.inviterUserId, inviterUserId))
-    .orderBy(desc(friendInvitations.sentAt))
+    .orderBy(desc(friendInvitations.sentAt));
 
   return invitations.map((invitation) => ({
     ...invitation,
     status: getOutgoingFriendInvitationStatus(invitation, now),
     suggestedInterests: parseInvitationInterests(invitation.preSeededInterests),
-  }))
+  }));
 }
 
 export type UpdateFriendInvitationInput = {
-  invitationId: string
-  inviterUserId: string
-  inviteePhone: string
-  inviteeDisplayName: string
-  preSeededInterests?: unknown
-  personalMessage?: string | null
-  now?: Date
-}
+  invitationId: string;
+  inviterUserId: string;
+  inviteePhone: string;
+  inviteeDisplayName: string;
+  preSeededInterests?: unknown;
+  personalMessage?: string | null;
+  now?: Date;
+};
 
 /**
  * Edit a still-pending outgoing invitation in place (B-Friends edit-before-click).
@@ -547,14 +548,11 @@ export async function updateFriendInvitation({
   personalMessage = null,
   now = new Date(),
 }: UpdateFriendInvitationInput): Promise<FriendInvitation | null> {
-  const normalizedInviteePhone = normalizeRequiredText(
-    inviteePhone,
-    'inviteePhone'
-  )
+  const normalizedInviteePhone = normalizeRequiredText(inviteePhone, 'inviteePhone');
   const normalizedInviteeDisplayName = normalizeRequiredText(
     inviteeDisplayName,
-    'inviteeDisplayName'
-  )
+    'inviteeDisplayName',
+  );
 
   const [invitation] = await db
     .update(friendInvitations)
@@ -570,12 +568,12 @@ export async function updateFriendInvitation({
         eq(friendInvitations.inviterUserId, inviterUserId),
         isNull(friendInvitations.acceptedAt),
         isNull(friendInvitations.cancelledAt),
-        gt(friendInvitations.expiresAt, now)
-      )
+        gt(friendInvitations.expiresAt, now),
+      ),
     )
-    .returning()
+    .returning();
 
-  return invitation ?? null
+  return invitation ?? null;
 }
 
 export async function cancelFriendInvitation({
@@ -583,9 +581,9 @@ export async function cancelFriendInvitation({
   inviterUserId,
   now = new Date(),
 }: {
-  invitationId: string
-  inviterUserId: string
-  now?: Date
+  invitationId: string;
+  inviterUserId: string;
+  now?: Date;
 }): Promise<FriendInvitation | null> {
   const [invitation] = await db
     .update(friendInvitations)
@@ -596,20 +594,20 @@ export async function cancelFriendInvitation({
         eq(friendInvitations.inviterUserId, inviterUserId),
         isNull(friendInvitations.acceptedAt),
         isNull(friendInvitations.cancelledAt),
-        gt(friendInvitations.expiresAt, now)
-      )
+        gt(friendInvitations.expiresAt, now),
+      ),
     )
-    .returning()
+    .returning();
 
-  return invitation ?? null
+  return invitation ?? null;
 }
 
 export async function deleteFriendInvitation({
   invitationId,
   inviterUserId,
 }: {
-  invitationId: string
-  inviterUserId: string
+  invitationId: string;
+  inviterUserId: string;
 }): Promise<FriendInvitation | null> {
   const [invitation] = await db
     .delete(friendInvitations)
@@ -617,12 +615,12 @@ export async function deleteFriendInvitation({
       and(
         eq(friendInvitations.id, invitationId),
         eq(friendInvitations.inviterUserId, inviterUserId),
-        isNotNull(friendInvitations.cancelledAt)
-      )
+        isNotNull(friendInvitations.cancelledAt),
+      ),
     )
-    .returning()
+    .returning();
 
-  return invitation ?? null
+  return invitation ?? null;
 }
 
 export async function markInvitationAccepted({
@@ -631,10 +629,10 @@ export async function markInvitationAccepted({
   verifiedPhone,
   now = new Date(),
 }: {
-  invitationId: string
-  inviteeUserId: string
-  verifiedPhone: string
-  now?: Date
+  invitationId: string;
+  inviteeUserId: string;
+  verifiedPhone: string;
+  now?: Date;
 }): Promise<FriendInvitation | null> {
   const [invitation] = await db
     .update(friendInvitations)
@@ -648,13 +646,13 @@ export async function markInvitationAccepted({
         eq(friendInvitations.inviteePhone, verifiedPhone),
         or(
           eq(friendInvitations.inviteeUserId, inviteeUserId),
-          isNull(friendInvitations.inviteeUserId)
-        )
-      )
+          isNull(friendInvitations.inviteeUserId),
+        ),
+      ),
     )
-    .returning()
+    .returning();
 
-  return invitation ?? null
+  return invitation ?? null;
 }
 
 export async function acceptFriendInvitation({
@@ -663,31 +661,31 @@ export async function acceptFriendInvitation({
   verifiedPhone,
   now = new Date(),
 }: {
-  token: string
-  inviteeUserId: string
-  verifiedPhone: string
-  now?: Date
+  token: string;
+  inviteeUserId: string;
+  verifiedPhone: string;
+  now?: Date;
 }): Promise<AcceptFriendInvitationResult> {
-  const invitation = await getInvitationByToken(token)
+  const invitation = await getInvitationByToken(token);
 
   if (!invitation) {
-    return { accepted: false, reason: 'missing' }
+    return { accepted: false, reason: 'missing' };
   }
 
   if (invitation.acceptedAt) {
-    return { accepted: false, reason: 'accepted' }
+    return { accepted: false, reason: 'accepted' };
   }
 
   if (invitation.cancelledAt) {
-    return { accepted: false, reason: 'cancelled' }
+    return { accepted: false, reason: 'cancelled' };
   }
 
   if (invitation.expiresAt <= now) {
-    return { accepted: false, reason: 'expired' }
+    return { accepted: false, reason: 'expired' };
   }
 
   if (invitation.inviterUserId === inviteeUserId) {
-    return { accepted: false, reason: 'self' }
+    return { accepted: false, reason: 'self' };
   }
 
   if (invitation.inviteePhone !== verifiedPhone) {
@@ -695,8 +693,8 @@ export async function acceptFriendInvitation({
       invitation_id: invitation.id,
       inviter_user_id: invitation.inviterUserId,
       invitee_user_id: inviteeUserId,
-    })
-    return { accepted: false, reason: 'phone_mismatch' }
+    });
+    return { accepted: false, reason: 'phone_mismatch' };
   }
 
   const [claimedInvitation] = await db.transaction(async (tx) => {
@@ -712,25 +710,25 @@ export async function acceptFriendInvitation({
           eq(friendInvitations.inviteePhone, verifiedPhone),
           or(
             eq(friendInvitations.inviteeUserId, inviteeUserId),
-            isNull(friendInvitations.inviteeUserId)
-          )
-        )
+            isNull(friendInvitations.inviteeUserId),
+          ),
+        ),
       )
-      .returning({ id: friendInvitations.id })
+      .returning({ id: friendInvitations.id });
 
-    if (!updatedInvitation) return []
+    if (!updatedInvitation) return [];
 
     await upsertInvitationFriendship(tx, {
       inviterUserId: invitation.inviterUserId,
       inviteeUserId,
       formedAt: now,
-    })
+    });
 
-    return [updatedInvitation]
-  })
+    return [updatedInvitation];
+  });
 
   if (!claimedInvitation) {
-    return { accepted: false, reason: 'claim_failed' }
+    return { accepted: false, reason: 'claim_failed' };
   }
 
   logTelemetry('friend_invite_accepted', {
@@ -738,7 +736,7 @@ export async function acceptFriendInvitation({
     inviter_user_id: invitation.inviterUserId,
     invitee_user_id: inviteeUserId,
     suggested_interest_count: parseInvitationInterests(invitation.preSeededInterests).length,
-  })
+  });
 
   // One-time inviter feed backfill (B-HomeSeed-1). Runs AFTER the acceptance tx
   // commits and only on a successful claim, so it fires exactly once per
@@ -747,7 +745,7 @@ export async function acceptFriendInvitation({
   await backfillInviterFeedItems({
     inviterUserId: invitation.inviterUserId,
     inviteeUserId,
-  })
+  });
 
-  return { accepted: true }
+  return { accepted: true };
 }

--- a/src/server/friends/user-invite-token.ts
+++ b/src/server/friends/user-invite-token.ts
@@ -1,23 +1,24 @@
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm';
 
-import { domainKey } from '@/lib/knowledge/domain-key'
-import { db, follows, profileDomainVisibility, users } from '@/server/db'
-import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests'
-import { getDailyPreferences } from '@/server/db/queries/daily-preferences'
+import { domainKey } from '@/lib/knowledge/domain-key';
+import { safeInviteName, sanitizeInviteLinkCategories } from '@/lib/invite-links';
+import { db, follows, profileDomainVisibility, users } from '@/server/db';
+import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
+import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import {
   attributeInviteLinkJoin,
   findLiveInviteLinkByToken,
   getJoinedInviteLink,
-} from '@/server/db/queries/invite-links'
-import { parsePreSeededInterests, type PreSeededInterest } from '@/server/db/queries/users'
-import { backfillInviterFeedItems } from '@/server/feed/backfill-inviter-feed'
-import { upsertInvitationFriendship } from '@/server/friends/friendships'
+} from '@/server/db/queries/invite-links';
+import { parsePreSeededInterests, type PreSeededInterest } from '@/server/db/queries/users';
+import { backfillInviterFeedItems } from '@/server/feed/backfill-inviter-feed';
+import { upsertInvitationFriendship } from '@/server/friends/friendships';
 
-export { generateUserInviteToken } from '@/server/db/queries/invite-links'
+export { generateUserInviteToken } from '@/server/db/queries/invite-links';
 
 // Cap applies to both sources: a curated inviteSeedInterests set and the
 // automatic fallback below.
-const SEED_TOPIC_CAP = 3
+const SEED_TOPIC_CAP = 3;
 
 // Resolves the topics a per-user invite link carries: whatever the inviter
 // curated in users.invite_seed_interests, or — when that's empty — an
@@ -45,27 +46,35 @@ export async function getInviteLinkSeedTopics(
     .select({ inviteSeedInterests: users.inviteSeedInterests })
     .from(users)
     .where(eq(users.id, inviterUserId))
-    .limit(1)
+    .limit(1);
 
-  const curated = parsePreSeededInterests(row?.inviteSeedInterests).slice(0, SEED_TOPIC_CAP)
-  let resolved = curated
+  const curated = sanitizeInviteLinkCategories(
+    parsePreSeededInterests(row?.inviteSeedInterests),
+  ).slice(0, SEED_TOPIC_CAP);
+  let resolved = curated;
 
   if (resolved.length === 0) {
     const [declared, dailyPreferences] = await Promise.all([
       getActiveDeclaredInterests(inviterUserId),
       getDailyPreferences(inviterUserId),
-    ])
-    const often = declared.filter((interest) => dailyPreferences.domainPreferenceFrequency[interest.domain] === 'often')
-    const rest = declared.filter((interest) => dailyPreferences.domainPreferenceFrequency[interest.domain] !== 'often')
+    ]);
+    const often = declared.filter(
+      (interest) => dailyPreferences.domainPreferenceFrequency[interest.domain] === 'often',
+    );
+    const rest = declared.filter(
+      (interest) => dailyPreferences.domainPreferenceFrequency[interest.domain] !== 'often',
+    );
     resolved = [...often, ...rest].slice(0, SEED_TOPIC_CAP).map((interest) => ({
       label: interest.domain,
       broadCategory: interest.broadCategory,
-    }))
+    }));
   }
 
-  if (slot === 0) return resolved
-  const single = resolved[slot - 1]
-  return single ? [single] : []
+  resolved = sanitizeInviteLinkCategories(resolved);
+
+  if (slot === 0) return resolved;
+  const single = resolved[slot - 1];
+  return single ? [single] : [];
 }
 
 // Slot-aware resolution for an already-joined invitee: reads which specific
@@ -74,10 +83,13 @@ export async function getInviteLinkSeedTopics(
 // pre-migration accounts, named-invite joins, or the rare organic mutual
 // follow getInviterForUser's fallback window also catches — so the caller can
 // fall back to its own unslotted resolution.
-export async function getSeedTopicsForJoinedLink(inviteeUserId: string): Promise<PreSeededInterest[] | null> {
-  const joined = await getJoinedInviteLink(inviteeUserId)
-  if (!joined) return null
-  return getInviteLinkSeedTopics(joined.inviterUserId, joined.slot)
+export async function getSeedTopicsForJoinedLink(
+  inviteeUserId: string,
+): Promise<PreSeededInterest[] | null> {
+  const joined = await getJoinedInviteLink(inviteeUserId);
+  if (!joined) return null;
+  if (joined.categories != null) return joined.categories;
+  return getInviteLinkSeedTopics(joined.inviterUserId, joined.slot);
 }
 
 // The curated set only — no automatic-fallback resolution. This is what the
@@ -90,11 +102,11 @@ export async function getCuratedInviteSeedTopics(userId: string): Promise<string
     .select({ inviteSeedInterests: users.inviteSeedInterests })
     .from(users)
     .where(eq(users.id, userId))
-    .limit(1)
+    .limit(1);
 
-  return parsePreSeededInterests(row?.inviteSeedInterests)
+  return sanitizeInviteLinkCategories(parsePreSeededInterests(row?.inviteSeedInterests))
     .slice(0, SEED_TOPIC_CAP)
-    .map((interest) => interest.label)
+    .map((interest) => interest.label);
 }
 
 // Overwrites the curated set. Callers are responsible for validating each
@@ -102,17 +114,7 @@ export async function getCuratedInviteSeedTopics(userId: string): Promise<string
 // and just cleans/caps/persists. An empty array clears the curated set,
 // reverting the link to the automatic fallback.
 export async function setCuratedInviteSeedTopics(userId: string, topics: string[]): Promise<void> {
-  const seen = new Set<string>()
-  const cleaned: string[] = []
-  for (const raw of topics) {
-    const topic = raw.trim()
-    if (!topic) continue
-    const key = topic.toLowerCase()
-    if (seen.has(key)) continue
-    seen.add(key)
-    cleaned.push(topic)
-    if (cleaned.length === SEED_TOPIC_CAP) break
-  }
+  const cleaned = sanitizeInviteLinkCategories(topics).map((topic) => topic.label);
 
   await db
     .update(users)
@@ -120,7 +122,7 @@ export async function setCuratedInviteSeedTopics(userId: string, topics: string[
       inviteSeedInterests: cleaned.map((label) => ({ label })),
       updatedAt: new Date(),
     })
-    .where(eq(users.id, userId))
+    .where(eq(users.id, userId));
 }
 
 // The bar for a visitor who is not yet a friend of the inviter: PUBLIC and
@@ -140,15 +142,15 @@ async function getPubliclyHiddenDomainKeys(userId: string): Promise<Set<string>>
       isVisible: profileDomainVisibility.isVisible,
     })
     .from(profileDomainVisibility)
-    .where(eq(profileDomainVisibility.userId, userId))
+    .where(eq(profileDomainVisibility.userId, userId));
 
-  const hidden = new Set<string>()
+  const hidden = new Set<string>();
   for (const row of rows) {
-    if (row.visibility === 'public' && row.isVisible) continue
-    const label = row.domain ?? row.canonicalSubcategory
-    if (label) hidden.add(domainKey(label))
+    if (row.visibility === 'public' && row.isVisible) continue;
+    const label = row.domain ?? row.canonicalSubcategory;
+    if (label) hidden.add(domainKey(label));
   }
-  return hidden
+  return hidden;
 }
 
 // Lifted from src/app/api/friend-invitations/route.ts:158-173 so invite-link
@@ -156,27 +158,27 @@ async function getPubliclyHiddenDomainKeys(userId: string): Promise<Set<string>>
 // a Request (route handlers) or a Headers map (server components reading
 // via next/headers).
 export function getBaseUrl(source?: Request | Headers): string {
-  const configured = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL
-  if (configured) return configured.replace(/\/$/, '')
+  const configured = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL;
+  if (configured) return configured.replace(/\/$/, '');
 
-  const vercelProd = process.env.VERCEL_PROJECT_PRODUCTION_URL
-  if (vercelProd) return `https://${vercelProd.replace(/\/$/, '')}`
+  const vercelProd = process.env.VERCEL_PROJECT_PRODUCTION_URL;
+  if (vercelProd) return `https://${vercelProd.replace(/\/$/, '')}`;
 
   if (source) {
-    const headers = source instanceof Request ? source.headers : source
-    const host = headers.get('x-forwarded-host') ?? headers.get('host')
-    const protocol = headers.get('x-forwarded-proto') ?? 'https'
-    if (host) return `${protocol}://${host}`
-    if (source instanceof Request) return new URL(source.url).origin
+    const headers = source instanceof Request ? source.headers : source;
+    const host = headers.get('x-forwarded-host') ?? headers.get('host');
+    const protocol = headers.get('x-forwarded-proto') ?? 'https';
+    if (host) return `${protocol}://${host}`;
+    if (source instanceof Request) return new URL(source.url).origin;
   }
 
-  return 'http://localhost:3000'
+  return 'http://localhost:3000';
 }
 
 export function buildInviteUrl(baseUrl: string, handle: string, token: string): string {
   // Per-user invite URL — see src/app/u/[handle]/[token]/page.tsx for the
   // route handler and why this isn't under /invite/.
-  return `${baseUrl}/u/${encodeURIComponent(handle)}/${encodeURIComponent(token)}`
+  return `${baseUrl}/u/${encodeURIComponent(handle)}/${encodeURIComponent(token)}`;
 }
 
 // Resolves /u/<handle>/<token>: looks up the inviter case-insensitively on
@@ -184,19 +186,22 @@ export function buildInviteUrl(baseUrl: string, handle: string, token: string): 
 // Returns null when the handle doesn't resolve, the link doesn't exist,
 // belongs to someone else, or was deleted (don't reveal which).
 export type InviteLinkResolution = {
-  inviterUserId: string
-  inviterHandle: string
-  inviterDisplayName: string | null
-  inviterAvatarColor: string | null
-  linkId: string
-  slot: number
+  inviterUserId: string;
+  inviterHandle: string;
+  inviterDisplayName: string | null;
+  inviterAvatarColor: string | null;
+  linkId: string;
+  slot: number;
   // The topics THIS link carries — all of the inviter's resolved set for an
   // untagged (slot 0) link, or just the one tagged topic — already filtered
   // to what a not-yet-friend visitor may see (getPubliclyHiddenDomainKeys).
-  seedTopics: string[]
-}
+  seedTopics: string[];
+};
 
-export async function resolveInviteLink(handle: string, token: string): Promise<InviteLinkResolution | null> {
+export async function resolveInviteLink(
+  handle: string,
+  token: string,
+): Promise<InviteLinkResolution | null> {
   const [row] = await db
     .select({
       id: users.id,
@@ -206,30 +211,32 @@ export async function resolveInviteLink(handle: string, token: string): Promise<
     })
     .from(users)
     .where(sql`LOWER(${users.handle}) = LOWER(${handle})`)
-    .limit(1)
+    .limit(1);
 
-  if (!row || !row.handle) return null
+  if (!row || !row.handle) return null;
 
-  const link = await findLiveInviteLinkByToken(row.id, token)
-  if (!link) return null
+  const link = await findLiveInviteLinkByToken(row.id, token);
+  if (!link) return null;
 
   const [topics, hiddenDomainKeys] = await Promise.all([
-    getInviteLinkSeedTopics(row.id, link.slot),
+    link.categories != null
+      ? Promise.resolve(link.categories)
+      : getInviteLinkSeedTopics(row.id, link.slot),
     getPubliclyHiddenDomainKeys(row.id),
-  ])
+  ]);
   const seedTopics = topics
     .filter((topic) => !hiddenDomainKeys.has(domainKey(topic.label)))
-    .map((topic) => topic.label)
+    .map((topic) => topic.label);
 
   return {
     inviterUserId: row.id,
     inviterHandle: row.handle,
-    inviterDisplayName: row.displayName,
+    inviterDisplayName: safeInviteName(row.displayName),
     inviterAvatarColor: row.avatarColor,
     linkId: link.id,
     slot: link.slot,
     seedTopics,
-  }
+  };
 }
 
 // True when someone follows `userId` on an approved edge — the footprint left
@@ -244,9 +251,9 @@ export async function hasInviteLinkFriendship(userId: string): Promise<boolean> 
     .select({ followerId: follows.followerId })
     .from(follows)
     .where(and(eq(follows.followeeId, userId), eq(follows.state, 'approved')))
-    .limit(1)
+    .limit(1);
 
-  return Boolean(row)
+  return Boolean(row);
 }
 
 // Called from verify-otp when the user arrives via /u/<handle>/<token>.
@@ -263,35 +270,35 @@ export async function acceptUserInviteLink({
   inviteeUserId,
   now = new Date(),
 }: {
-  handle: string
-  token: string
-  inviteeUserId: string
-  now?: Date
+  handle: string;
+  token: string;
+  inviteeUserId: string;
+  now?: Date;
 }): Promise<{ accepted: boolean }> {
-  const inviter = await resolveInviteLink(handle, token)
-  if (!inviter) return { accepted: false }
-  if (inviter.inviterUserId === inviteeUserId) return { accepted: false }
+  const inviter = await resolveInviteLink(handle, token);
+  if (!inviter) return { accepted: false };
+  if (inviter.inviterUserId === inviteeUserId) return { accepted: false };
 
   try {
     await upsertInvitationFriendship(db, {
       inviterUserId: inviter.inviterUserId,
       inviteeUserId,
       formedAt: now,
-    })
+    });
     // One-time inviter feed backfill (B-HomeSeed-1). Best-effort internally so
     // it can't throw — a backfill hiccup must never fail the link acceptance.
     await backfillInviterFeedItems({
       inviterUserId: inviter.inviterUserId,
       inviteeUserId,
-    })
+    });
     try {
-      await attributeInviteLinkJoin(inviteeUserId, inviter.linkId)
+      await attributeInviteLinkJoin(inviteeUserId, inviter.linkId);
     } catch {
       // Attribution is a nice-to-have (join counts, Suggested-friends
       // provenance) — never worth failing an otherwise-successful accept.
     }
-    return { accepted: true }
+    return { accepted: true };
   } catch {
-    return { accepted: false }
+    return { accepted: false };
   }
 }


### PR DESCRIPTION
## Summary
- Store exact validated categories on each invitation link while preserving legacy-link fallback behavior.
- Redesign creator-facing invitation cards, editing, joined counts, actions, and the three-link control.
- Add secure personalized recipient landing pages for both invitation URL types, with server-resolved inviter identity and safe fallbacks.
- Preserve invitation state through authentication and onboarding; keep recommendations optional, isolated per link, and friendship acceptance idempotent.
- Add focused creator, recipient, authentication, onboarding, isolation, and duplicate-redemption regression coverage.

## Verification
- Full test suite: 342 files passed, 3 skipped; 2,662 tests passed, 36 skipped.
- Final focused suite: 102 tests passed.
- TypeScript passed.
- Production build passed.
- ESLint passed with 0 errors and 5 pre-existing unrelated warnings.
- Color, spacing, radius, z-index, and type-size ratchets passed.
- Mobile 391x845 and desktop browser QA completed with no horizontal overflow.

## Deployment note
Run migration 0141_invite_link_categories.sql before deploying the application changes. Legacy invitation links remain valid and editable.