### PR TITLE
Re-file 33 off-domain rows; document the Woolf/Joyce drift mechanism

### DIFF
--- a/diagnosis/answer-leak-domain-drift-plan.md
+++ b/diagnosis/answer-leak-domain-drift-plan.md
@@ -989,10 +989,111 @@ indistinguishable from "nothing to catch that day." First run: no post-flip
 generation traffic yet, correctly reported as inconclusive rather than a
 false pass or fail.
 
+### 2026-09-08 (later still) — "why does Woolf keep generating Joyce" investigated and the historical damage cleaned up
+
+(Note: an earlier pass at this investigation was written up as an Update
+here, then lost to a concurrent edit of this file before it could be
+committed — re-summarizing it now since the "still not started" line above
+was stale.)
+
+**Two mechanisms, both confirmed against live prod data, not guessed:**
+
+1. **The content bug.** `canonical_subcategory` on a generated row is an
+   ECHO of whichever domain slot the model was answering in a batch
+   (`buildUserPrompt`'s numbered "Generate exactly one question for each of
+   the following N domains" list) — it is not independently verified.
+   `fact_key`, by contrast, is derived from what the model actually wrote.
+   This split is already called out in a comment at
+   `generate-questions.ts:876-882`. So every Joyce-under-Woolf row has
+   `canonical_subcategory = "Virginia Woolf's Novels and Essays"` but a
+   `fact_key` prefixed `james-joyce-irish-modernism-...` — the model was
+   asked for Woolf and genuinely wrote Joyce content. Not a bookkeeping bug;
+   a real generation-content mixup, most likely driven by how tightly Woolf
+   and Joyce are paired in training data (co-founders of stream-of-
+   consciousness modernism, landmark novels 3 years apart) — a prior the
+   static `SYSTEM_PROMPT` reinforces on every call by using both names as
+   its own back-to-back domain-labeling examples
+   (`generate-questions.ts:249,251,262`), independent of which domains a
+   given round even includes.
+
+2. **Why it's sustained, not a one-off (confirmed in code).**
+   `getRecentFactKeys` (`daily.ts:2569`) and `previousQuestionTexts`
+   (`generate-questions.ts:3094`) are scoped by `userId` only, across ALL a
+   user's domains, and — critically — **regardless of `is_duplicate`**. Both
+   render into every future prompt tagged `[canonical_subcategory]`. So once
+   one Joyce fact gets mislabeled `[Virginia Woolf's Novels and Essays]`,
+   every future Woolf-domain round sees it as an unintentional few-shot
+   precedent — AND demoting the row (`is_duplicate=true`, the only mitigation
+   applied on 2026-09-07) does NOT stop this, since the avoid-list queries
+   don't filter on duplicate status. This is consistent with what the data
+   showed: one user had this recur **24 times** across the full corpus (not
+   just the 22 the 2026-09-07 hand-verify pass caught), clustered almost
+   daily from 2026-05-03 to 2026-05-21, right after that user's separate
+   "Ulysses (Joyce Novel)" / "Dubliners & Joyce's Short Fiction" domains
+   stopped getting fresh generation.
+
+**Cleanup done today** (`scripts/refile-off-domain-rows-2026-09-08.ts`,
+dry-run verified then applied against prod, DB-verified after — not just
+script stdout): found and fixed **33 rows** across a full-corpus query (not
+limited to the previously-known 22), covering every off-domain cluster this
+doc has tracked — Joyce/Ulysses/Dubliners/Portrait-of-the-Artist under
+Woolf, E.M. Forster's Howards End under Woolf, "Rent" under Stephen Sondheim
+Musicals, Johannes Tinctoris under J.S. Bach & Baroque Counterpoint.
+
+- **14 re-filed AND restored to serving** — only where (a) the affected user
+  already has a real, established domain matching the true content (e.g.
+  "Ulysses (Joyce Novel)", "Dubliners & Joyce's Short Fiction", "Rent the
+  Musical" — all pre-existing, not invented), and (b) the row's own
+  `verification_reason` showed OFF_DOMAIN as the ONLY defect, with no
+  compounding FALSE_PREMISE / unsalvageable / likely-duplicate finding. One
+  of these (`6bdb3aa5`, "Michael Furey") was still **live and being served
+  under the wrong label at the moment this ran** — not just a historical
+  demoted row.
+- **19 relabeled only, left demoted** — either no existing target domain for
+  that user (Portrait of the Artist has no per-work domain for either
+  affected user; Forster; Rent for users without a Rent domain; Tinctoris —
+  none of these were invented as new servable domains, per Phase 3's caution
+  above), or the row carries an independent, separate defect besides the
+  filing (`cf0a6ed9`: unsalvageable answer-leak; `3f191608` and `00afdea4`:
+  false premise; `aad804c5`, `d21f6b62`: ambiguous/possible-duplicate
+  history; `ca2c1feb`: an explicit duplicate of the now-restored
+  `6fb3e187`). Relabeling these still closes the avoid-list feedback loop
+  even though the rows themselves never serve again.
+
+Verified after applying: **zero rows in the corpus remain filed under
+"Virginia Woolf's Novels and Essays"** whose `fact_key` names Joyce,
+Dubliners, or Forster content.
+
+**Not done / explicitly out of scope for today:** a full-corpus generalized
+audit for this same failure mode on OTHER tightly-paired domains (Proust,
+other same-movement author pairs, etc.) — this pass only covered the
+clusters already named in this doc's history. Also not built: a code-level
+fix to Mechanism 2 itself (e.g. excluding a domain's own already-flagged
+off-domain rows from that domain's avoid-list rendering going forward) — the
+relabeling done today fixes the SAME symptom for already-demoted rows going
+forward (a correctly-labeled row can't poison the wrong domain's avoid list
+anymore), but nothing yet stops a fresh future OFF_DOMAIN miss from doing
+the same thing again before it's caught and relabeled. With
+`DOMAIN_DRIFT_DROP_ENABLED` now on, fresh confirmed-off-domain rows are
+dropped before insert, which should prevent new instances of Mechanism 2
+from starting — today's cleanup was for the backlog that predates that flag.
+
+**Decision (Josh, 2026-09-08): hold the Mechanism 2 code fix pending
+diagnostics.** Deliberately NOT building the "exclude a domain's own
+flagged-off-domain rows from its future avoid-list" fix yet. `check:gate-flags`
+is the diagnostic this is waiting on — it needs to show
+`DOMAIN_DRIFT_DROP_ENABLED` actually catching fresh drift in real traffic
+first. If it's working, Mechanism 2 may simply not recur (nothing to fix);
+building the prevention code before that's confirmed risks solving a problem
+the drop flag already solves.
+
 ### Next steps
 1. **Run `npm run check:gate-flags`** once a day or two of real generation
-   traffic has passed since the flip, to confirm both flags are actually
-   doing something (or to catch a silent problem via the shared `quality`
-   gate health check).
-2. The "why does Woolf keep generating Joyce" investigation — still not
-   started.
+   traffic has passed since the flip — this is the blocking diagnostic for
+   the decision above, not just a health check.
+2. Only after that: revisit whether the Mechanism 2 code fix is still
+   needed, based on what the diagnostic shows.
+3. ~~The "why does Woolf keep generating Joyce" investigation~~ — done, see
+   above. Worth a follow-up only if the pattern recurs post-flip (it
+   shouldn't, now that `DOMAIN_DRIFT_DROP_ENABLED` is on) or if someone wants
+   the generalized full-corpus audit for other tightly-paired domains.

--- a/scripts/refile-off-domain-rows-2026-09-08.ts
+++ b/scripts/refile-off-domain-rows-2026-09-08.ts
@@ -1,0 +1,154 @@
+import 'dotenv/config';
+
+import { eq } from 'drizzle-orm';
+
+import { db, pool, generatedQuestions } from '../src/server/db';
+
+// Follow-up to scripts/demote-2026-09-07-off-domain-review.ts and
+// diagnosis/answer-leak-domain-drift-plan.md's "why does Woolf keep
+// generating Joyce" investigation (2026-09-08).
+//
+// Demoting an OFF_DOMAIN row (is_duplicate=true) does NOT stop it from
+// poisoning future generation: getRecentFactKeys / previousQuestionTexts pull
+// from GeneratedQuestion regardless of is_duplicate, and render each fact
+// tagged `[canonical_subcategory]` into the avoid-list of every future
+// generation round for that user. A Joyce fact demoted-but-still-labeled
+// "Virginia Woolf's Novels and Essays" keeps teaching the model, every day,
+// that this domain covers Joyce material — which is very likely WHY the
+// 2026-09-07 sweep found the same pattern recurring for weeks (see the doc).
+//
+// This script re-derives the CORRECT canonical_subcategory/broad_category
+// for every confirmed off-domain row found across the full corpus (not just
+// the 22 the 2026-09-07 hand-verify pass caught — this query is broader and
+// caught 11 more, including one still LIVE and being served:
+// 6bdb3aa5, "Michael Furey", filed under Woolf, is_duplicate=false).
+//
+// Two outcomes per row, decided by what's SAFE, not just what's correct:
+//   - RE-FILE + RESTORE to serving: only when (a) the user has a real,
+//     already-established domain matching the true content, AND (b) the
+//     row's own verification_reason shows OFF_DOMAIN as the ONLY defect
+//     (no FALSE_PREMISE / unsalvageable / duplicate-of-another-row
+//     complication). 12 rows qualify.
+//   - RELABEL ONLY, stay demoted: everything else — either no existing
+//     target domain (Portrait of the Artist, Forster, Rent for users with no
+//     Rent domain, Tinctoris), or a real independent content defect besides
+//     the filing (cf0a6ed9 unsalvageable answer-leak, 3f191608 + 00afdea4
+//     false premise), or an unclear/duplicate history (aad804c5, d21f6b62,
+//     ca2c1feb — the last is an explicit dup of 6fb3e187's same fact).
+//     Fixing the LABEL on these still closes the avoid-list feedback loop
+//     even though the row itself never serves again.
+//
+// Fallback labels for "no existing domain" cases reuse this exact user's own
+// established broad_category-as-domain convention (e.g. this repo already
+// files rows under "J.S. Bach & Baroque Counterpoint" as its own top-level
+// domain, not just as a broad_category) — not an invented new domain.
+//
+//   npx tsx -r dotenv/config scripts/refile-off-domain-rows-2026-09-08.ts dotenv_config_path=.env.local            # DRY RUN
+//   npx tsx -r dotenv/config scripts/refile-off-domain-rows-2026-09-08.ts dotenv_config_path=.env.local --apply    # writes
+
+const APPLY = process.argv.includes('--apply');
+
+type Row = {
+  id: string;
+  canonicalSubcategory: string;
+  broadCategory: string;
+  restore: boolean; // true = also set is_duplicate=false (un-demote)
+  note: string;
+};
+
+const ROWS: Row[] = [
+  // --- User 33da35b1: re-file to "Ulysses (Joyce Novel)" + restore (clean OFF_DOMAIN, no other defect) ---
+  { id: 'f8f27ce8-c3ff-4607-ab3d-1235e580156d', canonicalSubcategory: 'Ulysses (Joyce Novel)', broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Aeolus rhetoric' },
+  { id: '32a587c3-948d-4ec4-816e-47d71eb27cfd', canonicalSubcategory: 'Ulysses (Joyce Novel)', broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Oxen of the Sun' },
+  { id: '0f464841-159b-4581-ae3e-3a7d5d95fd3b', canonicalSubcategory: 'Ulysses (Joyce Novel)', broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Cyclops / Irish Literary Revival' },
+  { id: 'b7d9705a-c8a1-42d5-97f5-ef23dcd1fd3c', canonicalSubcategory: 'Ulysses (Joyce Novel)', broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Ithaca cocoa' },
+  { id: '6fb3e187-1c16-4077-8ce3-b74a273502b2', canonicalSubcategory: 'Ulysses (Joyce Novel)', broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Aeolus headlines (kept; ca2c1feb is its dup)' },
+  { id: 'b38a6c96-5b47-4cb1-b464-a49bc4a17401', canonicalSubcategory: 'Ulysses (Joyce Novel)', broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Sirens' },
+
+  // --- User 33da35b1: re-file to "Dubliners & Joyce's Short Fiction" + restore ---
+  { id: '75ab272f-a399-4bdb-ab7c-8a71c9dd813c', canonicalSubcategory: "Dubliners & Joyce's Short Fiction", broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Feast of the Epiphany' },
+  { id: 'c269be50-17fb-4b32-bb88-e905ec5d1c44', canonicalSubcategory: "Dubliners & Joyce's Short Fiction", broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Counterparts' },
+  { id: '98bacf63-e577-4f33-81a9-8958631fa823', canonicalSubcategory: "Dubliners & Joyce's Short Fiction", broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Eveline' },
+  { id: '02a618e2-e3d8-4d78-9cc3-216ff9aa5105', canonicalSubcategory: "Dubliners & Joyce's Short Fiction", broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Ivy Day' },
+  { id: '08199a4b-71f3-4b8f-b9cf-33e989fc9de5', canonicalSubcategory: "Dubliners & Joyce's Short Fiction", broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'The Dead' },
+  { id: '6bdb3aa5-4d60-49de-910a-0b81a0fe4bcb', canonicalSubcategory: "Dubliners & Joyce's Short Fiction", broadCategory: 'James Joyce & Irish Modernism', restore: true, note: 'Michael Furey — STILL LIVE (is_duplicate=false) under Woolf right now; relabel only, no is_duplicate change needed but harmless to set' },
+  { id: 'cf263b0e-7c5f-43d8-9f9f-e187a353a94d', canonicalSubcategory: "Dubliners & Joyce's Short Fiction", broadCategory: 'James Joyce & Irish Modernism', restore: true, note: "Eveline (helpless animal simile) — distinct fact_key from the also-restored 98bacf63's Eveline/Argentina fact, not a duplicate. Missed in the first pass; added after verifying the apply left it behind." },
+
+  // --- User f5ed1c59: re-file to "Rent the Musical" + restore (domain already exists, e.g. 42f619b6) ---
+  { id: 'f69900bf-0c27-4bf4-959d-e80b7340352f', canonicalSubcategory: 'Rent the Musical', broadCategory: 'Theater & Musicals', restore: true, note: 'Benny antagonist' },
+
+  // --- Relabel only, stay demoted: no existing target domain for this user ---
+  { id: '94093595-9555-42ba-b639-5fc82fe71c30', canonicalSubcategory: 'James Joyce & Irish Modernism', broadCategory: 'James Joyce & Irish Modernism', restore: false, note: '33da35b1 Portrait (lyrical/epical/dramatic) — no per-work domain exists' },
+  { id: 'f1064412-93f3-4f7e-9036-2c5670a43a52', canonicalSubcategory: 'James Joyce & Irish Modernism', broadCategory: 'James Joyce & Irish Modernism', restore: false, note: '33da35b1 Portrait (petition) — no per-work domain exists' },
+  { id: '2820a8bc-bf66-4017-ad1d-e0ef51a08626', canonicalSubcategory: 'James Joyce & Irish Modernism', broadCategory: 'James Joyce & Irish Modernism', restore: false, note: '33da35b1 Portrait (three nets) — no per-work domain exists' },
+  { id: '939c53c7-adb8-4123-94c2-c09e62463e77', canonicalSubcategory: 'James Joyce & Irish Modernism', broadCategory: 'James Joyce & Irish Modernism', restore: false, note: '33da35b1 Portrait (claritas) — original source of the 815b3ad8 bank-pick clone' },
+  { id: '139e1932-d4e4-4fc6-9f78-53a05cecadfe', canonicalSubcategory: '20th Century English Modernist Literature', broadCategory: '20th Century English Modernist Literature', restore: false, note: "f5ed1c59 Portrait (petition) — the ORIGINAL flagged incident row; no per-work domain, mirrors this user's own Ulysses broad_category" },
+  { id: '815b3ad8-3b54-4c64-a102-0854f223bcc3', canonicalSubcategory: '20th Century English Modernist Literature', broadCategory: '20th Century English Modernist Literature', restore: false, note: 'f5ed1c59 Portrait (claritas) — bank-pick clone of 939c53c7' },
+  { id: 'fd246545-63a6-490a-aaca-6990b83328c0', canonicalSubcategory: "E.M. Forster's Howards End", broadCategory: 'Literature', restore: false, note: '30c4be4b Forster — no Forster domain exists for this user' },
+  { id: '4b686fbd-c75f-44cb-909b-7ec670f8cd7c', canonicalSubcategory: "E.M. Forster's Howards End", broadCategory: 'Literature', restore: false, note: 'f5ed1c59 Forster — no Forster domain exists for this user' },
+  { id: '3cdabe19-a095-42f0-ae95-61b102456535', canonicalSubcategory: 'Rent (Jonathan Larson Musical)', broadCategory: 'Theater & Musicals', restore: false, note: '30c4be4b Rent — no Rent domain exists for this user' },
+  { id: '0f713f93-f0e8-4ad3-8ec6-504507dbcbbb', canonicalSubcategory: 'Rent (Jonathan Larson Musical)', broadCategory: 'Theater & Musicals', restore: false, note: '30c4be4b Rent (seasons of love) — no Rent domain, unclear prior demotion reason' },
+  { id: '81d53628-4707-418e-b244-92696b92abf7', canonicalSubcategory: 'Rent (Jonathan Larson Musical)', broadCategory: 'Theater & Musicals', restore: false, note: '30c4be4b Rent (Mimi/Roger) — no Rent domain exists for this user' },
+  { id: '00afdea4-d4f8-4066-bb50-14be796f80aa', canonicalSubcategory: 'Rent (Jonathan Larson Musical)', broadCategory: 'Theater & Musicals', restore: false, note: '30c4be4b Rent (Angel/drums) — ALSO has an independent FALSE_PREMISE defect; stays demoted regardless' },
+  { id: '072b5c66-b0cf-4fb6-af3b-522fc2ef01fb', canonicalSubcategory: 'Rent (Jonathan Larson Musical)', broadCategory: 'Theater & Musicals', restore: false, note: '565e41bd Rent — no Rent domain exists for this user' },
+  { id: '19c7961f-c16f-4cd6-8eee-88f47f375408', canonicalSubcategory: 'Renaissance Counterpoint (Johannes Tinctoris)', broadCategory: 'Music', restore: false, note: 'f5ed1c59 Tinctoris — no Renaissance/polyphony domain exists for this user (Bach ≠ Tinctoris by ~250 years)' },
+  { id: 'cf0a6ed9-ee5b-4095-9994-86f95ee8272f', canonicalSubcategory: "Dubliners & Joyce's Short Fiction", broadCategory: 'James Joyce & Irish Modernism', restore: false, note: "33da35b1 Araby — has an independent UNSALVAGEABLE answer-leak defect (bazaar name = story title); relabel for accuracy only, never serve" },
+  { id: '3f191608-e026-4970-a535-36139c999b45', canonicalSubcategory: "Dubliners & Joyce's Short Fiction", broadCategory: 'James Joyce & Irish Modernism', restore: false, note: '33da35b1 Dubliners (Catholic Church) — ALSO has an independent FALSE_PREMISE defect; stays demoted regardless' },
+  { id: 'aad804c5-ca0c-4a81-a675-860d1fc76bf6', canonicalSubcategory: 'Ulysses (Joyce Novel)', broadCategory: 'James Joyce & Irish Modernism', restore: false, note: '33da35b1 Ulysses (Shakespeare & Co) — verdict/reason unclear (verified/ok but is_duplicate=true already); relabel only, do not risk restoring a possible duplicate' },
+  { id: 'd21f6b62-ffbd-4239-a4e6-6f400044a65c', canonicalSubcategory: 'Ulysses (Joyce Novel)', broadCategory: 'James Joyce & Irish Modernism', restore: false, note: '33da35b1 Ulysses (June 16 1904) — reason/verdict null; relabel only, do not risk restoring a possible duplicate' },
+  { id: 'ca2c1feb-ee78-4b81-8db4-e33501e507c6', canonicalSubcategory: 'Ulysses (Joyce Novel)', broadCategory: 'James Joyce & Irish Modernism', restore: false, note: '33da35b1 Ulysses (Aeolus headlines) — explicit duplicate of the restored 6fb3e187; relabel only' },
+];
+
+async function main() {
+  const restoring = ROWS.filter((r) => r.restore).length;
+  console.log(
+    `[refile] ${ROWS.length} rows to relabel (${restoring} also restored to serving)${APPLY ? '' : ' (DRY RUN)'}`,
+  );
+  if (!APPLY) {
+    for (const r of ROWS) {
+      console.log(`  ${r.id} -> "${r.canonicalSubcategory}" (${r.broadCategory})${r.restore ? ' [RESTORE]' : ''} — ${r.note}`);
+    }
+    console.log('[refile] re-run with --apply to write.');
+    return;
+  }
+
+  const now = new Date();
+  let n = 0;
+  for (const r of ROWS) {
+    // Restored rows get a fresh, clean verdict — they're back in circulation.
+    // Relabel-only rows keep their ORIGINAL verification_reason untouched
+    // (the audit trail for why they're demoted, e.g. an independent
+    // unsalvageable-answer-leak or false-premise finding) — only the
+    // domain label is wrong there, not the verdict, so only
+    // canonical_subcategory/broad_category change.
+    const patch: Partial<typeof generatedQuestions.$inferInsert> = r.restore
+      ? {
+          canonicalSubcategory: r.canonicalSubcategory,
+          broadCategory: r.broadCategory,
+          isDuplicate: false,
+          verificationVerdict: 'ok',
+          verifiedAt: now,
+          verificationReason: `re-filed 2026-09-08 (was OFF_DOMAIN): ${r.note}`.slice(0, 400),
+        }
+      : {
+          canonicalSubcategory: r.canonicalSubcategory,
+          broadCategory: r.broadCategory,
+        };
+    const updated = await db
+      .update(generatedQuestions)
+      .set(patch)
+      .where(eq(generatedQuestions.id, r.id))
+      .returning({ id: generatedQuestions.id });
+    n += updated.length;
+  }
+  console.log(`[refile] updated ${n} row(s).`);
+}
+
+main()
+  .catch((err) => {
+    console.error('[refile] failed', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });


### PR DESCRIPTION
## Summary
- Investigates and documents (in `diagnosis/answer-leak-domain-drift-plan.md`) why "Virginia Woolf's Novels and Essays" kept generating Joyce content: `canonical_subcategory` echoes the requested domain slot rather than being independently verified, and the avoid-lists that feed every generation prompt (`getRecentFactKeys`, `previousQuestionTexts`) pull from a user's full history regardless of `is_duplicate` — so a mislabeled row keeps teaching future rounds the wrong domain covers that content, indefinitely, even after demotion.
- `scripts/refile-off-domain-rows-2026-09-08.ts`: a full-corpus query found 33 mislabeled rows (11 more than the 2026-09-07 hand-verify pass caught, including one still live and served). Already run against prod (dry-run verified, then applied, then DB-verified) — this PR is committing the script for the audit trail, not re-running it.
  - 14 re-filed to a real pre-existing domain and restored to serving (only where the sole recorded defect was OFF_DOMAIN, nothing else).
  - 19 relabeled only, left demoted (no safe existing target domain, or an independent content defect beyond the filing).
- Records Josh's decision to hold the follow-up code fix (stopping a *future* miss from restarting the same avoid-list poisoning) pending `check:gate-flags` diagnostics confirming `DOMAIN_DRIFT_DROP_ENABLED` is actually catching fresh drift in production.

## Test plan
- [x] `npx eslint scripts/refile-off-domain-rows-2026-09-08.ts` — clean
- [x] `npx tsc -p tsconfig.typecheck.json --noEmit` — no errors in the new file
- [x] Dry-run of the script reviewed before `--apply`
- [x] Applied against prod; verified via direct DB query that zero rows remain filed under "Virginia Woolf's Novels and Essays" with Joyce/Dubliners/Forster content, and the 14 restored rows are correctly labeled and servable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJwiXeNJPqExdRGRdZGrTh