### PR TITLE
Hold back hearted bank questions from sweep-bank-quality demotion

### DIFF
--- a/scripts/sweep-bank-quality.ts
+++ b/scripts/sweep-bank-quality.ts
@@ -10,6 +10,7 @@ import {
 } from '../src/server/daily/generate-questions';
 import { verdictToGeneratedPatch } from '../src/server/quality/verify-question';
 import { confirmOffDomain } from '../src/server/quality/off-domain-second-opinion';
+import { getHeartedBankQuestionIds } from '../src/server/quality/hearted-bank-questions';
 
 // One-time hygiene sweep over EXISTING bank stock.
 //
@@ -70,6 +71,8 @@ type Finding = {
   kind: 'deterministic' | 'llm' | 'off_domain';
   /** off_domain findings only: did the second opinion also agree? */
   confirmed?: boolean;
+  /** true if a player hearted this exact bank row — see getHeartedBankQuestionIds. */
+  hearted?: boolean;
 };
 
 function asLlmQuestion(row: BankRow): LlmQuestion {
@@ -181,6 +184,28 @@ async function main() {
     }
   }
 
+  // Hearted-question protection: a heart is a human saying this specific
+  // question was good. Every finding here is a taste/filing judgment
+  // (deterministic lexical check, quality gate, or off-domain filing) — never
+  // a factual-correctness one — so a hearted row is held back from auto-
+  // demotion for a human to look at instead, regardless of finding kind or
+  // flags. See hearted-bank-questions.ts for why this must never extend to
+  // the factual verification pipeline.
+  if (findings.length > 0) {
+    const heartedIds = await getHeartedBankQuestionIds(findings.map((f) => f.row.id));
+    for (const f of findings) f.hearted = heartedIds.has(f.row.id);
+    if (heartedIds.size > 0) {
+      console.log(`[sweep] hearted-question protection: ${heartedIds.size} flagged row(s) held back`);
+      for (const f of findings) {
+        if (f.hearted) {
+          console.log(
+            `  [held back] ${f.row.id} (${f.row.canonicalSubcategory}) — hearted by a player, ${f.kind} finding: ${f.reason.slice(0, 120)}`,
+          );
+        }
+      }
+    }
+  }
+
   const byKind = {
     deterministic: findings.filter((f) => f.kind === 'deterministic'),
     llm: findings.filter((f) => f.kind === 'llm'),
@@ -191,15 +216,16 @@ async function main() {
   );
   for (const f of findings) {
     console.log(
-      `\n  [${f.kind}] ${f.row.id}  (${f.row.canonicalSubcategory})\n    Q: ${f.row.questionText.slice(0, 130)}\n    A: ${f.row.answer.slice(0, 90)}\n    why: ${f.reason.slice(0, 160)}`,
+      `\n  [${f.kind}]${f.hearted ? ' [HEARTED]' : ''} ${f.row.id}  (${f.row.canonicalSubcategory})\n    Q: ${f.row.questionText.slice(0, 130)}\n    A: ${f.row.answer.slice(0, 90)}\n    why: ${f.reason.slice(0, 160)}`,
     );
   }
 
   // off_domain requires BOTH --include-off-domain AND the second opinion's
   // agreement (f.confirmed) — a row the first gate flagged but the second
-  // didn't confirm is never demoted by this script, flag or no flag.
+  // didn't confirm is never demoted by this script, flag or no flag. A
+  // hearted row is excluded outright, ahead of all other flags.
   const toDemote = findings.filter(
-    (f) => f.kind !== 'off_domain' || (INCLUDE_OFF_DOMAIN && f.confirmed),
+    (f) => !f.hearted && (f.kind !== 'off_domain' || (INCLUDE_OFF_DOMAIN && f.confirmed)),
   );
   if (!APPLY) {
     console.log(

--- a/src/server/quality/__tests__/hearted-bank-questions.test.ts
+++ b/src/server/quality/__tests__/hearted-bank-questions.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { state, dbMock } = vi.hoisted(() => {
+  const state = {
+    directRows: [] as Array<{ id: string | null }>,
+    joinedRows: [] as Array<{ id: string | null }>,
+    directWhere: undefined as unknown,
+    joinedWhere: undefined as unknown,
+  };
+
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async (predicate: unknown) => {
+          state.directWhere = predicate;
+          return state.directRows;
+        }),
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(async (predicate: unknown) => {
+            state.joinedWhere = predicate;
+            return state.joinedRows;
+          }),
+        })),
+      })),
+    })),
+  };
+
+  return { state, dbMock };
+});
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+}));
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  questionFeedback: { generatedQuestionId: 'questionFeedback.generatedQuestionId', questionId: 'questionFeedback.questionId', signal: 'questionFeedback.signal' },
+  questions: { id: 'questions.id', generatedQuestionId: 'questions.generatedQuestionId' },
+}));
+
+import { getHeartedBankQuestionIds } from '@/server/quality/hearted-bank-questions';
+
+describe('getHeartedBankQuestionIds', () => {
+  it('returns an empty set without querying when given no ids', async () => {
+    const result = await getHeartedBankQuestionIds([]);
+    expect(result.size).toBe(0);
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('unions hearts found directly on the bank row and via a served Question clone', async () => {
+    state.directRows = [{ id: 'bank-1' }];
+    state.joinedRows = [{ id: 'bank-2' }];
+
+    const result = await getHeartedBankQuestionIds(['bank-1', 'bank-2', 'bank-3']);
+
+    expect([...result].sort()).toEqual(['bank-1', 'bank-2']);
+  });
+
+  it('drops out any row with a null id from either path', async () => {
+    state.directRows = [{ id: null }];
+    state.joinedRows = [{ id: null }];
+
+    const result = await getHeartedBankQuestionIds(['bank-1']);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('de-dupes the input id list before querying', async () => {
+    state.directRows = [];
+    state.joinedRows = [];
+
+    await getHeartedBankQuestionIds(['bank-1', 'bank-1', 'bank-1']);
+
+    expect((state.directWhere as { parts: Array<{ values?: string[] }> }).parts[1].values).toEqual([
+      'bank-1',
+    ]);
+  });
+});

--- a/src/server/quality/hearted-bank-questions.ts
+++ b/src/server/quality/hearted-bank-questions.ts
@@ -1,0 +1,54 @@
+/**
+ * Hearted-question protection for bulk bank-hygiene sweeps.
+ *
+ * A heart (QuestionFeedback signal='thumbs_up') is a human saying this
+ * specific question was good. sweep-bank-quality's deterministic checks and
+ * quality/off-domain gate are taste-and-filing judgments, not factual-
+ * correctness checks — so a hearted row should never be silently swept away
+ * by them; a human should look first. This is deliberately narrower than the
+ * factual verification pipeline (verify-question.ts / the batch-verify cron):
+ * a heart says nothing about whether a fact is TRUE, so it must never hold
+ * back a factual demotion, only a taste/filing one.
+ *
+ * A heart can land on a bank row two ways: directly (QuestionFeedback.
+ * generated_question_id, the path the daily recap actually uses today) or on
+ * a canonical Question cloned from that bank row (QuestionFeedback.
+ * question_id, joined back via Question.generated_question_id). Both are
+ * checked so this doesn't silently miss hearts if the recap's target ever
+ * changes.
+ */
+
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { db, questionFeedback, questions } from '@/server/db';
+
+export async function getHeartedBankQuestionIds(
+  bankQuestionIds: readonly string[],
+): Promise<Set<string>> {
+  const ids = [...new Set(bankQuestionIds)];
+  if (ids.length === 0) return new Set();
+
+  const [direct, viaServedQuestion] = await Promise.all([
+    db
+      .select({ id: questionFeedback.generatedQuestionId })
+      .from(questionFeedback)
+      .where(
+        and(
+          eq(questionFeedback.signal, 'thumbs_up'),
+          inArray(questionFeedback.generatedQuestionId, ids),
+        ),
+      ),
+    db
+      .select({ id: questions.generatedQuestionId })
+      .from(questions)
+      .innerJoin(questionFeedback, eq(questionFeedback.questionId, questions.id))
+      .where(
+        and(eq(questionFeedback.signal, 'thumbs_up'), inArray(questions.generatedQuestionId, ids)),
+      ),
+  ]);
+
+  const hearted = new Set<string>();
+  for (const row of direct) if (row.id) hearted.add(row.id);
+  for (const row of viaServedQuestion) if (row.id) hearted.add(row.id);
+  return hearted;
+}


### PR DESCRIPTION
## Summary
- sweep-bank-quality's deterministic, quality-gate, and off-domain checks are taste/filing judgments, not factual-correctness checks. A row a player hearted (`QuestionFeedback.signal='thumbs_up'`) is now excluded from auto-demotion regardless of finding kind or `--include-off-domain`, and logged as `[HEARTED]`/held back for a human to review instead.
- New `getHeartedBankQuestionIds` checks both paths a heart can reach a bank row: directly on the bank row (`QuestionFeedback.generated_question_id`, the path the recap currently uses in practice) and via a served `Question` clone (`Question.generated_question_id` joined to `QuestionFeedback.question_id`).
- Deliberately scoped to this hygiene sweep only — does not touch the factual verification pipeline (`verify-question.ts` / the batch-verify cron), since a heart says a question was good, not that a fact is true.

## Test plan
- [x] `npx vitest run src/server/quality/__tests__/hearted-bank-questions.test.ts` — 4 new tests pass
- [x] `npx tsc -p tsconfig.typecheck.json` — clean
- [x] Dry-run (`--no-llm`) against prod: ran the new join with no errors; none of the 6 currently-flagged rows are hearted, so behavior is unchanged today

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJJmHsrrwbWwaoB3Pqkc4A